### PR TITLE
Optimize `write_to_file` in `windows-bindgen` to avoid unnecessary file writes

### DIFF
--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -257,7 +257,14 @@ fn write_to_file<C: AsRef<[u8]>>(path: &str, contents: C) -> Result<()> {
             .map_err(|_| Error::new("failed to create directory").with_path(path))?;
     }
 
-    std::fs::write(path, contents).map_err(|_| Error::new("failed to write file").with_path(path))
+    let existing = std::fs::read(path).unwrap_or_default();
+
+    if contents.as_ref() != existing {
+        std::fs::write(path, contents)
+            .map_err(|_| Error::new("failed to write file").with_path(path))?;
+    }
+
+    Ok(())
 }
 
 fn canonicalize(value: &str) -> Result<String> {

--- a/crates/tests/standalone/build.rs
+++ b/crates/tests/standalone/build.rs
@@ -202,15 +202,6 @@ fn write_vtbl(output: &str, filter: &[&str]) {
 }
 
 fn riddle(output: &str, filter: &[&str], config: &[&str]) {
-    // Rust-analyzer may re-run build scripts whenever a source file is deleted
-    // which causes an endless loop if the file is deleted from a build script.
-    // To workaround this, we truncate the file instead of deleting it.
-    // See https://github.com/microsoft/windows-rs/issues/2777
-    _ = std::fs::File::options()
-        .truncate(true)
-        .write(true)
-        .open(output);
-
     let mut command = std::process::Command::new("cargo");
 
     command.args([


### PR DESCRIPTION
Alternative to #3072 to avoid unnecessary file writes that trigger side effects in build systems and IDEs. 

I ended up doing the same thing for cppwinrt years ago as msbuild and razzle had a real problem for similar reasons. 