### PR TITLE
Directly run bindgen instead of recursively running Cargo, in tests/standalone

### DIFF
--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -9,6 +9,9 @@ description = "Windows metadata compiler"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 
+[lib]
+crate-type = ["rlib", "dylib"]
+
 [lints]
 workspace = true
 

--- a/crates/tests/standalone/Cargo.toml
+++ b/crates/tests/standalone/Cargo.toml
@@ -4,8 +4,16 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-core]
 path = "../../libs/core"
 
 [dependencies.windows-targets]
 path = "../../libs/targets"
+
+[build-dependencies.windows-bindgen]
+path = "../../libs/bindgen"
+default-features = false


### PR DESCRIPTION
This fixes several problems relating to the build script of the `crates/tests/standalone` crate.  This build script runs bindgen on a variety of inputs and generates source code.

The first problem is that the build script modifies source code during a build script, and does so unconditionally.  Because this process is relatively slow, these filesystem writes sometimes interfere with Git operations, because Git sees the intermediate (partially modified) state of these source files.  This has been a big hassle for me in running Git operations.

The partial solution to this first problem is to generate source files to a temporary path, then compare their contents to the final contents in the source tree.  If they are different, only then does the build script modify the source file.  If they are the same, no further action is taken.  This is not ideal -- it's not a good idea to have builds _modifying_ source code -- but at least it only does so when the contents need to change.  This avoids a lot of conflicts with Rust Analyzer, Git, etc.

The second problem is that Cargo is recursively running Cargo.  This is strongly discouraged -- you can have two different instances of Cargo overwriting the same files during a single build.  It ignores parameters passed to the original Cargo instance, it's difficult to debug, etc.

The solution to this second problem is to avoid running Cargo recursively, and to simply have the build script depend directly on the `windows-bindgen` crate.  This is also a _lot_ faster.  I measured the time it took to run `cargo test` on the `standalone` tests crate, by touching the timestamp on its `build.rs` file.  With the current code in `master`, it takes about 35 seconds.  With this PR, it takes about 17 seconds.  I also improved the diagnostics in the `build.rs` file, in case running bindgen fails.
