### PR TITLE
Infer return type in generated bindings

### DIFF
--- a/crates/libs/bindgen/src/rust/com_methods.rs
+++ b/crates/libs/bindgen/src/rust/com_methods.rs
@@ -134,7 +134,7 @@ pub fn writer(
             quote! {
                 #features
                 pub unsafe fn #name<#generics>(&self, #params) -> #return_type #where_clause {
-                    let mut result__: #return_type = core::mem::zeroed();
+                    let mut result__ = core::mem::zeroed();
                     (windows_core::Interface::vtable(self).#vname)(windows_core::Interface::as_raw(self), &mut result__, #args);
                     result__
                 }

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
@@ -251,7 +251,7 @@ impl core::ops::Deref for IDMLDispatchable {
 windows_core::imp::interface_hierarchy!(IDMLDispatchable, windows_core::IUnknown, IDMLObject, IDMLDeviceChild, IDMLPageable);
 impl IDMLDispatchable {
     pub unsafe fn GetBindingProperties(&self) -> DML_BINDING_PROPERTIES {
-        let mut result__: DML_BINDING_PROPERTIES = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetBindingProperties)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
@@ -46,7 +46,7 @@ impl core::ops::Deref for IIndependentFlipFramePresentStatistics {
 windows_core::imp::interface_hierarchy!(IIndependentFlipFramePresentStatistics, windows_core::IUnknown, IPresentStatistics);
 impl IIndependentFlipFramePresentStatistics {
     pub unsafe fn GetOutputAdapterLUID(&self) -> super::super::Foundation::LUID {
-        let mut result__: super::super::Foundation::LUID = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetOutputAdapterLUID)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -57,12 +57,12 @@ impl IIndependentFlipFramePresentStatistics {
         (windows_core::Interface::vtable(self).GetContentTag)(windows_core::Interface::as_raw(self))
     }
     pub unsafe fn GetDisplayedTime(&self) -> SystemInterruptTime {
-        let mut result__: SystemInterruptTime = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDisplayedTime)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
     pub unsafe fn GetPresentDuration(&self) -> SystemInterruptTime {
-        let mut result__: SystemInterruptTime = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetPresentDuration)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
@@ -117,19 +117,19 @@ windows_core::imp::interface_hierarchy!(ID2D1Bitmap, windows_core::IUnknown, ID2
 impl ID2D1Bitmap {
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetSize(&self) -> Common::D2D_SIZE_F {
-        let mut result__: Common::D2D_SIZE_F = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetSize)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetPixelSize(&self) -> Common::D2D_SIZE_U {
-        let mut result__: Common::D2D_SIZE_U = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetPixelSize)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
     #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
     pub unsafe fn GetPixelFormat(&self) -> Common::D2D1_PIXEL_FORMAT {
-        let mut result__: Common::D2D1_PIXEL_FORMAT = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetPixelFormat)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3513,7 +3513,7 @@ impl ID2D1Ink {
         (windows_core::Interface::vtable(self).SetStartPoint)(windows_core::Interface::as_raw(self), startpoint)
     }
     pub unsafe fn GetStartPoint(&self) -> D2D1_INK_POINT {
-        let mut result__: D2D1_INK_POINT = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetStartPoint)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3625,7 +3625,7 @@ windows_core::imp::interface_hierarchy!(ID2D1Layer, windows_core::IUnknown, ID2D
 impl ID2D1Layer {
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetSize(&self) -> Common::D2D_SIZE_F {
-        let mut result__: Common::D2D_SIZE_F = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetSize)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3659,13 +3659,13 @@ impl ID2D1LinearGradientBrush {
     }
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetStartPoint(&self) -> Common::D2D_POINT_2F {
-        let mut result__: Common::D2D_POINT_2F = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetStartPoint)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetEndPoint(&self) -> Common::D2D_POINT_2F {
-        let mut result__: Common::D2D_POINT_2F = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetEndPoint)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3775,7 +3775,7 @@ impl ID2D1OffsetTransform {
         (windows_core::Interface::vtable(self).SetOffset)(windows_core::Interface::as_raw(self), core::mem::transmute(offset))
     }
     pub unsafe fn GetOffset(&self) -> super::super::Foundation::POINT {
-        let mut result__: super::super::Foundation::POINT = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetOffset)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3985,13 +3985,13 @@ impl ID2D1RadialGradientBrush {
     }
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetCenter(&self) -> Common::D2D_POINT_2F {
-        let mut result__: Common::D2D_POINT_2F = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetCenter)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetGradientOriginOffset(&self) -> Common::D2D_POINT_2F {
-        let mut result__: Common::D2D_POINT_2F = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetGradientOriginOffset)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -4366,7 +4366,7 @@ impl ID2D1RenderTarget {
     }
     #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
     pub unsafe fn GetPixelFormat(&self) -> Common::D2D1_PIXEL_FORMAT {
-        let mut result__: Common::D2D1_PIXEL_FORMAT = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetPixelFormat)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -4378,13 +4378,13 @@ impl ID2D1RenderTarget {
     }
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetSize(&self) -> Common::D2D_SIZE_F {
-        let mut result__: Common::D2D_SIZE_F = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetSize)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetPixelSize(&self) -> Common::D2D_SIZE_U {
-        let mut result__: Common::D2D_SIZE_U = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetPixelSize)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -4635,7 +4635,7 @@ impl ID2D1SolidColorBrush {
     }
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetColor(&self) -> Common::D2D1_COLOR_F {
-        let mut result__: Common::D2D1_COLOR_F = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetColor)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -4850,7 +4850,7 @@ impl ID2D1SvgDocument {
     }
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
     pub unsafe fn GetViewportSize(&self) -> Common::D2D_SIZE_F {
-        let mut result__: Common::D2D_SIZE_F = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetViewportSize)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -158,7 +158,7 @@ impl ID3D12CommandQueue {
         (windows_core::Interface::vtable(self).GetClockCalibration)(windows_core::Interface::as_raw(self), pgputimestamp, pcputimestamp).ok()
     }
     pub unsafe fn GetDesc(&self) -> D3D12_COMMAND_QUEUE_DESC {
-        let mut result__: D3D12_COMMAND_QUEUE_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -628,17 +628,17 @@ impl core::ops::Deref for ID3D12DescriptorHeap {
 windows_core::imp::interface_hierarchy!(ID3D12DescriptorHeap, windows_core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ID3D12DescriptorHeap {
     pub unsafe fn GetDesc(&self) -> D3D12_DESCRIPTOR_HEAP_DESC {
-        let mut result__: D3D12_DESCRIPTOR_HEAP_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
     pub unsafe fn GetCPUDescriptorHandleForHeapStart(&self) -> D3D12_CPU_DESCRIPTOR_HANDLE {
-        let mut result__: D3D12_CPU_DESCRIPTOR_HANDLE = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetCPUDescriptorHandleForHeapStart)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
     pub unsafe fn GetGPUDescriptorHandleForHeapStart(&self) -> D3D12_GPU_DESCRIPTOR_HANDLE {
-        let mut result__: D3D12_GPU_DESCRIPTOR_HANDLE = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetGPUDescriptorHandleForHeapStart)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -765,12 +765,12 @@ impl ID3D12Device {
     }
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub unsafe fn GetResourceAllocationInfo(&self, visiblemask: u32, presourcedescs: &[D3D12_RESOURCE_DESC]) -> D3D12_RESOURCE_ALLOCATION_INFO {
-        let mut result__: D3D12_RESOURCE_ALLOCATION_INFO = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetResourceAllocationInfo)(windows_core::Interface::as_raw(self), &mut result__, visiblemask, presourcedescs.len().try_into().unwrap(), core::mem::transmute(presourcedescs.as_ptr()));
         result__
     }
     pub unsafe fn GetCustomHeapProperties(&self, nodemask: u32, heaptype: D3D12_HEAP_TYPE) -> D3D12_HEAP_PROPERTIES {
-        let mut result__: D3D12_HEAP_PROPERTIES = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetCustomHeapProperties)(windows_core::Interface::as_raw(self), &mut result__, nodemask, heaptype);
         result__
     }
@@ -871,7 +871,7 @@ impl ID3D12Device {
         (windows_core::Interface::vtable(self).GetResourceTiling)(windows_core::Interface::as_raw(self), ptiledresource.param().abi(), core::mem::transmute(pnumtilesforentireresource.unwrap_or(std::ptr::null_mut())), core::mem::transmute(ppackedmipdesc.unwrap_or(std::ptr::null_mut())), core::mem::transmute(pstandardtileshapefornonpackedmips.unwrap_or(std::ptr::null_mut())), core::mem::transmute(pnumsubresourcetilings.unwrap_or(std::ptr::null_mut())), firstsubresourcetilingtoget, psubresourcetilingsfornonpackedmips)
     }
     pub unsafe fn GetAdapterLuid(&self) -> super::super::Foundation::LUID {
-        let mut result__: super::super::Foundation::LUID = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetAdapterLuid)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -1070,7 +1070,7 @@ windows_core::imp::interface_hierarchy!(ID3D12Device12, windows_core::IUnknown, 
 impl ID3D12Device12 {
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub unsafe fn GetResourceAllocationInfo3(&self, visiblemask: u32, numresourcedescs: u32, presourcedescs: *const D3D12_RESOURCE_DESC1, pnumcastableformats: Option<*const u32>, ppcastableformats: Option<*const *const super::Dxgi::Common::DXGI_FORMAT>, presourceallocationinfo1: Option<*mut D3D12_RESOURCE_ALLOCATION_INFO1>) -> D3D12_RESOURCE_ALLOCATION_INFO {
-        let mut result__: D3D12_RESOURCE_ALLOCATION_INFO = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetResourceAllocationInfo3)(windows_core::Interface::as_raw(self), &mut result__, visiblemask, numresourcedescs, presourcedescs, core::mem::transmute(pnumcastableformats.unwrap_or(std::ptr::null())), core::mem::transmute(ppcastableformats.unwrap_or(std::ptr::null())), core::mem::transmute(presourceallocationinfo1.unwrap_or(std::ptr::null_mut())));
         result__
     }
@@ -1221,7 +1221,7 @@ impl ID3D12Device4 {
     }
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub unsafe fn GetResourceAllocationInfo1(&self, visiblemask: u32, numresourcedescs: u32, presourcedescs: *const D3D12_RESOURCE_DESC, presourceallocationinfo1: Option<*mut D3D12_RESOURCE_ALLOCATION_INFO1>) -> D3D12_RESOURCE_ALLOCATION_INFO {
-        let mut result__: D3D12_RESOURCE_ALLOCATION_INFO = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetResourceAllocationInfo1)(windows_core::Interface::as_raw(self), &mut result__, visiblemask, numresourcedescs, presourcedescs, core::mem::transmute(presourceallocationinfo1.unwrap_or(std::ptr::null_mut())));
         result__
     }
@@ -1379,7 +1379,7 @@ windows_core::imp::interface_hierarchy!(ID3D12Device8, windows_core::IUnknown, I
 impl ID3D12Device8 {
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub unsafe fn GetResourceAllocationInfo2(&self, visiblemask: u32, numresourcedescs: u32, presourcedescs: *const D3D12_RESOURCE_DESC1, presourceallocationinfo1: Option<*mut D3D12_RESOURCE_ALLOCATION_INFO1>) -> D3D12_RESOURCE_ALLOCATION_INFO {
-        let mut result__: D3D12_RESOURCE_ALLOCATION_INFO = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetResourceAllocationInfo2)(windows_core::Interface::as_raw(self), &mut result__, visiblemask, numresourcedescs, presourcedescs, core::mem::transmute(presourceallocationinfo1.unwrap_or(std::ptr::null_mut())));
         result__
     }
@@ -1502,7 +1502,7 @@ impl core::ops::Deref for ID3D12DeviceConfiguration {
 windows_core::imp::interface_hierarchy!(ID3D12DeviceConfiguration, windows_core::IUnknown);
 impl ID3D12DeviceConfiguration {
     pub unsafe fn GetDesc(&self) -> D3D12_DEVICE_CONFIGURATION_DESC {
-        let mut result__: D3D12_DEVICE_CONFIGURATION_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -2451,7 +2451,7 @@ impl core::ops::Deref for ID3D12Heap {
 windows_core::imp::interface_hierarchy!(ID3D12Heap, windows_core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12Pageable);
 impl ID3D12Heap {
     pub unsafe fn GetDesc(&self) -> D3D12_HEAP_DESC {
-        let mut result__: D3D12_HEAP_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -2959,7 +2959,7 @@ impl core::ops::Deref for ID3D12ProtectedResourceSession {
 windows_core::imp::interface_hierarchy!(ID3D12ProtectedResourceSession, windows_core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12ProtectedSession);
 impl ID3D12ProtectedResourceSession {
     pub unsafe fn GetDesc(&self) -> D3D12_PROTECTED_RESOURCE_SESSION_DESC {
-        let mut result__: D3D12_PROTECTED_RESOURCE_SESSION_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -2981,7 +2981,7 @@ impl core::ops::Deref for ID3D12ProtectedResourceSession1 {
 windows_core::imp::interface_hierarchy!(ID3D12ProtectedResourceSession1, windows_core::IUnknown, ID3D12Object, ID3D12DeviceChild, ID3D12ProtectedSession, ID3D12ProtectedResourceSession);
 impl ID3D12ProtectedResourceSession1 {
     pub unsafe fn GetDesc1(&self) -> D3D12_PROTECTED_RESOURCE_SESSION_DESC1 {
-        let mut result__: D3D12_PROTECTED_RESOURCE_SESSION_DESC1 = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc1)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3052,7 +3052,7 @@ impl ID3D12Resource {
     }
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub unsafe fn GetDesc(&self) -> D3D12_RESOURCE_DESC {
-        let mut result__: D3D12_RESOURCE_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3119,7 +3119,7 @@ windows_core::imp::interface_hierarchy!(ID3D12Resource2, windows_core::IUnknown,
 impl ID3D12Resource2 {
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub unsafe fn GetDesc1(&self) -> D3D12_RESOURCE_DESC1 {
-        let mut result__: D3D12_RESOURCE_DESC1 = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc1)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3240,7 +3240,7 @@ impl ID3D12ShaderCacheSession {
         (windows_core::Interface::vtable(self).SetDeleteOnDestroy)(windows_core::Interface::as_raw(self))
     }
     pub unsafe fn GetDesc(&self) -> D3D12_SHADER_CACHE_SESSION_DESC {
-        let mut result__: D3D12_SHADER_CACHE_SESSION_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3610,7 +3610,7 @@ impl core::ops::Deref for ID3D12SwapChainAssistant {
 windows_core::imp::interface_hierarchy!(ID3D12SwapChainAssistant, windows_core::IUnknown);
 impl ID3D12SwapChainAssistant {
     pub unsafe fn GetLUID(&self) -> super::super::Foundation::LUID {
-        let mut result__: super::super::Foundation::LUID = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetLUID)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
@@ -754,7 +754,7 @@ impl IKsPinPipe {
         (windows_core::Interface::vtable(self).KsSetPipeAllocatorFlag)(windows_core::Interface::as_raw(self), flag).ok()
     }
     pub unsafe fn KsGetPinBusCache(&self) -> windows_core::GUID {
-        let mut result__: windows_core::GUID = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).KsGetPinBusCache)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
@@ -2325,7 +2325,7 @@ windows_core::imp::interface_hierarchy!(ID3D12VideoDecoder, windows_core::IUnkno
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ID3D12VideoDecoder {
     pub unsafe fn GetDesc(&self) -> D3D12_VIDEO_DECODER_DESC {
-        let mut result__: D3D12_VIDEO_DECODER_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -2385,7 +2385,7 @@ windows_core::imp::interface_hierarchy!(ID3D12VideoDecoderHeap, windows_core::IU
 impl ID3D12VideoDecoderHeap {
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub unsafe fn GetDesc(&self) -> D3D12_VIDEO_DECODER_HEAP_DESC {
-        let mut result__: D3D12_VIDEO_DECODER_HEAP_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3037,7 +3037,7 @@ windows_core::imp::interface_hierarchy!(ID3D12VideoExtensionCommand, windows_cor
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 impl ID3D12VideoExtensionCommand {
     pub unsafe fn GetDesc(&self) -> D3D12_VIDEO_EXTENSION_COMMAND_DESC {
-        let mut result__: D3D12_VIDEO_EXTENSION_COMMAND_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3074,7 +3074,7 @@ windows_core::imp::interface_hierarchy!(ID3D12VideoMotionEstimator, windows_core
 impl ID3D12VideoMotionEstimator {
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub unsafe fn GetDesc(&self) -> D3D12_VIDEO_MOTION_ESTIMATOR_DESC {
-        let mut result__: D3D12_VIDEO_MOTION_ESTIMATOR_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3114,7 +3114,7 @@ windows_core::imp::interface_hierarchy!(ID3D12VideoMotionVectorHeap, windows_cor
 impl ID3D12VideoMotionVectorHeap {
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub unsafe fn GetDesc(&self) -> D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC {
-        let mut result__: D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }
@@ -3422,7 +3422,7 @@ impl ID3D12VideoProcessor {
     }
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
     pub unsafe fn GetOutputStreamDesc(&self) -> D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC {
-        let mut result__: D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC = core::mem::zeroed();
+        let mut result__ = core::mem::zeroed();
         (windows_core::Interface::vtable(self).GetOutputStreamDesc)(windows_core::Interface::as_raw(self), &mut result__);
         result__
     }


### PR DESCRIPTION
Just noticed that all other generated return types were being inferred except in this one case. 