### PR TITLE
Switch to `windows-2022` hosted runners

### DIFF
--- a/.github/actions/fix-environment/action.yml
+++ b/.github/actions/fix-environment/action.yml
@@ -54,7 +54,7 @@ runs:
     # 1. Old mingw-w64-* binutils that prevent deterministic builds.
     # 2. Missing llvm-dlltool in the native Windows LLVM package.
     - name: Update packages
-      shell: pwsh
+      shell: bash
       run: |
         pacman -S --noconfirm mingw-w64-x86_64-binutils
         pacman -S --noconfirm mingw-w64-x86_64-llvm

--- a/.github/actions/fix-environment/action.yml
+++ b/.github/actions/fix-environment/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Configure environment
       shell: pwsh
       run: |
-        $vs_root = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `
+        $vs_root = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
           -latest -property installationPath -format value
 
         switch -Wildcard ("${{ matrix.target }}")
@@ -29,19 +29,19 @@ runs:
           }
           "i686*"
           {
-            "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86" >> $env:GITHUB_PATH
+            "${env:ProgramFiles(x86)}\Windows Kits\10\bin\10.0.22000.0\x86" >> $env:GITHUB_PATH
             ((Resolve-Path "$vs_root\VC\Tools\MSVC\*\bin\Hostx86\x86")
               | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
           }
           "x86_64*"
           {
-            "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
+            "${env:ProgramFiles(x86)}\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
             ((Resolve-Path "$vs_root\VC\Tools\MSVC\*\bin\Hostx64\x64")
               | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
           }
           "aarch64*"
           {
-            "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
+            "${env:ProgramFiles(x86)}\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
             ((Resolve-Path "$vs_root\VC\Tools\MSVC\*\bin\Hostx64\x64")
               | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
           }
@@ -49,7 +49,7 @@ runs:
           {
             (Join-Path $env:GITHUB_WORKSPACE "target\debug\deps").ToString() >> $env:GITHUB_PATH
             (Join-Path $env:GITHUB_WORKSPACE "target\test\debug\deps").ToString() >> $env:GITHUB_PATH
-            "INCLUDE=C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
+            "INCLUDE=${env:ProgramFiles(x86)}\Windows Kits\10\include\10.0.22000.0\winrt;${env:ProgramFiles(x86)}\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
               >> $env:GITHUB_ENV
           }
         }

--- a/.github/actions/fix-environment/action.yml
+++ b/.github/actions/fix-environment/action.yml
@@ -54,7 +54,7 @@ runs:
     # 1. Old mingw-w64-* binutils that prevent deterministic builds.
     # 2. Missing llvm-dlltool in the native Windows LLVM package.
     - name: Update packages
-      shell: bash
+      shell: pwsh
       run: |
-        pacman -S --noconfirm mingw-w64-x86_64-binutils
-        pacman -S --noconfirm mingw-w64-x86_64-llvm
+        C:\msys64\usr\bin\pacman.exe -S --noconfirm mingw-w64-x86_64-binutils
+        C:\msys64\usr\bin\pacman.exe -S --noconfirm mingw-w64-x86_64-llvm

--- a/.github/actions/fix-environment/action.yml
+++ b/.github/actions/fix-environment/action.yml
@@ -3,14 +3,6 @@ description: GitHub VMs aren't configured correctly
 runs:
   using: "composite"
   steps:
-    # Workaround to address two issues with windows-2022 runners:
-    # 1. Old mingw-w64-* binutils that prevent deterministic builds.
-    # 2. Missing llvm-dlltool in the native Windows LLVM package.
-    - name: Update packages
-      shell: pwsh
-      run: |
-        pacman -S --noconfirm mingw-w64-x86_64-binutils
-        pacman -S --noconfirm mingw-w64-x86_64-llvm
     - name: Configure Cargo for GNU
       shell: pwsh
       run: |
@@ -58,3 +50,11 @@ runs:
               >> $env:GITHUB_ENV
           }
         }
+    # Workaround to address two issues with windows-2022 runners:
+    # 1. Old mingw-w64-* binutils that prevent deterministic builds.
+    # 2. Missing llvm-dlltool in the native Windows LLVM package.
+    - name: Update packages
+      shell: pwsh
+      run: |
+        pacman -S --noconfirm mingw-w64-x86_64-binutils
+        pacman -S --noconfirm mingw-w64-x86_64-llvm

--- a/.github/actions/fix-environment/action.yml
+++ b/.github/actions/fix-environment/action.yml
@@ -3,6 +3,14 @@ description: GitHub VMs aren't configured correctly
 runs:
   using: "composite"
   steps:
+    # Workaround to address two issues with windows-2022 runners:
+    # 1. Old mingw-w64-* binutils that prevent deterministic builds.
+    # 2. Missing llvm-dlltool in the native Windows LLVM package.
+    - name: Update packages
+      shell: pwsh
+      run: |
+        pacman -S --noconfirm mingw-w64-x86_64-binutils
+        pacman -S --noconfirm mingw-w64-x86_64-llvm
     - name: Configure Cargo for GNU
       shell: pwsh
       run: |

--- a/.github/actions/fix-environment/action.yml
+++ b/.github/actions/fix-environment/action.yml
@@ -27,19 +27,19 @@ runs:
           "i686*"
           {
             "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86" >> $env:GITHUB_PATH
-            ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx86\x86")
+            ((Resolve-Path "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\*\bin\Hostx86\x86")
               | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
           }
           "x86_64*"
           {
             "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
-            ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
+            ((Resolve-Path "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
               | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
           }
           "aarch64*"
           {
             "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
-            ((Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
+            ((Resolve-Path "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
               | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
           }
           "*"

--- a/.github/actions/fix-environment/action.yml
+++ b/.github/actions/fix-environment/action.yml
@@ -50,11 +50,14 @@ runs:
               >> $env:GITHUB_ENV
           }
         }
-    # Workaround to address two issues with windows-2022 runners:
-    # 1. Old mingw-w64-* binutils that prevent deterministic builds.
-    # 2. Missing llvm-dlltool in the native Windows LLVM package.
+    # Workaround to address several issues with windows-2022 runners:
+    # - Old mingw-w64-* binutils that prevent deterministic builds.
+    # - Missing llvm-dlltool in the native Windows LLVM package.
+    # - Missing mingw-w64 compiler packages.
     - name: Update packages
       shell: pwsh
       run: |
         C:\msys64\usr\bin\pacman.exe -S --noconfirm mingw-w64-x86_64-binutils
         C:\msys64\usr\bin\pacman.exe -S --noconfirm mingw-w64-x86_64-llvm
+        C:\msys64\usr\bin\pacman.exe -S --noconfirm mingw-w64-i686-gcc
+        C:\msys64\usr\bin\pacman.exe -S --noconfirm mingw-w64-x86_64-gcc

--- a/.github/actions/fix-environment/action.yml
+++ b/.github/actions/fix-environment/action.yml
@@ -18,6 +18,9 @@ runs:
     - name: Configure environment
       shell: pwsh
       run: |
+        $vs_root = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `
+          -latest -property installationPath -format value
+
         switch -Wildcard ("${{ matrix.target }}")
         {
           "*-pc-windows-gnu"
@@ -27,19 +30,19 @@ runs:
           "i686*"
           {
             "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86" >> $env:GITHUB_PATH
-            ((Resolve-Path "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\*\bin\Hostx86\x86")
+            ((Resolve-Path "$vs_root\VC\Tools\MSVC\*\bin\Hostx86\x86")
               | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
           }
           "x86_64*"
           {
             "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
-            ((Resolve-Path "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
+            ((Resolve-Path "$vs_root\VC\Tools\MSVC\*\bin\Hostx64\x64")
               | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
           }
           "aarch64*"
           {
             "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64" >> $env:GITHUB_PATH
-            ((Resolve-Path "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
+            ((Resolve-Path "$vs_root\VC\Tools\MSVC\*\bin\Hostx64\x64")
               | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
           }
           "*"

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       matrix:

--- a/.github/workflows/debugger_visualizer.yml
+++ b/.github/workflows/debugger_visualizer.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       matrix:

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           $path = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `
             -latest -property installationPath -format value
-          Write-Output "install_path=$path" >> $env::GITHUB_OUTPUT
+          "install_path=$path" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Build i686_msvc
         shell: cmd

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -31,7 +31,7 @@ jobs:
         id: visual-studio
         shell: pwsh
         run: |
-          $path = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `
+          $path = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
             -latest -property installationPath -format value
           "install_path=$path" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -30,19 +30,19 @@ jobs:
       - name: Build i686_msvc
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat" x86
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat" x86
           cargo run -p tool_msvc
 
       - name: Build x86_64_msvc
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat" amd64
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat" amd64
           cargo run -p tool_msvc
 
       - name: Build aarch64_msvc
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat" amd64_arm64
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat" amd64_arm64
           cargo run -p tool_msvc
 
       - name: Upload libs

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -27,22 +27,30 @@ jobs:
           set PATH=C:\msys64\mingw64\bin;%PATH%
           cargo run -p tool_gnu -- all
 
+      - name: Find Visual Studio
+        id: visual-studio
+        shell: pwsh
+        run: |
+          $path = & 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' `
+            -latest -property installationPath -format value
+          Write-Output "install_path=$path" >> $env::GITHUB_OUTPUT
+
       - name: Build i686_msvc
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat" x86
+          call "${{steps.visual-studio.outputs.install_path}}\VC\Auxiliary\Build\vcvars32.bat" x86
           cargo run -p tool_msvc
 
       - name: Build x86_64_msvc
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat" amd64
+          call "${{steps.visual-studio.outputs.install_path}}\VC\Auxiliary\Build\vcvars32.bat" amd64
           cargo run -p tool_msvc
 
       - name: Build aarch64_msvc
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat" amd64_arm64
+          call "${{steps.visual-studio.outputs.install_path}}\VC\Auxiliary\Build\vcvars32.bat" amd64_arm64
           cargo run -p tool_msvc
 
       - name: Upload libs
@@ -60,7 +68,7 @@ jobs:
       - name: Check dumpbin
         shell: pwsh
         run: |
-          $VisualStudioRoot = & vswhere -latest -property installationPath -format value
+          $VisualStudioRoot = "${{steps.visual-studio.outputs.install_path}}"
           $DumpbinPath = Resolve-Path "$VisualStudioRoot\VC\Tools\MSVC\*\bin\*\x86\dumpbin.exe" |
             Select -ExpandProperty Path -First 1
           $Tests = @(

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/msrv-windows.yml
+++ b/.github/workflows/msrv-windows.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         rust: [1.70.0, stable, nightly]
         runs-on:
-          - windows-2019
+          - windows-2022
           - ubuntu-latest
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/.github/workflows/no-default-features.yml
+++ b/.github/workflows/no-default-features.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       matrix:

--- a/.github/workflows/raw_dylib.yml
+++ b/.github/workflows/raw_dylib.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       matrix:

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -22,7 +22,7 @@ env:
 
 jobs:
   check:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       matrix:
@@ -119,7 +119,7 @@ env:
 
 jobs:
   check:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       matrix:
@@ -171,7 +171,7 @@ env:
 
 jobs:
   check:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       matrix:


### PR DESCRIPTION
In an attempt to fix #3054 build issues, I'm testing whether we can switch to the latest GitHub runners so that we can build with VS 2022 rather than 2019. 

I expect action.yml will also need to be "fixed" as it has some hardcoded paths. 