### PR TITLE
Simplify standalone test by calling `windows-bindgen` directly

### DIFF
--- a/crates/tests/standalone/Cargo.toml
+++ b/crates/tests/standalone/Cargo.toml
@@ -9,3 +9,6 @@ path = "../../libs/core"
 
 [dependencies.windows-targets]
 path = "../../libs/targets"
+
+[build-dependencies.windows-bindgen]
+path = "../../libs/bindgen"

--- a/crates/tests/standalone/build.rs
+++ b/crates/tests/standalone/build.rs
@@ -202,36 +202,9 @@ fn write_vtbl(output: &str, filter: &[&str]) {
 }
 
 fn riddle(output: &str, filter: &[&str], config: &[&str]) {
-    // Rust-analyzer may re-run build scripts whenever a source file is deleted
-    // which causes an endless loop if the file is deleted from a build script.
-    // To workaround this, we truncate the file instead of deleting it.
-    // See https://github.com/microsoft/windows-rs/issues/2777
-    _ = std::fs::File::options()
-        .truncate(true)
-        .write(true)
-        .open(output);
-
-    let mut command = std::process::Command::new("cargo");
-
-    command.args([
-        "run",
-        "-p",
-        "riddle",
-        "--target-dir",
-        "../../../target/test_standalone", // TODO: workaround for https://github.com/rust-lang/cargo/issues/6412
-        "--",
-        "--in",
-        "../../libs/bindgen/default",
-        "--out",
-        output,
-        "--filter",
-    ]);
-
-    command.args(filter);
-    command.args(["--config", "no-bindgen-comment"]);
-    command.args(config);
-
-    if !command.status().unwrap().success() {
-        panic!("Failed to run riddle");
-    }
+    let mut args = vec!["--out", output, "--filter"];
+    args.extend_from_slice(filter);
+    args.extend_from_slice(&["--config", "no-bindgen-comment"]);
+    args.extend_from_slice(config);
+    windows_bindgen::bindgen(args).unwrap();
 }


### PR DESCRIPTION
Originally, the standalone tests were calling `riddle` both to test `riddle` as well as to verify standalone code generation. But now that `riddle` is really just a very thin wrapper around `windows-bindgen` and the fact that it has separate testing, we can simplify this test to call `windows-bindgen` directly and avoid some potential issues with calling `cargo` repeatedly. 