### PR TITLE
Disable docs and tests for test crates

### DIFF
--- a/crates/tests/agile/Cargo.toml
+++ b/crates/tests/agile/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/agile_reference/Cargo.toml
+++ b/crates/tests/agile_reference/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/alternate_success_code/Cargo.toml
+++ b/crates/tests/alternate_success_code/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/arch/Cargo.toml
+++ b/crates/tests/arch/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/arch_feature/Cargo.toml
+++ b/crates/tests/arch_feature/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/array/Cargo.toml
+++ b/crates/tests/array/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/bcrypt/Cargo.toml
+++ b/crates/tests/bcrypt/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/bstr/Cargo.toml
+++ b/crates/tests/bstr/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/calling_convention/Cargo.toml
+++ b/crates/tests/calling_convention/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib)'] }
 

--- a/crates/tests/cfg_generic/Cargo.toml
+++ b/crates/tests/cfg_generic/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/collections/Cargo.toml
+++ b/crates/tests/collections/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/component/Cargo.toml
+++ b/crates/tests/component/Cargo.toml
@@ -6,6 +6,8 @@ publish = false
 
 [lib]
 crate-type = ["cdylib"]
+doc = false
+doctest = false
 
 [dependencies.windows-core]
 path = "../../libs/core"

--- a/crates/tests/component_client/Cargo.toml
+++ b/crates/tests/component_client/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-core]
 path = "../../libs/core"
 

--- a/crates/tests/const_fields/Cargo.toml
+++ b/crates/tests/const_fields/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/const_params/Cargo.toml
+++ b/crates/tests/const_params/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/const_ptrs/Cargo.toml
+++ b/crates/tests/const_ptrs/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/core/Cargo.toml
+++ b/crates/tests/core/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/debug/Cargo.toml
+++ b/crates/tests/debug/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/debug_inspectable/Cargo.toml
+++ b/crates/tests/debug_inspectable/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/debugger_visualizer/Cargo.toml
+++ b/crates/tests/debugger_visualizer/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_debugger_visualizer)'] }
 

--- a/crates/tests/deprecated/Cargo.toml
+++ b/crates/tests/deprecated/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/dispatch/Cargo.toml
+++ b/crates/tests/dispatch/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/does_not_return/Cargo.toml
+++ b/crates/tests/does_not_return/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/enums/Cargo.toml
+++ b/crates/tests/enums/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/error/Cargo.toml
+++ b/crates/tests/error/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/event/Cargo.toml
+++ b/crates/tests/event/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/extensions/Cargo.toml
+++ b/crates/tests/extensions/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/handles/Cargo.toml
+++ b/crates/tests/handles/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/helpers/Cargo.toml
+++ b/crates/tests/helpers/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-targets]
 path = "../../libs/targets"

--- a/crates/tests/implement/Cargo.toml
+++ b/crates/tests/implement/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/implement_core/Cargo.toml
+++ b/crates/tests/implement_core/Cargo.toml
@@ -3,6 +3,10 @@ name = "test_implement_core"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-core]
 path = "../../libs/core"
 

--- a/crates/tests/interface/Cargo.toml
+++ b/crates/tests/interface/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/interface_core/Cargo.toml
+++ b/crates/tests/interface_core/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-core]
 path = "../../libs/core"

--- a/crates/tests/interop/Cargo.toml
+++ b/crates/tests/interop/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/lib/Cargo.toml
+++ b/crates/tests/lib/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/linux/Cargo.toml
+++ b/crates/tests/linux/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/literals/Cargo.toml
+++ b/crates/tests/literals/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 

--- a/crates/tests/match/Cargo.toml
+++ b/crates/tests/match/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/matrix3x2/Cargo.toml
+++ b/crates/tests/matrix3x2/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/metadata/Cargo.toml
+++ b/crates/tests/metadata/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies]
 metadata = { package = "windows-metadata", path = "../../libs/metadata" }
 

--- a/crates/tests/msrv/Cargo.toml
+++ b/crates/tests/msrv/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/no_std/Cargo.toml
+++ b/crates/tests/no_std/Cargo.toml
@@ -3,6 +3,10 @@ name = "no_std"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-core]
 path = "../../libs/core"
 default-features = false

--- a/crates/tests/no_use/Cargo.toml
+++ b/crates/tests/no_use/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/noexcept/Cargo.toml
+++ b/crates/tests/noexcept/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-core]
 path = "../../libs/core"
 

--- a/crates/tests/not_dll/Cargo.toml
+++ b/crates/tests/not_dll/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/query_signature/Cargo.toml
+++ b/crates/tests/query_signature/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/readme/Cargo.toml
+++ b/crates/tests/readme/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/registry/Cargo.toml
+++ b/crates/tests/registry/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-registry]
 path = "../../libs/registry"
 

--- a/crates/tests/reserved/Cargo.toml
+++ b/crates/tests/reserved/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/resources/Cargo.toml
+++ b/crates/tests/resources/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/result/Cargo.toml
+++ b/crates/tests/result/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-result]
 path = "../../libs/result"
 

--- a/crates/tests/return_handle/Cargo.toml
+++ b/crates/tests/return_handle/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/return_struct/Cargo.toml
+++ b/crates/tests/return_struct/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/riddle/Cargo.toml
+++ b/crates/tests/riddle/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-core]
 path = "../../libs/core"
 

--- a/crates/tests/standalone/Cargo.toml
+++ b/crates/tests/standalone/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-core]
 path = "../../libs/core"
 

--- a/crates/tests/string_param/Cargo.toml
+++ b/crates/tests/string_param/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/structs/Cargo.toml
+++ b/crates/tests/structs/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/sys/Cargo.toml
+++ b/crates/tests/sys/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [

--- a/crates/tests/targets/Cargo.toml
+++ b/crates/tests/targets/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-targets]
 path = "../../libs/targets"
 

--- a/crates/tests/unions/Cargo.toml
+++ b/crates/tests/unions/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/variant/Cargo.toml
+++ b/crates/tests/variant/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows-core]
 path = "../../libs/core"
 

--- a/crates/tests/wdk/Cargo.toml
+++ b/crates/tests/wdk/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/weak/Cargo.toml
+++ b/crates/tests/weak/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/weak_ref/Cargo.toml
+++ b/crates/tests/weak_ref/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/win32/Cargo.toml
+++ b/crates/tests/win32/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/win32_arrays/Cargo.toml
+++ b/crates/tests/win32_arrays/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/window_long/Cargo.toml
+++ b/crates/tests/window_long/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [

--- a/crates/tests/winrt/Cargo.toml
+++ b/crates/tests/winrt/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+doc = false
+doctest = false
+
 [dependencies.windows]
 path = "../../libs/windows"
 features = [


### PR DESCRIPTION
Just reduces some of the noise and unnecessary work when testing all crates. 