### PR TITLE
Fix for Clippy `HSTRING` interior mutability warnings in nightly

### DIFF
--- a/crates/libs/core/src/strings/literals.rs
+++ b/crates/libs/core/src/strings/literals.rs
@@ -41,6 +41,7 @@ macro_rules! h {
     ($s:literal) => {{
         const INPUT: &[u8] = $s.as_bytes();
         const OUTPUT_LEN: usize = $crate::utf16_len(INPUT) + 1;
+        #[allow(clippy::declare_interior_mutable_const)]
         const RESULT: $crate::HSTRING = {
             if OUTPUT_LEN == 1 {
                 unsafe { ::std::mem::transmute(::std::ptr::null::<u16>()) }
@@ -51,6 +52,7 @@ macro_rules! h {
                 unsafe { ::std::mem::transmute::<&$crate::HSTRING_HEADER, $crate::HSTRING>(&HEADER) }
             }
         };
+        #[allow(clippy::borrow_interior_mutable_const)]
         &RESULT
     }};
 }


### PR DESCRIPTION
Fixes: #3020. 

Disables interior mutability lints on the HSTRING macro due to a false positive.

More information:
* https://rust-lang.github.io/rust-clippy/master/index.html#/declare_interior_mutable_const
* https://rust-lang.github.io/rust-clippy/master/index.html#/borrow_interior_mutable_const