### PR TITLE
Derive `Copy`, `Clone`, and `Debug` for handles

### DIFF
--- a/crates/libs/bindgen/src/rust/handles.rs
+++ b/crates/libs/bindgen/src/rust/handles.rs
@@ -100,24 +100,13 @@ pub fn gen_win_handle(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
 
     let mut tokens = quote! {
         #[repr(transparent)]
-        #[derive(PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
         pub struct #ident(pub #signature);
         #is_invalid
         #free
         impl Default for #ident {
             fn default() -> Self {
                 unsafe { core::mem::zeroed() }
-            }
-        }
-        impl Clone for #ident {
-            fn clone(&self) -> Self {
-                *self
-            }
-        }
-        impl Copy for #ident {}
-        impl core::fmt::Debug for #ident {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                f.debug_tuple(#name).field(&self.0).finish()
             }
         }
         impl windows_core::TypeKind for #ident {

--- a/crates/libs/bindgen/src/rust/standalone.rs
+++ b/crates/libs/bindgen/src/rust/standalone.rs
@@ -64,17 +64,12 @@ pub fn standalone_imp(writer: &Writer) -> String {
                     "GUID",
                     quote! {
                         #[repr(C)]
+                        #[derive(Clone, Copy)]
                         pub struct GUID {
                             pub data1: u32,
                             pub data2: u16,
                             pub data3: u16,
                             pub data4: [u8; 8],
-                        }
-                        impl Copy for GUID {}
-                        impl Clone for GUID {
-                            fn clone(&self) -> Self {
-                                *self
-                            }
                         }
                         impl GUID {
                             pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/libs/core/src/imp/bindings.rs
+++ b/crates/libs/core/src/imp/bindings.rs
@@ -516,17 +516,12 @@ impl Clone for FUNCDESC {
 pub type FUNCFLAGS = u16;
 pub type FUNCKIND = i32;
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/libs/result/src/bindings.rs
+++ b/crates/libs/result/src/bindings.rs
@@ -27,17 +27,12 @@ pub const FORMAT_MESSAGE_FROM_SYSTEM: FORMAT_MESSAGE_OPTIONS = 4096u32;
 pub const FORMAT_MESSAGE_IGNORE_INSERTS: FORMAT_MESSAGE_OPTIONS = 512u32;
 pub type FORMAT_MESSAGE_OPTIONS = u32;
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/libs/windows/src/Windows/Wdk/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Foundation/mod.rs
@@ -928,22 +928,11 @@ impl Default for DISPATCHER_HEADER_0_6 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DMA_COMMON_BUFFER_VECTOR(pub isize);
 impl Default for DMA_COMMON_BUFFER_VECTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for DMA_COMMON_BUFFER_VECTOR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for DMA_COMMON_BUFFER_VECTOR {}
-impl core::fmt::Debug for DMA_COMMON_BUFFER_VECTOR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("DMA_COMMON_BUFFER_VECTOR").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for DMA_COMMON_BUFFER_VECTOR {
@@ -1057,44 +1046,22 @@ impl Default for DRIVER_OBJECT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ECP_HEADER(pub isize);
 impl Default for ECP_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for ECP_HEADER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for ECP_HEADER {}
-impl core::fmt::Debug for ECP_HEADER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("ECP_HEADER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for ECP_HEADER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ECP_LIST(pub isize);
 impl Default for ECP_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for ECP_LIST {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for ECP_LIST {}
-impl core::fmt::Debug for ECP_LIST {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("ECP_LIST").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for ECP_LIST {
@@ -1421,44 +1388,22 @@ impl Default for FILE_OBJECT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct IOMMU_DMA_DEVICE(pub isize);
 impl Default for IOMMU_DMA_DEVICE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for IOMMU_DMA_DEVICE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for IOMMU_DMA_DEVICE {}
-impl core::fmt::Debug for IOMMU_DMA_DEVICE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("IOMMU_DMA_DEVICE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for IOMMU_DMA_DEVICE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct IOMMU_DMA_DOMAIN(pub isize);
 impl Default for IOMMU_DMA_DOMAIN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for IOMMU_DMA_DOMAIN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for IOMMU_DMA_DOMAIN {}
-impl core::fmt::Debug for IOMMU_DMA_DOMAIN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("IOMMU_DMA_DOMAIN").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for IOMMU_DMA_DOMAIN {
@@ -3637,22 +3582,11 @@ impl Default for KDPC_0_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct KENLISTMENT(pub isize);
 impl Default for KENLISTMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for KENLISTMENT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for KENLISTMENT {}
-impl core::fmt::Debug for KENLISTMENT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("KENLISTMENT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for KENLISTMENT {
@@ -3682,44 +3616,22 @@ impl Default for KEVENT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct KGDT(pub isize);
 impl Default for KGDT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for KGDT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for KGDT {}
-impl core::fmt::Debug for KGDT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("KGDT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for KGDT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct KIDT(pub isize);
 impl Default for KIDT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for KIDT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for KIDT {}
-impl core::fmt::Debug for KIDT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("KIDT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for KIDT {
@@ -3814,44 +3726,22 @@ impl Default for KMUTANT_0_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct KPCR(pub isize);
 impl Default for KPCR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for KPCR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for KPCR {}
-impl core::fmt::Debug for KPCR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("KPCR").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for KPCR {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct KPRCB(pub isize);
 impl Default for KPRCB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for KPRCB {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for KPRCB {}
-impl core::fmt::Debug for KPRCB {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("KPRCB").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for KPRCB {
@@ -3885,88 +3775,44 @@ impl Default for KQUEUE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct KRESOURCEMANAGER(pub isize);
 impl Default for KRESOURCEMANAGER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for KRESOURCEMANAGER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for KRESOURCEMANAGER {}
-impl core::fmt::Debug for KRESOURCEMANAGER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("KRESOURCEMANAGER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for KRESOURCEMANAGER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct KTM(pub isize);
 impl Default for KTM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for KTM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for KTM {}
-impl core::fmt::Debug for KTM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("KTM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for KTM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct KTRANSACTION(pub isize);
 impl Default for KTRANSACTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for KTRANSACTION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for KTRANSACTION {}
-impl core::fmt::Debug for KTRANSACTION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("KTRANSACTION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for KTRANSACTION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct KTSS(pub isize);
 impl Default for KTSS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for KTSS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for KTSS {}
-impl core::fmt::Debug for KTSS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("KTSS").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for KTSS {
@@ -4027,22 +3873,11 @@ impl Default for KWAIT_BLOCK_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LOADER_PARAMETER_BLOCK(pub isize);
 impl Default for LOADER_PARAMETER_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for LOADER_PARAMETER_BLOCK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for LOADER_PARAMETER_BLOCK {}
-impl core::fmt::Debug for LOADER_PARAMETER_BLOCK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("LOADER_PARAMETER_BLOCK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for LOADER_PARAMETER_BLOCK {
@@ -4283,550 +4118,275 @@ impl Default for OWNER_ENTRY_0_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PAFFINITY_TOKEN(pub isize);
 impl Default for PAFFINITY_TOKEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PAFFINITY_TOKEN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PAFFINITY_TOKEN {}
-impl core::fmt::Debug for PAFFINITY_TOKEN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PAFFINITY_TOKEN").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PAFFINITY_TOKEN {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PBUS_HANDLER(pub isize);
 impl Default for PBUS_HANDLER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PBUS_HANDLER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PBUS_HANDLER {}
-impl core::fmt::Debug for PBUS_HANDLER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PBUS_HANDLER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PBUS_HANDLER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PCALLBACK_OBJECT(pub isize);
 impl Default for PCALLBACK_OBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PCALLBACK_OBJECT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PCALLBACK_OBJECT {}
-impl core::fmt::Debug for PCALLBACK_OBJECT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PCALLBACK_OBJECT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PCALLBACK_OBJECT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PDEVICE_HANDLER_OBJECT(pub isize);
 impl Default for PDEVICE_HANDLER_OBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PDEVICE_HANDLER_OBJECT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PDEVICE_HANDLER_OBJECT {}
-impl core::fmt::Debug for PDEVICE_HANDLER_OBJECT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PDEVICE_HANDLER_OBJECT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PDEVICE_HANDLER_OBJECT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PEJOB(pub isize);
 impl Default for PEJOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PEJOB {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PEJOB {}
-impl core::fmt::Debug for PEJOB {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PEJOB").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PEJOB {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PEPROCESS(pub isize);
 impl Default for PEPROCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PEPROCESS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PEPROCESS {}
-impl core::fmt::Debug for PEPROCESS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PEPROCESS").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PEPROCESS {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PESILO(pub isize);
 impl Default for PESILO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PESILO {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PESILO {}
-impl core::fmt::Debug for PESILO {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PESILO").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PESILO {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PETHREAD(pub isize);
 impl Default for PETHREAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PETHREAD {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PETHREAD {}
-impl core::fmt::Debug for PETHREAD {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PETHREAD").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PETHREAD {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PEX_RUNDOWN_REF_CACHE_AWARE(pub isize);
 impl Default for PEX_RUNDOWN_REF_CACHE_AWARE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PEX_RUNDOWN_REF_CACHE_AWARE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PEX_RUNDOWN_REF_CACHE_AWARE {}
-impl core::fmt::Debug for PEX_RUNDOWN_REF_CACHE_AWARE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PEX_RUNDOWN_REF_CACHE_AWARE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PEX_RUNDOWN_REF_CACHE_AWARE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PEX_TIMER(pub isize);
 impl Default for PEX_TIMER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PEX_TIMER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PEX_TIMER {}
-impl core::fmt::Debug for PEX_TIMER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PEX_TIMER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PEX_TIMER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PIO_REMOVE_LOCK_TRACKING_BLOCK(pub isize);
 impl Default for PIO_REMOVE_LOCK_TRACKING_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PIO_REMOVE_LOCK_TRACKING_BLOCK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PIO_REMOVE_LOCK_TRACKING_BLOCK {}
-impl core::fmt::Debug for PIO_REMOVE_LOCK_TRACKING_BLOCK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PIO_REMOVE_LOCK_TRACKING_BLOCK").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PIO_REMOVE_LOCK_TRACKING_BLOCK {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PIO_TIMER(pub isize);
 impl Default for PIO_TIMER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PIO_TIMER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PIO_TIMER {}
-impl core::fmt::Debug for PIO_TIMER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PIO_TIMER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PIO_TIMER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PIO_WORKITEM(pub isize);
 impl Default for PIO_WORKITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PIO_WORKITEM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PIO_WORKITEM {}
-impl core::fmt::Debug for PIO_WORKITEM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PIO_WORKITEM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PIO_WORKITEM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PKINTERRUPT(pub isize);
 impl Default for PKINTERRUPT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PKINTERRUPT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PKINTERRUPT {}
-impl core::fmt::Debug for PKINTERRUPT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PKINTERRUPT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PKINTERRUPT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PKPROCESS(pub isize);
 impl Default for PKPROCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PKPROCESS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PKPROCESS {}
-impl core::fmt::Debug for PKPROCESS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PKPROCESS").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PKPROCESS {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PKTHREAD(pub isize);
 impl Default for PKTHREAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PKTHREAD {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PKTHREAD {}
-impl core::fmt::Debug for PKTHREAD {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PKTHREAD").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PKTHREAD {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PNOTIFY_SYNC(pub isize);
 impl Default for PNOTIFY_SYNC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PNOTIFY_SYNC {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PNOTIFY_SYNC {}
-impl core::fmt::Debug for PNOTIFY_SYNC {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PNOTIFY_SYNC").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PNOTIFY_SYNC {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct POBJECT_TYPE(pub isize);
 impl Default for POBJECT_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for POBJECT_TYPE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for POBJECT_TYPE {}
-impl core::fmt::Debug for POBJECT_TYPE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("POBJECT_TYPE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for POBJECT_TYPE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct POHANDLE(pub isize);
 impl Default for POHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for POHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for POHANDLE {}
-impl core::fmt::Debug for POHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("POHANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for POHANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PPCW_BUFFER(pub isize);
 impl Default for PPCW_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PPCW_BUFFER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PPCW_BUFFER {}
-impl core::fmt::Debug for PPCW_BUFFER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PPCW_BUFFER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PPCW_BUFFER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PPCW_INSTANCE(pub isize);
 impl Default for PPCW_INSTANCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PPCW_INSTANCE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PPCW_INSTANCE {}
-impl core::fmt::Debug for PPCW_INSTANCE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PPCW_INSTANCE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PPCW_INSTANCE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PPCW_REGISTRATION(pub isize);
 impl Default for PPCW_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PPCW_REGISTRATION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PPCW_REGISTRATION {}
-impl core::fmt::Debug for PPCW_REGISTRATION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PPCW_REGISTRATION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PPCW_REGISTRATION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PRKPROCESS(pub isize);
 impl Default for PRKPROCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PRKPROCESS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PRKPROCESS {}
-impl core::fmt::Debug for PRKPROCESS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PRKPROCESS").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PRKPROCESS {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PRKTHREAD(pub isize);
 impl Default for PRKTHREAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PRKTHREAD {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PRKTHREAD {}
-impl core::fmt::Debug for PRKTHREAD {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PRKTHREAD").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PRKTHREAD {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PSILO_MONITOR(pub isize);
 impl Default for PSILO_MONITOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PSILO_MONITOR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PSILO_MONITOR {}
-impl core::fmt::Debug for PSILO_MONITOR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PSILO_MONITOR").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PSILO_MONITOR {
@@ -4935,22 +4495,11 @@ impl Default for SECURITY_SUBJECT_CONTEXT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SspiAsyncContext(pub isize);
 impl Default for SspiAsyncContext {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SspiAsyncContext {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SspiAsyncContext {}
-impl core::fmt::Debug for SspiAsyncContext {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SspiAsyncContext").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SspiAsyncContext {
@@ -5075,66 +4624,33 @@ impl Default for WORK_QUEUE_ITEM {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct _DEVICE_OBJECT_POWER_EXTENSION(pub isize);
 impl Default for _DEVICE_OBJECT_POWER_EXTENSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for _DEVICE_OBJECT_POWER_EXTENSION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for _DEVICE_OBJECT_POWER_EXTENSION {}
-impl core::fmt::Debug for _DEVICE_OBJECT_POWER_EXTENSION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("_DEVICE_OBJECT_POWER_EXTENSION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for _DEVICE_OBJECT_POWER_EXTENSION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct _IORING_OBJECT(pub isize);
 impl Default for _IORING_OBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for _IORING_OBJECT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for _IORING_OBJECT {}
-impl core::fmt::Debug for _IORING_OBJECT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("_IORING_OBJECT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for _IORING_OBJECT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct _SCSI_REQUEST_BLOCK(pub isize);
 impl Default for _SCSI_REQUEST_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for _SCSI_REQUEST_BLOCK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for _SCSI_REQUEST_BLOCK {}
-impl core::fmt::Debug for _SCSI_REQUEST_BLOCK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("_SCSI_REQUEST_BLOCK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for _SCSI_REQUEST_BLOCK {

--- a/crates/libs/windows/src/Windows/Wdk/NetworkManagement/Ndis/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/NetworkManagement/Ndis/mod.rs
@@ -3518,44 +3518,22 @@ impl Default for CO_CALL_MANAGER_PARAMETERS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CO_CALL_PARAMETERS(pub isize);
 impl Default for CO_CALL_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for CO_CALL_PARAMETERS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for CO_CALL_PARAMETERS {}
-impl core::fmt::Debug for CO_CALL_PARAMETERS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("CO_CALL_PARAMETERS").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for CO_CALL_PARAMETERS {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CO_MEDIA_PARAMETERS(pub isize);
 impl Default for CO_MEDIA_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for CO_MEDIA_PARAMETERS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for CO_MEDIA_PARAMETERS {}
-impl core::fmt::Debug for CO_MEDIA_PARAMETERS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("CO_MEDIA_PARAMETERS").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for CO_MEDIA_PARAMETERS {
@@ -3654,22 +3632,11 @@ impl Default for CO_SPECIFIC_PARAMETERS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ETH_FILTER(pub isize);
 impl Default for ETH_FILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for ETH_FILTER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for ETH_FILTER {}
-impl core::fmt::Debug for ETH_FILTER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("ETH_FILTER").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for ETH_FILTER {
@@ -4677,44 +4644,22 @@ impl Default for NDIS_802_11_WEP {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_AF_LIST(pub isize);
 impl Default for NDIS_AF_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for NDIS_AF_LIST {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_AF_LIST {}
-impl core::fmt::Debug for NDIS_AF_LIST {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_AF_LIST").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for NDIS_AF_LIST {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_CALL_MANAGER_CHARACTERISTICS(pub isize);
 impl Default for NDIS_CALL_MANAGER_CHARACTERISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NDIS_CALL_MANAGER_CHARACTERISTICS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_CALL_MANAGER_CHARACTERISTICS {}
-impl core::fmt::Debug for NDIS_CALL_MANAGER_CHARACTERISTICS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_CALL_MANAGER_CHARACTERISTICS").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NDIS_CALL_MANAGER_CHARACTERISTICS {
@@ -5484,22 +5429,11 @@ impl Default for NDIS_LINK_STATE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_MINIPORT_BLOCK(pub isize);
 impl Default for NDIS_MINIPORT_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NDIS_MINIPORT_BLOCK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_MINIPORT_BLOCK {}
-impl core::fmt::Debug for NDIS_MINIPORT_BLOCK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_MINIPORT_BLOCK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NDIS_MINIPORT_BLOCK {
@@ -5534,22 +5468,11 @@ impl Default for NDIS_MINIPORT_TIMER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_M_DRIVER_BLOCK(pub isize);
 impl Default for NDIS_M_DRIVER_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NDIS_M_DRIVER_BLOCK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_M_DRIVER_BLOCK {}
-impl core::fmt::Debug for NDIS_M_DRIVER_BLOCK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_M_DRIVER_BLOCK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NDIS_M_DRIVER_BLOCK {
@@ -5676,22 +5599,11 @@ impl Default for NDIS_OFFLOAD_PARAMETERS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_OPEN_BLOCK(pub isize);
 impl Default for NDIS_OPEN_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NDIS_OPEN_BLOCK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_OPEN_BLOCK {}
-impl core::fmt::Debug for NDIS_OPEN_BLOCK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_OPEN_BLOCK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NDIS_OPEN_BLOCK {
@@ -5858,66 +5770,33 @@ impl Default for NDIS_PCI_DEVICE_CUSTOM_PROPERTIES {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_PD_COUNTER_HANDLE(pub isize);
 impl Default for NDIS_PD_COUNTER_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for NDIS_PD_COUNTER_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_PD_COUNTER_HANDLE {}
-impl core::fmt::Debug for NDIS_PD_COUNTER_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_PD_COUNTER_HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for NDIS_PD_COUNTER_HANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_PD_FILTER_HANDLE(pub isize);
 impl Default for NDIS_PD_FILTER_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for NDIS_PD_FILTER_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_PD_FILTER_HANDLE {}
-impl core::fmt::Debug for NDIS_PD_FILTER_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_PD_FILTER_HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for NDIS_PD_FILTER_HANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_PD_PROVIDER_HANDLE(pub isize);
 impl Default for NDIS_PD_PROVIDER_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NDIS_PD_PROVIDER_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_PD_PROVIDER_HANDLE {}
-impl core::fmt::Debug for NDIS_PD_PROVIDER_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_PD_PROVIDER_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NDIS_PD_PROVIDER_HANDLE {
@@ -6049,22 +5928,11 @@ impl Default for NDIS_PNP_CAPABILITIES {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_POLL_HANDLE(pub isize);
 impl Default for NDIS_POLL_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NDIS_POLL_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_POLL_HANDLE {}
-impl core::fmt::Debug for NDIS_POLL_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_POLL_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NDIS_POLL_HANDLE {
@@ -6304,22 +6172,11 @@ impl Default for NDIS_PORT_STATE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_PROTOCOL_BLOCK(pub isize);
 impl Default for NDIS_PROTOCOL_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NDIS_PROTOCOL_BLOCK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_PROTOCOL_BLOCK {}
-impl core::fmt::Debug for NDIS_PROTOCOL_BLOCK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_PROTOCOL_BLOCK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NDIS_PROTOCOL_BLOCK {
@@ -8346,22 +8203,11 @@ impl Default for NDIS_WORK_ITEM {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDIS_WRAPPER_HANDLE(pub isize);
 impl Default for NDIS_WRAPPER_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NDIS_WRAPPER_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDIS_WRAPPER_HANDLE {}
-impl core::fmt::Debug for NDIS_WRAPPER_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDIS_WRAPPER_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NDIS_WRAPPER_HANDLE {
@@ -8524,22 +8370,11 @@ impl Default for NETWORK_ADDRESS_LIST {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NULL_FILTER(pub isize);
 impl Default for NULL_FILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NULL_FILTER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NULL_FILTER {}
-impl core::fmt::Debug for NULL_FILTER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NULL_FILTER").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NULL_FILTER {
@@ -8912,22 +8747,11 @@ impl Default for TRANSPORT_HEADER_OFFSET {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TR_FILTER(pub isize);
 impl Default for TR_FILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for TR_FILTER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for TR_FILTER {}
-impl core::fmt::Debug for TR_FILTER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("TR_FILTER").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for TR_FILTER {

--- a/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/Minifilters/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/Minifilters/mod.rs
@@ -5024,7 +5024,7 @@ impl Default for FLT_VOLUME_PROPERTIES {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PFLT_CONTEXT(pub *mut core::ffi::c_void);
 impl PFLT_CONTEXT {
     pub fn is_invalid(&self) -> bool {
@@ -5036,147 +5036,70 @@ impl Default for PFLT_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PFLT_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PFLT_CONTEXT {}
-impl core::fmt::Debug for PFLT_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PFLT_CONTEXT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PFLT_CONTEXT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PFLT_DEFERRED_IO_WORKITEM(pub isize);
 impl Default for PFLT_DEFERRED_IO_WORKITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PFLT_DEFERRED_IO_WORKITEM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PFLT_DEFERRED_IO_WORKITEM {}
-impl core::fmt::Debug for PFLT_DEFERRED_IO_WORKITEM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PFLT_DEFERRED_IO_WORKITEM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PFLT_DEFERRED_IO_WORKITEM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PFLT_FILTER(pub isize);
 impl Default for PFLT_FILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PFLT_FILTER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PFLT_FILTER {}
-impl core::fmt::Debug for PFLT_FILTER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PFLT_FILTER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PFLT_FILTER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PFLT_GENERIC_WORKITEM(pub isize);
 impl Default for PFLT_GENERIC_WORKITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PFLT_GENERIC_WORKITEM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PFLT_GENERIC_WORKITEM {}
-impl core::fmt::Debug for PFLT_GENERIC_WORKITEM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PFLT_GENERIC_WORKITEM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PFLT_GENERIC_WORKITEM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PFLT_INSTANCE(pub isize);
 impl Default for PFLT_INSTANCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PFLT_INSTANCE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PFLT_INSTANCE {}
-impl core::fmt::Debug for PFLT_INSTANCE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PFLT_INSTANCE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PFLT_INSTANCE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PFLT_PORT(pub isize);
 impl Default for PFLT_PORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PFLT_PORT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PFLT_PORT {}
-impl core::fmt::Debug for PFLT_PORT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PFLT_PORT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PFLT_PORT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PFLT_VOLUME(pub isize);
 impl Default for PFLT_VOLUME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PFLT_VOLUME {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PFLT_VOLUME {}
-impl core::fmt::Debug for PFLT_VOLUME {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PFLT_VOLUME").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PFLT_VOLUME {

--- a/crates/libs/windows/src/Windows/Wdk/System/OfflineRegistry/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/System/OfflineRegistry/mod.rs
@@ -203,7 +203,7 @@ pub unsafe fn ORStart() -> super::super::super::Win32::Foundation::WIN32_ERROR {
     ORStart()
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ORHKEY(pub isize);
 impl ORHKEY {
     pub fn is_invalid(&self) -> bool {
@@ -220,17 +220,6 @@ impl windows_core::Free for ORHKEY {
 impl Default for ORHKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for ORHKEY {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for ORHKEY {}
-impl core::fmt::Debug for ORHKEY {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("ORHKEY").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for ORHKEY {

--- a/crates/libs/windows/src/Windows/Wdk/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/System/SystemServices/mod.rs
@@ -34647,22 +34647,11 @@ impl Default for SECURE_DRIVER_INTERFACE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SECURITY_CONTEXT_TRACKING_MODE(pub u8);
 impl Default for SECURITY_CONTEXT_TRACKING_MODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SECURITY_CONTEXT_TRACKING_MODE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SECURITY_CONTEXT_TRACKING_MODE {}
-impl core::fmt::Debug for SECURITY_CONTEXT_TRACKING_MODE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SECURITY_CONTEXT_TRACKING_MODE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SECURITY_CONTEXT_TRACKING_MODE {

--- a/crates/libs/windows/src/Windows/Win32/Devices/AllJoyn/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/AllJoyn/mod.rs
@@ -5134,44 +5134,22 @@ impl core::fmt::Debug for alljoyn_typeid {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_aboutdata(pub isize);
 impl Default for alljoyn_aboutdata {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_aboutdata {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_aboutdata {}
-impl core::fmt::Debug for alljoyn_aboutdata {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_aboutdata").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_aboutdata {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_aboutdatalistener(pub isize);
 impl Default for alljoyn_aboutdatalistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_aboutdatalistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_aboutdatalistener {}
-impl core::fmt::Debug for alljoyn_aboutdatalistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_aboutdatalistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_aboutdatalistener {
@@ -5202,88 +5180,44 @@ impl Default for alljoyn_aboutdatalistener_callbacks {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_abouticon(pub isize);
 impl Default for alljoyn_abouticon {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_abouticon {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_abouticon {}
-impl core::fmt::Debug for alljoyn_abouticon {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_abouticon").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_abouticon {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_abouticonobj(pub isize);
 impl Default for alljoyn_abouticonobj {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_abouticonobj {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_abouticonobj {}
-impl core::fmt::Debug for alljoyn_abouticonobj {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_abouticonobj").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_abouticonobj {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_abouticonproxy(pub isize);
 impl Default for alljoyn_abouticonproxy {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_abouticonproxy {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_abouticonproxy {}
-impl core::fmt::Debug for alljoyn_abouticonproxy {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_abouticonproxy").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_abouticonproxy {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_aboutlistener(pub isize);
 impl Default for alljoyn_aboutlistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_aboutlistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_aboutlistener {}
-impl core::fmt::Debug for alljoyn_aboutlistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_aboutlistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_aboutlistener {
@@ -5313,88 +5247,44 @@ impl Default for alljoyn_aboutlistener_callback {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_aboutobj(pub isize);
 impl Default for alljoyn_aboutobj {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_aboutobj {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_aboutobj {}
-impl core::fmt::Debug for alljoyn_aboutobj {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_aboutobj").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_aboutobj {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_aboutobjectdescription(pub isize);
 impl Default for alljoyn_aboutobjectdescription {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_aboutobjectdescription {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_aboutobjectdescription {}
-impl core::fmt::Debug for alljoyn_aboutobjectdescription {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_aboutobjectdescription").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_aboutobjectdescription {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_aboutproxy(pub isize);
 impl Default for alljoyn_aboutproxy {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_aboutproxy {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_aboutproxy {}
-impl core::fmt::Debug for alljoyn_aboutproxy {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_aboutproxy").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_aboutproxy {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_applicationstatelistener(pub isize);
 impl Default for alljoyn_applicationstatelistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_applicationstatelistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_applicationstatelistener {}
-impl core::fmt::Debug for alljoyn_applicationstatelistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_applicationstatelistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_applicationstatelistener {
@@ -5424,22 +5314,11 @@ impl Default for alljoyn_applicationstatelistener_callbacks {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_authlistener(pub isize);
 impl Default for alljoyn_authlistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_authlistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_authlistener {}
-impl core::fmt::Debug for alljoyn_authlistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_authlistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_authlistener {
@@ -5498,66 +5377,33 @@ impl Default for alljoyn_authlistenerasync_callbacks {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_autopinger(pub isize);
 impl Default for alljoyn_autopinger {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_autopinger {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_autopinger {}
-impl core::fmt::Debug for alljoyn_autopinger {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_autopinger").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_autopinger {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_busattachment(pub isize);
 impl Default for alljoyn_busattachment {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_busattachment {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_busattachment {}
-impl core::fmt::Debug for alljoyn_busattachment {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_busattachment").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_busattachment {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_buslistener(pub isize);
 impl Default for alljoyn_buslistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_buslistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_buslistener {}
-impl core::fmt::Debug for alljoyn_buslistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_buslistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_buslistener {
@@ -5594,22 +5440,11 @@ impl Default for alljoyn_buslistener_callbacks {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_busobject(pub isize);
 impl Default for alljoyn_busobject {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_busobject {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_busobject {}
-impl core::fmt::Debug for alljoyn_busobject {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_busobject").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_busobject {
@@ -5729,44 +5564,22 @@ impl Default for alljoyn_certificateidarray {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_credentials(pub isize);
 impl Default for alljoyn_credentials {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_credentials {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_credentials {}
-impl core::fmt::Debug for alljoyn_credentials {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_credentials").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_credentials {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_interfacedescription(pub isize);
 impl Default for alljoyn_interfacedescription {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_interfacedescription {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_interfacedescription {}
-impl core::fmt::Debug for alljoyn_interfacedescription {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_interfacedescription").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_interfacedescription {
@@ -5840,44 +5653,22 @@ impl Default for alljoyn_interfacedescription_property {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_keystore(pub isize);
 impl Default for alljoyn_keystore {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_keystore {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_keystore {}
-impl core::fmt::Debug for alljoyn_keystore {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_keystore").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_keystore {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_keystorelistener(pub isize);
 impl Default for alljoyn_keystorelistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_keystorelistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_keystorelistener {}
-impl core::fmt::Debug for alljoyn_keystorelistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_keystorelistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_keystorelistener {
@@ -5964,88 +5755,44 @@ impl Default for alljoyn_manifestarray {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_message(pub isize);
 impl Default for alljoyn_message {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_message {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_message {}
-impl core::fmt::Debug for alljoyn_message {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_message").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_message {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_msgarg(pub isize);
 impl Default for alljoyn_msgarg {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_msgarg {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_msgarg {}
-impl core::fmt::Debug for alljoyn_msgarg {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_msgarg").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_msgarg {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_observer(pub isize);
 impl Default for alljoyn_observer {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_observer {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_observer {}
-impl core::fmt::Debug for alljoyn_observer {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_observer").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_observer {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_observerlistener(pub isize);
 impl Default for alljoyn_observerlistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_observerlistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_observerlistener {}
-impl core::fmt::Debug for alljoyn_observerlistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_observerlistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_observerlistener {
@@ -6076,22 +5823,11 @@ impl Default for alljoyn_observerlistener_callback {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_permissionconfigurationlistener(pub isize);
 impl Default for alljoyn_permissionconfigurationlistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_permissionconfigurationlistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_permissionconfigurationlistener {}
-impl core::fmt::Debug for alljoyn_permissionconfigurationlistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_permissionconfigurationlistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_permissionconfigurationlistener {
@@ -6124,44 +5860,22 @@ impl Default for alljoyn_permissionconfigurationlistener_callbacks {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_permissionconfigurator(pub isize);
 impl Default for alljoyn_permissionconfigurator {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_permissionconfigurator {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_permissionconfigurator {}
-impl core::fmt::Debug for alljoyn_permissionconfigurator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_permissionconfigurator").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_permissionconfigurator {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_pinglistener(pub isize);
 impl Default for alljoyn_pinglistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_pinglistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_pinglistener {}
-impl core::fmt::Debug for alljoyn_pinglistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_pinglistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_pinglistener {
@@ -6192,88 +5906,44 @@ impl Default for alljoyn_pinglistener_callback {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_proxybusobject(pub isize);
 impl Default for alljoyn_proxybusobject {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_proxybusobject {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_proxybusobject {}
-impl core::fmt::Debug for alljoyn_proxybusobject {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_proxybusobject").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_proxybusobject {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_proxybusobject_ref(pub isize);
 impl Default for alljoyn_proxybusobject_ref {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_proxybusobject_ref {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_proxybusobject_ref {}
-impl core::fmt::Debug for alljoyn_proxybusobject_ref {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_proxybusobject_ref").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_proxybusobject_ref {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_securityapplicationproxy(pub isize);
 impl Default for alljoyn_securityapplicationproxy {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_securityapplicationproxy {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_securityapplicationproxy {}
-impl core::fmt::Debug for alljoyn_securityapplicationproxy {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_securityapplicationproxy").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_securityapplicationproxy {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_sessionlistener(pub isize);
 impl Default for alljoyn_sessionlistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_sessionlistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_sessionlistener {}
-impl core::fmt::Debug for alljoyn_sessionlistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_sessionlistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_sessionlistener {
@@ -6305,44 +5975,22 @@ impl Default for alljoyn_sessionlistener_callbacks {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_sessionopts(pub isize);
 impl Default for alljoyn_sessionopts {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for alljoyn_sessionopts {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_sessionopts {}
-impl core::fmt::Debug for alljoyn_sessionopts {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_sessionopts").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for alljoyn_sessionopts {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct alljoyn_sessionportlistener(pub isize);
 impl Default for alljoyn_sessionportlistener {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for alljoyn_sessionportlistener {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for alljoyn_sessionportlistener {}
-impl core::fmt::Debug for alljoyn_sessionportlistener {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("alljoyn_sessionportlistener").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for alljoyn_sessionportlistener {

--- a/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
@@ -3966,66 +3966,33 @@ impl Default for WINBIO_VERSION {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WINIBIO_ENGINE_CONTEXT(pub isize);
 impl Default for WINIBIO_ENGINE_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for WINIBIO_ENGINE_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WINIBIO_ENGINE_CONTEXT {}
-impl core::fmt::Debug for WINIBIO_ENGINE_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WINIBIO_ENGINE_CONTEXT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for WINIBIO_ENGINE_CONTEXT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WINIBIO_SENSOR_CONTEXT(pub isize);
 impl Default for WINIBIO_SENSOR_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for WINIBIO_SENSOR_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WINIBIO_SENSOR_CONTEXT {}
-impl core::fmt::Debug for WINIBIO_SENSOR_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WINIBIO_SENSOR_CONTEXT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for WINIBIO_SENSOR_CONTEXT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WINIBIO_STORAGE_CONTEXT(pub isize);
 impl Default for WINIBIO_STORAGE_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WINIBIO_STORAGE_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WINIBIO_STORAGE_CONTEXT {}
-impl core::fmt::Debug for WINIBIO_STORAGE_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WINIBIO_STORAGE_CONTEXT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WINIBIO_STORAGE_CONTEXT {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
@@ -2431,7 +2431,7 @@ impl Default for BTH_SET_SERVICE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HANDLE_SDP_TYPE(pub u64);
 impl HANDLE_SDP_TYPE {
     pub fn is_invalid(&self) -> bool {
@@ -2443,22 +2443,11 @@ impl Default for HANDLE_SDP_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HANDLE_SDP_TYPE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HANDLE_SDP_TYPE {}
-impl core::fmt::Debug for HANDLE_SDP_TYPE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HANDLE_SDP_TYPE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HANDLE_SDP_TYPE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HBLUETOOTH_DEVICE_FIND(pub isize);
 impl HBLUETOOTH_DEVICE_FIND {
     pub fn is_invalid(&self) -> bool {
@@ -2477,22 +2466,11 @@ impl Default for HBLUETOOTH_DEVICE_FIND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HBLUETOOTH_DEVICE_FIND {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HBLUETOOTH_DEVICE_FIND {}
-impl core::fmt::Debug for HBLUETOOTH_DEVICE_FIND {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HBLUETOOTH_DEVICE_FIND").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HBLUETOOTH_DEVICE_FIND {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HBLUETOOTH_RADIO_FIND(pub isize);
 impl HBLUETOOTH_RADIO_FIND {
     pub fn is_invalid(&self) -> bool {
@@ -2509,17 +2487,6 @@ impl windows_core::Free for HBLUETOOTH_RADIO_FIND {
 impl Default for HBLUETOOTH_RADIO_FIND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HBLUETOOTH_RADIO_FIND {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HBLUETOOTH_RADIO_FIND {}
-impl core::fmt::Debug for HBLUETOOTH_RADIO_FIND {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HBLUETOOTH_RADIO_FIND").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HBLUETOOTH_RADIO_FIND {

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
@@ -8358,7 +8358,7 @@ impl Default for FILE_IN_CABINET_INFO_W {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCMNOTIFICATION(pub isize);
 impl HCMNOTIFICATION {
     pub fn is_invalid(&self) -> bool {
@@ -8370,22 +8370,11 @@ impl Default for HCMNOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCMNOTIFICATION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCMNOTIFICATION {}
-impl core::fmt::Debug for HCMNOTIFICATION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCMNOTIFICATION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCMNOTIFICATION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDEVINFO(pub isize);
 impl HDEVINFO {
     pub fn is_invalid(&self) -> bool {
@@ -8402,17 +8391,6 @@ impl windows_core::Free for HDEVINFO {
 impl Default for HDEVINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HDEVINFO {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDEVINFO {}
-impl core::fmt::Debug for HDEVINFO {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDEVINFO").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HDEVINFO {

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceQuery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceQuery/mod.rs
@@ -510,22 +510,11 @@ impl Default for DEV_QUERY_RESULT_ACTION_DATA_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDEVQUERY(pub isize);
 impl Default for HDEVQUERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HDEVQUERY {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDEVQUERY {}
-impl core::fmt::Debug for HDEVQUERY {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDEVQUERY").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HDEVQUERY {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
@@ -3284,7 +3284,7 @@ impl Default for DEVINFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DHPDEV(pub isize);
 impl DHPDEV {
     pub fn is_invalid(&self) -> bool {
@@ -3296,22 +3296,11 @@ impl Default for DHPDEV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for DHPDEV {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for DHPDEV {}
-impl core::fmt::Debug for DHPDEV {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("DHPDEV").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for DHPDEV {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DHSURF(pub isize);
 impl DHSURF {
     pub fn is_invalid(&self) -> bool {
@@ -3321,17 +3310,6 @@ impl DHSURF {
 impl Default for DHSURF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for DHSURF {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for DHSURF {}
-impl core::fmt::Debug for DHSURF {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("DHSURF").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for DHSURF {
@@ -6130,7 +6108,7 @@ impl Default for GLYPHPOS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HBM(pub isize);
 impl HBM {
     pub fn is_invalid(&self) -> bool {
@@ -6142,22 +6120,11 @@ impl Default for HBM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HBM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HBM {}
-impl core::fmt::Debug for HBM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HBM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HBM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDEV(pub isize);
 impl HDEV {
     pub fn is_invalid(&self) -> bool {
@@ -6169,22 +6136,11 @@ impl Default for HDEV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDEV {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDEV {}
-impl core::fmt::Debug for HDEV {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDEV").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDEV {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDRVOBJ(pub isize);
 impl HDRVOBJ {
     pub fn is_invalid(&self) -> bool {
@@ -6196,22 +6152,11 @@ impl Default for HDRVOBJ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDRVOBJ {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDRVOBJ {}
-impl core::fmt::Debug for HDRVOBJ {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDRVOBJ").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDRVOBJ {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HFASTMUTEX(pub isize);
 impl HFASTMUTEX {
     pub fn is_invalid(&self) -> bool {
@@ -6223,22 +6168,11 @@ impl Default for HFASTMUTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HFASTMUTEX {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HFASTMUTEX {}
-impl core::fmt::Debug for HFASTMUTEX {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HFASTMUTEX").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HFASTMUTEX {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HSEMAPHORE(pub isize);
 impl HSEMAPHORE {
     pub fn is_invalid(&self) -> bool {
@@ -6257,22 +6191,11 @@ impl Default for HSEMAPHORE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HSEMAPHORE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HSEMAPHORE {}
-impl core::fmt::Debug for HSEMAPHORE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HSEMAPHORE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HSEMAPHORE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HSURF(pub isize);
 impl HSURF {
     pub fn is_invalid(&self) -> bool {
@@ -6282,17 +6205,6 @@ impl HSURF {
 impl Default for HSURF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HSURF {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HSURF {}
-impl core::fmt::Debug for HSURF {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HSURF").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HSURF {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
@@ -1169,7 +1169,7 @@ impl core::fmt::Debug for SW_DEVICE_LIFETIME {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HSWDEVICE(pub isize);
 impl HSWDEVICE {
     pub fn is_invalid(&self) -> bool {
@@ -1179,17 +1179,6 @@ impl HSWDEVICE {
 impl Default for HSWDEVICE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HSWDEVICE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HSWDEVICE {}
-impl core::fmt::Debug for HSWDEVICE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HSWDEVICE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HSWDEVICE {

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -8017,22 +8017,11 @@ impl Default for MOUSE_UNIT_ID_PARAMETER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PHIDP_PREPARSED_DATA(pub isize);
 impl Default for PHIDP_PREPARSED_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PHIDP_PREPARSED_DATA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PHIDP_PREPARSED_DATA {}
-impl core::fmt::Debug for PHIDP_PREPARSED_DATA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PHIDP_PREPARSED_DATA").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PHIDP_PREPARSED_DATA {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Properties/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Properties/mod.rs
@@ -351,22 +351,11 @@ impl Default for DEVPROPKEY {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DEVPROP_BOOLEAN(pub u8);
 impl Default for DEVPROP_BOOLEAN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for DEVPROP_BOOLEAN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for DEVPROP_BOOLEAN {}
-impl core::fmt::Debug for DEVPROP_BOOLEAN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("DEVPROP_BOOLEAN").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for DEVPROP_BOOLEAN {

--- a/crates/libs/windows/src/Windows/Win32/Devices/SerialCommunication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/SerialCommunication/mod.rs
@@ -151,7 +151,7 @@ impl core::fmt::Debug for SERENUM_PORTION {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCOMDB(pub isize);
 impl HCOMDB {
     pub fn is_invalid(&self) -> bool {
@@ -161,17 +161,6 @@ impl HCOMDB {
 impl Default for HCOMDB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HCOMDB {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCOMDB {}
-impl core::fmt::Debug for HCOMDB {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCOMDB").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HCOMDB {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
@@ -10030,198 +10030,99 @@ impl Default for DTR {
 }
 pub const DispatchMapper: windows_core::GUID = windows_core::GUID::from_u128(0xe9225296_c759_11d1_a02b_00c04fb6809f);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDRVCALL(pub isize);
 impl Default for HDRVCALL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDRVCALL {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDRVCALL {}
-impl core::fmt::Debug for HDRVCALL {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDRVCALL").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDRVCALL {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDRVDIALOGINSTANCE(pub isize);
 impl Default for HDRVDIALOGINSTANCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDRVDIALOGINSTANCE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDRVDIALOGINSTANCE {}
-impl core::fmt::Debug for HDRVDIALOGINSTANCE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDRVDIALOGINSTANCE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDRVDIALOGINSTANCE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDRVLINE(pub isize);
 impl Default for HDRVLINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDRVLINE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDRVLINE {}
-impl core::fmt::Debug for HDRVLINE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDRVLINE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDRVLINE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDRVMSPLINE(pub isize);
 impl Default for HDRVMSPLINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDRVMSPLINE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDRVMSPLINE {}
-impl core::fmt::Debug for HDRVMSPLINE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDRVMSPLINE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDRVMSPLINE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDRVPHONE(pub isize);
 impl Default for HDRVPHONE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDRVPHONE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDRVPHONE {}
-impl core::fmt::Debug for HDRVPHONE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDRVPHONE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDRVPHONE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HPROVIDER(pub isize);
 impl Default for HPROVIDER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HPROVIDER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HPROVIDER {}
-impl core::fmt::Debug for HPROVIDER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HPROVIDER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HPROVIDER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HTAPICALL(pub isize);
 impl Default for HTAPICALL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HTAPICALL {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HTAPICALL {}
-impl core::fmt::Debug for HTAPICALL {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HTAPICALL").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HTAPICALL {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HTAPILINE(pub isize);
 impl Default for HTAPILINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HTAPILINE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HTAPILINE {}
-impl core::fmt::Debug for HTAPILINE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HTAPILINE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HTAPILINE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HTAPIPHONE(pub isize);
 impl Default for HTAPIPHONE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HTAPIPHONE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HTAPIPHONE {}
-impl core::fmt::Debug for HTAPIPHONE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HTAPIPHONE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HTAPIPHONE {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Usb/mod.rs
@@ -2948,22 +2948,11 @@ impl Default for USB_BUS_STATISTICS_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct USB_CHANGE_REGISTRATION_HANDLE(pub isize);
 impl Default for USB_CHANGE_REGISTRATION_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for USB_CHANGE_REGISTRATION_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for USB_CHANGE_REGISTRATION_HANDLE {}
-impl core::fmt::Debug for USB_CHANGE_REGISTRATION_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("USB_CHANGE_REGISTRATION_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for USB_CHANGE_REGISTRATION_HANDLE {
@@ -5961,7 +5950,7 @@ impl Default for USB_USB2HW_VERSION_PARAMETERS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WINUSB_INTERFACE_HANDLE(pub isize);
 impl WINUSB_INTERFACE_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -5978,17 +5967,6 @@ impl windows_core::Free for WINUSB_INTERFACE_HANDLE {
 impl Default for WINUSB_INTERFACE_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WINUSB_INTERFACE_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WINUSB_INTERFACE_HANDLE {}
-impl core::fmt::Debug for WINUSB_INTERFACE_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WINUSB_INTERFACE_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WINUSB_INTERFACE_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -10533,66 +10533,33 @@ impl Default for APP_LOCAL_DEVICE_ID {
 }
 #[must_use]
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BOOL(pub i32);
 impl Default for BOOL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for BOOL {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for BOOL {}
-impl core::fmt::Debug for BOOL {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("BOOL").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for BOOL {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BOOLEAN(pub u8);
 impl Default for BOOLEAN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for BOOLEAN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for BOOLEAN {}
-impl core::fmt::Debug for BOOLEAN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("BOOLEAN").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for BOOLEAN {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct COLORREF(pub u32);
 impl Default for COLORREF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for COLORREF {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for COLORREF {}
-impl core::fmt::Debug for COLORREF {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("COLORREF").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for COLORREF {
@@ -10778,7 +10745,7 @@ impl Default for FLOAT128 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HANDLE(pub isize);
 impl HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -10797,44 +10764,22 @@ impl Default for HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HANDLE {}
-impl core::fmt::Debug for HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HANDLE_PTR(pub usize);
 impl Default for HANDLE_PTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HANDLE_PTR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HANDLE_PTR {}
-impl core::fmt::Debug for HANDLE_PTR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HANDLE_PTR").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HANDLE_PTR {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HGLOBAL(pub *mut core::ffi::c_void);
 impl HGLOBAL {
     pub fn is_invalid(&self) -> bool {
@@ -10853,22 +10798,11 @@ impl Default for HGLOBAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HGLOBAL {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HGLOBAL {}
-impl core::fmt::Debug for HGLOBAL {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HGLOBAL").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HGLOBAL {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HINSTANCE(pub isize);
 impl HINSTANCE {
     pub fn is_invalid(&self) -> bool {
@@ -10887,17 +10821,6 @@ impl Default for HINSTANCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HINSTANCE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HINSTANCE {}
-impl core::fmt::Debug for HINSTANCE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HINSTANCE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HINSTANCE {
     type TypeKind = windows_core::CopyType;
 }
@@ -10908,7 +10831,7 @@ impl From<HINSTANCE> for HMODULE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HLOCAL(pub *mut core::ffi::c_void);
 impl HLOCAL {
     pub fn is_invalid(&self) -> bool {
@@ -10927,44 +10850,22 @@ impl Default for HLOCAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HLOCAL {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HLOCAL {}
-impl core::fmt::Debug for HLOCAL {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HLOCAL").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HLOCAL {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HLSURF(pub isize);
 impl Default for HLSURF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HLSURF {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HLSURF {}
-impl core::fmt::Debug for HLSURF {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HLSURF").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HLSURF {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMODULE(pub isize);
 impl HMODULE {
     pub fn is_invalid(&self) -> bool {
@@ -10983,17 +10884,6 @@ impl Default for HMODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HMODULE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMODULE {}
-impl core::fmt::Debug for HMODULE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMODULE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HMODULE {
     type TypeKind = windows_core::CopyType;
 }
@@ -11004,7 +10894,7 @@ impl From<HMODULE> for HINSTANCE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRSRC(pub isize);
 impl HRSRC {
     pub fn is_invalid(&self) -> bool {
@@ -11016,103 +10906,48 @@ impl Default for HRSRC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HRSRC {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRSRC {}
-impl core::fmt::Debug for HRSRC {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRSRC").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HRSRC {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HSPRITE(pub isize);
 impl Default for HSPRITE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HSPRITE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HSPRITE {}
-impl core::fmt::Debug for HSPRITE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HSPRITE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HSPRITE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HSTR(pub isize);
 impl Default for HSTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HSTR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HSTR {}
-impl core::fmt::Debug for HSTR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HSTR").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HSTR {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HUMPD(pub isize);
 impl Default for HUMPD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HUMPD {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HUMPD {}
-impl core::fmt::Debug for HUMPD {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HUMPD").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HUMPD {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HWND(pub isize);
 impl Default for HWND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HWND {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HWND {}
-impl core::fmt::Debug for HWND {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HWND").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HWND {
@@ -11125,44 +10960,22 @@ impl From<HWND> for HANDLE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LPARAM(pub isize);
 impl Default for LPARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for LPARAM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for LPARAM {}
-impl core::fmt::Debug for LPARAM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("LPARAM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for LPARAM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LRESULT(pub isize);
 impl Default for LRESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for LRESULT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for LRESULT {}
-impl core::fmt::Debug for LRESULT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("LRESULT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for LRESULT {
@@ -11200,22 +11013,11 @@ impl Default for LUID {
 }
 #[must_use]
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NTSTATUS(pub i32);
 impl Default for NTSTATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NTSTATUS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NTSTATUS {}
-impl core::fmt::Debug for NTSTATUS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NTSTATUS").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NTSTATUS {
@@ -11312,7 +11114,7 @@ impl Default for POINTS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PSID(pub *mut core::ffi::c_void);
 impl PSID {
     pub fn is_invalid(&self) -> bool {
@@ -11322,17 +11124,6 @@ impl PSID {
 impl Default for PSID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PSID {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PSID {}
-impl core::fmt::Debug for PSID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PSID").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PSID {
@@ -11403,22 +11194,11 @@ impl Default for RECTL {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SHANDLE_PTR(pub isize);
 impl Default for SHANDLE_PTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SHANDLE_PTR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SHANDLE_PTR {}
-impl core::fmt::Debug for SHANDLE_PTR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SHANDLE_PTR").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SHANDLE_PTR {
@@ -11522,44 +11302,22 @@ impl Default for UNICODE_STRING {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct VARIANT_BOOL(pub i16);
 impl Default for VARIANT_BOOL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for VARIANT_BOOL {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for VARIANT_BOOL {}
-impl core::fmt::Debug for VARIANT_BOOL {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("VARIANT_BOOL").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for VARIANT_BOOL {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WPARAM(pub usize);
 impl Default for WPARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WPARAM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WPARAM {}
-impl core::fmt::Debug for WPARAM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WPARAM").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WPARAM {

--- a/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
@@ -13852,7 +13852,7 @@ impl Default for GOFFSET {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HIMC(pub isize);
 impl HIMC {
     pub fn is_invalid(&self) -> bool {
@@ -13864,22 +13864,11 @@ impl Default for HIMC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HIMC {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HIMC {}
-impl core::fmt::Debug for HIMC {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HIMC").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HIMC {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HIMCC(pub isize);
 impl HIMCC {
     pub fn is_invalid(&self) -> bool {
@@ -13891,22 +13880,11 @@ impl Default for HIMCC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HIMCC {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HIMCC {}
-impl core::fmt::Debug for HIMCC {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HIMCC").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HIMCC {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HSAVEDUILANGUAGES(pub isize);
 impl HSAVEDUILANGUAGES {
     pub fn is_invalid(&self) -> bool {
@@ -13916,17 +13894,6 @@ impl HSAVEDUILANGUAGES {
 impl Default for HSAVEDUILANGUAGES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HSAVEDUILANGUAGES {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HSAVEDUILANGUAGES {}
-impl core::fmt::Debug for HSAVEDUILANGUAGES {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HSAVEDUILANGUAGES").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HSAVEDUILANGUAGES {
@@ -15061,88 +15028,44 @@ impl Default for TEXTRANGE_PROPERTIES {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UBiDi(pub isize);
 impl Default for UBiDi {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UBiDi {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UBiDi {}
-impl core::fmt::Debug for UBiDi {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UBiDi").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UBiDi {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UBiDiTransform(pub isize);
 impl Default for UBiDiTransform {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UBiDiTransform {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UBiDiTransform {}
-impl core::fmt::Debug for UBiDiTransform {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UBiDiTransform").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UBiDiTransform {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UBreakIterator(pub isize);
 impl Default for UBreakIterator {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UBreakIterator {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UBreakIterator {}
-impl core::fmt::Debug for UBreakIterator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UBreakIterator").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UBreakIterator {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UCPMap(pub isize);
 impl Default for UCPMap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for UCPMap {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UCPMap {}
-impl core::fmt::Debug for UCPMap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UCPMap").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for UCPMap {
@@ -15200,22 +15123,11 @@ impl Default for UCPTrieData {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UCaseMap(pub isize);
 impl Default for UCaseMap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for UCaseMap {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UCaseMap {}
-impl core::fmt::Debug for UCaseMap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UCaseMap").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for UCaseMap {
@@ -15260,132 +15172,66 @@ impl Default for UCharIterator {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UCharsetDetector(pub isize);
 impl Default for UCharsetDetector {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UCharsetDetector {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UCharsetDetector {}
-impl core::fmt::Debug for UCharsetDetector {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UCharsetDetector").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UCharsetDetector {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UCharsetMatch(pub isize);
 impl Default for UCharsetMatch {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UCharsetMatch {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UCharsetMatch {}
-impl core::fmt::Debug for UCharsetMatch {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UCharsetMatch").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UCharsetMatch {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UCollationElements(pub isize);
 impl Default for UCollationElements {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UCollationElements {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UCollationElements {}
-impl core::fmt::Debug for UCollationElements {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UCollationElements").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UCollationElements {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UCollator(pub isize);
 impl Default for UCollator {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UCollator {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UCollator {}
-impl core::fmt::Debug for UCollator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UCollator").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UCollator {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UConstrainedFieldPosition(pub isize);
 impl Default for UConstrainedFieldPosition {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UConstrainedFieldPosition {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UConstrainedFieldPosition {}
-impl core::fmt::Debug for UConstrainedFieldPosition {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UConstrainedFieldPosition").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UConstrainedFieldPosition {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UConverter(pub isize);
 impl Default for UConverter {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for UConverter {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UConverter {}
-impl core::fmt::Debug for UConverter {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UConverter").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for UConverter {
@@ -15428,22 +15274,11 @@ impl Default for UConverterFromUnicodeArgs {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UConverterSelector(pub isize);
 impl Default for UConverterSelector {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for UConverterSelector {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UConverterSelector {}
-impl core::fmt::Debug for UConverterSelector {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UConverterSelector").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for UConverterSelector {
@@ -15486,66 +15321,33 @@ impl Default for UConverterToUnicodeArgs {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UDateFormatSymbols(pub isize);
 impl Default for UDateFormatSymbols {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UDateFormatSymbols {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UDateFormatSymbols {}
-impl core::fmt::Debug for UDateFormatSymbols {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UDateFormatSymbols").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UDateFormatSymbols {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UDateIntervalFormat(pub isize);
 impl Default for UDateIntervalFormat {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UDateIntervalFormat {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UDateIntervalFormat {}
-impl core::fmt::Debug for UDateIntervalFormat {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UDateIntervalFormat").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UDateIntervalFormat {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UEnumeration(pub isize);
 impl Default for UEnumeration {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for UEnumeration {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UEnumeration {}
-impl core::fmt::Debug for UEnumeration {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UEnumeration").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for UEnumeration {
@@ -15583,220 +15385,110 @@ impl Default for UFieldPosition {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UFieldPositionIterator(pub isize);
 impl Default for UFieldPositionIterator {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UFieldPositionIterator {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UFieldPositionIterator {}
-impl core::fmt::Debug for UFieldPositionIterator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UFieldPositionIterator").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UFieldPositionIterator {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UFormattedDateInterval(pub isize);
 impl Default for UFormattedDateInterval {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UFormattedDateInterval {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UFormattedDateInterval {}
-impl core::fmt::Debug for UFormattedDateInterval {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UFormattedDateInterval").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UFormattedDateInterval {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UFormattedList(pub isize);
 impl Default for UFormattedList {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UFormattedList {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UFormattedList {}
-impl core::fmt::Debug for UFormattedList {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UFormattedList").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UFormattedList {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UFormattedNumber(pub isize);
 impl Default for UFormattedNumber {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UFormattedNumber {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UFormattedNumber {}
-impl core::fmt::Debug for UFormattedNumber {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UFormattedNumber").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UFormattedNumber {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UFormattedNumberRange(pub isize);
 impl Default for UFormattedNumberRange {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UFormattedNumberRange {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UFormattedNumberRange {}
-impl core::fmt::Debug for UFormattedNumberRange {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UFormattedNumberRange").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UFormattedNumberRange {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UFormattedRelativeDateTime(pub isize);
 impl Default for UFormattedRelativeDateTime {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UFormattedRelativeDateTime {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UFormattedRelativeDateTime {}
-impl core::fmt::Debug for UFormattedRelativeDateTime {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UFormattedRelativeDateTime").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UFormattedRelativeDateTime {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UFormattedValue(pub isize);
 impl Default for UFormattedValue {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UFormattedValue {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UFormattedValue {}
-impl core::fmt::Debug for UFormattedValue {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UFormattedValue").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UFormattedValue {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UGenderInfo(pub isize);
 impl Default for UGenderInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UGenderInfo {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UGenderInfo {}
-impl core::fmt::Debug for UGenderInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UGenderInfo").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UGenderInfo {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UHashtable(pub isize);
 impl Default for UHashtable {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UHashtable {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UHashtable {}
-impl core::fmt::Debug for UHashtable {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UHashtable").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UHashtable {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UIDNA(pub isize);
 impl Default for UIDNA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for UIDNA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UIDNA {}
-impl core::fmt::Debug for UIDNA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UIDNA").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for UIDNA {
@@ -15837,88 +15529,44 @@ impl Default for UIDNAInfo {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UListFormatter(pub isize);
 impl Default for UListFormatter {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UListFormatter {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UListFormatter {}
-impl core::fmt::Debug for UListFormatter {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UListFormatter").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UListFormatter {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ULocaleData(pub isize);
 impl Default for ULocaleData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for ULocaleData {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for ULocaleData {}
-impl core::fmt::Debug for ULocaleData {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("ULocaleData").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for ULocaleData {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ULocaleDisplayNames(pub isize);
 impl Default for ULocaleDisplayNames {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for ULocaleDisplayNames {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for ULocaleDisplayNames {}
-impl core::fmt::Debug for ULocaleDisplayNames {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("ULocaleDisplayNames").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for ULocaleDisplayNames {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UMutableCPTrie(pub isize);
 impl Default for UMutableCPTrie {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for UMutableCPTrie {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UMutableCPTrie {}
-impl core::fmt::Debug for UMutableCPTrie {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UMutableCPTrie").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for UMutableCPTrie {
@@ -15955,66 +15603,33 @@ impl Default for UNICODERANGE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UNormalizer2(pub isize);
 impl Default for UNormalizer2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UNormalizer2 {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UNormalizer2 {}
-impl core::fmt::Debug for UNormalizer2 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UNormalizer2").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UNormalizer2 {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UNumberFormatter(pub isize);
 impl Default for UNumberFormatter {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UNumberFormatter {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UNumberFormatter {}
-impl core::fmt::Debug for UNumberFormatter {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UNumberFormatter").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UNumberFormatter {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UNumberingSystem(pub isize);
 impl Default for UNumberingSystem {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for UNumberingSystem {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UNumberingSystem {}
-impl core::fmt::Debug for UNumberingSystem {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UNumberingSystem").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for UNumberingSystem {
@@ -16053,88 +15668,44 @@ impl Default for UParseError {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UPluralRules(pub isize);
 impl Default for UPluralRules {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UPluralRules {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UPluralRules {}
-impl core::fmt::Debug for UPluralRules {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UPluralRules").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UPluralRules {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct URegion(pub isize);
 impl Default for URegion {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for URegion {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for URegion {}
-impl core::fmt::Debug for URegion {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("URegion").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for URegion {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct URegularExpression(pub isize);
 impl Default for URegularExpression {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for URegularExpression {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for URegularExpression {}
-impl core::fmt::Debug for URegularExpression {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("URegularExpression").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for URegularExpression {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct URelativeDateTimeFormatter(pub isize);
 impl Default for URelativeDateTimeFormatter {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for URelativeDateTimeFormatter {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for URelativeDateTimeFormatter {}
-impl core::fmt::Debug for URelativeDateTimeFormatter {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("URelativeDateTimeFormatter").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for URelativeDateTimeFormatter {
@@ -16175,44 +15746,22 @@ impl Default for UReplaceableCallbacks {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UResourceBundle(pub isize);
 impl Default for UResourceBundle {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UResourceBundle {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UResourceBundle {}
-impl core::fmt::Debug for UResourceBundle {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UResourceBundle").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UResourceBundle {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct USearch(pub isize);
 impl Default for USearch {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for USearch {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for USearch {}
-impl core::fmt::Debug for USearch {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("USearch").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for USearch {
@@ -16251,110 +15800,55 @@ impl Default for USerializedSet {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct USet(pub isize);
 impl Default for USet {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for USet {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for USet {}
-impl core::fmt::Debug for USet {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("USet").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for USet {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct USpoofCheckResult(pub isize);
 impl Default for USpoofCheckResult {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for USpoofCheckResult {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for USpoofCheckResult {}
-impl core::fmt::Debug for USpoofCheckResult {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("USpoofCheckResult").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for USpoofCheckResult {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct USpoofChecker(pub isize);
 impl Default for USpoofChecker {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for USpoofChecker {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for USpoofChecker {}
-impl core::fmt::Debug for USpoofChecker {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("USpoofChecker").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for USpoofChecker {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UStringPrepProfile(pub isize);
 impl Default for UStringPrepProfile {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for UStringPrepProfile {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UStringPrepProfile {}
-impl core::fmt::Debug for UStringPrepProfile {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UStringPrepProfile").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for UStringPrepProfile {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UStringSearch(pub isize);
 impl Default for UStringSearch {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for UStringSearch {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UStringSearch {}
-impl core::fmt::Debug for UStringSearch {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UStringSearch").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for UStringSearch {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
@@ -13408,88 +13408,44 @@ impl Default for IUNKNOWN_LIST {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LPDDFXROP(pub isize);
 impl Default for LPDDFXROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for LPDDFXROP {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for LPDDFXROP {}
-impl core::fmt::Debug for LPDDFXROP {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("LPDDFXROP").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for LPDDFXROP {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PDD_DESTROYDRIVERDATA(pub isize);
 impl Default for PDD_DESTROYDRIVERDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PDD_DESTROYDRIVERDATA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PDD_DESTROYDRIVERDATA {}
-impl core::fmt::Debug for PDD_DESTROYDRIVERDATA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PDD_DESTROYDRIVERDATA").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PDD_DESTROYDRIVERDATA {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PDD_GETVPORTAUTOFLIPSURFACEDATA(pub isize);
 impl Default for PDD_GETVPORTAUTOFLIPSURFACEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PDD_GETVPORTAUTOFLIPSURFACEDATA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PDD_GETVPORTAUTOFLIPSURFACEDATA {}
-impl core::fmt::Debug for PDD_GETVPORTAUTOFLIPSURFACEDATA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PDD_GETVPORTAUTOFLIPSURFACEDATA").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PDD_GETVPORTAUTOFLIPSURFACEDATA {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PDD_SETMODEDATA(pub isize);
 impl Default for PDD_SETMODEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PDD_SETMODEDATA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PDD_SETMODEDATA {}
-impl core::fmt::Debug for PDD_SETMODEDATA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PDD_SETMODEDATA").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PDD_SETMODEDATA {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
@@ -10661,7 +10661,7 @@ impl Default for HANDLETABLE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HBITMAP(pub isize);
 impl HBITMAP {
     pub fn is_invalid(&self) -> bool {
@@ -10680,17 +10680,6 @@ impl Default for HBITMAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HBITMAP {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HBITMAP {}
-impl core::fmt::Debug for HBITMAP {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HBITMAP").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HBITMAP {
     type TypeKind = windows_core::CopyType;
 }
@@ -10701,7 +10690,7 @@ impl From<HBITMAP> for HGDIOBJ {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HBRUSH(pub isize);
 impl HBRUSH {
     pub fn is_invalid(&self) -> bool {
@@ -10720,17 +10709,6 @@ impl Default for HBRUSH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HBRUSH {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HBRUSH {}
-impl core::fmt::Debug for HBRUSH {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HBRUSH").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HBRUSH {
     type TypeKind = windows_core::CopyType;
 }
@@ -10741,7 +10719,7 @@ impl From<HBRUSH> for HGDIOBJ {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDC(pub isize);
 impl HDC {
     pub fn is_invalid(&self) -> bool {
@@ -10753,22 +10731,11 @@ impl Default for HDC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDC {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDC {}
-impl core::fmt::Debug for HDC {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDC").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDC {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HENHMETAFILE(pub isize);
 impl HENHMETAFILE {
     pub fn is_invalid(&self) -> bool {
@@ -10787,22 +10754,11 @@ impl Default for HENHMETAFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HENHMETAFILE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HENHMETAFILE {}
-impl core::fmt::Debug for HENHMETAFILE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HENHMETAFILE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HENHMETAFILE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HFONT(pub isize);
 impl HFONT {
     pub fn is_invalid(&self) -> bool {
@@ -10821,17 +10777,6 @@ impl Default for HFONT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HFONT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HFONT {}
-impl core::fmt::Debug for HFONT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HFONT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HFONT {
     type TypeKind = windows_core::CopyType;
 }
@@ -10842,7 +10787,7 @@ impl From<HFONT> for HGDIOBJ {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HGDIOBJ(pub isize);
 impl HGDIOBJ {
     pub fn is_invalid(&self) -> bool {
@@ -10854,22 +10799,11 @@ impl Default for HGDIOBJ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HGDIOBJ {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HGDIOBJ {}
-impl core::fmt::Debug for HGDIOBJ {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HGDIOBJ").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HGDIOBJ {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMETAFILE(pub isize);
 impl HMETAFILE {
     pub fn is_invalid(&self) -> bool {
@@ -10888,22 +10822,11 @@ impl Default for HMETAFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HMETAFILE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMETAFILE {}
-impl core::fmt::Debug for HMETAFILE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMETAFILE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HMETAFILE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMONITOR(pub isize);
 impl HMONITOR {
     pub fn is_invalid(&self) -> bool {
@@ -10915,22 +10838,11 @@ impl Default for HMONITOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HMONITOR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMONITOR {}
-impl core::fmt::Debug for HMONITOR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMONITOR").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HMONITOR {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HPALETTE(pub isize);
 impl HPALETTE {
     pub fn is_invalid(&self) -> bool {
@@ -10949,17 +10861,6 @@ impl Default for HPALETTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HPALETTE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HPALETTE {}
-impl core::fmt::Debug for HPALETTE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HPALETTE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HPALETTE {
     type TypeKind = windows_core::CopyType;
 }
@@ -10970,7 +10871,7 @@ impl From<HPALETTE> for HGDIOBJ {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HPEN(pub isize);
 impl HPEN {
     pub fn is_invalid(&self) -> bool {
@@ -10989,17 +10890,6 @@ impl Default for HPEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HPEN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HPEN {}
-impl core::fmt::Debug for HPEN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HPEN").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HPEN {
     type TypeKind = windows_core::CopyType;
 }
@@ -11010,7 +10900,7 @@ impl From<HPEN> for HGDIOBJ {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRGN(pub isize);
 impl HRGN {
     pub fn is_invalid(&self) -> bool {
@@ -11027,17 +10917,6 @@ impl windows_core::Free for HRGN {
 impl Default for HRGN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HRGN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRGN {}
-impl core::fmt::Debug for HRGN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRGN").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HRGN {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/GdiPlus/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/GdiPlus/mod.rs
@@ -5148,22 +5148,11 @@ impl core::fmt::Debug for WrapMode {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Bitmap(pub isize);
 impl Default for Bitmap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for Bitmap {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for Bitmap {}
-impl core::fmt::Debug for Bitmap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Bitmap").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for Bitmap {
@@ -5322,44 +5311,22 @@ impl Default for BrightnessContrastParams {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CGpEffect(pub isize);
 impl Default for CGpEffect {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for CGpEffect {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for CGpEffect {}
-impl core::fmt::Debug for CGpEffect {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("CGpEffect").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for CGpEffect {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CachedBitmap(pub isize);
 impl Default for CachedBitmap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for CachedBitmap {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for CachedBitmap {}
-impl core::fmt::Debug for CachedBitmap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("CachedBitmap").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for CachedBitmap {
@@ -5876,22 +5843,11 @@ impl Default for ColorPalette {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CustomLineCap(pub isize);
 impl Default for CustomLineCap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for CustomLineCap {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for CustomLineCap {}
-impl core::fmt::Debug for CustomLineCap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("CustomLineCap").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for CustomLineCap {
@@ -6052,66 +6008,33 @@ impl Default for EncoderParameters {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Font(pub isize);
 impl Default for Font {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for Font {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for Font {}
-impl core::fmt::Debug for Font {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Font").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for Font {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FontCollection(pub isize);
 impl Default for FontCollection {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for FontCollection {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for FontCollection {}
-impl core::fmt::Debug for FontCollection {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("FontCollection").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for FontCollection {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FontFamily(pub isize);
 impl Default for FontFamily {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for FontFamily {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for FontFamily {}
-impl core::fmt::Debug for FontFamily {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("FontFamily").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for FontFamily {
@@ -6210,528 +6133,264 @@ impl Default for GdiplusStartupOutput {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpAdjustableArrowCap(pub isize);
 impl Default for GpAdjustableArrowCap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpAdjustableArrowCap {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpAdjustableArrowCap {}
-impl core::fmt::Debug for GpAdjustableArrowCap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpAdjustableArrowCap").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpAdjustableArrowCap {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpBitmap(pub isize);
 impl Default for GpBitmap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpBitmap {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpBitmap {}
-impl core::fmt::Debug for GpBitmap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpBitmap").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpBitmap {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpBrush(pub isize);
 impl Default for GpBrush {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpBrush {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpBrush {}
-impl core::fmt::Debug for GpBrush {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpBrush").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpBrush {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpCachedBitmap(pub isize);
 impl Default for GpCachedBitmap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpCachedBitmap {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpCachedBitmap {}
-impl core::fmt::Debug for GpCachedBitmap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpCachedBitmap").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpCachedBitmap {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpCustomLineCap(pub isize);
 impl Default for GpCustomLineCap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpCustomLineCap {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpCustomLineCap {}
-impl core::fmt::Debug for GpCustomLineCap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpCustomLineCap").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpCustomLineCap {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpFont(pub isize);
 impl Default for GpFont {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpFont {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpFont {}
-impl core::fmt::Debug for GpFont {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpFont").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpFont {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpFontCollection(pub isize);
 impl Default for GpFontCollection {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpFontCollection {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpFontCollection {}
-impl core::fmt::Debug for GpFontCollection {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpFontCollection").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpFontCollection {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpFontFamily(pub isize);
 impl Default for GpFontFamily {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpFontFamily {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpFontFamily {}
-impl core::fmt::Debug for GpFontFamily {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpFontFamily").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpFontFamily {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpGraphics(pub isize);
 impl Default for GpGraphics {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpGraphics {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpGraphics {}
-impl core::fmt::Debug for GpGraphics {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpGraphics").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpGraphics {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpHatch(pub isize);
 impl Default for GpHatch {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpHatch {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpHatch {}
-impl core::fmt::Debug for GpHatch {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpHatch").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpHatch {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpImage(pub isize);
 impl Default for GpImage {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpImage {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpImage {}
-impl core::fmt::Debug for GpImage {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpImage").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpImage {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpImageAttributes(pub isize);
 impl Default for GpImageAttributes {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpImageAttributes {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpImageAttributes {}
-impl core::fmt::Debug for GpImageAttributes {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpImageAttributes").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpImageAttributes {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpInstalledFontCollection(pub isize);
 impl Default for GpInstalledFontCollection {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpInstalledFontCollection {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpInstalledFontCollection {}
-impl core::fmt::Debug for GpInstalledFontCollection {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpInstalledFontCollection").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpInstalledFontCollection {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpLineGradient(pub isize);
 impl Default for GpLineGradient {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpLineGradient {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpLineGradient {}
-impl core::fmt::Debug for GpLineGradient {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpLineGradient").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpLineGradient {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpMetafile(pub isize);
 impl Default for GpMetafile {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpMetafile {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpMetafile {}
-impl core::fmt::Debug for GpMetafile {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpMetafile").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpMetafile {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpPath(pub isize);
 impl Default for GpPath {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpPath {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpPath {}
-impl core::fmt::Debug for GpPath {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpPath").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpPath {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpPathGradient(pub isize);
 impl Default for GpPathGradient {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpPathGradient {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpPathGradient {}
-impl core::fmt::Debug for GpPathGradient {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpPathGradient").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpPathGradient {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpPathIterator(pub isize);
 impl Default for GpPathIterator {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpPathIterator {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpPathIterator {}
-impl core::fmt::Debug for GpPathIterator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpPathIterator").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpPathIterator {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpPen(pub isize);
 impl Default for GpPen {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpPen {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpPen {}
-impl core::fmt::Debug for GpPen {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpPen").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpPen {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpPrivateFontCollection(pub isize);
 impl Default for GpPrivateFontCollection {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpPrivateFontCollection {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpPrivateFontCollection {}
-impl core::fmt::Debug for GpPrivateFontCollection {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpPrivateFontCollection").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpPrivateFontCollection {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpRegion(pub isize);
 impl Default for GpRegion {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpRegion {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpRegion {}
-impl core::fmt::Debug for GpRegion {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpRegion").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpRegion {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpSolidFill(pub isize);
 impl Default for GpSolidFill {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpSolidFill {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpSolidFill {}
-impl core::fmt::Debug for GpSolidFill {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpSolidFill").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpSolidFill {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpStringFormat(pub isize);
 impl Default for GpStringFormat {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GpStringFormat {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpStringFormat {}
-impl core::fmt::Debug for GpStringFormat {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpStringFormat").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GpStringFormat {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpTexture(pub isize);
 impl Default for GpTexture {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for GpTexture {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GpTexture {}
-impl core::fmt::Debug for GpTexture {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GpTexture").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for GpTexture {
@@ -6798,22 +6457,11 @@ impl Default for HueSaturationLightnessParams {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Image(pub isize);
 impl Default for Image {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for Image {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for Image {}
-impl core::fmt::Debug for Image {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Image").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for Image {
@@ -6910,22 +6558,11 @@ impl Default for ImageItemData {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InstalledFontCollection(pub isize);
 impl Default for InstalledFontCollection {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for InstalledFontCollection {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for InstalledFontCollection {}
-impl core::fmt::Debug for InstalledFontCollection {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("InstalledFontCollection").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for InstalledFontCollection {
@@ -6992,44 +6629,22 @@ impl Default for LevelsParams {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Matrix(pub isize);
 impl Default for Matrix {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for Matrix {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for Matrix {}
-impl core::fmt::Debug for Matrix {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Matrix").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for Matrix {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Metafile(pub isize);
 impl Default for Metafile {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for Metafile {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for Metafile {}
-impl core::fmt::Debug for Metafile {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Metafile").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for Metafile {
@@ -7128,22 +6743,11 @@ impl Default for PWMFRect16 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PathData(pub isize);
 impl Default for PathData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PathData {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PathData {}
-impl core::fmt::Debug for PathData {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PathData").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PathData {
@@ -7210,22 +6814,11 @@ impl Default for PointF {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PrivateFontCollection(pub isize);
 impl Default for PrivateFontCollection {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PrivateFontCollection {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PrivateFontCollection {}
-impl core::fmt::Debug for PrivateFontCollection {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PrivateFontCollection").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PrivateFontCollection {
@@ -7387,22 +6980,11 @@ impl Default for RedEyeCorrectionParams {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Region(pub isize);
 impl Default for Region {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for Region {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for Region {}
-impl core::fmt::Debug for Region {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Region").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for Region {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
@@ -2981,66 +2981,33 @@ impl Default for EMRPIXELFORMAT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GLUnurbs(pub isize);
 impl Default for GLUnurbs {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GLUnurbs {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GLUnurbs {}
-impl core::fmt::Debug for GLUnurbs {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GLUnurbs").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GLUnurbs {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GLUquadric(pub isize);
 impl Default for GLUquadric {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for GLUquadric {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GLUquadric {}
-impl core::fmt::Debug for GLUquadric {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GLUquadric").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for GLUquadric {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GLUtesselator(pub isize);
 impl Default for GLUtesselator {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for GLUtesselator {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for GLUtesselator {}
-impl core::fmt::Debug for GLUtesselator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("GLUtesselator").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for GLUtesselator {
@@ -3080,7 +3047,7 @@ impl Default for GLYPHMETRICSFLOAT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HGLRC(pub isize);
 impl HGLRC {
     pub fn is_invalid(&self) -> bool {
@@ -3097,17 +3064,6 @@ impl windows_core::Free for HGLRC {
 impl Default for HGLRC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HGLRC {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HGLRC {}
-impl core::fmt::Debug for HGLRC {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HGLRC").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HGLRC {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
@@ -5711,7 +5711,7 @@ impl Default for ECHOWAVEFILTER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HACMDRIVER(pub isize);
 impl HACMDRIVER {
     pub fn is_invalid(&self) -> bool {
@@ -5723,22 +5723,11 @@ impl Default for HACMDRIVER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HACMDRIVER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HACMDRIVER {}
-impl core::fmt::Debug for HACMDRIVER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HACMDRIVER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HACMDRIVER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HACMDRIVERID(pub isize);
 impl HACMDRIVERID {
     pub fn is_invalid(&self) -> bool {
@@ -5750,22 +5739,11 @@ impl Default for HACMDRIVERID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HACMDRIVERID {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HACMDRIVERID {}
-impl core::fmt::Debug for HACMDRIVERID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HACMDRIVERID").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HACMDRIVERID {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HACMOBJ(pub isize);
 impl HACMOBJ {
     pub fn is_invalid(&self) -> bool {
@@ -5777,22 +5755,11 @@ impl Default for HACMOBJ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HACMOBJ {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HACMOBJ {}
-impl core::fmt::Debug for HACMOBJ {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HACMOBJ").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HACMOBJ {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HACMSTREAM(pub isize);
 impl HACMSTREAM {
     pub fn is_invalid(&self) -> bool {
@@ -5804,22 +5771,11 @@ impl Default for HACMSTREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HACMSTREAM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HACMSTREAM {}
-impl core::fmt::Debug for HACMSTREAM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HACMSTREAM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HACMSTREAM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMIDI(pub isize);
 impl HMIDI {
     pub fn is_invalid(&self) -> bool {
@@ -5831,22 +5787,11 @@ impl Default for HMIDI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HMIDI {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMIDI {}
-impl core::fmt::Debug for HMIDI {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMIDI").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HMIDI {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMIDIIN(pub isize);
 impl HMIDIIN {
     pub fn is_invalid(&self) -> bool {
@@ -5858,22 +5803,11 @@ impl Default for HMIDIIN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HMIDIIN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMIDIIN {}
-impl core::fmt::Debug for HMIDIIN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMIDIIN").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HMIDIIN {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMIDIOUT(pub isize);
 impl HMIDIOUT {
     pub fn is_invalid(&self) -> bool {
@@ -5885,22 +5819,11 @@ impl Default for HMIDIOUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HMIDIOUT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMIDIOUT {}
-impl core::fmt::Debug for HMIDIOUT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMIDIOUT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HMIDIOUT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMIDISTRM(pub isize);
 impl HMIDISTRM {
     pub fn is_invalid(&self) -> bool {
@@ -5912,22 +5835,11 @@ impl Default for HMIDISTRM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HMIDISTRM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMIDISTRM {}
-impl core::fmt::Debug for HMIDISTRM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMIDISTRM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HMIDISTRM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMIXER(pub isize);
 impl HMIXER {
     pub fn is_invalid(&self) -> bool {
@@ -5939,22 +5851,11 @@ impl Default for HMIXER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HMIXER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMIXER {}
-impl core::fmt::Debug for HMIXER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMIXER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HMIXER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMIXEROBJ(pub isize);
 impl HMIXEROBJ {
     pub fn is_invalid(&self) -> bool {
@@ -5966,22 +5867,11 @@ impl Default for HMIXEROBJ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HMIXEROBJ {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMIXEROBJ {}
-impl core::fmt::Debug for HMIXEROBJ {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMIXEROBJ").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HMIXEROBJ {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HWAVE(pub isize);
 impl HWAVE {
     pub fn is_invalid(&self) -> bool {
@@ -5993,22 +5883,11 @@ impl Default for HWAVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HWAVE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HWAVE {}
-impl core::fmt::Debug for HWAVE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HWAVE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HWAVE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HWAVEIN(pub isize);
 impl HWAVEIN {
     pub fn is_invalid(&self) -> bool {
@@ -6020,22 +5899,11 @@ impl Default for HWAVEIN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HWAVEIN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HWAVEIN {}
-impl core::fmt::Debug for HWAVEIN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HWAVEIN").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HWAVEIN {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HWAVEOUT(pub isize);
 impl HWAVEOUT {
     pub fn is_invalid(&self) -> bool {
@@ -6045,17 +5913,6 @@ impl HWAVEOUT {
 impl Default for HWAVEOUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HWAVEOUT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HWAVEOUT {}
-impl core::fmt::Debug for HWAVEOUT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HWAVEOUT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HWAVEOUT {

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
@@ -7469,7 +7469,7 @@ impl Default for GSM610WAVEFORMAT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDRVR(pub isize);
 impl HDRVR {
     pub fn is_invalid(&self) -> bool {
@@ -7481,22 +7481,11 @@ impl Default for HDRVR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDRVR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDRVR {}
-impl core::fmt::Debug for HDRVR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDRVR").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDRVR {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HIC(pub isize);
 impl HIC {
     pub fn is_invalid(&self) -> bool {
@@ -7508,22 +7497,11 @@ impl Default for HIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HIC {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HIC {}
-impl core::fmt::Debug for HIC {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HIC").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HIC {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMMIO(pub isize);
 impl HMMIO {
     pub fn is_invalid(&self) -> bool {
@@ -7535,22 +7513,11 @@ impl Default for HMMIO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HMMIO {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMMIO {}
-impl core::fmt::Debug for HMMIO {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMMIO").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HMMIO {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HVIDEO(pub isize);
 impl HVIDEO {
     pub fn is_invalid(&self) -> bool {
@@ -7560,17 +7527,6 @@ impl HVIDEO {
 impl Default for HVIDEO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HVIDEO {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HVIDEO {}
-impl core::fmt::Debug for HVIDEO {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HVIDEO").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HVIDEO {

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
@@ -9486,7 +9486,7 @@ impl Default for SPEVENTSOURCEINFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SPGRAMMARHANDLE(pub isize);
 impl SPGRAMMARHANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -9496,17 +9496,6 @@ impl SPGRAMMARHANDLE {
 impl Default for SPGRAMMARHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SPGRAMMARHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SPGRAMMARHANDLE {}
-impl core::fmt::Debug for SPGRAMMARHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SPGRAMMARHANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SPGRAMMARHANDLE {
@@ -9842,7 +9831,7 @@ impl Default for SPPHRASEPROPERTY_0_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SPPHRASEPROPERTYHANDLE(pub isize);
 impl SPPHRASEPROPERTYHANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -9852,17 +9841,6 @@ impl SPPHRASEPROPERTYHANDLE {
 impl Default for SPPHRASEPROPERTYHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SPPHRASEPROPERTYHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SPPHRASEPROPERTYHANDLE {}
-impl core::fmt::Debug for SPPHRASEPROPERTYHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SPPHRASEPROPERTYHANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SPPHRASEPROPERTYHANDLE {
@@ -9937,7 +9915,7 @@ impl Default for SPPHRASERULE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SPPHRASERULEHANDLE(pub isize);
 impl SPPHRASERULEHANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -9947,17 +9925,6 @@ impl SPPHRASERULEHANDLE {
 impl Default for SPPHRASERULEHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SPPHRASERULEHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SPPHRASERULEHANDLE {}
-impl core::fmt::Debug for SPPHRASERULEHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SPPHRASERULEHANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SPPHRASERULEHANDLE {
@@ -10058,7 +10025,7 @@ impl Default for SPPROPERTYINFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SPRECOCONTEXTHANDLE(pub isize);
 impl SPRECOCONTEXTHANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -10068,17 +10035,6 @@ impl SPRECOCONTEXTHANDLE {
 impl Default for SPRECOCONTEXTHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SPRECOCONTEXTHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SPRECOCONTEXTHANDLE {}
-impl core::fmt::Debug for SPRECOCONTEXTHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SPRECOCONTEXTHANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SPRECOCONTEXTHANDLE {
@@ -10331,7 +10287,7 @@ impl Default for SPRULEENTRY {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SPRULEHANDLE(pub isize);
 impl SPRULEHANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -10341,17 +10297,6 @@ impl SPRULEHANDLE {
 impl Default for SPRULEHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SPRULEHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SPRULEHANDLE {}
-impl core::fmt::Debug for SPRULEHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SPRULEHANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SPRULEHANDLE {
@@ -10579,7 +10524,7 @@ impl Default for SPSHORTCUTPAIRLIST {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SPSTATEHANDLE(pub isize);
 impl SPSTATEHANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -10589,17 +10534,6 @@ impl SPSTATEHANDLE {
 impl Default for SPSTATEHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SPSTATEHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SPSTATEHANDLE {}
-impl core::fmt::Debug for SPSTATEHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SPSTATEHANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SPSTATEHANDLE {
@@ -10867,7 +10801,7 @@ impl Default for SPTRANSITIONENTRY_1_2 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SPTRANSITIONID(pub isize);
 impl SPTRANSITIONID {
     pub fn is_invalid(&self) -> bool {
@@ -10877,17 +10811,6 @@ impl SPTRANSITIONID {
 impl Default for SPTRANSITIONID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SPTRANSITIONID {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SPTRANSITIONID {}
-impl core::fmt::Debug for SPTRANSITIONID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SPTRANSITIONID").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SPTRANSITIONID {
@@ -11181,7 +11104,7 @@ impl Default for SPWORDENTRY {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SPWORDHANDLE(pub isize);
 impl SPWORDHANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -11191,17 +11114,6 @@ impl SPWORDHANDLE {
 impl Default for SPWORDHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SPWORDHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SPWORDHANDLE {}
-impl core::fmt::Debug for SPWORDHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SPWORDHANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SPWORDHANDLE {

--- a/crates/libs/windows/src/Windows/Win32/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/mod.rs
@@ -283,7 +283,7 @@ impl core::ops::Not for TIMECODE_SAMPLE_FLAGS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HTASK(pub isize);
 impl HTASK {
     pub fn is_invalid(&self) -> bool {
@@ -293,17 +293,6 @@ impl HTASK {
 impl Default for HTASK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HTASK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HTASK {}
-impl core::fmt::Debug for HTASK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HTASK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HTASK {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/IpHelper/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/IpHelper/mod.rs
@@ -2584,7 +2584,7 @@ impl Default for FIXED_INFO_W2KSP1 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HIFTIMESTAMPCHANGE(pub isize);
 impl HIFTIMESTAMPCHANGE {
     pub fn is_invalid(&self) -> bool {
@@ -2594,17 +2594,6 @@ impl HIFTIMESTAMPCHANGE {
 impl Default for HIFTIMESTAMPCHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HIFTIMESTAMPCHANGE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HIFTIMESTAMPCHANGE {}
-impl core::fmt::Debug for HIFTIMESTAMPCHANGE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HIFTIMESTAMPCHANGE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HIFTIMESTAMPCHANGE {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/QoS/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/QoS/mod.rs
@@ -2200,7 +2200,7 @@ impl Default for LPMIPTABLE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LPM_HANDLE(pub isize);
 impl LPM_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -2210,17 +2210,6 @@ impl LPM_HANDLE {
 impl Default for LPM_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for LPM_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for LPM_HANDLE {}
-impl core::fmt::Debug for LPM_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("LPM_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for LPM_HANDLE {
@@ -2940,7 +2929,7 @@ impl Default for RESV_STYLE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RHANDLE(pub isize);
 impl RHANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -2950,17 +2939,6 @@ impl RHANDLE {
 impl Default for RHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for RHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for RHANDLE {}
-impl core::fmt::Debug for RHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("RHANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for RHANDLE {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
@@ -3243,7 +3243,7 @@ impl Default for GRE_CONFIG_PARAMS0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRASCONN(pub isize);
 impl HRASCONN {
     pub fn is_invalid(&self) -> bool {
@@ -3253,17 +3253,6 @@ impl HRASCONN {
 impl Default for HRASCONN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HRASCONN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRASCONN {}
-impl core::fmt::Debug for HRASCONN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRASCONN").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HRASCONN {

--- a/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
@@ -8901,7 +8901,7 @@ impl Default for ADS_SEARCH_COLUMN {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ADS_SEARCH_HANDLE(pub isize);
 impl ADS_SEARCH_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -8911,17 +8911,6 @@ impl ADS_SEARCH_HANDLE {
 impl Default for ADS_SEARCH_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for ADS_SEARCH_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for ADS_SEARCH_HANDLE {}
-impl core::fmt::Debug for ADS_SEARCH_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("ADS_SEARCH_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for ADS_SEARCH_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
@@ -12592,572 +12592,286 @@ impl Default for GROUP_FAILURE_INFO_BUFFER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCHANGE(pub isize);
 impl Default for HCHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCHANGE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCHANGE {}
-impl core::fmt::Debug for HCHANGE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCHANGE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCHANGE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCLUSCRYPTPROVIDER(pub isize);
 impl Default for HCLUSCRYPTPROVIDER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCLUSCRYPTPROVIDER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCLUSCRYPTPROVIDER {}
-impl core::fmt::Debug for HCLUSCRYPTPROVIDER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCLUSCRYPTPROVIDER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCLUSCRYPTPROVIDER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCLUSENUM(pub isize);
 impl Default for HCLUSENUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCLUSENUM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCLUSENUM {}
-impl core::fmt::Debug for HCLUSENUM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCLUSENUM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCLUSENUM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCLUSENUMEX(pub isize);
 impl Default for HCLUSENUMEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCLUSENUMEX {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCLUSENUMEX {}
-impl core::fmt::Debug for HCLUSENUMEX {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCLUSENUMEX").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCLUSENUMEX {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCLUSTER(pub isize);
 impl Default for HCLUSTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCLUSTER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCLUSTER {}
-impl core::fmt::Debug for HCLUSTER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCLUSTER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCLUSTER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HGROUP(pub isize);
 impl Default for HGROUP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HGROUP {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HGROUP {}
-impl core::fmt::Debug for HGROUP {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HGROUP").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HGROUP {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HGROUPENUM(pub isize);
 impl Default for HGROUPENUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HGROUPENUM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HGROUPENUM {}
-impl core::fmt::Debug for HGROUPENUM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HGROUPENUM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HGROUPENUM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HGROUPENUMEX(pub isize);
 impl Default for HGROUPENUMEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HGROUPENUMEX {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HGROUPENUMEX {}
-impl core::fmt::Debug for HGROUPENUMEX {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HGROUPENUMEX").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HGROUPENUMEX {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HGROUPSET(pub isize);
 impl Default for HGROUPSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HGROUPSET {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HGROUPSET {}
-impl core::fmt::Debug for HGROUPSET {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HGROUPSET").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HGROUPSET {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HGROUPSETENUM(pub isize);
 impl Default for HGROUPSETENUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HGROUPSETENUM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HGROUPSETENUM {}
-impl core::fmt::Debug for HGROUPSETENUM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HGROUPSETENUM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HGROUPSETENUM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HNETINTERFACE(pub isize);
 impl Default for HNETINTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HNETINTERFACE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HNETINTERFACE {}
-impl core::fmt::Debug for HNETINTERFACE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HNETINTERFACE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HNETINTERFACE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HNETINTERFACEENUM(pub isize);
 impl Default for HNETINTERFACEENUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HNETINTERFACEENUM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HNETINTERFACEENUM {}
-impl core::fmt::Debug for HNETINTERFACEENUM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HNETINTERFACEENUM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HNETINTERFACEENUM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HNETWORK(pub isize);
 impl Default for HNETWORK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HNETWORK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HNETWORK {}
-impl core::fmt::Debug for HNETWORK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HNETWORK").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HNETWORK {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HNETWORKENUM(pub isize);
 impl Default for HNETWORKENUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HNETWORKENUM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HNETWORKENUM {}
-impl core::fmt::Debug for HNETWORKENUM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HNETWORKENUM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HNETWORKENUM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HNODE(pub isize);
 impl Default for HNODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HNODE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HNODE {}
-impl core::fmt::Debug for HNODE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HNODE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HNODE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HNODEENUM(pub isize);
 impl Default for HNODEENUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HNODEENUM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HNODEENUM {}
-impl core::fmt::Debug for HNODEENUM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HNODEENUM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HNODEENUM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HNODEENUMEX(pub isize);
 impl Default for HNODEENUMEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HNODEENUMEX {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HNODEENUMEX {}
-impl core::fmt::Debug for HNODEENUMEX {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HNODEENUMEX").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HNODEENUMEX {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HREGBATCH(pub isize);
 impl Default for HREGBATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HREGBATCH {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HREGBATCH {}
-impl core::fmt::Debug for HREGBATCH {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HREGBATCH").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HREGBATCH {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HREGBATCHNOTIFICATION(pub isize);
 impl Default for HREGBATCHNOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HREGBATCHNOTIFICATION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HREGBATCHNOTIFICATION {}
-impl core::fmt::Debug for HREGBATCHNOTIFICATION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HREGBATCHNOTIFICATION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HREGBATCHNOTIFICATION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HREGBATCHPORT(pub isize);
 impl Default for HREGBATCHPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HREGBATCHPORT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HREGBATCHPORT {}
-impl core::fmt::Debug for HREGBATCHPORT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HREGBATCHPORT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HREGBATCHPORT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HREGREADBATCH(pub isize);
 impl Default for HREGREADBATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HREGREADBATCH {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HREGREADBATCH {}
-impl core::fmt::Debug for HREGREADBATCH {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HREGREADBATCH").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HREGREADBATCH {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HREGREADBATCHREPLY(pub isize);
 impl Default for HREGREADBATCHREPLY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HREGREADBATCHREPLY {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HREGREADBATCHREPLY {}
-impl core::fmt::Debug for HREGREADBATCHREPLY {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HREGREADBATCHREPLY").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HREGREADBATCHREPLY {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRESENUM(pub isize);
 impl Default for HRESENUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HRESENUM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRESENUM {}
-impl core::fmt::Debug for HRESENUM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRESENUM").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HRESENUM {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRESENUMEX(pub isize);
 impl Default for HRESENUMEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HRESENUMEX {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRESENUMEX {}
-impl core::fmt::Debug for HRESENUMEX {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRESENUMEX").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HRESENUMEX {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRESOURCE(pub isize);
 impl Default for HRESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HRESOURCE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRESOURCE {}
-impl core::fmt::Debug for HRESOURCE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRESOURCE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HRESOURCE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRESTYPEENUM(pub isize);
 impl Default for HRESTYPEENUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HRESTYPEENUM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRESTYPEENUM {}
-impl core::fmt::Debug for HRESTYPEENUM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRESTYPEENUM").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HRESTYPEENUM {

--- a/crates/libs/windows/src/Windows/Win32/Networking/Ldap/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Ldap/mod.rs
@@ -2815,22 +2815,11 @@ impl Default for LDAP_VERSION_INFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PLDAPSearch(pub isize);
 impl Default for PLDAPSearch {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PLDAPSearch {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PLDAPSearch {}
-impl core::fmt::Debug for PLDAPSearch {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PLDAPSearch").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PLDAPSearch {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WebSocket/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WebSocket/mod.rs
@@ -278,7 +278,7 @@ impl Default for WEB_SOCKET_BUFFER_1 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WEB_SOCKET_HANDLE(pub isize);
 impl WEB_SOCKET_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -288,17 +288,6 @@ impl WEB_SOCKET_HANDLE {
 impl Default for WEB_SOCKET_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WEB_SOCKET_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WEB_SOCKET_HANDLE {}
-impl core::fmt::Debug for WEB_SOCKET_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WEB_SOCKET_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WEB_SOCKET_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
@@ -4732,7 +4732,7 @@ impl Default for HTTP_PUSH_TRANSPORT_SETTING {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HTTP_PUSH_WAIT_HANDLE(pub isize);
 impl HTTP_PUSH_WAIT_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -4742,17 +4742,6 @@ impl HTTP_PUSH_WAIT_HANDLE {
 impl Default for HTTP_PUSH_WAIT_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HTTP_PUSH_WAIT_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HTTP_PUSH_WAIT_HANDLE {}
-impl core::fmt::Debug for HTTP_PUSH_WAIT_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HTTP_PUSH_WAIT_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HTTP_PUSH_WAIT_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -9245,22 +9245,11 @@ impl Default for RIO_BUF {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RIO_BUFFERID(pub isize);
 impl Default for RIO_BUFFERID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for RIO_BUFFERID {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for RIO_BUFFERID {}
-impl core::fmt::Debug for RIO_BUFFERID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("RIO_BUFFERID").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for RIO_BUFFERID {
@@ -9296,22 +9285,11 @@ impl Default for RIO_CMSG_BUFFER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RIO_CQ(pub isize);
 impl Default for RIO_CQ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for RIO_CQ {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for RIO_CQ {}
-impl core::fmt::Debug for RIO_CQ {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("RIO_CQ").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for RIO_CQ {
@@ -9453,22 +9431,11 @@ impl Default for RIO_NOTIFICATION_COMPLETION_0_1 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RIO_RQ(pub isize);
 impl Default for RIO_RQ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for RIO_RQ {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for RIO_RQ {}
-impl core::fmt::Debug for RIO_RQ {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("RIO_RQ").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for RIO_RQ {
@@ -10738,22 +10705,11 @@ impl Default for SOCKADDR_VNS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SOCKET(pub usize);
 impl Default for SOCKET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SOCKET {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SOCKET {}
-impl core::fmt::Debug for SOCKET {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SOCKET").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SOCKET {
@@ -12486,7 +12442,7 @@ impl Default for WSADATA {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WSAEVENT(pub isize);
 impl WSAEVENT {
     pub fn is_invalid(&self) -> bool {
@@ -12496,17 +12452,6 @@ impl WSAEVENT {
 impl Default for WSAEVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WSAEVENT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WSAEVENT {}
-impl core::fmt::Debug for WSAEVENT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WSAEVENT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WSAEVENT {
@@ -13742,22 +13687,11 @@ impl Default for sockaddr_in6_old {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct socklen_t(pub i32);
 impl Default for socklen_t {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for socklen_t {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for socklen_t {}
-impl core::fmt::Debug for socklen_t {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("socklen_t").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for socklen_t {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
@@ -4771,22 +4771,11 @@ impl Default for WS_CERT_SIGNED_SAML_AUTHENTICATOR {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_CHANNEL(pub isize);
 impl Default for WS_CHANNEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_CHANNEL {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_CHANNEL {}
-impl core::fmt::Debug for WS_CHANNEL {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_CHANNEL").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_CHANNEL {
@@ -5727,22 +5716,11 @@ impl Default for WS_ENUM_VALUE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_ERROR(pub isize);
 impl Default for WS_ERROR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_ERROR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_ERROR {}
-impl core::fmt::Debug for WS_ERROR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_ERROR").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_ERROR {
@@ -6032,22 +6010,11 @@ impl Default for WS_GUID_DESCRIPTION {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_HEAP(pub isize);
 impl Default for WS_HEAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_HEAP {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_HEAP {}
-impl core::fmt::Debug for WS_HEAP {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_HEAP").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_HEAP {
@@ -7259,22 +7226,11 @@ impl Default for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_TEMPLATE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_LISTENER(pub isize);
 impl Default for WS_LISTENER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_LISTENER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_LISTENER {}
-impl core::fmt::Debug for WS_LISTENER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_LISTENER").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_LISTENER {
@@ -7342,22 +7298,11 @@ impl Default for WS_LISTENER_PROPERTY {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_MESSAGE(pub isize);
 impl Default for WS_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_MESSAGE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_MESSAGE {}
-impl core::fmt::Debug for WS_MESSAGE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_MESSAGE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_MESSAGE {
@@ -7455,22 +7400,11 @@ impl Default for WS_MESSAGE_PROPERTY {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_METADATA(pub isize);
 impl Default for WS_METADATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_METADATA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_METADATA {}
-impl core::fmt::Debug for WS_METADATA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_METADATA").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_METADATA {
@@ -7743,22 +7677,11 @@ impl Default for WS_OPAQUE_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_OPERATION_CONTEXT(pub isize);
 impl Default for WS_OPERATION_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_OPERATION_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_OPERATION_CONTEXT {}
-impl core::fmt::Debug for WS_OPERATION_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_OPERATION_CONTEXT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_OPERATION_CONTEXT {
@@ -7827,22 +7750,11 @@ impl Default for WS_PARAMETER_DESCRIPTION {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_POLICY(pub isize);
 impl Default for WS_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_POLICY {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_POLICY {}
-impl core::fmt::Debug for WS_POLICY {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_POLICY").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_POLICY {
@@ -8558,22 +8470,11 @@ impl Default for WS_SECURITY_CONSTRAINTS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_SECURITY_CONTEXT(pub isize);
 impl Default for WS_SECURITY_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_SECURITY_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_SECURITY_CONTEXT {}
-impl core::fmt::Debug for WS_SECURITY_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_SECURITY_CONTEXT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_SECURITY_CONTEXT {
@@ -8975,22 +8876,11 @@ impl Default for WS_SECURITY_PROPERTY_CONSTRAINT_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_SECURITY_TOKEN(pub isize);
 impl Default for WS_SECURITY_TOKEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_SECURITY_TOKEN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_SECURITY_TOKEN {}
-impl core::fmt::Debug for WS_SECURITY_TOKEN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_SECURITY_TOKEN").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_SECURITY_TOKEN {
@@ -9115,22 +9005,11 @@ impl Default for WS_SERVICE_ENDPOINT_PROPERTY {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_SERVICE_HOST(pub isize);
 impl Default for WS_SERVICE_HOST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_SERVICE_HOST {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_SERVICE_HOST {}
-impl core::fmt::Debug for WS_SERVICE_HOST {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_SERVICE_HOST").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_SERVICE_HOST {
@@ -9276,22 +9155,11 @@ impl Default for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_SERVICE_PROXY(pub isize);
 impl Default for WS_SERVICE_PROXY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_SERVICE_PROXY {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_SERVICE_PROXY {}
-impl core::fmt::Debug for WS_SERVICE_PROXY {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_SERVICE_PROXY").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_SERVICE_PROXY {
@@ -11000,22 +10868,11 @@ impl Default for WS_XML_BOOL_TEXT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_XML_BUFFER(pub isize);
 impl Default for WS_XML_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_XML_BUFFER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_XML_BUFFER {}
-impl core::fmt::Debug for WS_XML_BUFFER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_XML_BUFFER").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_XML_BUFFER {
@@ -11594,22 +11451,11 @@ impl Default for WS_XML_QNAME_TEXT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_XML_READER(pub isize);
 impl Default for WS_XML_READER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_XML_READER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_XML_READER {}
-impl core::fmt::Debug for WS_XML_READER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_XML_READER").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_XML_READER {
@@ -12249,22 +12095,11 @@ impl Default for WS_XML_UTF8_TEXT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WS_XML_WRITER(pub isize);
 impl Default for WS_XML_WRITER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WS_XML_WRITER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WS_XML_WRITER {}
-impl core::fmt::Debug for WS_XML_WRITER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WS_XML_WRITER").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WS_XML_WRITER {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -7798,7 +7798,7 @@ impl Default for LSA_FOREST_TRUST_SCANNER_INFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LSA_HANDLE(pub isize);
 impl LSA_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -7815,17 +7815,6 @@ impl windows_core::Free for LSA_HANDLE {
 impl Default for LSA_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for LSA_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for LSA_HANDLE {}
-impl core::fmt::Debug for LSA_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("LSA_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for LSA_HANDLE {
@@ -16584,22 +16573,11 @@ impl Default for X509Certificate {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct _HMAPPER(pub isize);
 impl Default for _HMAPPER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for _HMAPPER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for _HMAPPER {}
-impl core::fmt::Debug for _HMAPPER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("_HMAPPER").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for _HMAPPER {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
@@ -5419,7 +5419,7 @@ impl Default for AUDIT_PARAMS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AUTHZ_ACCESS_CHECK_RESULTS_HANDLE(pub isize);
 impl AUTHZ_ACCESS_CHECK_RESULTS_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -5429,17 +5429,6 @@ impl AUTHZ_ACCESS_CHECK_RESULTS_HANDLE {
 impl Default for AUTHZ_ACCESS_CHECK_RESULTS_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for AUTHZ_ACCESS_CHECK_RESULTS_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for AUTHZ_ACCESS_CHECK_RESULTS_HANDLE {}
-impl core::fmt::Debug for AUTHZ_ACCESS_CHECK_RESULTS_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("AUTHZ_ACCESS_CHECK_RESULTS_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for AUTHZ_ACCESS_CHECK_RESULTS_HANDLE {
@@ -5511,7 +5500,7 @@ impl Default for AUTHZ_ACCESS_REQUEST {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AUTHZ_AUDIT_EVENT_HANDLE(pub isize);
 impl AUTHZ_AUDIT_EVENT_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -5523,22 +5512,11 @@ impl Default for AUTHZ_AUDIT_EVENT_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for AUTHZ_AUDIT_EVENT_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for AUTHZ_AUDIT_EVENT_HANDLE {}
-impl core::fmt::Debug for AUTHZ_AUDIT_EVENT_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("AUTHZ_AUDIT_EVENT_HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for AUTHZ_AUDIT_EVENT_HANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AUTHZ_AUDIT_EVENT_TYPE_HANDLE(pub isize);
 impl AUTHZ_AUDIT_EVENT_TYPE_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -5548,17 +5526,6 @@ impl AUTHZ_AUDIT_EVENT_TYPE_HANDLE {
 impl Default for AUTHZ_AUDIT_EVENT_TYPE_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for AUTHZ_AUDIT_EVENT_TYPE_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for AUTHZ_AUDIT_EVENT_TYPE_HANDLE {}
-impl core::fmt::Debug for AUTHZ_AUDIT_EVENT_TYPE_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("AUTHZ_AUDIT_EVENT_TYPE_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for AUTHZ_AUDIT_EVENT_TYPE_HANDLE {
@@ -5637,7 +5604,7 @@ impl Default for AUTHZ_AUDIT_EVENT_TYPE_UNION {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE(pub isize);
 impl AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -5649,22 +5616,11 @@ impl Default for AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE {}
-impl core::fmt::Debug for AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for AUTHZ_CAP_CHANGE_SUBSCRIPTION_HANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AUTHZ_CLIENT_CONTEXT_HANDLE(pub isize);
 impl AUTHZ_CLIENT_CONTEXT_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -5674,17 +5630,6 @@ impl AUTHZ_CLIENT_CONTEXT_HANDLE {
 impl Default for AUTHZ_CLIENT_CONTEXT_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for AUTHZ_CLIENT_CONTEXT_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for AUTHZ_CLIENT_CONTEXT_HANDLE {}
-impl core::fmt::Debug for AUTHZ_CLIENT_CONTEXT_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("AUTHZ_CLIENT_CONTEXT_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for AUTHZ_CLIENT_CONTEXT_HANDLE {
@@ -5750,7 +5695,7 @@ impl Default for AUTHZ_REGISTRATION_OBJECT_TYPE_NAME_OFFSET {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AUTHZ_RESOURCE_MANAGER_HANDLE(pub isize);
 impl AUTHZ_RESOURCE_MANAGER_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -5760,17 +5705,6 @@ impl AUTHZ_RESOURCE_MANAGER_HANDLE {
 impl Default for AUTHZ_RESOURCE_MANAGER_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for AUTHZ_RESOURCE_MANAGER_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for AUTHZ_RESOURCE_MANAGER_HANDLE {}
-impl core::fmt::Debug for AUTHZ_RESOURCE_MANAGER_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("AUTHZ_RESOURCE_MANAGER_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for AUTHZ_RESOURCE_MANAGER_HANDLE {
@@ -5956,7 +5890,7 @@ impl Default for AUTHZ_SECURITY_ATTRIBUTE_V1_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AUTHZ_SECURITY_EVENT_PROVIDER_HANDLE(pub isize);
 impl AUTHZ_SECURITY_EVENT_PROVIDER_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -5966,17 +5900,6 @@ impl AUTHZ_SECURITY_EVENT_PROVIDER_HANDLE {
 impl Default for AUTHZ_SECURITY_EVENT_PROVIDER_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for AUTHZ_SECURITY_EVENT_PROVIDER_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for AUTHZ_SECURITY_EVENT_PROVIDER_HANDLE {}
-impl core::fmt::Debug for AUTHZ_SECURITY_EVENT_PROVIDER_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("AUTHZ_SECURITY_EVENT_PROVIDER_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for AUTHZ_SECURITY_EVENT_PROVIDER_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
@@ -8792,7 +8792,7 @@ impl Default for BCRYPT_ALGORITHM_IDENTIFIER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BCRYPT_ALG_HANDLE(pub *mut core::ffi::c_void);
 impl BCRYPT_ALG_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -8809,17 +8809,6 @@ impl windows_core::Free for BCRYPT_ALG_HANDLE {
 impl Default for BCRYPT_ALG_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for BCRYPT_ALG_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for BCRYPT_ALG_HANDLE {}
-impl core::fmt::Debug for BCRYPT_ALG_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("BCRYPT_ALG_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for BCRYPT_ALG_HANDLE {
@@ -9182,7 +9171,7 @@ impl Default for BCRYPT_ECC_CURVE_NAMES {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BCRYPT_HANDLE(pub *mut core::ffi::c_void);
 impl BCRYPT_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -9194,22 +9183,11 @@ impl Default for BCRYPT_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for BCRYPT_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for BCRYPT_HANDLE {}
-impl core::fmt::Debug for BCRYPT_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("BCRYPT_HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for BCRYPT_HANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BCRYPT_HASH_HANDLE(pub *mut core::ffi::c_void);
 impl BCRYPT_HASH_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -9226,17 +9204,6 @@ impl windows_core::Free for BCRYPT_HASH_HANDLE {
 impl Default for BCRYPT_HASH_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for BCRYPT_HASH_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for BCRYPT_HASH_HANDLE {}
-impl core::fmt::Debug for BCRYPT_HASH_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("BCRYPT_HASH_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for BCRYPT_HASH_HANDLE {
@@ -9339,7 +9306,7 @@ impl Default for BCRYPT_KEY_DATA_BLOB_HEADER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BCRYPT_KEY_HANDLE(pub *mut core::ffi::c_void);
 impl BCRYPT_KEY_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -9356,17 +9323,6 @@ impl windows_core::Free for BCRYPT_KEY_HANDLE {
 impl Default for BCRYPT_KEY_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for BCRYPT_KEY_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for BCRYPT_KEY_HANDLE {}
-impl core::fmt::Debug for BCRYPT_KEY_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("BCRYPT_KEY_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for BCRYPT_KEY_HANDLE {
@@ -9685,7 +9641,7 @@ impl Default for BCRYPT_RSAKEY_BLOB {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BCRYPT_SECRET_HANDLE(pub *mut core::ffi::c_void);
 impl BCRYPT_SECRET_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -9702,17 +9658,6 @@ impl windows_core::Free for BCRYPT_SECRET_HANDLE {
 impl Default for BCRYPT_SECRET_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for BCRYPT_SECRET_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for BCRYPT_SECRET_HANDLE {}
-impl core::fmt::Debug for BCRYPT_SECRET_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("BCRYPT_SECRET_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for BCRYPT_SECRET_HANDLE {
@@ -19122,7 +19067,7 @@ impl Default for GENERIC_XML_TOKEN {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCERTCHAINENGINE(pub isize);
 impl HCERTCHAINENGINE {
     pub fn is_invalid(&self) -> bool {
@@ -19141,22 +19086,11 @@ impl Default for HCERTCHAINENGINE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCERTCHAINENGINE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCERTCHAINENGINE {}
-impl core::fmt::Debug for HCERTCHAINENGINE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCERTCHAINENGINE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCERTCHAINENGINE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCERTSTORE(pub *mut core::ffi::c_void);
 impl HCERTSTORE {
     pub fn is_invalid(&self) -> bool {
@@ -19168,22 +19102,11 @@ impl Default for HCERTSTORE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCERTSTORE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCERTSTORE {}
-impl core::fmt::Debug for HCERTSTORE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCERTSTORE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCERTSTORE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCERTSTOREPROV(pub *mut core::ffi::c_void);
 impl HCERTSTOREPROV {
     pub fn is_invalid(&self) -> bool {
@@ -19195,22 +19118,11 @@ impl Default for HCERTSTOREPROV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCERTSTOREPROV {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCERTSTOREPROV {}
-impl core::fmt::Debug for HCERTSTOREPROV {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCERTSTOREPROV").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCERTSTOREPROV {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCRYPTASYNC(pub isize);
 impl HCRYPTASYNC {
     pub fn is_invalid(&self) -> bool {
@@ -19229,22 +19141,11 @@ impl Default for HCRYPTASYNC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCRYPTASYNC {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCRYPTASYNC {}
-impl core::fmt::Debug for HCRYPTASYNC {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCRYPTASYNC").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCRYPTASYNC {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCRYPTPROV_LEGACY(pub usize);
 impl HCRYPTPROV_LEGACY {
     pub fn is_invalid(&self) -> bool {
@@ -19256,22 +19157,11 @@ impl Default for HCRYPTPROV_LEGACY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCRYPTPROV_LEGACY {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCRYPTPROV_LEGACY {}
-impl core::fmt::Debug for HCRYPTPROV_LEGACY {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCRYPTPROV_LEGACY").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCRYPTPROV_LEGACY {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCRYPTPROV_OR_NCRYPT_KEY_HANDLE(pub usize);
 impl HCRYPTPROV_OR_NCRYPT_KEY_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -19281,17 +19171,6 @@ impl HCRYPTPROV_OR_NCRYPT_KEY_HANDLE {
 impl Default for HCRYPTPROV_OR_NCRYPT_KEY_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HCRYPTPROV_OR_NCRYPT_KEY_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCRYPTPROV_OR_NCRYPT_KEY_HANDLE {}
-impl core::fmt::Debug for HCRYPTPROV_OR_NCRYPT_KEY_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCRYPTPROV_OR_NCRYPT_KEY_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HCRYPTPROV_OR_NCRYPT_KEY_HANDLE {
@@ -19681,7 +19560,7 @@ impl Default for NCRYPT_EXPORTED_ISOLATED_KEY_HEADER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NCRYPT_HANDLE(pub usize);
 impl NCRYPT_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -19693,22 +19572,11 @@ impl Default for NCRYPT_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for NCRYPT_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NCRYPT_HANDLE {}
-impl core::fmt::Debug for NCRYPT_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NCRYPT_HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for NCRYPT_HANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NCRYPT_HASH_HANDLE(pub usize);
 impl NCRYPT_HASH_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -19718,17 +19586,6 @@ impl NCRYPT_HASH_HANDLE {
 impl Default for NCRYPT_HASH_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NCRYPT_HASH_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NCRYPT_HASH_HANDLE {}
-impl core::fmt::Debug for NCRYPT_HASH_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NCRYPT_HASH_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NCRYPT_HASH_HANDLE {
@@ -19863,7 +19720,7 @@ impl Default for NCRYPT_KEY_BLOB_HEADER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NCRYPT_KEY_HANDLE(pub usize);
 impl NCRYPT_KEY_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -19880,17 +19737,6 @@ impl windows_core::Free for NCRYPT_KEY_HANDLE {
 impl Default for NCRYPT_KEY_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NCRYPT_KEY_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NCRYPT_KEY_HANDLE {}
-impl core::fmt::Debug for NCRYPT_KEY_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NCRYPT_KEY_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NCRYPT_KEY_HANDLE {
@@ -20110,7 +19956,7 @@ impl Default for NCRYPT_PROTECT_STREAM_INFO_EX {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NCRYPT_PROV_HANDLE(pub usize);
 impl NCRYPT_PROV_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -20129,17 +19975,6 @@ impl Default for NCRYPT_PROV_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for NCRYPT_PROV_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NCRYPT_PROV_HANDLE {}
-impl core::fmt::Debug for NCRYPT_PROV_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NCRYPT_PROV_HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for NCRYPT_PROV_HANDLE {
     type TypeKind = windows_core::CopyType;
 }
@@ -20150,7 +19985,7 @@ impl From<NCRYPT_PROV_HANDLE> for NCRYPT_HANDLE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NCRYPT_SECRET_HANDLE(pub usize);
 impl NCRYPT_SECRET_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -20160,17 +19995,6 @@ impl NCRYPT_SECRET_HANDLE {
 impl Default for NCRYPT_SECRET_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NCRYPT_SECRET_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NCRYPT_SECRET_HANDLE {}
-impl core::fmt::Debug for NCRYPT_SECRET_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NCRYPT_SECRET_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NCRYPT_SECRET_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/Security/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/mod.rs
@@ -2754,7 +2754,7 @@ impl Default for GENERIC_MAPPING {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDIAGNOSTIC_DATA_QUERY_SESSION(pub isize);
 impl HDIAGNOSTIC_DATA_QUERY_SESSION {
     pub fn is_invalid(&self) -> bool {
@@ -2766,22 +2766,11 @@ impl Default for HDIAGNOSTIC_DATA_QUERY_SESSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDIAGNOSTIC_DATA_QUERY_SESSION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDIAGNOSTIC_DATA_QUERY_SESSION {}
-impl core::fmt::Debug for HDIAGNOSTIC_DATA_QUERY_SESSION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDIAGNOSTIC_DATA_QUERY_SESSION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDIAGNOSTIC_DATA_QUERY_SESSION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDIAGNOSTIC_EVENT_CATEGORY_DESCRIPTION(pub isize);
 impl HDIAGNOSTIC_EVENT_CATEGORY_DESCRIPTION {
     pub fn is_invalid(&self) -> bool {
@@ -2793,22 +2782,11 @@ impl Default for HDIAGNOSTIC_EVENT_CATEGORY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDIAGNOSTIC_EVENT_CATEGORY_DESCRIPTION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDIAGNOSTIC_EVENT_CATEGORY_DESCRIPTION {}
-impl core::fmt::Debug for HDIAGNOSTIC_EVENT_CATEGORY_DESCRIPTION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDIAGNOSTIC_EVENT_CATEGORY_DESCRIPTION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDIAGNOSTIC_EVENT_CATEGORY_DESCRIPTION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDIAGNOSTIC_EVENT_PRODUCER_DESCRIPTION(pub isize);
 impl HDIAGNOSTIC_EVENT_PRODUCER_DESCRIPTION {
     pub fn is_invalid(&self) -> bool {
@@ -2820,22 +2798,11 @@ impl Default for HDIAGNOSTIC_EVENT_PRODUCER_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDIAGNOSTIC_EVENT_PRODUCER_DESCRIPTION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDIAGNOSTIC_EVENT_PRODUCER_DESCRIPTION {}
-impl core::fmt::Debug for HDIAGNOSTIC_EVENT_PRODUCER_DESCRIPTION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDIAGNOSTIC_EVENT_PRODUCER_DESCRIPTION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDIAGNOSTIC_EVENT_PRODUCER_DESCRIPTION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDIAGNOSTIC_EVENT_TAG_DESCRIPTION(pub isize);
 impl HDIAGNOSTIC_EVENT_TAG_DESCRIPTION {
     pub fn is_invalid(&self) -> bool {
@@ -2847,22 +2814,11 @@ impl Default for HDIAGNOSTIC_EVENT_TAG_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDIAGNOSTIC_EVENT_TAG_DESCRIPTION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDIAGNOSTIC_EVENT_TAG_DESCRIPTION {}
-impl core::fmt::Debug for HDIAGNOSTIC_EVENT_TAG_DESCRIPTION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDIAGNOSTIC_EVENT_TAG_DESCRIPTION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDIAGNOSTIC_EVENT_TAG_DESCRIPTION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDIAGNOSTIC_RECORD(pub isize);
 impl HDIAGNOSTIC_RECORD {
     pub fn is_invalid(&self) -> bool {
@@ -2874,22 +2830,11 @@ impl Default for HDIAGNOSTIC_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDIAGNOSTIC_RECORD {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDIAGNOSTIC_RECORD {}
-impl core::fmt::Debug for HDIAGNOSTIC_RECORD {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDIAGNOSTIC_RECORD").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDIAGNOSTIC_RECORD {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDIAGNOSTIC_REPORT(pub isize);
 impl HDIAGNOSTIC_REPORT {
     pub fn is_invalid(&self) -> bool {
@@ -2899,17 +2844,6 @@ impl HDIAGNOSTIC_REPORT {
 impl Default for HDIAGNOSTIC_REPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HDIAGNOSTIC_REPORT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDIAGNOSTIC_REPORT {}
-impl core::fmt::Debug for HDIAGNOSTIC_REPORT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDIAGNOSTIC_REPORT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HDIAGNOSTIC_REPORT {
@@ -2983,7 +2917,7 @@ impl Default for LUID_AND_ATTRIBUTES {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NCRYPT_DESCRIPTOR_HANDLE(pub isize);
 impl NCRYPT_DESCRIPTOR_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -2995,22 +2929,11 @@ impl Default for NCRYPT_DESCRIPTOR_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for NCRYPT_DESCRIPTOR_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NCRYPT_DESCRIPTOR_HANDLE {}
-impl core::fmt::Debug for NCRYPT_DESCRIPTOR_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NCRYPT_DESCRIPTOR_HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for NCRYPT_DESCRIPTOR_HANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NCRYPT_STREAM_HANDLE(pub isize);
 impl NCRYPT_STREAM_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -3020,17 +2943,6 @@ impl NCRYPT_STREAM_HANDLE {
 impl Default for NCRYPT_STREAM_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NCRYPT_STREAM_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NCRYPT_STREAM_HANDLE {}
-impl core::fmt::Debug for NCRYPT_STREAM_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NCRYPT_STREAM_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NCRYPT_STREAM_HANDLE {
@@ -3099,7 +3011,7 @@ impl Default for PRIVILEGE_SET {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PSECURITY_DESCRIPTOR(pub *mut core::ffi::c_void);
 impl PSECURITY_DESCRIPTOR {
     pub fn is_invalid(&self) -> bool {
@@ -3109,17 +3021,6 @@ impl PSECURITY_DESCRIPTOR {
 impl Default for PSECURITY_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PSECURITY_DESCRIPTOR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PSECURITY_DESCRIPTOR {}
-impl core::fmt::Debug for PSECURITY_DESCRIPTOR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PSECURITY_DESCRIPTOR").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PSECURITY_DESCRIPTOR {
@@ -3160,7 +3061,7 @@ impl Default for QUOTA_LIMITS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SAFER_LEVEL_HANDLE(pub isize);
 impl SAFER_LEVEL_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -3172,22 +3073,11 @@ impl Default for SAFER_LEVEL_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for SAFER_LEVEL_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SAFER_LEVEL_HANDLE {}
-impl core::fmt::Debug for SAFER_LEVEL_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SAFER_LEVEL_HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for SAFER_LEVEL_HANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SC_HANDLE(pub isize);
 impl SC_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -3197,17 +3087,6 @@ impl SC_HANDLE {
 impl Default for SC_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SC_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SC_HANDLE {}
-impl core::fmt::Debug for SC_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SC_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SC_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
@@ -2850,7 +2850,7 @@ impl Default for CF_CALLBACK_REGISTRATION {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CF_CONNECTION_KEY(pub i64);
 impl CF_CONNECTION_KEY {
     pub fn is_invalid(&self) -> bool {
@@ -2860,17 +2860,6 @@ impl CF_CONNECTION_KEY {
 impl Default for CF_CONNECTION_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for CF_CONNECTION_KEY {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for CF_CONNECTION_KEY {}
-impl core::fmt::Debug for CF_CONNECTION_KEY {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("CF_CONNECTION_KEY").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for CF_CONNECTION_KEY {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Compression/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Compression/mod.rs
@@ -107,7 +107,7 @@ impl core::fmt::Debug for COMPRESS_INFORMATION_CLASS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct COMPRESSOR_HANDLE(pub isize);
 impl COMPRESSOR_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -117,17 +117,6 @@ impl COMPRESSOR_HANDLE {
 impl Default for COMPRESSOR_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for COMPRESSOR_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for COMPRESSOR_HANDLE {}
-impl core::fmt::Debug for COMPRESSOR_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("COMPRESSOR_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for COMPRESSOR_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -9752,22 +9752,11 @@ impl Default for FIO_CONTEXT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HIORING(pub isize);
 impl Default for HIORING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HIORING {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HIORING {}
-impl core::fmt::Debug for HIORING {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HIORING").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HIORING {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
@@ -4686,22 +4686,11 @@ impl Default for IMMP_MPV_STORE_DRIVER_HANDLE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LPMSGSESS(pub isize);
 impl Default for LPMSGSESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for LPMSGSESS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for LPMSGSESS {}
-impl core::fmt::Debug for LPMSGSESS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("LPMSGSESS").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for LPMSGSESS {

--- a/crates/libs/windows/src/Windows/Win32/Storage/InstallableFileSystems/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/InstallableFileSystems/mod.rs
@@ -768,7 +768,7 @@ impl Default for FILTER_VOLUME_STANDARD_INFORMATION {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HFILTER(pub isize);
 impl HFILTER {
     pub fn is_invalid(&self) -> bool {
@@ -787,22 +787,11 @@ impl Default for HFILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HFILTER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HFILTER {}
-impl core::fmt::Debug for HFILTER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HFILTER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HFILTER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HFILTER_INSTANCE(pub isize);
 impl HFILTER_INSTANCE {
     pub fn is_invalid(&self) -> bool {
@@ -819,17 +808,6 @@ impl windows_core::Free for HFILTER_INSTANCE {
 impl Default for HFILTER_INSTANCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HFILTER_INSTANCE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HFILTER_INSTANCE {}
-impl core::fmt::Debug for HFILTER_INSTANCE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HFILTER_INSTANCE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HFILTER_INSTANCE {

--- a/crates/libs/windows/src/Windows/Win32/Storage/IscsiDisc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IscsiDisc/mod.rs
@@ -4270,22 +4270,11 @@ impl Default for STORAGE_FIRMWARE_SLOT_INFO_V2 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct _ADAPTER_OBJECT(pub isize);
 impl Default for _ADAPTER_OBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for _ADAPTER_OBJECT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for _ADAPTER_OBJECT {}
-impl core::fmt::Debug for _ADAPTER_OBJECT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("_ADAPTER_OBJECT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for _ADAPTER_OBJECT {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Jet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Jet/mod.rs
@@ -5102,7 +5102,7 @@ impl Default for JET_LOGTIME_1_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct JET_LS(pub usize);
 impl JET_LS {
     pub fn is_invalid(&self) -> bool {
@@ -5112,17 +5112,6 @@ impl JET_LS {
 impl Default for JET_LS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for JET_LS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for JET_LS {}
-impl core::fmt::Debug for JET_LS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("JET_LS").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for JET_LS {
@@ -5373,7 +5362,7 @@ impl Default for JET_OPERATIONCONTEXT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct JET_OSSNAPID(pub usize);
 impl JET_OSSNAPID {
     pub fn is_invalid(&self) -> bool {
@@ -5383,17 +5372,6 @@ impl JET_OSSNAPID {
 impl Default for JET_OSSNAPID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for JET_OSSNAPID {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for JET_OSSNAPID {}
-impl core::fmt::Debug for JET_OSSNAPID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("JET_OSSNAPID").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for JET_OSSNAPID {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
@@ -4147,22 +4147,11 @@ pub const AppxFactory: windows_core::GUID = windows_core::GUID::from_u128(0x5842
 pub const AppxPackageEditor: windows_core::GUID = windows_core::GUID::from_u128(0xf004f2ca_aebc_4b0d_bf58_e516d5bcc0ab);
 pub const AppxPackagingDiagnosticEventSinkManager: windows_core::GUID = windows_core::GUID::from_u128(0x50ca0a46_1588_4161_8ed2_ef9e469ced5d);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PACKAGEDEPENDENCY_CONTEXT(pub isize);
 impl Default for PACKAGEDEPENDENCY_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PACKAGEDEPENDENCY_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PACKAGEDEPENDENCY_CONTEXT {}
-impl core::fmt::Debug for PACKAGEDEPENDENCY_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PACKAGEDEPENDENCY_CONTEXT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PACKAGEDEPENDENCY_CONTEXT {
@@ -4352,22 +4341,11 @@ impl Default for PACKAGE_VERSION_0_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE(pub isize);
 impl Default for PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE {}
-impl core::fmt::Debug for PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PACKAGE_VIRTUALIZATION_CONTEXT_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
@@ -664,7 +664,7 @@ impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PRJ_DIR_ENTRY_BUFFER_HANDLE(pub isize);
 impl PRJ_DIR_ENTRY_BUFFER_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -674,17 +674,6 @@ impl PRJ_DIR_ENTRY_BUFFER_HANDLE {
 impl Default for PRJ_DIR_ENTRY_BUFFER_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PRJ_DIR_ENTRY_BUFFER_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PRJ_DIR_ENTRY_BUFFER_HANDLE {}
-impl core::fmt::Debug for PRJ_DIR_ENTRY_BUFFER_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PRJ_DIR_ENTRY_BUFFER_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PRJ_DIR_ENTRY_BUFFER_HANDLE {
@@ -793,7 +782,7 @@ impl Default for PRJ_FILE_BASIC_INFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT(pub isize);
 impl PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT {
     pub fn is_invalid(&self) -> bool {
@@ -803,17 +792,6 @@ impl PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT {
 impl Default for PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT {}
-impl core::fmt::Debug for PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT {

--- a/crates/libs/windows/src/Windows/Win32/Storage/StructuredStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/StructuredStorage/mod.rs
@@ -1,5 +1,5 @@
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct JET_API_PTR(pub usize);
 impl JET_API_PTR {
     pub fn is_invalid(&self) -> bool {
@@ -11,22 +11,11 @@ impl Default for JET_API_PTR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for JET_API_PTR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for JET_API_PTR {}
-impl core::fmt::Debug for JET_API_PTR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("JET_API_PTR").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for JET_API_PTR {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct JET_HANDLE(pub usize);
 impl JET_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -38,22 +27,11 @@ impl Default for JET_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for JET_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for JET_HANDLE {}
-impl core::fmt::Debug for JET_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("JET_HANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for JET_HANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct JET_INSTANCE(pub usize);
 impl JET_INSTANCE {
     pub fn is_invalid(&self) -> bool {
@@ -65,22 +43,11 @@ impl Default for JET_INSTANCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for JET_INSTANCE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for JET_INSTANCE {}
-impl core::fmt::Debug for JET_INSTANCE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("JET_INSTANCE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for JET_INSTANCE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct JET_SESID(pub usize);
 impl JET_SESID {
     pub fn is_invalid(&self) -> bool {
@@ -92,22 +59,11 @@ impl Default for JET_SESID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for JET_SESID {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for JET_SESID {}
-impl core::fmt::Debug for JET_SESID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("JET_SESID").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for JET_SESID {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct JET_TABLEID(pub usize);
 impl JET_TABLEID {
     pub fn is_invalid(&self) -> bool {
@@ -117,17 +73,6 @@ impl JET_TABLEID {
 impl Default for JET_TABLEID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for JET_TABLEID {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for JET_TABLEID {}
-impl core::fmt::Debug for JET_TABLEID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("JET_TABLEID").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for JET_TABLEID {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
@@ -5308,7 +5308,7 @@ impl Default for DRAWPATRECT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HPTPROVIDER(pub isize);
 impl HPTPROVIDER {
     pub fn is_invalid(&self) -> bool {
@@ -5318,17 +5318,6 @@ impl HPTPROVIDER {
 impl Default for HPTPROVIDER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HPTPROVIDER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HPTPROVIDER {}
-impl core::fmt::Debug for HPTPROVIDER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HPTPROVIDER").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HPTPROVIDER {

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
@@ -2492,22 +2492,11 @@ impl Default for FlagList {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LPWABACTIONITEM(pub isize);
 impl Default for LPWABACTIONITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for LPWABACTIONITEM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for LPWABACTIONITEM {}
-impl core::fmt::Debug for LPWABACTIONITEM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("LPWABACTIONITEM").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for LPWABACTIONITEM {

--- a/crates/libs/windows/src/Windows/Win32/System/Antimalware/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Antimalware/mod.rs
@@ -533,7 +533,7 @@ impl Default for AMSI_UAC_REQUEST_PACKAGED_APP_INFO {
 }
 pub const CAntimalware: windows_core::GUID = windows_core::GUID::from_u128(0xfdb00e52_a214_4aa1_8fba_4357bb0072ec);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HAMSICONTEXT(pub isize);
 impl HAMSICONTEXT {
     pub fn is_invalid(&self) -> bool {
@@ -545,22 +545,11 @@ impl Default for HAMSICONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HAMSICONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HAMSICONTEXT {}
-impl core::fmt::Debug for HAMSICONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HAMSICONTEXT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HAMSICONTEXT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HAMSISESSION(pub isize);
 impl HAMSISESSION {
     pub fn is_invalid(&self) -> bool {
@@ -570,17 +559,6 @@ impl HAMSISESSION {
 impl Default for HAMSISESSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HAMSISESSION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HAMSISESSION {}
-impl core::fmt::Debug for HAMSISESSION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HAMSISESSION").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HAMSISESSION {

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
@@ -7997,7 +7997,7 @@ impl Default for MSIFILEHASHINFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MSIHANDLE(pub u32);
 impl MSIHANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -8014,17 +8014,6 @@ impl windows_core::Free for MSIHANDLE {
 impl Default for MSIHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for MSIHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for MSIHANDLE {}
-impl core::fmt::Debug for MSIHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("MSIHANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for MSIHANDLE {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -6814,7 +6814,7 @@ impl Default for COSERVERINFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CO_DEVICE_CATALOG_COOKIE(pub isize);
 impl CO_DEVICE_CATALOG_COOKIE {
     pub fn is_invalid(&self) -> bool {
@@ -6826,22 +6826,11 @@ impl Default for CO_DEVICE_CATALOG_COOKIE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for CO_DEVICE_CATALOG_COOKIE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for CO_DEVICE_CATALOG_COOKIE {}
-impl core::fmt::Debug for CO_DEVICE_CATALOG_COOKIE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("CO_DEVICE_CATALOG_COOKIE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for CO_DEVICE_CATALOG_COOKIE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CO_MTA_USAGE_COOKIE(pub isize);
 impl CO_MTA_USAGE_COOKIE {
     pub fn is_invalid(&self) -> bool {
@@ -6851,17 +6840,6 @@ impl CO_MTA_USAGE_COOKIE {
 impl Default for CO_MTA_USAGE_COOKIE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for CO_MTA_USAGE_COOKIE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for CO_MTA_USAGE_COOKIE {}
-impl core::fmt::Debug for CO_MTA_USAGE_COOKIE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("CO_MTA_USAGE_COOKIE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for CO_MTA_USAGE_COOKIE {
@@ -7594,22 +7572,11 @@ impl Default for MULTI_QI {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MachineGlobalObjectTableRegistrationToken(pub isize);
 impl Default for MachineGlobalObjectTableRegistrationToken {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for MachineGlobalObjectTableRegistrationToken {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for MachineGlobalObjectTableRegistrationToken {}
-impl core::fmt::Debug for MachineGlobalObjectTableRegistrationToken {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("MachineGlobalObjectTableRegistrationToken").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for MachineGlobalObjectTableRegistrationToken {

--- a/crates/libs/windows/src/Windows/Win32/System/Console/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Console/mod.rs
@@ -1406,7 +1406,7 @@ impl Default for FOCUS_EVENT_RECORD {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HPCON(pub isize);
 impl HPCON {
     pub fn is_invalid(&self) -> bool {
@@ -1423,17 +1423,6 @@ impl windows_core::Free for HPCON {
 impl Default for HPCON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HPCON {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HPCON {}
-impl core::fmt::Debug for HPCON {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HPCON").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HPCON {

--- a/crates/libs/windows/src/Windows/Win32/System/DataExchange/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DataExchange/mod.rs
@@ -1189,7 +1189,7 @@ impl Default for DDEUP {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCONV(pub isize);
 impl HCONV {
     pub fn is_invalid(&self) -> bool {
@@ -1201,22 +1201,11 @@ impl Default for HCONV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCONV {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCONV {}
-impl core::fmt::Debug for HCONV {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCONV").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCONV {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCONVLIST(pub isize);
 impl HCONVLIST {
     pub fn is_invalid(&self) -> bool {
@@ -1228,22 +1217,11 @@ impl Default for HCONVLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCONVLIST {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCONVLIST {}
-impl core::fmt::Debug for HCONVLIST {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCONVLIST").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCONVLIST {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDDEDATA(pub isize);
 impl HDDEDATA {
     pub fn is_invalid(&self) -> bool {
@@ -1255,22 +1233,11 @@ impl Default for HDDEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDDEDATA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDDEDATA {}
-impl core::fmt::Debug for HDDEDATA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDDEDATA").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDDEDATA {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HSZ(pub isize);
 impl HSZ {
     pub fn is_invalid(&self) -> bool {
@@ -1280,17 +1247,6 @@ impl HSZ {
 impl Default for HSZ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HSZ {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HSZ {}
-impl core::fmt::Debug for HSZ {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HSZ").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HSZ {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -4531,7 +4531,7 @@ impl Default for TDH_CONTEXT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TDH_HANDLE(pub isize);
 impl TDH_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -4548,17 +4548,6 @@ impl windows_core::Free for TDH_HANDLE {
 impl Default for TDH_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for TDH_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for TDH_HANDLE {}
-impl core::fmt::Debug for TDH_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("TDH_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for TDH_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
@@ -390,7 +390,7 @@ impl core::fmt::Debug for PSS_WALK_INFORMATION_CLASS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HPSS(pub isize);
 impl HPSS {
     pub fn is_invalid(&self) -> bool {
@@ -402,22 +402,11 @@ impl Default for HPSS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HPSS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HPSS {}
-impl core::fmt::Debug for HPSS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HPSS").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HPSS {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HPSSWALK(pub isize);
 impl HPSSWALK {
     pub fn is_invalid(&self) -> bool {
@@ -427,17 +416,6 @@ impl HPSSWALK {
 impl Default for HPSSWALK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HPSSWALK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HPSSWALK {}
-impl core::fmt::Debug for HPSSWALK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HPSSWALK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HPSSWALK {

--- a/crates/libs/windows/src/Windows/Win32/System/ErrorReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ErrorReporting/mod.rs
@@ -682,7 +682,7 @@ impl core::fmt::Debug for WER_SUBMIT_RESULT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HREPORT(pub isize);
 impl HREPORT {
     pub fn is_invalid(&self) -> bool {
@@ -701,22 +701,11 @@ impl Default for HREPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HREPORT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HREPORT {}
-impl core::fmt::Debug for HREPORT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HREPORT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HREPORT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HREPORTSTORE(pub isize);
 impl HREPORTSTORE {
     pub fn is_invalid(&self) -> bool {
@@ -733,17 +722,6 @@ impl windows_core::Free for HREPORTSTORE {
 impl Default for HREPORTSTORE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HREPORTSTORE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HREPORTSTORE {}
-impl core::fmt::Debug for HREPORTSTORE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HREPORTSTORE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HREPORTSTORE {

--- a/crates/libs/windows/src/Windows/Win32/System/EventLog/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventLog/mod.rs
@@ -1073,7 +1073,7 @@ impl Default for EVENTSFORLOGFILE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct EVT_HANDLE(pub isize);
 impl EVT_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -1090,17 +1090,6 @@ impl windows_core::Free for EVT_HANDLE {
 impl Default for EVT_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for EVT_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for EVT_HANDLE {}
-impl core::fmt::Debug for EVT_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("EVT_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for EVT_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/System/HostCompute/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/HostCompute/mod.rs
@@ -1,5 +1,5 @@
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCS_CALLBACK(pub isize);
 impl HCS_CALLBACK {
     pub fn is_invalid(&self) -> bool {
@@ -9,17 +9,6 @@ impl HCS_CALLBACK {
 impl Default for HCS_CALLBACK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HCS_CALLBACK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCS_CALLBACK {}
-impl core::fmt::Debug for HCS_CALLBACK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCS_CALLBACK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HCS_CALLBACK {

--- a/crates/libs/windows/src/Windows/Win32/System/HostComputeSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/HostComputeSystem/mod.rs
@@ -873,7 +873,7 @@ impl Default for HCS_EVENT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCS_OPERATION(pub isize);
 impl HCS_OPERATION {
     pub fn is_invalid(&self) -> bool {
@@ -892,22 +892,11 @@ impl Default for HCS_OPERATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCS_OPERATION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCS_OPERATION {}
-impl core::fmt::Debug for HCS_OPERATION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCS_OPERATION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCS_OPERATION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCS_PROCESS(pub isize);
 impl HCS_PROCESS {
     pub fn is_invalid(&self) -> bool {
@@ -924,17 +913,6 @@ impl windows_core::Free for HCS_PROCESS {
 impl Default for HCS_PROCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HCS_PROCESS {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCS_PROCESS {}
-impl core::fmt::Debug for HCS_PROCESS {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCS_PROCESS").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HCS_PROCESS {
@@ -974,7 +952,7 @@ impl Default for HCS_PROCESS_INFORMATION {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCS_SYSTEM(pub isize);
 impl HCS_SYSTEM {
     pub fn is_invalid(&self) -> bool {
@@ -991,17 +969,6 @@ impl windows_core::Free for HCS_SYSTEM {
 impl Default for HCS_SYSTEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HCS_SYSTEM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCS_SYSTEM {}
-impl core::fmt::Debug for HCS_SYSTEM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCS_SYSTEM").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HCS_SYSTEM {

--- a/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
@@ -3855,7 +3855,7 @@ impl Default for WHV_NOTIFICATION_PORT_PARAMETERS_0_0 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WHV_PARTITION_HANDLE(pub isize);
 impl WHV_PARTITION_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -3872,17 +3872,6 @@ impl windows_core::Free for WHV_PARTITION_HANDLE {
 impl Default for WHV_PARTITION_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WHV_PARTITION_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WHV_PARTITION_HANDLE {}
-impl core::fmt::Debug for WHV_PARTITION_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WHV_PARTITION_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WHV_PARTITION_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
@@ -1945,7 +1945,7 @@ impl Default for EXTENSION_CONTROL_BLOCK {
 }
 pub const FtpProvider: windows_core::GUID = windows_core::GUID::from_u128(0x70bdc667_33b2_45f0_ac52_c3ca46f7a656);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCONN(pub *mut core::ffi::c_void);
 impl HCONN {
     pub fn is_invalid(&self) -> bool {
@@ -1955,17 +1955,6 @@ impl HCONN {
 impl Default for HCONN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HCONN {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCONN {}
-impl core::fmt::Debug for HCONN {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCONN").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HCONN {

--- a/crates/libs/windows/src/Windows/Win32/System/Memory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Memory/mod.rs
@@ -1393,22 +1393,11 @@ impl core::fmt::Debug for WIN32_MEMORY_PARTITION_INFORMATION_CLASS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AtlThunkData_t(pub isize);
 impl Default for AtlThunkData_t {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for AtlThunkData_t {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for AtlThunkData_t {}
-impl core::fmt::Debug for AtlThunkData_t {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("AtlThunkData_t").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for AtlThunkData_t {

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
@@ -11600,7 +11600,7 @@ impl Default for OLEVERB {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct OLE_HANDLE(pub u32);
 impl OLE_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -11610,17 +11610,6 @@ impl OLE_HANDLE {
 impl Default for OLE_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for OLE_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for OLE_HANDLE {}
-impl core::fmt::Debug for OLE_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("OLE_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for OLE_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
@@ -2365,7 +2365,7 @@ impl Default for GLOBAL_USER_POWER_POLICY {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HPOWERNOTIFY(pub isize);
 impl HPOWERNOTIFY {
     pub fn is_invalid(&self) -> bool {
@@ -2382,17 +2382,6 @@ impl windows_core::Free for HPOWERNOTIFY {
 impl Default for HPOWERNOTIFY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HPOWERNOTIFY {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HPOWERNOTIFY {}
-impl core::fmt::Debug for HPOWERNOTIFY {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HPOWERNOTIFY").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HPOWERNOTIFY {

--- a/crates/libs/windows/src/Windows/Win32/System/Registry/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Registry/mod.rs
@@ -1990,7 +1990,7 @@ impl Default for DSKTLSYSTEMTIME {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HKEY(pub isize);
 impl HKEY {
     pub fn is_invalid(&self) -> bool {
@@ -2007,17 +2007,6 @@ impl windows_core::Free for HKEY {
 impl Default for HKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HKEY {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HKEY {}
-impl core::fmt::Debug for HKEY {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HKEY").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HKEY {

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
@@ -1693,22 +1693,11 @@ impl core::fmt::Debug for WSManShellFlag {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WSMAN_API_HANDLE(pub isize);
 impl Default for WSMAN_API_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WSMAN_API_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WSMAN_API_HANDLE {}
-impl core::fmt::Debug for WSMAN_API_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WSMAN_API_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WSMAN_API_HANDLE {
@@ -1847,22 +1836,11 @@ impl Default for WSMAN_COMMAND_ARG_SET {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WSMAN_COMMAND_HANDLE(pub isize);
 impl Default for WSMAN_COMMAND_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WSMAN_COMMAND_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WSMAN_COMMAND_HANDLE {}
-impl core::fmt::Debug for WSMAN_COMMAND_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WSMAN_COMMAND_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WSMAN_COMMAND_HANDLE {
@@ -2187,22 +2165,11 @@ impl Default for WSMAN_KEY {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WSMAN_OPERATION_HANDLE(pub isize);
 impl Default for WSMAN_OPERATION_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WSMAN_OPERATION_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WSMAN_OPERATION_HANDLE {}
-impl core::fmt::Debug for WSMAN_OPERATION_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WSMAN_OPERATION_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WSMAN_OPERATION_HANDLE {
@@ -2530,22 +2497,11 @@ impl Default for WSMAN_SENDER_DETAILS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WSMAN_SESSION_HANDLE(pub isize);
 impl Default for WSMAN_SESSION_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WSMAN_SESSION_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WSMAN_SESSION_HANDLE {}
-impl core::fmt::Debug for WSMAN_SESSION_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WSMAN_SESSION_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WSMAN_SESSION_HANDLE {
@@ -2605,22 +2561,11 @@ impl Default for WSMAN_SHELL_DISCONNECT_INFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct WSMAN_SHELL_HANDLE(pub isize);
 impl Default for WSMAN_SHELL_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for WSMAN_SHELL_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for WSMAN_SHELL_HANDLE {}
-impl core::fmt::Debug for WSMAN_SHELL_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("WSMAN_SHELL_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for WSMAN_SHELL_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
@@ -6773,22 +6773,11 @@ impl Default for NDR64_VAR_ARRAY_HEADER_FORMAT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDR_ALLOC_ALL_NODES_CONTEXT(pub isize);
 impl Default for NDR_ALLOC_ALL_NODES_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NDR_ALLOC_ALL_NODES_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDR_ALLOC_ALL_NODES_CONTEXT {}
-impl core::fmt::Debug for NDR_ALLOC_ALL_NODES_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDR_ALLOC_ALL_NODES_CONTEXT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NDR_ALLOC_ALL_NODES_CONTEXT {
@@ -6881,22 +6870,11 @@ impl Default for NDR_EXPR_DESC {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NDR_POINTER_QUEUE_STATE(pub isize);
 impl Default for NDR_POINTER_QUEUE_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for NDR_POINTER_QUEUE_STATE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for NDR_POINTER_QUEUE_STATE {}
-impl core::fmt::Debug for NDR_POINTER_QUEUE_STATE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("NDR_POINTER_QUEUE_STATE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for NDR_POINTER_QUEUE_STATE {
@@ -7016,44 +6994,22 @@ impl Default for NDR_USER_MARSHAL_INFO_LEVEL1 {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PNDR_ASYNC_MESSAGE(pub isize);
 impl Default for PNDR_ASYNC_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PNDR_ASYNC_MESSAGE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PNDR_ASYNC_MESSAGE {}
-impl core::fmt::Debug for PNDR_ASYNC_MESSAGE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PNDR_ASYNC_MESSAGE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PNDR_ASYNC_MESSAGE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PNDR_CORRELATION_INFO(pub isize);
 impl Default for PNDR_CORRELATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PNDR_CORRELATION_INFO {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PNDR_CORRELATION_INFO {}
-impl core::fmt::Debug for PNDR_CORRELATION_INFO {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PNDR_CORRELATION_INFO").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PNDR_CORRELATION_INFO {
@@ -9756,22 +9712,11 @@ impl Default for XMIT_ROUTINE_QUINTUPLE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct _NDR_PROC_CONTEXT(pub isize);
 impl Default for _NDR_PROC_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for _NDR_PROC_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for _NDR_PROC_CONTEXT {}
-impl core::fmt::Debug for _NDR_PROC_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("_NDR_PROC_CONTEXT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for _NDR_PROC_CONTEXT {

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -15742,7 +15742,7 @@ impl Default for FILTERED_DATA_SOURCES {
 }
 pub const FilterRegistration: windows_core::GUID = windows_core::GUID::from_u128(0x9e175b8d_f52a_11d8_b9a5_505054503030);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HACCESSOR(pub usize);
 impl HACCESSOR {
     pub fn is_invalid(&self) -> bool {
@@ -15752,17 +15752,6 @@ impl HACCESSOR {
 impl Default for HACCESSOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HACCESSOR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HACCESSOR {}
-impl core::fmt::Debug for HACCESSOR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HACCESSOR").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HACCESSOR {

--- a/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
@@ -1161,22 +1161,11 @@ impl Default for ENUM_SERVICE_STATUS_PROCESSW {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PSC_NOTIFICATION_REGISTRATION(pub isize);
 impl Default for PSC_NOTIFICATION_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PSC_NOTIFICATION_REGISTRATION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PSC_NOTIFICATION_REGISTRATION {}
-impl core::fmt::Debug for PSC_NOTIFICATION_REGISTRATION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PSC_NOTIFICATION_REGISTRATION").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PSC_NOTIFICATION_REGISTRATION {
@@ -1984,7 +1973,7 @@ impl Default for SERVICE_STATUS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SERVICE_STATUS_HANDLE(pub isize);
 impl SERVICE_STATUS_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -1994,17 +1983,6 @@ impl SERVICE_STATUS_HANDLE {
 impl Default for SERVICE_STATUS_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SERVICE_STATUS_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SERVICE_STATUS_HANDLE {}
-impl core::fmt::Debug for SERVICE_STATUS_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SERVICE_STATUS_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SERVICE_STATUS_HANDLE {

--- a/crates/libs/windows/src/Windows/Win32/System/StationsAndDesktops/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/StationsAndDesktops/mod.rs
@@ -464,7 +464,7 @@ impl Default for BSMINFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDESK(pub isize);
 impl HDESK {
     pub fn is_invalid(&self) -> bool {
@@ -483,22 +483,11 @@ impl Default for HDESK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDESK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDESK {}
-impl core::fmt::Debug for HDESK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDESK").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDESK {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HWINSTA(pub isize);
 impl HWINSTA {
     pub fn is_invalid(&self) -> bool {
@@ -515,17 +504,6 @@ impl windows_core::Free for HWINSTA {
 impl Default for HWINSTA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HWINSTA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HWINSTA {}
-impl core::fmt::Debug for HWINSTA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HWINSTA").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HWINSTA {

--- a/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
@@ -3733,7 +3733,7 @@ impl Default for IO_COUNTERS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LPPROC_THREAD_ATTRIBUTE_LIST(pub *mut core::ffi::c_void);
 impl LPPROC_THREAD_ATTRIBUTE_LIST {
     pub fn is_invalid(&self) -> bool {
@@ -3743,17 +3743,6 @@ impl LPPROC_THREAD_ATTRIBUTE_LIST {
 impl Default for LPPROC_THREAD_ATTRIBUTE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for LPPROC_THREAD_ATTRIBUTE_LIST {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for LPPROC_THREAD_ATTRIBUTE_LIST {}
-impl core::fmt::Debug for LPPROC_THREAD_ATTRIBUTE_LIST {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("LPPROC_THREAD_ATTRIBUTE_LIST").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for LPPROC_THREAD_ATTRIBUTE_LIST {
@@ -4283,7 +4272,7 @@ impl Default for PROCESS_PROTECTION_LEVEL_INFORMATION {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PTP_CALLBACK_INSTANCE(pub isize);
 impl PTP_CALLBACK_INSTANCE {
     pub fn is_invalid(&self) -> bool {
@@ -4295,44 +4284,22 @@ impl Default for PTP_CALLBACK_INSTANCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PTP_CALLBACK_INSTANCE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PTP_CALLBACK_INSTANCE {}
-impl core::fmt::Debug for PTP_CALLBACK_INSTANCE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PTP_CALLBACK_INSTANCE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PTP_CALLBACK_INSTANCE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PTP_CLEANUP_GROUP(pub isize);
 impl Default for PTP_CLEANUP_GROUP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PTP_CLEANUP_GROUP {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PTP_CLEANUP_GROUP {}
-impl core::fmt::Debug for PTP_CLEANUP_GROUP {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PTP_CLEANUP_GROUP").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PTP_CLEANUP_GROUP {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PTP_IO(pub isize);
 impl PTP_IO {
     pub fn is_invalid(&self) -> bool {
@@ -4344,44 +4311,22 @@ impl Default for PTP_IO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PTP_IO {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PTP_IO {}
-impl core::fmt::Debug for PTP_IO {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PTP_IO").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PTP_IO {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PTP_POOL(pub isize);
 impl Default for PTP_POOL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PTP_POOL {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PTP_POOL {}
-impl core::fmt::Debug for PTP_POOL {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PTP_POOL").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PTP_POOL {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PTP_TIMER(pub isize);
 impl PTP_TIMER {
     pub fn is_invalid(&self) -> bool {
@@ -4393,22 +4338,11 @@ impl Default for PTP_TIMER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PTP_TIMER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PTP_TIMER {}
-impl core::fmt::Debug for PTP_TIMER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PTP_TIMER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PTP_TIMER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PTP_WAIT(pub isize);
 impl PTP_WAIT {
     pub fn is_invalid(&self) -> bool {
@@ -4420,22 +4354,11 @@ impl Default for PTP_WAIT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PTP_WAIT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PTP_WAIT {}
-impl core::fmt::Debug for PTP_WAIT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PTP_WAIT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PTP_WAIT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PTP_WORK(pub isize);
 impl PTP_WORK {
     pub fn is_invalid(&self) -> bool {
@@ -4445,17 +4368,6 @@ impl PTP_WORK {
 impl Default for PTP_WORK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PTP_WORK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PTP_WORK {}
-impl core::fmt::Debug for PTP_WORK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PTP_WORK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PTP_WORK {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -1595,7 +1595,7 @@ impl core::fmt::Debug for TrustLevel {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct APARTMENT_SHUTDOWN_REGISTRATION_COOKIE(pub isize);
 impl APARTMENT_SHUTDOWN_REGISTRATION_COOKIE {
     pub fn is_invalid(&self) -> bool {
@@ -1605,17 +1605,6 @@ impl APARTMENT_SHUTDOWN_REGISTRATION_COOKIE {
 impl Default for APARTMENT_SHUTDOWN_REGISTRATION_COOKIE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for APARTMENT_SHUTDOWN_REGISTRATION_COOKIE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for APARTMENT_SHUTDOWN_REGISTRATION_COOKIE {}
-impl core::fmt::Debug for APARTMENT_SHUTDOWN_REGISTRATION_COOKIE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("APARTMENT_SHUTDOWN_REGISTRATION_COOKIE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for APARTMENT_SHUTDOWN_REGISTRATION_COOKIE {
@@ -1682,7 +1671,7 @@ impl Default for EventRegistrationToken {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HSTRING_BUFFER(pub isize);
 impl HSTRING_BUFFER {
     pub fn is_invalid(&self) -> bool {
@@ -1692,17 +1681,6 @@ impl HSTRING_BUFFER {
 impl Default for HSTRING_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HSTRING_BUFFER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HSTRING_BUFFER {}
-impl core::fmt::Debug for HSTRING_BUFFER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HSTRING_BUFFER").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HSTRING_BUFFER {
@@ -1742,7 +1720,7 @@ impl Default for HSTRING_HEADER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ROPARAMIIDHANDLE(pub isize);
 impl ROPARAMIIDHANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -1754,37 +1732,15 @@ impl Default for ROPARAMIIDHANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for ROPARAMIIDHANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for ROPARAMIIDHANDLE {}
-impl core::fmt::Debug for ROPARAMIIDHANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("ROPARAMIIDHANDLE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for ROPARAMIIDHANDLE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RO_REGISTRATION_COOKIE(pub isize);
 impl Default for RO_REGISTRATION_COOKIE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for RO_REGISTRATION_COOKIE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for RO_REGISTRATION_COOKIE {}
-impl core::fmt::Debug for RO_REGISTRATION_COOKIE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("RO_REGISTRATION_COOKIE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for RO_REGISTRATION_COOKIE {

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
@@ -3595,7 +3595,7 @@ impl Default for FEATURE_ERROR {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FEATURE_STATE_CHANGE_SUBSCRIPTION(pub isize);
 impl FEATURE_STATE_CHANGE_SUBSCRIPTION {
     pub fn is_invalid(&self) -> bool {
@@ -3607,22 +3607,11 @@ impl Default for FEATURE_STATE_CHANGE_SUBSCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for FEATURE_STATE_CHANGE_SUBSCRIPTION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for FEATURE_STATE_CHANGE_SUBSCRIPTION {}
-impl core::fmt::Debug for FEATURE_STATE_CHANGE_SUBSCRIPTION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("FEATURE_STATE_CHANGE_SUBSCRIPTION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for FEATURE_STATE_CHANGE_SUBSCRIPTION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct FH_SERVICE_PIPE_HANDLE(pub isize);
 impl FH_SERVICE_PIPE_HANDLE {
     pub fn is_invalid(&self) -> bool {
@@ -3632,17 +3621,6 @@ impl FH_SERVICE_PIPE_HANDLE {
 impl Default for FH_SERVICE_PIPE_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for FH_SERVICE_PIPE_HANDLE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for FH_SERVICE_PIPE_HANDLE {}
-impl core::fmt::Debug for FH_SERVICE_PIPE_HANDLE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("FH_SERVICE_PIPE_HANDLE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for FH_SERVICE_PIPE_HANDLE {
@@ -3678,7 +3656,7 @@ impl Default for FILE_CASE_SENSITIVE_INFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HWINWATCH(pub isize);
 impl HWINWATCH {
     pub fn is_invalid(&self) -> bool {
@@ -3688,17 +3666,6 @@ impl HWINWATCH {
 impl Default for HWINWATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HWINWATCH {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HWINWATCH {}
-impl core::fmt::Debug for HWINWATCH {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HWINWATCH").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HWINWATCH {

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
@@ -8570,22 +8570,11 @@ impl Default for MI_Module {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MI_Module_Self(pub isize);
 impl Default for MI_Module_Self {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for MI_Module_Self {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for MI_Module_Self {}
-impl core::fmt::Debug for MI_Module_Self {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("MI_Module_Self").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for MI_Module_Self {

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
@@ -9652,7 +9652,7 @@ impl Default for HIGHCONTRASTW {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HUIAEVENT(pub isize);
 impl HUIAEVENT {
     pub fn is_invalid(&self) -> bool {
@@ -9664,22 +9664,11 @@ impl Default for HUIAEVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HUIAEVENT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HUIAEVENT {}
-impl core::fmt::Debug for HUIAEVENT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HUIAEVENT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HUIAEVENT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HUIANODE(pub isize);
 impl HUIANODE {
     pub fn is_invalid(&self) -> bool {
@@ -9691,22 +9680,11 @@ impl Default for HUIANODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HUIANODE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HUIANODE {}
-impl core::fmt::Debug for HUIANODE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HUIANODE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HUIANODE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HUIAPATTERNOBJECT(pub isize);
 impl HUIAPATTERNOBJECT {
     pub fn is_invalid(&self) -> bool {
@@ -9718,22 +9696,11 @@ impl Default for HUIAPATTERNOBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HUIAPATTERNOBJECT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HUIAPATTERNOBJECT {}
-impl core::fmt::Debug for HUIAPATTERNOBJECT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HUIAPATTERNOBJECT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HUIAPATTERNOBJECT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HUIATEXTRANGE(pub isize);
 impl HUIATEXTRANGE {
     pub fn is_invalid(&self) -> bool {
@@ -9745,22 +9712,11 @@ impl Default for HUIATEXTRANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HUIATEXTRANGE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HUIATEXTRANGE {}
-impl core::fmt::Debug for HUIATEXTRANGE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HUIATEXTRANGE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HUIATEXTRANGE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HWINEVENTHOOK(pub isize);
 impl HWINEVENTHOOK {
     pub fn is_invalid(&self) -> bool {
@@ -9777,17 +9733,6 @@ impl windows_core::Free for HWINEVENTHOOK {
 impl Default for HWINEVENTHOOK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HWINEVENTHOOK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HWINEVENTHOOK {}
-impl core::fmt::Debug for HWINEVENTHOOK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HWINEVENTHOOK").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HWINEVENTHOOK {

--- a/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
@@ -1764,22 +1764,11 @@ pub const UIAnimationTransitionFactory2: windows_core::GUID = windows_core::GUID
 pub const UIAnimationTransitionLibrary: windows_core::GUID = windows_core::GUID::from_u128(0x1d6322ad_aa85_4ef5_a828_86d71067d145);
 pub const UIAnimationTransitionLibrary2: windows_core::GUID = windows_core::GUID::from_u128(0x812f944a_c5c8_4cd9_b0a6_b3da802f228d);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UI_ANIMATION_KEYFRAME(pub isize);
 impl Default for UI_ANIMATION_KEYFRAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for UI_ANIMATION_KEYFRAME {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for UI_ANIMATION_KEYFRAME {}
-impl core::fmt::Debug for UI_ANIMATION_KEYFRAME {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("UI_ANIMATION_KEYFRAME").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for UI_ANIMATION_KEYFRAME {

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
@@ -1894,7 +1894,7 @@ impl Default for GamutShellTriangle {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCOLORSPACE(pub isize);
 impl HCOLORSPACE {
     pub fn is_invalid(&self) -> bool {
@@ -1911,17 +1911,6 @@ impl windows_core::Free for HCOLORSPACE {
 impl Default for HCOLORSPACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HCOLORSPACE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCOLORSPACE {}
-impl core::fmt::Debug for HCOLORSPACE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCOLORSPACE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HCOLORSPACE {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
@@ -12465,7 +12465,7 @@ impl Default for HDLAYOUT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDPA(pub isize);
 impl HDPA {
     pub fn is_invalid(&self) -> bool {
@@ -12477,22 +12477,11 @@ impl Default for HDPA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDPA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDPA {}
-impl core::fmt::Debug for HDPA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDPA").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDPA {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDSA(pub isize);
 impl HDSA {
     pub fn is_invalid(&self) -> bool {
@@ -12502,17 +12491,6 @@ impl HDSA {
 impl Default for HDSA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HDSA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDSA {}
-impl core::fmt::Debug for HDSA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDSA").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HDSA {
@@ -12579,7 +12557,7 @@ impl Default for HD_TEXTFILTERW {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HIMAGELIST(pub isize);
 impl HIMAGELIST {
     pub fn is_invalid(&self) -> bool {
@@ -12598,22 +12576,11 @@ impl Default for HIMAGELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HIMAGELIST {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HIMAGELIST {}
-impl core::fmt::Debug for HIMAGELIST {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HIMAGELIST").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HIMAGELIST {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HPROPSHEETPAGE(pub isize);
 impl HPROPSHEETPAGE {
     pub fn is_invalid(&self) -> bool {
@@ -12632,22 +12599,11 @@ impl Default for HPROPSHEETPAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HPROPSHEETPAGE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HPROPSHEETPAGE {}
-impl core::fmt::Debug for HPROPSHEETPAGE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HPROPSHEETPAGE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HPROPSHEETPAGE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HSYNTHETICPOINTERDEVICE(pub isize);
 impl HSYNTHETICPOINTERDEVICE {
     pub fn is_invalid(&self) -> bool {
@@ -12659,22 +12615,11 @@ impl Default for HSYNTHETICPOINTERDEVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HSYNTHETICPOINTERDEVICE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HSYNTHETICPOINTERDEVICE {}
-impl core::fmt::Debug for HSYNTHETICPOINTERDEVICE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HSYNTHETICPOINTERDEVICE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HSYNTHETICPOINTERDEVICE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HTHEME(pub isize);
 impl HTHEME {
     pub fn is_invalid(&self) -> bool {
@@ -12693,37 +12638,15 @@ impl Default for HTHEME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HTHEME {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HTHEME {}
-impl core::fmt::Debug for HTHEME {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HTHEME").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HTHEME {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HTREEITEM(pub isize);
 impl Default for HTREEITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HTREEITEM {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HTREEITEM {}
-impl core::fmt::Debug for HTREEITEM {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HTREEITEM").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HTREEITEM {

--- a/crates/libs/windows/src/Windows/Win32/UI/HiDpi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/HiDpi/mod.rs
@@ -375,7 +375,7 @@ impl core::fmt::Debug for PROCESS_DPI_AWARENESS {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DPI_AWARENESS_CONTEXT(pub isize);
 impl DPI_AWARENESS_CONTEXT {
     pub fn is_invalid(&self) -> bool {
@@ -385,17 +385,6 @@ impl DPI_AWARENESS_CONTEXT {
 impl Default for DPI_AWARENESS_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for DPI_AWARENESS_CONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for DPI_AWARENESS_CONTEXT {}
-impl core::fmt::Debug for DPI_AWARENESS_CONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("DPI_AWARENESS_CONTEXT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for DPI_AWARENESS_CONTEXT {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
@@ -761,7 +761,7 @@ impl Default for GESTURENOTIFYSTRUCT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HGESTUREINFO(pub isize);
 impl HGESTUREINFO {
     pub fn is_invalid(&self) -> bool {
@@ -773,22 +773,11 @@ impl Default for HGESTUREINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HGESTUREINFO {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HGESTUREINFO {}
-impl core::fmt::Debug for HGESTUREINFO {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HGESTUREINFO").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HGESTUREINFO {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HTOUCHINPUT(pub isize);
 impl HTOUCHINPUT {
     pub fn is_invalid(&self) -> bool {
@@ -798,17 +787,6 @@ impl HTOUCHINPUT {
 impl Default for HTOUCHINPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HTOUCHINPUT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HTOUCHINPUT {}
-impl core::fmt::Debug for HTOUCHINPUT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HTOUCHINPUT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HTOUCHINPUT {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/mod.rs
@@ -215,7 +215,7 @@ impl core::fmt::Debug for RID_DEVICE_INFO_TYPE {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRAWINPUT(pub isize);
 impl HRAWINPUT {
     pub fn is_invalid(&self) -> bool {
@@ -225,17 +225,6 @@ impl HRAWINPUT {
 impl Default for HRAWINPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HRAWINPUT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRAWINPUT {}
-impl core::fmt::Debug for HRAWINPUT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRAWINPUT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HRAWINPUT {

--- a/crates/libs/windows/src/Windows/Win32/UI/InteractionContext/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/InteractionContext/mod.rs
@@ -612,7 +612,7 @@ impl Default for CROSS_SLIDE_PARAMETER {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HINTERACTIONCONTEXT(pub isize);
 impl HINTERACTIONCONTEXT {
     pub fn is_invalid(&self) -> bool {
@@ -622,17 +622,6 @@ impl HINTERACTIONCONTEXT {
 impl Default for HINTERACTIONCONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HINTERACTIONCONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HINTERACTIONCONTEXT {}
-impl core::fmt::Debug for HINTERACTIONCONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HINTERACTIONCONTEXT").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HINTERACTIONCONTEXT {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
@@ -2413,22 +2413,11 @@ impl core::fmt::Debug for _PERSIST_SPROPSTORE_FLAGS {
 pub const InMemoryPropertyStore: windows_core::GUID = windows_core::GUID::from_u128(0x9a02e012_6303_4e1e_b9a1_630f802592c5);
 pub const InMemoryPropertyStoreMarshalByValue: windows_core::GUID = windows_core::GUID::from_u128(0xd4ca0e2d_6da7_4b75_a97c_5f306f0eaedc);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PCUSERIALIZEDPROPSTORAGE(pub isize);
 impl Default for PCUSERIALIZEDPROPSTORAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PCUSERIALIZEDPROPSTORAGE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PCUSERIALIZEDPROPSTORAGE {}
-impl core::fmt::Debug for PCUSERIALIZEDPROPSTORAGE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PCUSERIALIZEDPROPSTORAGE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PCUSERIALIZEDPROPSTORAGE {
@@ -2495,22 +2484,11 @@ impl Default for PROPPRG {
 }
 pub const PropertySystem: windows_core::GUID = windows_core::GUID::from_u128(0xb8967f85_58ae_4f46_9fb2_5d7904798f4b);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SERIALIZEDPROPSTORAGE(pub isize);
 impl Default for SERIALIZEDPROPSTORAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for SERIALIZEDPROPSTORAGE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for SERIALIZEDPROPSTORAGE {}
-impl core::fmt::Debug for SERIALIZEDPROPSTORAGE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("SERIALIZEDPROPSTORAGE").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for SERIALIZEDPROPSTORAGE {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
@@ -35500,7 +35500,7 @@ pub const FrameworkInputPane: windows_core::GUID = windows_core::GUID::from_u128
 pub const FreeSpaceCategorizer: windows_core::GUID = windows_core::GUID::from_u128(0xb5607793_24ac_44c7_82e2_831726aa6cb7);
 pub const GenericCredentialProvider: windows_core::GUID = windows_core::GUID::from_u128(0x25cbb996_92ed_457e_b28c_4774084bd562);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDROP(pub isize);
 impl HDROP {
     pub fn is_invalid(&self) -> bool {
@@ -35510,17 +35510,6 @@ impl HDROP {
 impl Default for HDROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HDROP {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDROP {}
-impl core::fmt::Debug for HDROP {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDROP").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HDROP {
@@ -35724,7 +35713,7 @@ impl Default for HLTBINFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HPSXA(pub isize);
 impl HPSXA {
     pub fn is_invalid(&self) -> bool {
@@ -35734,17 +35723,6 @@ impl HPSXA {
 impl Default for HPSXA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HPSXA {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HPSXA {}
-impl core::fmt::Debug for HPSXA {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HPSXA").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HPSXA {
@@ -36639,44 +36617,22 @@ pub const OnexCredentialProvider: windows_core::GUID = windows_core::GUID::from_
 pub const OnexPlapSmartcardCredentialProvider: windows_core::GUID = windows_core::GUID::from_u128(0x33c86cd6_705f_4ba1_9adb_67070b837775);
 pub const OpenControlPanel: windows_core::GUID = windows_core::GUID::from_u128(0x06622d85_6856_4460_8de1_a81921b41c4b);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PAPPCONSTRAIN_REGISTRATION(pub isize);
 impl Default for PAPPCONSTRAIN_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for PAPPCONSTRAIN_REGISTRATION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PAPPCONSTRAIN_REGISTRATION {}
-impl core::fmt::Debug for PAPPCONSTRAIN_REGISTRATION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PAPPCONSTRAIN_REGISTRATION").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for PAPPCONSTRAIN_REGISTRATION {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PAPPSTATE_REGISTRATION(pub isize);
 impl Default for PAPPSTATE_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for PAPPSTATE_REGISTRATION {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for PAPPSTATE_REGISTRATION {}
-impl core::fmt::Debug for PAPPSTATE_REGISTRATION {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PAPPSTATE_REGISTRATION").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for PAPPSTATE_REGISTRATION {

--- a/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
@@ -8556,7 +8556,7 @@ impl Default for GESTURE_DATA {
 }
 pub const GestureRecognizer: windows_core::GUID = windows_core::GUID::from_u128(0xea30c654_c62c_441f_ac00_95f9a196782c);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRECOALT(pub isize);
 impl HRECOALT {
     pub fn is_invalid(&self) -> bool {
@@ -8568,22 +8568,11 @@ impl Default for HRECOALT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HRECOALT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRECOALT {}
-impl core::fmt::Debug for HRECOALT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRECOALT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HRECOALT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRECOCONTEXT(pub isize);
 impl HRECOCONTEXT {
     pub fn is_invalid(&self) -> bool {
@@ -8595,22 +8584,11 @@ impl Default for HRECOCONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HRECOCONTEXT {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRECOCONTEXT {}
-impl core::fmt::Debug for HRECOCONTEXT {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRECOCONTEXT").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HRECOCONTEXT {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRECOGNIZER(pub isize);
 impl HRECOGNIZER {
     pub fn is_invalid(&self) -> bool {
@@ -8622,22 +8600,11 @@ impl Default for HRECOGNIZER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HRECOGNIZER {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRECOGNIZER {}
-impl core::fmt::Debug for HRECOGNIZER {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRECOGNIZER").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HRECOGNIZER {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRECOLATTICE(pub isize);
 impl HRECOLATTICE {
     pub fn is_invalid(&self) -> bool {
@@ -8649,22 +8616,11 @@ impl Default for HRECOLATTICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HRECOLATTICE {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRECOLATTICE {}
-impl core::fmt::Debug for HRECOLATTICE {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRECOLATTICE").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HRECOLATTICE {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRECOWORDLIST(pub isize);
 impl HRECOWORDLIST {
     pub fn is_invalid(&self) -> bool {
@@ -8674,17 +8630,6 @@ impl HRECOWORDLIST {
 impl Default for HRECOWORDLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HRECOWORDLIST {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HRECOWORDLIST {}
-impl core::fmt::Debug for HRECOWORDLIST {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HRECOWORDLIST").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HRECOWORDLIST {

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
@@ -6794,7 +6794,7 @@ pub const AccServerDocMgr: windows_core::GUID = windows_core::GUID::from_u128(0x
 pub const AccStore: windows_core::GUID = windows_core::GUID::from_u128(0x5440837f_4bff_4ae5_a1b1_7722ecc6332a);
 pub const DocWrap: windows_core::GUID = windows_core::GUID::from_u128(0xbf426f7e_7a5e_44d6_830c_a390ea9462a3);
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HKL(pub isize);
 impl HKL {
     pub fn is_invalid(&self) -> bool {
@@ -6804,17 +6804,6 @@ impl HKL {
 impl Default for HKL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HKL {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HKL {}
-impl core::fmt::Debug for HKL {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HKL").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HKL {

--- a/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -8805,7 +8805,7 @@ impl Default for GUITHREADINFO {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HACCEL(pub isize);
 impl HACCEL {
     pub fn is_invalid(&self) -> bool {
@@ -8822,17 +8822,6 @@ impl windows_core::Free for HACCEL {
 impl Default for HACCEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HACCEL {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HACCEL {}
-impl core::fmt::Debug for HACCEL {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HACCEL").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HACCEL {
@@ -8871,7 +8860,7 @@ impl Default for HARDWAREHOOKSTRUCT {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HCURSOR(pub isize);
 impl HCURSOR {
     pub fn is_invalid(&self) -> bool {
@@ -8890,17 +8879,6 @@ impl Default for HCURSOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HCURSOR {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HCURSOR {}
-impl core::fmt::Debug for HCURSOR {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HCURSOR").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HCURSOR {
     type TypeKind = windows_core::CopyType;
 }
@@ -8911,7 +8889,7 @@ impl From<HCURSOR> for HICON {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDEVNOTIFY(pub *mut core::ffi::c_void);
 impl HDEVNOTIFY {
     pub fn is_invalid(&self) -> bool {
@@ -8930,22 +8908,11 @@ impl Default for HDEVNOTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDEVNOTIFY {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDEVNOTIFY {}
-impl core::fmt::Debug for HDEVNOTIFY {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDEVNOTIFY").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDEVNOTIFY {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HDWP(pub isize);
 impl HDWP {
     pub fn is_invalid(&self) -> bool {
@@ -8957,22 +8924,11 @@ impl Default for HDWP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HDWP {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HDWP {}
-impl core::fmt::Debug for HDWP {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HDWP").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HDWP {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HHOOK(pub isize);
 impl HHOOK {
     pub fn is_invalid(&self) -> bool {
@@ -8991,22 +8947,11 @@ impl Default for HHOOK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HHOOK {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HHOOK {}
-impl core::fmt::Debug for HHOOK {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HHOOK").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HHOOK {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HICON(pub isize);
 impl HICON {
     pub fn is_invalid(&self) -> bool {
@@ -9025,22 +8970,11 @@ impl Default for HICON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl Clone for HICON {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HICON {}
-impl core::fmt::Debug for HICON {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HICON").field(&self.0).finish()
-    }
-}
 impl windows_core::TypeKind for HICON {
     type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HMENU(pub isize);
 impl HMENU {
     pub fn is_invalid(&self) -> bool {
@@ -9057,17 +8991,6 @@ impl windows_core::Free for HMENU {
 impl Default for HMENU {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
-    }
-}
-impl Clone for HMENU {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for HMENU {}
-impl core::fmt::Debug for HMENU {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("HMENU").field(&self.0).finish()
     }
 }
 impl windows_core::TypeKind for HMENU {

--- a/crates/tests/standalone/src/b_guid.rs
+++ b/crates/tests/standalone/src/b_guid.rs
@@ -7,17 +7,12 @@
 )]
 windows_targets::link!("ole32.dll" "system" fn CoCreateGuid(pguid : *mut GUID) -> HRESULT);
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/tests/standalone/src/b_nested.rs
+++ b/crates/tests/standalone/src/b_nested.rs
@@ -111,17 +111,12 @@ impl Clone for FILETIME {
     }
 }
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/tests/standalone/src/b_test.rs
+++ b/crates/tests/standalone/src/b_test.rs
@@ -15,17 +15,12 @@ pub type BOOL = i32;
 pub type CLSCTX = u32;
 pub const CLSCTX_ALL: CLSCTX = 23u32;
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/tests/standalone/src/b_variant.rs
+++ b/crates/tests/standalone/src/b_variant.rs
@@ -191,17 +191,12 @@ impl Clone for FUNCDESC {
 pub type FUNCFLAGS = u16;
 pub type FUNCKIND = i32;
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/tests/standalone/src/b_vtbl_0.rs
+++ b/crates/tests/standalone/src/b_vtbl_0.rs
@@ -6,17 +6,12 @@
     clippy::all
 )]
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/tests/standalone/src/b_vtbl_1.rs
+++ b/crates/tests/standalone/src/b_vtbl_1.rs
@@ -191,17 +191,12 @@ impl Clone for FUNCDESC {
 pub type FUNCFLAGS = u16;
 pub type FUNCKIND = i32;
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/tests/standalone/src/b_vtbl_2.rs
+++ b/crates/tests/standalone/src/b_vtbl_2.rs
@@ -6,17 +6,12 @@
     clippy::all
 )]
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/tests/standalone/src/b_vtbl_3.rs
+++ b/crates/tests/standalone/src/b_vtbl_3.rs
@@ -6,17 +6,12 @@
     clippy::all
 )]
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {

--- a/crates/tests/standalone/src/b_vtbl_4.rs
+++ b/crates/tests/standalone/src/b_vtbl_4.rs
@@ -7,17 +7,12 @@
 )]
 pub type BOOL = i32;
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct GUID {
     pub data1: u32,
     pub data2: u16,
     pub data3: u16,
     pub data4: [u8; 8],
-}
-impl Copy for GUID {}
-impl Clone for GUID {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 impl GUID {
     pub const fn from_u128(uuid: u128) -> Self {


### PR DESCRIPTION
This just reduces code gen and improves readability. 