### PR TITLE
Simplify derefencing `Ref` interface parameters

### DIFF
--- a/crates/libs/core/src/ref.rs
+++ b/crates/libs/core/src/ref.rs
@@ -4,6 +4,17 @@ use super::*;
 #[repr(transparent)]
 pub struct Ref<'a, T: Type<T>>(T::Abi, std::marker::PhantomData<&'a T>);
 
+impl<'a, T: Type<T, Default = Option<T>, Abi = *mut std::ffi::c_void>> Ref<'a, T> {
+    /// Converts the argument to a [Result<&T>] reference.
+    pub fn ok(&self) -> Result<&T> {
+        if self.0.is_null() {
+            Err(Error::from_hresult(imp::E_POINTER))
+        } else {
+            unsafe { Ok(std::mem::transmute::<&*mut std::ffi::c_void, &T>(&self.0)) }
+        }
+    }
+}
+
 impl<'a, T: Type<T>> std::ops::Deref for Ref<'a, T> {
     type Target = T::Default;
     fn deref(&self) -> &Self::Target {

--- a/crates/tests/interface_core/tests/ref_ok.rs
+++ b/crates/tests/interface_core/tests/ref_ok.rs
@@ -1,0 +1,46 @@
+#![allow(non_snake_case)]
+
+use windows_core::*;
+
+#[interface("09428a59-5b40-4e4c-9175-e7a78514316d")]
+unsafe trait ITest: IUnknown {
+    unsafe fn Test(&self, result: &mut i32) -> Result<()>;
+    unsafe fn TestOther(&self, other: Ref<ITest>, result: &mut i32) -> Result<()>;
+}
+
+#[implement(ITest)]
+struct Test(i32);
+
+impl ITest_Impl for Test {
+    unsafe fn Test(&self, result: &mut i32) -> Result<()> {
+        *result = self.0;
+        Ok(())
+    }
+    unsafe fn TestOther(&self, other: Ref<ITest>, result: &mut i32) -> Result<()> {
+        other.ok()?.Test(result)
+    }
+}
+
+#[test]
+fn test() -> Result<()> {
+    unsafe {
+        let a: ITest = Test(123).into();
+        let b: ITest = Test(456).into();
+
+        let mut result = 0;
+
+        a.Test(&mut result)?;
+        assert_eq!(result, 123);
+
+        b.Test(&mut result)?;
+        assert_eq!(result, 456);
+
+        b.TestOther(&a, &mut result)?;
+        assert_eq!(result, 123);
+
+        a.TestOther(&b, &mut result)?;
+        assert_eq!(result, 456);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Building on #3025, this adds a simpler way to deal with nullable input parameters that are required but without forcing an expensive reference count bump. Here's an example of the new `ok` method:

```Rust
#![allow(non_snake_case)]
use windows_core::*;

#[interface("09428a59-5b40-4e4c-9175-e7a78514316d")]
unsafe trait ITest: IUnknown {
    unsafe fn Print(&self) -> Result<()>;
    unsafe fn PrintOther(&self, other: Ref<ITest>) -> Result<()>;
}

#[implement(ITest)]
struct Test;

impl ITest_Impl for Test {
    unsafe fn Print(&self) -> Result<()> {
        println!("Test");
        Ok(())
    }
    unsafe fn PrintOther(&self, other: Ref<ITest>) -> Result<()> {
        other.ok()?.Print()
     // ^^^^^^^^^^^^^^^^^^^
    }
}

fn main() -> Result<()> {
    unsafe {
        let test: ITest = Test.into();
        test.Print()?;
        test.PrintOther(&test)?;
        Ok(())
    }
}
```

The `ok` method simplifies what would otherwise require something like this:

```Rust
other.as_ref().ok_or(Error::from(E_POINTER))?.Print()
```