### PR TITLE
Fix default `rustfmt` for repo

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+newline_style = "Unix"


### PR DESCRIPTION
While investigating the test stability (#3072, #3079) I noticed that #3064 regressed the `rustfmt` for the repo. The repo must use "Unix" style line endings to avoid all kinds of diff/merge issues with git but #3064 removed the repo-wide `rustfmt.toml` configuration file. This just reinstates this default formatting for all code in the repo. 