### PR TITLE
Use malloc on non-Windows platforms

### DIFF
--- a/crates/libs/core/src/imp/heap.rs
+++ b/crates/libs/core/src/imp/heap.rs
@@ -53,8 +53,6 @@ pub unsafe fn heap_free(ptr: *mut c_void) {
             fn free(ptr: *mut c_void);
         }
 
-        if !ptr.is_null() {
-            free(ptr);
-        }
+        free(ptr);
     }
 }


### PR DESCRIPTION
This is part of fixing #3083 .  This allows non-Windows code to use more of the COM support from `windows-core`.

This changes the `heap_alloc` function (and related) to use `malloc` on non-Windows platforms, instead of `HeapAlloc`.

With this change, I can now build DWriteCore using `windows-rs` crates.
