### PR TITLE
NatVis does not need to be conditional

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,5 @@
 [build]
 rustflags = [
-    # "--cfg", "windows_debugger_visualizer",
     # "--cfg", "windows_raw_dylib",
     # "-C", "target-feature=+crt-static",
 ]

--- a/.github/workflows/debugger_visualizer.yml
+++ b/.github/workflows/debugger_visualizer.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  RUSTFLAGS: -Dwarnings --cfg windows_debugger_visualizer
+  RUSTFLAGS: -Dwarnings
 
 jobs:
   check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ exclude = [
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
 missing_docs = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows_debugger_visualizer)'] }
+unexpected_cfgs = { level = "warn" }

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -4,10 +4,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![doc(html_no_source)]
 #![allow(non_snake_case)]
-#![cfg_attr(
-    windows_debugger_visualizer,
-    debugger_visualizer(natvis_file = "../.natvis")
-)]
+#![debugger_visualizer(natvis_file = "../.natvis")]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
 extern crate self as windows_core;

--- a/crates/libs/result/src/lib.rs
+++ b/crates/libs/result/src/lib.rs
@@ -2,10 +2,7 @@
 Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs>
 */
 
-#![cfg_attr(
-    windows_debugger_visualizer,
-    debugger_visualizer(natvis_file = "../.natvis")
-)]
+#![debugger_visualizer(natvis_file = "../.natvis")]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(not(windows), allow(unused_imports))]
 

--- a/crates/libs/targets/Cargo.toml
+++ b/crates/libs/targets/Cargo.toml
@@ -10,8 +10,10 @@ description = "Import libs for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 
-[lints]
-workspace = true
+[lints.rust]
+rust_2018_idioms = { level = "warn", priority = -1 }
+missing_docs = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib)'] }
 
 [target.'cfg(all(target_arch = "x86", target_env = "msvc", not(windows_raw_dylib)))'.dependencies]
 windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.52.5" }

--- a/crates/tests/debugger_visualizer/Cargo.toml
+++ b/crates/tests/debugger_visualizer/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_debugger_visualizer)'] }
+unexpected_cfgs = { level = "warn" }
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/debugger_visualizer/tests/test.rs
+++ b/crates/tests/debugger_visualizer/tests/test.rs
@@ -1,4 +1,4 @@
-#![cfg(windows_debugger_visualizer)]
+#![cfg(windows)]
 
 use debugger_test::*;
 use windows::core::*;


### PR DESCRIPTION
The NatVis integration feature in Rust does not need to be made conditional. It was designed so that you can declare a NatVis file for any crate and the Rust compiler determines whether that is enabled for a particular platform.  Right now, it's only enabled for Windows.  On other platforms, it is safely and silently ignored.

So we don't need any conditional logic around NatVis.
