### PR TITLE
Remove `unused_qualifications` entirely

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,5 @@ exclude = [
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
-unused_qualifications = "allow" # See https://github.com/microsoft/windows-rs/issues/3076
 missing_docs = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows_debugger_visualizer)'] }


### PR DESCRIPTION
Minor update to #3074 - there's no need to list all the lints we don't use.