### PR TITLE
Re-enable `unexpected_cfgs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ exclude = [
 rust_2018_idioms = "warn"
 unused_qualifications = "warn"
 missing_docs = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows_debugger_visualizer)'] }

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -3,7 +3,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 */
 
 #![doc(html_no_source)]
-#![allow(non_snake_case, unexpected_cfgs)]
+#![allow(non_snake_case)]
 #![cfg_attr(windows_debugger_visualizer, debugger_visualizer(natvis_file = "../.natvis"))]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 

--- a/crates/libs/result/src/lib.rs
+++ b/crates/libs/result/src/lib.rs
@@ -2,7 +2,6 @@
 Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs>
 */
 
-#![allow(unexpected_cfgs)]
 #![cfg_attr(
     windows_debugger_visualizer,
     debugger_visualizer(natvis_file = "../.natvis")

--- a/crates/libs/targets/src/lib.rs
+++ b/crates/libs/targets/src/lib.rs
@@ -3,7 +3,6 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 */
 
 #![no_std]
-#![allow(unexpected_cfgs)]
 
 /// Defines an external function to import.
 #[cfg(all(windows_raw_dylib, target_arch = "x86"))]

--- a/crates/tests/calling_convention/tests/sys.rs
+++ b/crates/tests/calling_convention/tests/sys.rs
@@ -1,5 +1,3 @@
-#![allow(unexpected_cfgs)]
-
 use windows_sys::{
     core::*, Win32::Foundation::*, Win32::Networking::Ldap::*, Win32::System::SystemInformation::*,
     Win32::UI::WindowsAndMessaging::*,

--- a/crates/tests/calling_convention/tests/win.rs
+++ b/crates/tests/calling_convention/tests/win.rs
@@ -1,5 +1,3 @@
-#![allow(unexpected_cfgs)]
-
 use windows::{
     Win32::Foundation::*, Win32::Networking::Ldap::*, Win32::System::SystemInformation::*,
 };

--- a/crates/tests/debugger_visualizer/tests/test.rs
+++ b/crates/tests/debugger_visualizer/tests/test.rs
@@ -1,4 +1,3 @@
-#![allow(unexpected_cfgs)]
 #![cfg(windows_debugger_visualizer)]
 
 use debugger_test::*;


### PR DESCRIPTION
This is an attempt to re-enable `unexpected_cfgs` using the new `unexpected_cfgs` config in `Cargo.toml`. This avoids the need for a build script while still checking for typos in global cfgs.