### PR TITLE
Implement COM interfaces on `ComObject<T>` instead of `T`

### DIFF
--- a/crates/libs/bindgen/src/rust/implements.rs
+++ b/crates/libs/bindgen/src/rust/implements.rs
@@ -97,10 +97,15 @@ pub fn writer(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
 
         if has_unknown_base {
             quote! {
-                unsafe extern "system" fn #name<#constraints Identity: windows_core::IUnknownImpl<Impl = Impl>, Impl: #impl_ident<#generic_names>, const OFFSET: isize> #vtbl_signature {
+                unsafe extern "system" fn #name<
+                    #constraints
+                    Identity: windows_core::IUnknownImpl,
+                    OuterToImpl: ::windows_core::ComGetImpl<Identity>,
+                    const OFFSET: isize
+                > #vtbl_signature where OuterToImpl::Impl: #impl_ident<#generic_names> {
                     // offset the `this` pointer by `OFFSET` times the size of a pointer and cast it as an IUnknown implementation
-                    let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-                    let this = (*this).get_impl();
+                    let this_outer: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                    let this = OuterToImpl::get_impl(this_outer);
                     #invoke_upcall
                 }
             }
@@ -123,7 +128,7 @@ pub fn writer(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
         Some(metadata::Type::TypeDef(def, generics)) => {
             let name = writer.type_def_name_imp(*def, generics, "_Vtbl");
             if has_unknown_base {
-                methods.combine(&quote! { base__: #name::new::<Identity, Impl, OFFSET>(), });
+                methods.combine(&quote! { base__: #name::new::<Identity, OuterToImpl, OFFSET>(), });
             } else {
                 methods.combine(&quote! { base__: #name::new::<Impl>(), });
             }
@@ -136,7 +141,8 @@ pub fn writer(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
     for method in def.methods() {
         let name = method_names.add(method);
         if has_unknown_base {
-            methods.combine(&quote! { #name: #name::<#generic_names Identity, Impl, OFFSET>, });
+            methods
+                .combine(&quote! { #name: #name::<#generic_names Identity, OuterToImpl, OFFSET>, });
         } else {
             methods.combine(&quote! { #name: #name::<Impl>, });
         }
@@ -151,7 +157,12 @@ pub fn writer(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
             #runtime_name
             #features
             impl<#constraints> #vtbl_ident<#generic_names> {
-                pub const fn new<Identity: windows_core::IUnknownImpl<Impl = Impl>, Impl: #impl_ident<#generic_names>, const OFFSET: isize>() -> #vtbl_ident<#generic_names> {
+                pub const fn new<
+                    Identity: windows_core::IUnknownImpl,
+                    OuterToImpl: ::windows_core::ComGetImpl<Identity>,
+                    const OFFSET: isize
+                >() -> #vtbl_ident<#generic_names>
+                where OuterToImpl::Impl : #impl_ident<#generic_names> {
                     #(#method_impls)*
                     Self{
                         #methods

--- a/crates/libs/core/src/com_object.rs
+++ b/crates/libs/core/src/com_object.rs
@@ -337,12 +337,12 @@ impl<T: ComObjectInner> Borrow<T> for ComObject<T> {
 /// This trait is part of the implementation of `windows-rs` and is not meant to be used directly
 /// by user code. This trait is not stable and may change at any time.
 #[doc(hidden)]
-pub trait ComGetImpl<Outer> {
+pub trait ComGetImpl<T: ComObjectInner> {
     /// The type that implements the COM interface.
     type Impl;
 
     /// At runtime, casts from the outer object type to the implementation type.
-    fn get_impl(outer: &Outer) -> &Self::Impl;
+    fn get_impl(object: &ComObject<T>) -> &Self::Impl;
 }
 
 /// Selects the "inner" type of a COM object implementation. This implementation uses the
@@ -352,18 +352,15 @@ pub trait ComGetImpl<Outer> {
 /// This struct is part of the implementation of `windows-rs` and is not meant to be used directly
 /// by user code. This trait is not stable and may change at any time.
 #[doc(hidden)]
-pub struct ComGetImplInner<Outer> {
-    _marker: core::marker::PhantomData<Outer>,
+pub struct ComGetImplInner<T> {
+    _marker: core::marker::PhantomData<T>,
 }
 
-impl<Outer> ComGetImpl<Outer> for ComGetImplInner<Outer>
-where
-    Outer: IUnknownImpl,
-{
-    type Impl = <Outer as IUnknownImpl>::Impl;
+impl<T: ComObjectInner> ComGetImpl<T> for ComGetImplInner<T> {
+    type Impl = T;
 
-    fn get_impl(outer: &Outer) -> &Self::Impl {
-        <Outer as IUnknownImpl>::get_impl(outer)
+    fn get_impl(object: &ComObject<T>) -> &Self::Impl {
+        object.get_impl()
     }
 }
 
@@ -373,14 +370,14 @@ where
 /// This struct is part of the implementation of `windows-rs` and is not meant to be used directly
 /// by user code. This trait is not stable and may change at any time.
 #[doc(hidden)]
-pub struct ComGetImplOuter<Outer> {
-    _marker: core::marker::PhantomData<Outer>,
+pub struct ComGetImplOuter<T> {
+    _marker: core::marker::PhantomData<T>,
 }
 
-impl<Outer> ComGetImpl<Outer> for ComGetImplOuter<Outer> {
-    type Impl = Outer;
+impl<T: ComObjectInner> ComGetImpl<T> for ComGetImplOuter<T> {
+    type Impl = ComObject<T>;
 
-    fn get_impl(outer: &Outer) -> &Self::Impl {
-        outer
+    fn get_impl(object: &ComObject<T>) -> &Self::Impl {
+        object
     }
 }

--- a/crates/libs/core/src/unknown.rs
+++ b/crates/libs/core/src/unknown.rs
@@ -70,7 +70,7 @@ impl core::fmt::Debug for IUnknown {
 #[doc(hidden)]
 pub trait IUnknownImpl {
     /// The contained user type, e.g. `MyApp`. Also known as the "inner" type.
-    type Impl;
+    type Impl: ComObjectInner<Outer = Self>;
 
     /// Get a reference to the backing implementation.
     fn get_impl(&self) -> &Self::Impl;

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -79,10 +79,10 @@ pub fn implement(
             let vtbl_ident = implement.to_vtbl_ident();
             let outer_to_impl = match implement.impl_location {
                 ImplLocation::Outer => {
-                    quote!(::windows_core::ComGetImplOuter<#impl_ident #generics>)
+                    quote!(::windows_core::ComGetImplOuter<#original_ident #generics>)
                 }
                 ImplLocation::Inner => {
-                    quote!(::windows_core::ComGetImplInner<#impl_ident #generics>)
+                    quote!(::windows_core::ComGetImplInner<#original_ident #generics>)
                 }
             };
             let offset = proc_macro2::Literal::isize_unsuffixed(-1 - enumerate as isize);

--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -135,8 +135,8 @@ impl Interface {
 
                 if m.is_result() {
                     quote! {
-                        #[inline(always)]
-                        #vis unsafe fn #name<#(#generics),*>(&self, #(#params),*) #ret {
+                    #[inline(always)]
+                    #vis unsafe fn #name<#(#generics),*>(&self, #(#params),*) #ret {
                             (::windows_core::Interface::vtable(self).#name)(::windows_core::Interface::as_raw(self), #(#args),*).ok()
                         }
                     }
@@ -214,7 +214,7 @@ impl Interface {
         let parent_vtable_generics = if self.parent_is_iunknown() {
             quote!(Identity, OFFSET)
         } else {
-            quote!(Identity, Impl, OFFSET)
+            quote!(Identity, OuterToImpl, OFFSET)
         };
         let parent_vtable = self.parent_vtable();
 
@@ -253,13 +253,35 @@ impl Interface {
 
                 if parent_vtable.is_some() {
                     quote! {
-                        unsafe extern "system" fn #name<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: #trait_name, const OFFSET: isize>(this: *mut ::core::ffi::c_void, #(#args),*) #ret {
-                            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-                            let this_impl: &Impl = (*this).get_impl();
+                        unsafe extern "system" fn #name<
+                            Identity: ::windows_core::IUnknownImpl,
+                            OuterToImpl: ::windows_core::ComGetImpl<Identity>,
+                            const OFFSET: isize
+                        >(
+                            this: *mut ::core::ffi::c_void, // <-- This is the COM "this" pointer, which is not the same as &T or &T_Impl.
+                            #(#args),*
+                        ) #ret
+                        where
+                            OuterToImpl::Impl : #trait_name
+                        {
+                            // This step is essentially a virtual dispatch adjustor thunk. Its purpose is to adjust
+                            // the "this" pointer from the address used by the COM interface to the root of the
+                            // MyApp_Impl object.  Since a given MyApp_Impl may implement more than one COM interface
+                            // (and more than one COM interface chain), we need to know how to get from COM's "this"
+                            // back to &MyApp_Impl. The OFFSET constant gives us the value (in pointer-sized units).
+                            let this_outer: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+
+                            // This step selects the part of the MyApp_Impl object which implements a given COM interface,
+                            // i.e. IFoo_Impl trait. There are really only two possibilities: either MyApp_Impl or MyApp
+                            // implements a given IFoo_Impl trait. The ComGetImplInner and ComGetImplOuter types
+                            // allow the code that specialized this function to select which one is used.
+                            let this_impl: &OuterToImpl::Impl = OuterToImpl::get_impl(this_outer);
+
+                            // Last, we invoke the implementation function.
                             // We use explicit <Impl as IFoo_Impl> so that we can select the correct method
                             // for situations where IFoo3 derives from IFoo2 and both declare a method with
                             // the same name.
-                            <Impl as #trait_name>::#name(this_impl, #(#params),*).into()
+                            <OuterToImpl::Impl as #trait_name>::#name(this_impl, #(#params),*).into()
                         }
                     }
                 } else {
@@ -274,24 +296,16 @@ impl Interface {
             })
             .collect::<Vec<_>>();
 
-        let entries = self
-            .methods
-            .iter()
-            .map(|m| {
-                let name = &m.name;
-                if parent_vtable.is_some() {
-                    quote! {
-                            #name: #name::<Identity, Impl, OFFSET>
-                    }
-                } else {
-                    quote! {
-                            #name: #name::<Impl>
-                    }
-                }
-            })
-            .collect::<Vec<_>>();
-
         if let Some(parent_vtable) = parent_vtable {
+            let entries = self
+                .methods
+                .iter()
+                .map(|m| {
+                    let name = &m.name;
+                    quote!(#name: #name::<Identity, OuterToImpl, OFFSET>)
+                })
+                .collect::<Vec<_>>();
+
             quote! {
                 #[repr(C)]
                 #[doc(hidden)]
@@ -300,7 +314,14 @@ impl Interface {
                     #(#vtable_entries)*
                 }
                 impl #vtable_name {
-                    pub const fn new<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: #trait_name, const OFFSET: isize>() -> Self {
+                    pub const fn new<
+                        Identity: ::windows_core::IUnknownImpl,
+                        OuterToImpl: ::windows_core::ComGetImpl<Identity>,
+                        const OFFSET: isize,
+                    >() -> Self
+                    where
+                        OuterToImpl::Impl : #trait_name
+                    {
                         #(#functions)*
                         Self { base__: #parent_vtable::new::<#parent_vtable_generics>(), #(#entries),* }
                     }
@@ -313,6 +334,15 @@ impl Interface {
                 }
             }
         } else {
+            let entries = self
+                .methods
+                .iter()
+                .map(|m| {
+                    let name = &m.name;
+                    quote!(#name: #name::<Impl>)
+                })
+                .collect::<Vec<_>>();
+
             quote! {
                 #[repr(C)]
                 #[doc(hidden)]

--- a/crates/samples/components/json_validator_winrt/src/bindings.rs
+++ b/crates/samples/components/json_validator_winrt/src/bindings.rs
@@ -114,21 +114,28 @@ impl windows_core::RuntimeName for IJsonValidator {
 }
 impl IJsonValidator_Vtbl {
     pub const fn new<
-        Identity: windows_core::IUnknownImpl<Impl = Impl>,
-        Impl: IJsonValidator_Impl,
+        Identity: windows_core::IUnknownImpl,
+        OuterToImpl: ::windows_core::ComGetImpl<Identity>,
         const OFFSET: isize,
-    >() -> IJsonValidator_Vtbl {
+    >() -> IJsonValidator_Vtbl
+    where
+        OuterToImpl::Impl: IJsonValidator_Impl,
+    {
         unsafe extern "system" fn Validate<
-            Identity: windows_core::IUnknownImpl<Impl = Impl>,
-            Impl: IJsonValidator_Impl,
+            Identity: windows_core::IUnknownImpl,
+            OuterToImpl: ::windows_core::ComGetImpl<Identity>,
             const OFFSET: isize,
         >(
             this: *mut core::ffi::c_void,
             value: core::mem::MaybeUninit<windows_core::HSTRING>,
             result__: *mut core::mem::MaybeUninit<windows_core::HSTRING>,
-        ) -> windows_core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        ) -> windows_core::HRESULT
+        where
+            OuterToImpl::Impl: IJsonValidator_Impl,
+        {
+            let this_outer: &Identity =
+                &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+            let this = OuterToImpl::get_impl(this_outer);
             match IJsonValidator_Impl::Validate(this, core::mem::transmute(&value)) {
                 Ok(ok__) => {
                     core::ptr::write(result__, core::mem::transmute_copy(&ok__));
@@ -140,7 +147,7 @@ impl IJsonValidator_Vtbl {
         }
         Self {
             base__: windows_core::IInspectable_Vtbl::new::<Identity, IJsonValidator, OFFSET>(),
-            Validate: Validate::<Identity, Impl, OFFSET>,
+            Validate: Validate::<Identity, OuterToImpl, OFFSET>,
         }
     }
     pub fn matches(iid: &windows_core::GUID) -> bool {
@@ -156,21 +163,28 @@ impl windows_core::RuntimeName for IJsonValidatorFactory {
 }
 impl IJsonValidatorFactory_Vtbl {
     pub const fn new<
-        Identity: windows_core::IUnknownImpl<Impl = Impl>,
-        Impl: IJsonValidatorFactory_Impl,
+        Identity: windows_core::IUnknownImpl,
+        OuterToImpl: ::windows_core::ComGetImpl<Identity>,
         const OFFSET: isize,
-    >() -> IJsonValidatorFactory_Vtbl {
+    >() -> IJsonValidatorFactory_Vtbl
+    where
+        OuterToImpl::Impl: IJsonValidatorFactory_Impl,
+    {
         unsafe extern "system" fn CreateInstance<
-            Identity: windows_core::IUnknownImpl<Impl = Impl>,
-            Impl: IJsonValidatorFactory_Impl,
+            Identity: windows_core::IUnknownImpl,
+            OuterToImpl: ::windows_core::ComGetImpl<Identity>,
             const OFFSET: isize,
         >(
             this: *mut core::ffi::c_void,
             schema: core::mem::MaybeUninit<windows_core::HSTRING>,
             result__: *mut *mut core::ffi::c_void,
-        ) -> windows_core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        ) -> windows_core::HRESULT
+        where
+            OuterToImpl::Impl: IJsonValidatorFactory_Impl,
+        {
+            let this_outer: &Identity =
+                &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+            let this = OuterToImpl::get_impl(this_outer);
             match IJsonValidatorFactory_Impl::CreateInstance(this, core::mem::transmute(&schema)) {
                 Ok(ok__) => {
                     core::ptr::write(result__, core::mem::transmute_copy(&ok__));
@@ -183,7 +197,7 @@ impl IJsonValidatorFactory_Vtbl {
         Self {
             base__: windows_core::IInspectable_Vtbl::new::<Identity, IJsonValidatorFactory, OFFSET>(
             ),
-            CreateInstance: CreateInstance::<Identity, Impl, OFFSET>,
+            CreateInstance: CreateInstance::<Identity, OuterToImpl, OFFSET>,
         }
     }
     pub fn matches(iid: &windows_core::GUID) -> bool {

--- a/crates/tests/component/src/bindings.rs
+++ b/crates/tests/component/src/bindings.rs
@@ -50,24 +50,31 @@ pub mod Nested {
     }
     impl IThing_Vtbl {
         pub const fn new<
-            Identity: windows_core::IUnknownImpl<Impl = Impl>,
-            Impl: IThing_Impl,
+            Identity: windows_core::IUnknownImpl,
+            OuterToImpl: ::windows_core::ComGetImpl<Identity>,
             const OFFSET: isize,
-        >() -> IThing_Vtbl {
+        >() -> IThing_Vtbl
+        where
+            OuterToImpl::Impl: IThing_Impl,
+        {
             unsafe extern "system" fn Method<
-                Identity: windows_core::IUnknownImpl<Impl = Impl>,
-                Impl: IThing_Impl,
+                Identity: windows_core::IUnknownImpl,
+                OuterToImpl: ::windows_core::ComGetImpl<Identity>,
                 const OFFSET: isize,
             >(
                 this: *mut core::ffi::c_void,
-            ) -> windows_core::HRESULT {
-                let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-                let this = (*this).get_impl();
+            ) -> windows_core::HRESULT
+            where
+                OuterToImpl::Impl: IThing_Impl,
+            {
+                let this_outer: &Identity =
+                    &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+                let this = OuterToImpl::get_impl(this_outer);
                 IThing_Impl::Method(this).into()
             }
             Self {
                 base__: windows_core::IInspectable_Vtbl::new::<Identity, IThing, OFFSET>(),
-                Method: Method::<Identity, Impl, OFFSET>,
+                Method: Method::<Identity, OuterToImpl, OFFSET>,
             }
         }
         pub fn matches(iid: &windows_core::GUID) -> bool {
@@ -433,20 +440,27 @@ impl windows_core::RuntimeName for IClass {
 }
 impl IClass_Vtbl {
     pub const fn new<
-        Identity: windows_core::IUnknownImpl<Impl = Impl>,
-        Impl: IClass_Impl,
+        Identity: windows_core::IUnknownImpl,
+        OuterToImpl: ::windows_core::ComGetImpl<Identity>,
         const OFFSET: isize,
-    >() -> IClass_Vtbl {
+    >() -> IClass_Vtbl
+    where
+        OuterToImpl::Impl: IClass_Impl,
+    {
         unsafe extern "system" fn Property<
-            Identity: windows_core::IUnknownImpl<Impl = Impl>,
-            Impl: IClass_Impl,
+            Identity: windows_core::IUnknownImpl,
+            OuterToImpl: ::windows_core::ComGetImpl<Identity>,
             const OFFSET: isize,
         >(
             this: *mut core::ffi::c_void,
             result__: *mut i32,
-        ) -> windows_core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        ) -> windows_core::HRESULT
+        where
+            OuterToImpl::Impl: IClass_Impl,
+        {
+            let this_outer: &Identity =
+                &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+            let this = OuterToImpl::get_impl(this_outer);
             match IClass_Impl::Property(this) {
                 Ok(ok__) => {
                     core::ptr::write(result__, core::mem::transmute_copy(&ok__));
@@ -456,27 +470,35 @@ impl IClass_Vtbl {
             }
         }
         unsafe extern "system" fn SetProperty<
-            Identity: windows_core::IUnknownImpl<Impl = Impl>,
-            Impl: IClass_Impl,
+            Identity: windows_core::IUnknownImpl,
+            OuterToImpl: ::windows_core::ComGetImpl<Identity>,
             const OFFSET: isize,
         >(
             this: *mut core::ffi::c_void,
             value: i32,
-        ) -> windows_core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        ) -> windows_core::HRESULT
+        where
+            OuterToImpl::Impl: IClass_Impl,
+        {
+            let this_outer: &Identity =
+                &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+            let this = OuterToImpl::get_impl(this_outer);
             IClass_Impl::SetProperty(this, value).into()
         }
         unsafe extern "system" fn Flags<
-            Identity: windows_core::IUnknownImpl<Impl = Impl>,
-            Impl: IClass_Impl,
+            Identity: windows_core::IUnknownImpl,
+            OuterToImpl: ::windows_core::ComGetImpl<Identity>,
             const OFFSET: isize,
         >(
             this: *mut core::ffi::c_void,
             result__: *mut Flags,
-        ) -> windows_core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        ) -> windows_core::HRESULT
+        where
+            OuterToImpl::Impl: IClass_Impl,
+        {
+            let this_outer: &Identity =
+                &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+            let this = OuterToImpl::get_impl(this_outer);
             match IClass_Impl::Flags(this) {
                 Ok(ok__) => {
                     core::ptr::write(result__, core::mem::transmute_copy(&ok__));
@@ -486,8 +508,8 @@ impl IClass_Vtbl {
             }
         }
         unsafe extern "system" fn Int32Array<
-            Identity: windows_core::IUnknownImpl<Impl = Impl>,
-            Impl: IClass_Impl,
+            Identity: windows_core::IUnknownImpl,
+            OuterToImpl: ::windows_core::ComGetImpl<Identity>,
             const OFFSET: isize,
         >(
             this: *mut core::ffi::c_void,
@@ -499,9 +521,13 @@ impl IClass_Vtbl {
             c: *mut *mut i32,
             result_size__: *mut u32,
             result__: *mut *mut i32,
-        ) -> windows_core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        ) -> windows_core::HRESULT
+        where
+            OuterToImpl::Impl: IClass_Impl,
+        {
+            let this_outer: &Identity =
+                &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+            let this = OuterToImpl::get_impl(this_outer);
             match IClass_Impl::Int32Array(
                 this,
                 core::slice::from_raw_parts(core::mem::transmute_copy(&a), a_array_size as usize),
@@ -525,8 +551,8 @@ impl IClass_Vtbl {
             }
         }
         unsafe extern "system" fn StringArray<
-            Identity: windows_core::IUnknownImpl<Impl = Impl>,
-            Impl: IClass_Impl,
+            Identity: windows_core::IUnknownImpl,
+            OuterToImpl: ::windows_core::ComGetImpl<Identity>,
             const OFFSET: isize,
         >(
             this: *mut core::ffi::c_void,
@@ -538,9 +564,13 @@ impl IClass_Vtbl {
             c: *mut *mut core::mem::MaybeUninit<windows_core::HSTRING>,
             result_size__: *mut u32,
             result__: *mut *mut core::mem::MaybeUninit<windows_core::HSTRING>,
-        ) -> windows_core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        ) -> windows_core::HRESULT
+        where
+            OuterToImpl::Impl: IClass_Impl,
+        {
+            let this_outer: &Identity =
+                &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+            let this = OuterToImpl::get_impl(this_outer);
             match IClass_Impl::StringArray(
                 this,
                 core::slice::from_raw_parts(core::mem::transmute_copy(&a), a_array_size as usize),
@@ -564,8 +594,8 @@ impl IClass_Vtbl {
             }
         }
         unsafe extern "system" fn Input<
-            Identity: windows_core::IUnknownImpl<Impl = Impl>,
-            Impl: IClass_Impl,
+            Identity: windows_core::IUnknownImpl,
+            OuterToImpl: ::windows_core::ComGetImpl<Identity>,
             const OFFSET: isize,
         >(
             this: *mut core::ffi::c_void,
@@ -573,9 +603,13 @@ impl IClass_Vtbl {
             b: *mut core::ffi::c_void,
             c: *mut core::ffi::c_void,
             d: *mut core::ffi::c_void,
-        ) -> windows_core::HRESULT {
-            let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
-            let this = (*this).get_impl();
+        ) -> windows_core::HRESULT
+        where
+            OuterToImpl::Impl: IClass_Impl,
+        {
+            let this_outer: &Identity =
+                &*((this as *const *const ()).offset(OFFSET) as *const Identity);
+            let this = OuterToImpl::get_impl(this_outer);
             IClass_Impl::Input(
                 this,
                 windows_core::from_raw_borrowed(&a),
@@ -587,12 +621,12 @@ impl IClass_Vtbl {
         }
         Self {
             base__: windows_core::IInspectable_Vtbl::new::<Identity, IClass, OFFSET>(),
-            Property: Property::<Identity, Impl, OFFSET>,
-            SetProperty: SetProperty::<Identity, Impl, OFFSET>,
-            Flags: Flags::<Identity, Impl, OFFSET>,
-            Int32Array: Int32Array::<Identity, Impl, OFFSET>,
-            StringArray: StringArray::<Identity, Impl, OFFSET>,
-            Input: Input::<Identity, Impl, OFFSET>,
+            Property: Property::<Identity, OuterToImpl, OFFSET>,
+            SetProperty: SetProperty::<Identity, OuterToImpl, OFFSET>,
+            Flags: Flags::<Identity, OuterToImpl, OFFSET>,
+            Int32Array: Int32Array::<Identity, OuterToImpl, OFFSET>,
+            StringArray: StringArray::<Identity, OuterToImpl, OFFSET>,
+            Input: Input::<Identity, OuterToImpl, OFFSET>,
         }
     }
     pub fn matches(iid: &windows_core::GUID) -> bool {

--- a/crates/tests/implement_core/src/impl_on_outer.rs
+++ b/crates/tests/implement_core/src/impl_on_outer.rs
@@ -3,6 +3,7 @@ use windows_core::*;
 #[interface("cccccccc-0000-0000-0000-000000000001")]
 unsafe trait IFoo: IUnknown {
     fn hello(&self);
+    fn self_as_bar(&self) -> IBar;
 }
 
 #[interface("cccccccc-0000-0000-0000-000000000002")]
@@ -25,17 +26,22 @@ unsafe trait IBar: IUnknown {
 #[implement(IFoo3 @ Outer, IBar)]
 struct MyApp {}
 
-impl IFoo_Impl for MyApp_Impl {
+impl IFoo_Impl for ComObject<MyApp> {
     unsafe fn hello(&self) {
         println!("MyApp as IFoo: hello");
     }
+
+    unsafe fn self_as_bar(&self) -> IBar {
+        println!("MyApp as IFoo::self_as_bar");
+        self.to_interface()
+    }
 }
-impl IFoo2_Impl for MyApp_Impl {
+impl IFoo2_Impl for ComObject<MyApp> {
     unsafe fn hello(&self) {
         println!("MyApp as IFoo2: hello");
     }
 }
-impl IFoo3_Impl for MyApp_Impl {
+impl IFoo3_Impl for ComObject<MyApp> {
     unsafe fn hello(&self) {
         println!("MyApp as IFoo3: hello");
     }
@@ -58,6 +64,11 @@ fn basic() {
         ifoo.hello();
         ifoo2.hello();
         ifoo3.hello();
+        ibar.goodbye();
+    }
+
+    unsafe {
+        let ibar = ifoo3.self_as_bar();
         ibar.goodbye();
     }
 }

--- a/crates/tests/implement_core/src/impl_on_outer.rs
+++ b/crates/tests/implement_core/src/impl_on_outer.rs
@@ -1,0 +1,63 @@
+use windows_core::*;
+
+#[interface("cccccccc-0000-0000-0000-000000000001")]
+unsafe trait IFoo: IUnknown {
+    fn hello(&self);
+}
+
+#[interface("cccccccc-0000-0000-0000-000000000002")]
+unsafe trait IFoo2: IFoo {
+    fn hello(&self);
+}
+
+#[interface("cccccccc-0000-0000-0000-000000000003")]
+unsafe trait IFoo3: IFoo2 {
+    fn hello(&self);
+}
+
+#[interface("cccccccc-0000-0000-0000-000000000004")]
+unsafe trait IBar: IUnknown {
+    fn goodbye(&self);
+}
+
+// This tests that we can compile a COM object that has some COM interfaces implemented on the
+// outer object and some on the inner object.
+#[implement(IFoo3 @ Outer, IBar)]
+struct MyApp {}
+
+impl IFoo_Impl for MyApp_Impl {
+    unsafe fn hello(&self) {
+        println!("MyApp as IFoo: hello");
+    }
+}
+impl IFoo2_Impl for MyApp_Impl {
+    unsafe fn hello(&self) {
+        println!("MyApp as IFoo2: hello");
+    }
+}
+impl IFoo3_Impl for MyApp_Impl {
+    unsafe fn hello(&self) {
+        println!("MyApp as IFoo3: hello");
+    }
+}
+
+impl IBar_Impl for MyApp {
+    unsafe fn goodbye(&self) {
+        println!("MyApp as IBar: goodbye");
+    }
+}
+
+#[test]
+fn basic() {
+    let app = ComObject::new(MyApp {});
+    let ifoo3: IFoo3 = app.cast().unwrap();
+    let ifoo2: IFoo2 = app.cast().unwrap();
+    let ifoo: IFoo = app.cast().unwrap();
+    let ibar: IBar = app.cast().unwrap();
+    unsafe {
+        ifoo.hello();
+        ifoo2.hello();
+        ifoo3.hello();
+        ibar.goodbye();
+    }
+}

--- a/crates/tests/implement_core/src/lib.rs
+++ b/crates/tests/implement_core/src/lib.rs
@@ -5,3 +5,4 @@
 
 mod com_chain;
 mod com_object;
+mod impl_on_outer;


### PR DESCRIPTION
This is a DRAFT PR, meant as a variation of #3065  for discussion.  I've also intentionally left out the bindings updates for all the crates.
