### PR TITLE
Fix warnings from Rust 1.80.0 nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ exclude = [
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
-unused_qualifications = "warn"
+unused_qualifications = "allow" # See https://github.com/microsoft/windows-rs/issues/3076
 missing_docs = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows_debugger_visualizer)'] }
-
-# See https://github.com/microsoft/windows-rs/issues/3076
-unused-qualifications = { level = "allow" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ rust_2018_idioms = { level = "warn", priority = -1 }
 unused_qualifications = "warn"
 missing_docs = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows_debugger_visualizer)'] }
+
+# See https://github.com/microsoft/windows-rs/issues/3076
+unused-qualifications = { level = "allow" }

--- a/crates/libs/core/src/imp/weak_ref_count.rs
+++ b/crates/libs/core/src/imp/weak_ref_count.rs
@@ -63,8 +63,7 @@ impl WeakRefCount {
 
         let tear_off = TearOff::new(object, count_or_pointer as u32);
         let tear_off_ptr: *mut c_void = transmute_copy(&tear_off);
-        let encoding: usize =
-            ((tear_off_ptr as usize) >> 1) | (1 << (core::mem::size_of::<usize>() * 8 - 1));
+        let encoding: usize = ((tear_off_ptr as usize) >> 1) | (1 << (usize::BITS - 1));
 
         loop {
             match self.0.compare_exchange_weak(


### PR DESCRIPTION
CI jobs are failing because Rust nightly tools have added new warnings. This PR fixes all warnings as of nightly 2024-06-04.