### PR TITLE
Allow `windows-result` to work on non-Windows platforms

### DIFF
--- a/crates/libs/result/src/lib.rs
+++ b/crates/libs/result/src/lib.rs
@@ -7,6 +7,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
     debugger_visualizer(natvis_file = "../.natvis")
 )]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![cfg_attr(not(windows), allow(unused_imports))]
 
 extern crate alloc;
 
@@ -16,10 +17,14 @@ use alloc::vec::Vec;
 mod bindings;
 use bindings::*;
 
+#[cfg(windows)]
 mod com;
+#[cfg(windows)]
 use com::*;
 
+#[cfg(windows)]
 mod strings;
+#[cfg(windows)]
 use strings::*;
 
 mod error;

--- a/crates/tests/linux/tests/hresult.rs
+++ b/crates/tests/linux/tests/hresult.rs
@@ -1,0 +1,34 @@
+// This tests code paths in `windows-result` that are different on non-Windows platforms.
+#![cfg(not(windows))]
+
+use windows::core::Error;
+use windows::Win32::Foundation::{E_FAIL, S_OK};
+
+#[test]
+fn basic_hresult() {
+    assert!(E_FAIL.is_err());
+    assert!(S_OK.is_ok());
+
+    let ok_message = S_OK.message();
+    assert_eq!(ok_message, "0x00000000");
+}
+
+#[test]
+fn error_message_is_not_supported() {
+    let e = Error::new(S_OK, "this gets ignored");
+    let message = e.message();
+    assert_eq!(message, "0x00000000");
+}
+
+#[test]
+#[should_panic]
+fn from_win32_panics() {
+    // from_win32() is not implemented on non-Windows platforms.
+    let _e = Error::from_win32();
+}
+
+#[test]
+fn error_from_hresult() {
+    let e = Error::from(E_FAIL);
+    assert_eq!(e.code(), E_FAIL);
+}


### PR DESCRIPTION
This updates the `windows-result` crate so that it can compile and work on non-Windows platforms.  Right now, there are dependencies on things like `GetErrorInfo`, which are obviously not present on other platforms.

This modifies `Error` so that the `info` field is only present on Windows. Everything that reads/writes that field is also made conditional.

I also manually imported definitions for some HRESULT constants, so that we did not need to rely on bindgen for them.  This was necessary because none of the bindings should be used on non-Windows platforms.  When we convert from `std::io::ErrorKind` to `HRESULT`, we do our best to map things to error codes that make sense, although some of them are a bit of a stretch.

This is one part of fixing #3083.