### PR TITLE
Fix Debug impls for COM interfaces

### DIFF
--- a/crates/libs/core/src/imp/mod.rs
+++ b/crates/libs/core/src/imp/mod.rs
@@ -77,21 +77,31 @@ pub use required_hierarchy;
 macro_rules! define_interface {
     ($name:ident, $vtbl:ident, $iid:literal) => {
         #[repr(transparent)]
-        #[derive(::core::cmp::PartialEq, ::core::cmp::Eq, ::core::fmt::Debug, ::core::clone::Clone)]
+        #[derive(::core::cmp::PartialEq, ::core::cmp::Eq, ::core::clone::Clone)]
         pub struct $name(::windows_core::IUnknown);
         unsafe impl ::windows_core::Interface for $name {
             type Vtable = $vtbl;
             const IID: ::windows_core::GUID = ::windows_core::GUID::from_u128($iid);
         }
+        impl ::core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.debug_tuple(stringify!($name)).field(&::windows_core::Interface::as_raw(self)).finish()
+            }
+        }
     };
     ($name:ident, $vtbl:ident) => {
         #[repr(transparent)]
-        #[derive(::core::cmp::PartialEq, ::core::cmp::Eq, ::core::fmt::Debug, ::core::clone::Clone)]
+        #[derive(::core::cmp::PartialEq, ::core::cmp::Eq, ::core::clone::Clone)]
         pub struct $name(::std::ptr::NonNull<::std::ffi::c_void>);
         unsafe impl ::windows_core::Interface for $name {
             type Vtable = $vtbl;
             const IID: ::windows_core::GUID = ::windows_core::GUID::zeroed();
             const UNKNOWN: bool = false;
+        }
+        impl ::core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.debug_tuple(stringify!($name)).field(&self.0).finish()
+            }
         }
     };
 }

--- a/crates/libs/core/src/unknown.rs
+++ b/crates/libs/core/src/unknown.rs
@@ -55,7 +55,7 @@ impl Eq for IUnknown {}
 
 impl core::fmt::Debug for IUnknown {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("IUnknown").field(&self.0).finish()
+        f.debug_tuple("IUnknown").field(&self.as_raw()).finish()
     }
 }
 

--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -361,7 +361,7 @@ impl Interface {
             impl ::core::cmp::Eq for #name {}
             impl ::core::fmt::Debug for #name {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.debug_tuple(#name_string).field(&self.as_raw()).finish()
+                    f.debug_tuple(#name_string).field(&::windows_core::Interface::as_raw(self)).finish()
                 }
             }
         }

--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -361,7 +361,7 @@ impl Interface {
             impl ::core::cmp::Eq for #name {}
             impl ::core::fmt::Debug for #name {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    f.debug_tuple(#name_string).field(&self.0).finish()
+                    f.debug_tuple(#name_string).field(&self.as_raw()).finish()
                 }
             }
         }

--- a/crates/tests/agile_reference/tests/tests.rs
+++ b/crates/tests/agile_reference/tests/tests.rs
@@ -20,6 +20,6 @@ fn agile_debug() -> Result<()> {
     assert!(format!("{uri:?}").starts_with("Uri(IUnknown(0x"));
 
     let reference = AgileReference::new(&uri)?;
-    assert!(format!("{reference:?}").starts_with("AgileReference(IAgileReference(IUnknown(0x"));
+    assert!(format!("{reference:?}").starts_with("AgileReference(IAgileReference(0x"));
     Ok(())
 }

--- a/crates/tests/implement_core/src/com_object.rs
+++ b/crates/tests/implement_core/src/com_object.rs
@@ -416,6 +416,15 @@ fn common_method_name() {
     assert_eq!(unsafe { ibar2.common() }, std::f32::consts::PI);
 }
 
+#[test]
+fn debug_fmt() {
+    let app = MyApp::new(42);
+    let iunknown: IUnknown = app.to_interface();
+    println!("IUnknown = {iunknown:?}");
+    let ifoo: IFoo = app.to_interface();
+    println!("IFoo = {ifoo:?}");
+}
+
 // This tests that we can place a type that is not Send in a ComObject.
 // Compilation is sufficient to test.
 #[implement(IBar)]


### PR DESCRIPTION
Currently, the Debug impl for COM interfaces shows the recursive interface chain, like so:

```
IDWriteFontFace5(IDWriteFontFace4(IDWriteFontFace3(IDWriteFontFace2(IDWriteFontFace(0xNNN)))))
```

That's not very useful. This PR trims it down to just the current interface:

```
IDWriteFontFace5(0xNNN)
```

