### PR TITLE
Simplify `windows-registry` readme

### DIFF
--- a/crates/libs/registry/readme.md
+++ b/crates/libs/registry/readme.md
@@ -19,7 +19,7 @@ Read and write registry keys and values as needed:
 use windows_registry::*;
 
 fn main() -> Result<()> {
-    let key = CURRENT_USER.create(r#"software\\windows-rs"#)?;
+    let key = CURRENT_USER.create("software\\windows-rs")?;
 
     key.set_u32("number", 123)?;
     key.set_string("name", "Rust")?;


### PR DESCRIPTION
We don't need the raw string literal for this simple example. 