### PR TITLE
Fix soundness hole in ComObject

### DIFF
--- a/crates/libs/core/src/unknown.rs
+++ b/crates/libs/core/src/unknown.rs
@@ -68,9 +68,6 @@ pub trait IUnknownImpl {
     /// The contained user type, e.g. `MyApp`. Also known as the "inner" type.
     type Impl;
 
-    /// Initializes a new heap box and returns it.
-    fn new_box(value: Self::Impl) -> Box<Self>;
-
     /// Get a reference to the backing implementation.
     fn get_impl(&self) -> &Self::Impl;
 


### PR DESCRIPTION
This fixes a soundness hole in `ComObject`. The soundness hole is that we should never allow safe Rust code to hold an _owned_ instance of `MyApp_Impl` objects (implementations of COM objects) because those objects contain reference counts and provide safely-callable methods that adjust those reference counts.  If Rust code holds an owned instance of such a type, then we don't control its lifetime; it may be placed on the stack, in a `static`, etc. and we have no control over that.

This PR closes the soundness hole by providing only one way to get access to any `MyApp_Impl` type -- these types are immediately placed into a heap allocation and the only way to access them is through a `ComObject` reference.

A few other minor improvements:

* `ComObject::as_reference()` and friends now work with `IInspectable`.
* Switched vtable pointers to use `&'static` instead of `*const`.
* Move vtable initializers directly into the function which uses them, so symbol names don't "leak" outward.
* Converted some existing `From` implementations to use safe `ComObject` code.
