### PR TITLE
The `Debug` derive macro does not need to be qualified

### DIFF
--- a/crates/libs/bindgen/src/rust/classes.rs
+++ b/crates/libs/bindgen/src/rust/classes.rs
@@ -100,7 +100,7 @@ fn gen_class(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
         let mut tokens = quote! {
             #features
             #[repr(transparent)]
-            #[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+            #[derive(PartialEq, Eq, Debug, Clone)]
             pub struct #name(windows_core::IUnknown);
         };
 

--- a/crates/libs/bindgen/src/rust/delegates.rs
+++ b/crates/libs/bindgen/src/rust/delegates.rs
@@ -92,7 +92,7 @@ fn gen_win_delegate(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
         quote! {
             #features
             #[repr(transparent)]
-            #[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+            #[derive(PartialEq, Eq, Debug, Clone)]
             pub struct #ident(windows_core::IUnknown, #phantoms) where #constraints;
         }
     };

--- a/crates/libs/bindgen/src/rust/interfaces.rs
+++ b/crates/libs/bindgen/src/rust/interfaces.rs
@@ -63,7 +63,7 @@ fn gen_win_interface(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
             tokens.combine(&quote! {
                 #features
                 #[repr(transparent)]
-                #[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+                #[derive(PartialEq, Eq, Debug, Clone)]
                 pub struct #ident(windows_core::IUnknown, #phantoms) where #constraints;
             });
         }

--- a/crates/libs/core/src/imp/com_bindings.rs
+++ b/crates/libs/core/src/imp/com_bindings.rs
@@ -957,7 +957,7 @@ pub struct IPropertyValueStatics_Vtbl {
     ) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IReference<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;

--- a/crates/libs/windows/src/Windows/AI/MachineLearning/mod.rs
+++ b/crates/libs/windows/src/Windows/AI/MachineLearning/mod.rs
@@ -1017,7 +1017,7 @@ pub struct ITensorUInt8BitStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageFeatureDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageFeatureDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ImageFeatureDescriptor, ILearningModelFeatureDescriptor);
@@ -1101,7 +1101,7 @@ impl windows_core::RuntimeName for ImageFeatureDescriptor {
 unsafe impl Send for ImageFeatureDescriptor {}
 unsafe impl Sync for ImageFeatureDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageFeatureValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageFeatureValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ImageFeatureValue, ILearningModelFeatureValue);
@@ -1150,7 +1150,7 @@ impl windows_core::RuntimeName for ImageFeatureValue {
 unsafe impl Send for ImageFeatureValue {}
 unsafe impl Sync for ImageFeatureValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LearningModel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LearningModel, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LearningModel, super::super::Foundation::IClosable);
@@ -1315,7 +1315,7 @@ impl windows_core::RuntimeName for LearningModel {
 unsafe impl Send for LearningModel {}
 unsafe impl Sync for LearningModel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LearningModelBinding(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LearningModelBinding, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -1422,7 +1422,7 @@ impl IntoIterator for &LearningModelBinding {
 unsafe impl Send for LearningModelBinding {}
 unsafe impl Sync for LearningModelBinding {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LearningModelDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LearningModelDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl LearningModelDevice {
@@ -1482,7 +1482,7 @@ impl windows_core::RuntimeName for LearningModelDevice {
 unsafe impl Send for LearningModelDevice {}
 unsafe impl Sync for LearningModelDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LearningModelEvaluationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LearningModelEvaluationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl LearningModelEvaluationResult {
@@ -1529,7 +1529,7 @@ impl windows_core::RuntimeName for LearningModelEvaluationResult {
 unsafe impl Send for LearningModelEvaluationResult {}
 unsafe impl Sync for LearningModelEvaluationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LearningModelSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LearningModelSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LearningModelSession, super::super::Foundation::IClosable);
@@ -1656,7 +1656,7 @@ impl windows_core::RuntimeName for LearningModelSession {
 unsafe impl Send for LearningModelSession {}
 unsafe impl Sync for LearningModelSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LearningModelSessionOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LearningModelSessionOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl LearningModelSessionOptions {
@@ -1707,7 +1707,7 @@ impl windows_core::RuntimeName for LearningModelSessionOptions {
 unsafe impl Send for LearningModelSessionOptions {}
 unsafe impl Sync for LearningModelSessionOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MapFeatureDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MapFeatureDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MapFeatureDescriptor, ILearningModelFeatureDescriptor);
@@ -1768,7 +1768,7 @@ impl windows_core::RuntimeName for MapFeatureDescriptor {
 unsafe impl Send for MapFeatureDescriptor {}
 unsafe impl Sync for MapFeatureDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SequenceFeatureDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SequenceFeatureDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SequenceFeatureDescriptor, ILearningModelFeatureDescriptor);
@@ -1822,7 +1822,7 @@ impl windows_core::RuntimeName for SequenceFeatureDescriptor {
 unsafe impl Send for SequenceFeatureDescriptor {}
 unsafe impl Sync for SequenceFeatureDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorBoolean(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorBoolean, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorBoolean, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -1945,7 +1945,7 @@ impl windows_core::RuntimeName for TensorBoolean {
 unsafe impl Send for TensorBoolean {}
 unsafe impl Sync for TensorBoolean {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorDouble(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorDouble, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorDouble, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -2068,7 +2068,7 @@ impl windows_core::RuntimeName for TensorDouble {
 unsafe impl Send for TensorDouble {}
 unsafe impl Sync for TensorDouble {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorFeatureDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorFeatureDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorFeatureDescriptor, ILearningModelFeatureDescriptor);
@@ -2130,7 +2130,7 @@ impl windows_core::RuntimeName for TensorFeatureDescriptor {
 unsafe impl Send for TensorFeatureDescriptor {}
 unsafe impl Sync for TensorFeatureDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorFloat(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorFloat, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorFloat, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -2253,7 +2253,7 @@ impl windows_core::RuntimeName for TensorFloat {
 unsafe impl Send for TensorFloat {}
 unsafe impl Sync for TensorFloat {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorFloat16Bit(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorFloat16Bit, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorFloat16Bit, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -2376,7 +2376,7 @@ impl windows_core::RuntimeName for TensorFloat16Bit {
 unsafe impl Send for TensorFloat16Bit {}
 unsafe impl Sync for TensorFloat16Bit {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorInt16Bit(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorInt16Bit, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorInt16Bit, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -2499,7 +2499,7 @@ impl windows_core::RuntimeName for TensorInt16Bit {
 unsafe impl Send for TensorInt16Bit {}
 unsafe impl Sync for TensorInt16Bit {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorInt32Bit(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorInt32Bit, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorInt32Bit, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -2622,7 +2622,7 @@ impl windows_core::RuntimeName for TensorInt32Bit {
 unsafe impl Send for TensorInt32Bit {}
 unsafe impl Sync for TensorInt32Bit {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorInt64Bit(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorInt64Bit, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorInt64Bit, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -2745,7 +2745,7 @@ impl windows_core::RuntimeName for TensorInt64Bit {
 unsafe impl Send for TensorInt64Bit {}
 unsafe impl Sync for TensorInt64Bit {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorInt8Bit(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorInt8Bit, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorInt8Bit, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -2868,7 +2868,7 @@ impl windows_core::RuntimeName for TensorInt8Bit {
 unsafe impl Send for TensorInt8Bit {}
 unsafe impl Sync for TensorInt8Bit {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorString(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorString, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorString, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -2981,7 +2981,7 @@ impl windows_core::RuntimeName for TensorString {
 unsafe impl Send for TensorString {}
 unsafe impl Sync for TensorString {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorUInt16Bit(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorUInt16Bit, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorUInt16Bit, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -3104,7 +3104,7 @@ impl windows_core::RuntimeName for TensorUInt16Bit {
 unsafe impl Send for TensorUInt16Bit {}
 unsafe impl Sync for TensorUInt16Bit {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorUInt32Bit(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorUInt32Bit, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorUInt32Bit, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -3227,7 +3227,7 @@ impl windows_core::RuntimeName for TensorUInt32Bit {
 unsafe impl Send for TensorUInt32Bit {}
 unsafe impl Sync for TensorUInt32Bit {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorUInt64Bit(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorUInt64Bit, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorUInt64Bit, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);
@@ -3350,7 +3350,7 @@ impl windows_core::RuntimeName for TensorUInt64Bit {
 unsafe impl Send for TensorUInt64Bit {}
 unsafe impl Sync for TensorUInt64Bit {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TensorUInt8Bit(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TensorUInt8Bit, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TensorUInt8Bit, super::super::Foundation::IClosable, ILearningModelFeatureValue, super::super::Foundation::IMemoryBuffer, ITensor);

--- a/crates/libs/windows/src/Windows/ApplicationModel/Activation/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Activation/mod.rs
@@ -3317,7 +3317,7 @@ pub struct IWebAuthenticationBrokerContinuationEventArgs_Vtbl {
     WebAuthenticationResult: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentsProviderAddAppointmentActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentsProviderAddAppointmentActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppointmentsProviderAddAppointmentActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IAppointmentsProviderActivatedEventArgs, IAppointmentsProviderAddAppointmentActivatedEventArgs);
@@ -3380,7 +3380,7 @@ impl windows_core::RuntimeName for AppointmentsProviderAddAppointmentActivatedEv
 unsafe impl Send for AppointmentsProviderAddAppointmentActivatedEventArgs {}
 unsafe impl Sync for AppointmentsProviderAddAppointmentActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentsProviderRemoveAppointmentActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentsProviderRemoveAppointmentActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppointmentsProviderRemoveAppointmentActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IAppointmentsProviderActivatedEventArgs, IAppointmentsProviderRemoveAppointmentActivatedEventArgs);
@@ -3443,7 +3443,7 @@ impl windows_core::RuntimeName for AppointmentsProviderRemoveAppointmentActivate
 unsafe impl Send for AppointmentsProviderRemoveAppointmentActivatedEventArgs {}
 unsafe impl Sync for AppointmentsProviderRemoveAppointmentActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentsProviderReplaceAppointmentActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentsProviderReplaceAppointmentActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppointmentsProviderReplaceAppointmentActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IAppointmentsProviderActivatedEventArgs, IAppointmentsProviderReplaceAppointmentActivatedEventArgs);
@@ -3506,7 +3506,7 @@ impl windows_core::RuntimeName for AppointmentsProviderReplaceAppointmentActivat
 unsafe impl Send for AppointmentsProviderReplaceAppointmentActivatedEventArgs {}
 unsafe impl Sync for AppointmentsProviderReplaceAppointmentActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentsProviderShowAppointmentDetailsActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentsProviderShowAppointmentDetailsActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppointmentsProviderShowAppointmentDetailsActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IAppointmentsProviderActivatedEventArgs, IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs);
@@ -3582,7 +3582,7 @@ impl windows_core::RuntimeName for AppointmentsProviderShowAppointmentDetailsAct
 unsafe impl Send for AppointmentsProviderShowAppointmentDetailsActivatedEventArgs {}
 unsafe impl Sync for AppointmentsProviderShowAppointmentDetailsActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentsProviderShowTimeFrameActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentsProviderShowTimeFrameActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppointmentsProviderShowTimeFrameActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IAppointmentsProviderActivatedEventArgs, IAppointmentsProviderShowTimeFrameActivatedEventArgs);
@@ -3651,7 +3651,7 @@ impl windows_core::RuntimeName for AppointmentsProviderShowTimeFrameActivatedEve
 unsafe impl Send for AppointmentsProviderShowTimeFrameActivatedEventArgs {}
 unsafe impl Sync for AppointmentsProviderShowTimeFrameActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BackgroundActivatedEventArgs, IBackgroundActivatedEventArgs);
@@ -3678,7 +3678,7 @@ impl windows_core::RuntimeName for BackgroundActivatedEventArgs {
 unsafe impl Send for BackgroundActivatedEventArgs {}
 unsafe impl Sync for BackgroundActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerPreviewActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerPreviewActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BarcodeScannerPreviewActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IBarcodeScannerPreviewActivatedEventArgs);
@@ -3733,7 +3733,7 @@ impl windows_core::RuntimeName for BarcodeScannerPreviewActivatedEventArgs {
 unsafe impl Send for BarcodeScannerPreviewActivatedEventArgs {}
 unsafe impl Sync for BarcodeScannerPreviewActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CachedFileUpdaterActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CachedFileUpdaterActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CachedFileUpdaterActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, ICachedFileUpdaterActivatedEventArgs);
@@ -3789,7 +3789,7 @@ impl windows_core::RuntimeName for CachedFileUpdaterActivatedEventArgs {
 unsafe impl Send for CachedFileUpdaterActivatedEventArgs {}
 unsafe impl Sync for CachedFileUpdaterActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CameraSettingsActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CameraSettingsActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CameraSettingsActivatedEventArgs, IActivatedEventArgs, ICameraSettingsActivatedEventArgs);
@@ -3843,7 +3843,7 @@ impl windows_core::RuntimeName for CameraSettingsActivatedEventArgs {
 unsafe impl Send for CameraSettingsActivatedEventArgs {}
 unsafe impl Sync for CameraSettingsActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CommandLineActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CommandLineActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CommandLineActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, ICommandLineActivatedEventArgs);
@@ -3898,7 +3898,7 @@ impl windows_core::RuntimeName for CommandLineActivatedEventArgs {
 unsafe impl Send for CommandLineActivatedEventArgs {}
 unsafe impl Sync for CommandLineActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CommandLineActivationOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CommandLineActivationOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl CommandLineActivationOperation {
@@ -3948,7 +3948,7 @@ impl windows_core::RuntimeName for CommandLineActivationOperation {
 unsafe impl Send for CommandLineActivationOperation {}
 unsafe impl Sync for CommandLineActivationOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactCallActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactCallActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactCallActivatedEventArgs, IActivatedEventArgs, IContactActivatedEventArgs, IContactCallActivatedEventArgs);
@@ -4017,7 +4017,7 @@ impl windows_core::RuntimeName for ContactCallActivatedEventArgs {
 unsafe impl Send for ContactCallActivatedEventArgs {}
 unsafe impl Sync for ContactCallActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactMapActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactMapActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactMapActivatedEventArgs, IActivatedEventArgs, IContactActivatedEventArgs, IContactMapActivatedEventArgs);
@@ -4080,7 +4080,7 @@ impl windows_core::RuntimeName for ContactMapActivatedEventArgs {
 unsafe impl Send for ContactMapActivatedEventArgs {}
 unsafe impl Sync for ContactMapActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactMessageActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactMessageActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactMessageActivatedEventArgs, IActivatedEventArgs, IContactActivatedEventArgs, IContactMessageActivatedEventArgs);
@@ -4149,7 +4149,7 @@ impl windows_core::RuntimeName for ContactMessageActivatedEventArgs {
 unsafe impl Send for ContactMessageActivatedEventArgs {}
 unsafe impl Sync for ContactMessageActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactPanelActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactPanelActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactPanelActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IContactPanelActivatedEventArgs);
@@ -4213,7 +4213,7 @@ impl windows_core::RuntimeName for ContactPanelActivatedEventArgs {
 unsafe impl Send for ContactPanelActivatedEventArgs {}
 unsafe impl Sync for ContactPanelActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactPickerActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactPickerActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactPickerActivatedEventArgs, IActivatedEventArgs, IContactPickerActivatedEventArgs);
@@ -4261,7 +4261,7 @@ impl windows_core::RuntimeName for ContactPickerActivatedEventArgs {
 unsafe impl Send for ContactPickerActivatedEventArgs {}
 unsafe impl Sync for ContactPickerActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactPostActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactPostActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactPostActivatedEventArgs, IActivatedEventArgs, IContactActivatedEventArgs, IContactPostActivatedEventArgs);
@@ -4330,7 +4330,7 @@ impl windows_core::RuntimeName for ContactPostActivatedEventArgs {
 unsafe impl Send for ContactPostActivatedEventArgs {}
 unsafe impl Sync for ContactPostActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactVideoCallActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactVideoCallActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactVideoCallActivatedEventArgs, IActivatedEventArgs, IContactActivatedEventArgs, IContactVideoCallActivatedEventArgs);
@@ -4399,7 +4399,7 @@ impl windows_core::RuntimeName for ContactVideoCallActivatedEventArgs {
 unsafe impl Send for ContactVideoCallActivatedEventArgs {}
 unsafe impl Sync for ContactVideoCallActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DeviceActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IApplicationViewActivatedEventArgs, IDeviceActivatedEventArgs, IViewSwitcherProvider);
@@ -4476,7 +4476,7 @@ impl windows_core::RuntimeName for DeviceActivatedEventArgs {
 unsafe impl Send for DeviceActivatedEventArgs {}
 unsafe impl Sync for DeviceActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DevicePairingActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DevicePairingActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DevicePairingActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IDevicePairingActivatedEventArgs);
@@ -4532,7 +4532,7 @@ impl windows_core::RuntimeName for DevicePairingActivatedEventArgs {
 unsafe impl Send for DevicePairingActivatedEventArgs {}
 unsafe impl Sync for DevicePairingActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DialReceiverActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DialReceiverActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DialReceiverActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IApplicationViewActivatedEventArgs, IDialReceiverActivatedEventArgs, ILaunchActivatedEventArgs, IViewSwitcherProvider);
@@ -4616,7 +4616,7 @@ impl windows_core::RuntimeName for DialReceiverActivatedEventArgs {
 unsafe impl Send for DialReceiverActivatedEventArgs {}
 unsafe impl Sync for DialReceiverActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FileActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IApplicationViewActivatedEventArgs, IFileActivatedEventArgs, IFileActivatedEventArgsWithCallerPackageFamilyName, IFileActivatedEventArgsWithNeighboringFiles, IViewSwitcherProvider);
@@ -4709,7 +4709,7 @@ impl windows_core::RuntimeName for FileActivatedEventArgs {
 unsafe impl Send for FileActivatedEventArgs {}
 unsafe impl Sync for FileActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileOpenPickerActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileOpenPickerActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FileOpenPickerActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IFileOpenPickerActivatedEventArgs, IFileOpenPickerActivatedEventArgs2);
@@ -4773,7 +4773,7 @@ unsafe impl Send for FileOpenPickerActivatedEventArgs {}
 unsafe impl Sync for FileOpenPickerActivatedEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileOpenPickerContinuationEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(FileOpenPickerContinuationEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -4845,7 +4845,7 @@ unsafe impl Send for FileOpenPickerContinuationEventArgs {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for FileOpenPickerContinuationEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileSavePickerActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileSavePickerActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FileSavePickerActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IFileSavePickerActivatedEventArgs, IFileSavePickerActivatedEventArgs2);
@@ -4916,7 +4916,7 @@ unsafe impl Send for FileSavePickerActivatedEventArgs {}
 unsafe impl Sync for FileSavePickerActivatedEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileSavePickerContinuationEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(FileSavePickerContinuationEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -4989,7 +4989,7 @@ unsafe impl Send for FileSavePickerContinuationEventArgs {}
 unsafe impl Sync for FileSavePickerContinuationEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FolderPickerContinuationEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(FolderPickerContinuationEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -5061,7 +5061,7 @@ unsafe impl Send for FolderPickerContinuationEventArgs {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for FolderPickerContinuationEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LaunchActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LaunchActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LaunchActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IApplicationViewActivatedEventArgs, ILaunchActivatedEventArgs, ILaunchActivatedEventArgs2, IPrelaunchActivatedEventArgs, IViewSwitcherProvider);
@@ -5152,7 +5152,7 @@ impl windows_core::RuntimeName for LaunchActivatedEventArgs {
 unsafe impl Send for LaunchActivatedEventArgs {}
 unsafe impl Sync for LaunchActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockScreenActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockScreenActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LockScreenActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, ILockScreenActivatedEventArgs);
@@ -5207,7 +5207,7 @@ impl windows_core::RuntimeName for LockScreenActivatedEventArgs {
 unsafe impl Send for LockScreenActivatedEventArgs {}
 unsafe impl Sync for LockScreenActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockScreenCallActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockScreenCallActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LockScreenCallActivatedEventArgs, IActivatedEventArgs, IApplicationViewActivatedEventArgs, ILaunchActivatedEventArgs, ILockScreenCallActivatedEventArgs, IViewSwitcherProvider);
@@ -5284,7 +5284,7 @@ impl windows_core::RuntimeName for LockScreenCallActivatedEventArgs {
 unsafe impl Send for LockScreenCallActivatedEventArgs {}
 unsafe impl Sync for LockScreenCallActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockScreenComponentActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockScreenComponentActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LockScreenComponentActivatedEventArgs, IActivatedEventArgs);
@@ -5324,7 +5324,7 @@ impl windows_core::RuntimeName for LockScreenComponentActivatedEventArgs {
 unsafe impl Send for LockScreenComponentActivatedEventArgs {}
 unsafe impl Sync for LockScreenComponentActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PhoneCallActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IPhoneCallActivatedEventArgs);
@@ -5379,7 +5379,7 @@ impl windows_core::RuntimeName for PhoneCallActivatedEventArgs {
 unsafe impl Send for PhoneCallActivatedEventArgs {}
 unsafe impl Sync for PhoneCallActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PickerReturnedActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PickerReturnedActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PickerReturnedActivatedEventArgs, IActivatedEventArgs, IPickerReturnedActivatedEventArgs);
@@ -5426,7 +5426,7 @@ impl windows_core::RuntimeName for PickerReturnedActivatedEventArgs {
 unsafe impl Send for PickerReturnedActivatedEventArgs {}
 unsafe impl Sync for PickerReturnedActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DWorkflowActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DWorkflowActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Print3DWorkflowActivatedEventArgs, IActivatedEventArgs, IPrint3DWorkflowActivatedEventArgs);
@@ -5474,7 +5474,7 @@ impl windows_core::RuntimeName for Print3DWorkflowActivatedEventArgs {
 unsafe impl Send for Print3DWorkflowActivatedEventArgs {}
 unsafe impl Sync for Print3DWorkflowActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskSettingsActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskSettingsActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintTaskSettingsActivatedEventArgs, IActivatedEventArgs, IPrintTaskSettingsActivatedEventArgs);
@@ -5522,7 +5522,7 @@ impl windows_core::RuntimeName for PrintTaskSettingsActivatedEventArgs {
 unsafe impl Send for PrintTaskSettingsActivatedEventArgs {}
 unsafe impl Sync for PrintTaskSettingsActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtocolActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtocolActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ProtocolActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IApplicationViewActivatedEventArgs, IProtocolActivatedEventArgs, IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData, IViewSwitcherProvider);
@@ -5607,7 +5607,7 @@ impl windows_core::RuntimeName for ProtocolActivatedEventArgs {
 unsafe impl Send for ProtocolActivatedEventArgs {}
 unsafe impl Sync for ProtocolActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtocolForResultsActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtocolForResultsActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ProtocolForResultsActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IApplicationViewActivatedEventArgs, IProtocolActivatedEventArgs, IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData, IProtocolForResultsActivatedEventArgs, IViewSwitcherProvider);
@@ -5700,7 +5700,7 @@ impl windows_core::RuntimeName for ProtocolForResultsActivatedEventArgs {
 unsafe impl Send for ProtocolForResultsActivatedEventArgs {}
 unsafe impl Sync for ProtocolForResultsActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RestrictedLaunchActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RestrictedLaunchActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RestrictedLaunchActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IRestrictedLaunchActivatedEventArgs);
@@ -5755,7 +5755,7 @@ impl windows_core::RuntimeName for RestrictedLaunchActivatedEventArgs {
 unsafe impl Send for RestrictedLaunchActivatedEventArgs {}
 unsafe impl Sync for RestrictedLaunchActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SearchActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SearchActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IApplicationViewActivatedEventArgs, ISearchActivatedEventArgs, ISearchActivatedEventArgsWithLinguisticDetails, IViewSwitcherProvider);
@@ -5840,7 +5840,7 @@ impl windows_core::RuntimeName for SearchActivatedEventArgs {
 unsafe impl Send for SearchActivatedEventArgs {}
 unsafe impl Sync for SearchActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShareTargetActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShareTargetActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ShareTargetActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IShareTargetActivatedEventArgs);
@@ -5896,7 +5896,7 @@ impl windows_core::RuntimeName for ShareTargetActivatedEventArgs {
 unsafe impl Send for ShareTargetActivatedEventArgs {}
 unsafe impl Sync for ShareTargetActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SplashScreen(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SplashScreen, windows_core::IUnknown, windows_core::IInspectable);
 impl SplashScreen {
@@ -5933,7 +5933,7 @@ impl windows_core::RuntimeName for SplashScreen {
     const NAME: &'static str = "Windows.ApplicationModel.Activation.SplashScreen";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StartupTaskActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StartupTaskActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StartupTaskActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IStartupTaskActivatedEventArgs);
@@ -5988,7 +5988,7 @@ impl windows_core::RuntimeName for StartupTaskActivatedEventArgs {
 unsafe impl Send for StartupTaskActivatedEventArgs {}
 unsafe impl Sync for StartupTaskActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TileActivatedInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TileActivatedInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl TileActivatedInfo {
@@ -6014,7 +6014,7 @@ impl windows_core::RuntimeName for TileActivatedInfo {
 unsafe impl Send for TileActivatedInfo {}
 unsafe impl Sync for TileActivatedInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastNotificationActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastNotificationActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ToastNotificationActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IApplicationViewActivatedEventArgs, IToastNotificationActivatedEventArgs);
@@ -6084,7 +6084,7 @@ impl windows_core::RuntimeName for ToastNotificationActivatedEventArgs {
 unsafe impl Send for ToastNotificationActivatedEventArgs {}
 unsafe impl Sync for ToastNotificationActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataAccountProviderActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataAccountProviderActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UserDataAccountProviderActivatedEventArgs, IActivatedEventArgs, IUserDataAccountProviderActivatedEventArgs);
@@ -6132,7 +6132,7 @@ impl windows_core::RuntimeName for UserDataAccountProviderActivatedEventArgs {
 unsafe impl Send for UserDataAccountProviderActivatedEventArgs {}
 unsafe impl Sync for UserDataAccountProviderActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommandActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommandActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VoiceCommandActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IVoiceCommandActivatedEventArgs);
@@ -6189,7 +6189,7 @@ unsafe impl Send for VoiceCommandActivatedEventArgs {}
 unsafe impl Sync for VoiceCommandActivatedEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WalletActionActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(WalletActionActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -6261,7 +6261,7 @@ unsafe impl Send for WalletActionActivatedEventArgs {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for WalletActionActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProviderActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProviderActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAccountProviderActivatedEventArgs, IActivatedEventArgs, IActivatedEventArgsWithUser, IWebAccountProviderActivatedEventArgs);
@@ -6317,7 +6317,7 @@ impl windows_core::RuntimeName for WebAccountProviderActivatedEventArgs {
 unsafe impl Send for WebAccountProviderActivatedEventArgs {}
 unsafe impl Sync for WebAccountProviderActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAuthenticationBrokerContinuationEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAuthenticationBrokerContinuationEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAuthenticationBrokerContinuationEventArgs, IActivatedEventArgs, IContinuationActivatedEventArgs, IWebAuthenticationBrokerContinuationEventArgs);

--- a/crates/libs/windows/src/Windows/ApplicationModel/AppExtensions/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/AppExtensions/mod.rs
@@ -119,7 +119,7 @@ pub struct IAppExtensionPackageUpdatingEventArgs_Vtbl {
     pub Package: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppExtension(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppExtension, windows_core::IUnknown, windows_core::IInspectable);
 impl AppExtension {
@@ -195,7 +195,7 @@ impl windows_core::RuntimeName for AppExtension {
 unsafe impl Send for AppExtension {}
 unsafe impl Sync for AppExtension {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppExtensionCatalog(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppExtensionCatalog, windows_core::IUnknown, windows_core::IInspectable);
 impl AppExtensionCatalog {
@@ -307,7 +307,7 @@ impl windows_core::RuntimeName for AppExtensionCatalog {
     const NAME: &'static str = "Windows.ApplicationModel.AppExtensions.AppExtensionCatalog";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppExtensionPackageInstalledEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppExtensionPackageInstalledEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppExtensionPackageInstalledEventArgs {
@@ -347,7 +347,7 @@ impl windows_core::RuntimeName for AppExtensionPackageInstalledEventArgs {
 unsafe impl Send for AppExtensionPackageInstalledEventArgs {}
 unsafe impl Sync for AppExtensionPackageInstalledEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppExtensionPackageStatusChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppExtensionPackageStatusChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppExtensionPackageStatusChangedEventArgs {
@@ -379,7 +379,7 @@ impl windows_core::RuntimeName for AppExtensionPackageStatusChangedEventArgs {
 unsafe impl Send for AppExtensionPackageStatusChangedEventArgs {}
 unsafe impl Sync for AppExtensionPackageStatusChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppExtensionPackageUninstallingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppExtensionPackageUninstallingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppExtensionPackageUninstallingEventArgs {
@@ -411,7 +411,7 @@ impl windows_core::RuntimeName for AppExtensionPackageUninstallingEventArgs {
 unsafe impl Send for AppExtensionPackageUninstallingEventArgs {}
 unsafe impl Sync for AppExtensionPackageUninstallingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppExtensionPackageUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppExtensionPackageUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppExtensionPackageUpdatedEventArgs {
@@ -451,7 +451,7 @@ impl windows_core::RuntimeName for AppExtensionPackageUpdatedEventArgs {
 unsafe impl Send for AppExtensionPackageUpdatedEventArgs {}
 unsafe impl Sync for AppExtensionPackageUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppExtensionPackageUpdatingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppExtensionPackageUpdatingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppExtensionPackageUpdatingEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/AppService/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/AppService/mod.rs
@@ -190,7 +190,7 @@ impl windows_core::RuntimeName for AppServiceCatalog {
     const NAME: &'static str = "Windows.ApplicationModel.AppService.AppServiceCatalog";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppServiceClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppServiceClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppServiceClosedEventArgs {
@@ -215,7 +215,7 @@ impl windows_core::RuntimeName for AppServiceClosedEventArgs {
 unsafe impl Send for AppServiceClosedEventArgs {}
 unsafe impl Sync for AppServiceClosedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppServiceConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppServiceConnection, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppServiceConnection, super::super::Foundation::IClosable);
@@ -357,7 +357,7 @@ impl windows_core::RuntimeName for AppServiceConnection {
 unsafe impl Send for AppServiceConnection {}
 unsafe impl Sync for AppServiceConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppServiceDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppServiceDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl AppServiceDeferral {
@@ -379,7 +379,7 @@ impl windows_core::RuntimeName for AppServiceDeferral {
 unsafe impl Send for AppServiceDeferral {}
 unsafe impl Sync for AppServiceDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppServiceRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppServiceRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl AppServiceRequest {
@@ -416,7 +416,7 @@ impl windows_core::RuntimeName for AppServiceRequest {
 unsafe impl Send for AppServiceRequest {}
 unsafe impl Sync for AppServiceRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppServiceRequestReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppServiceRequestReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppServiceRequestReceivedEventArgs {
@@ -448,7 +448,7 @@ impl windows_core::RuntimeName for AppServiceRequestReceivedEventArgs {
 unsafe impl Send for AppServiceRequestReceivedEventArgs {}
 unsafe impl Sync for AppServiceRequestReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppServiceResponse(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppServiceResponse, windows_core::IUnknown, windows_core::IInspectable);
 impl AppServiceResponse {
@@ -481,7 +481,7 @@ impl windows_core::RuntimeName for AppServiceResponse {
 unsafe impl Send for AppServiceResponse {}
 unsafe impl Sync for AppServiceResponse {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppServiceTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppServiceTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl AppServiceTriggerDetails {
@@ -541,7 +541,7 @@ impl windows_core::RuntimeName for AppServiceTriggerDetails {
 unsafe impl Send for AppServiceTriggerDetails {}
 unsafe impl Sync for AppServiceTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StatelessAppServiceResponse(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StatelessAppServiceResponse, windows_core::IUnknown, windows_core::IInspectable);
 impl StatelessAppServiceResponse {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/AppointmentsProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/AppointmentsProvider/mod.rs
@@ -65,7 +65,7 @@ pub struct IReplaceAppointmentOperation_Vtbl {
     pub DismissUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AddAppointmentOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AddAppointmentOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl AddAppointmentOperation {
@@ -159,7 +159,7 @@ impl windows_core::RuntimeName for AppointmentsProviderLaunchActionVerbs {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentsProvider.AppointmentsProviderLaunchActionVerbs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoveAppointmentOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoveAppointmentOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoveAppointmentOperation {
@@ -214,7 +214,7 @@ impl windows_core::RuntimeName for RemoveAppointmentOperation {
 unsafe impl Send for RemoveAppointmentOperation {}
 unsafe impl Sync for RemoveAppointmentOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ReplaceAppointmentOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ReplaceAppointmentOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl ReplaceAppointmentOperation {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/DataProvider/mod.rs
@@ -187,7 +187,7 @@ pub struct IAppointmentDataProviderTriggerDetails_Vtbl {
     pub Connection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarCancelMeetingRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarCancelMeetingRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarCancelMeetingRequest {
@@ -261,7 +261,7 @@ impl windows_core::RuntimeName for AppointmentCalendarCancelMeetingRequest {
 unsafe impl Send for AppointmentCalendarCancelMeetingRequest {}
 unsafe impl Sync for AppointmentCalendarCancelMeetingRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarCancelMeetingRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarCancelMeetingRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarCancelMeetingRequestEventArgs {
@@ -293,7 +293,7 @@ impl windows_core::RuntimeName for AppointmentCalendarCancelMeetingRequestEventA
 unsafe impl Send for AppointmentCalendarCancelMeetingRequestEventArgs {}
 unsafe impl Sync for AppointmentCalendarCancelMeetingRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarCreateOrUpdateAppointmentRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarCreateOrUpdateAppointmentRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarCreateOrUpdateAppointmentRequest {
@@ -357,7 +357,7 @@ impl windows_core::RuntimeName for AppointmentCalendarCreateOrUpdateAppointmentR
 unsafe impl Send for AppointmentCalendarCreateOrUpdateAppointmentRequest {}
 unsafe impl Sync for AppointmentCalendarCreateOrUpdateAppointmentRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {
@@ -389,7 +389,7 @@ impl windows_core::RuntimeName for AppointmentCalendarCreateOrUpdateAppointmentR
 unsafe impl Send for AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {}
 unsafe impl Sync for AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarForwardMeetingRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarForwardMeetingRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarForwardMeetingRequest {
@@ -471,7 +471,7 @@ impl windows_core::RuntimeName for AppointmentCalendarForwardMeetingRequest {
 unsafe impl Send for AppointmentCalendarForwardMeetingRequest {}
 unsafe impl Sync for AppointmentCalendarForwardMeetingRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarForwardMeetingRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarForwardMeetingRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarForwardMeetingRequestEventArgs {
@@ -503,7 +503,7 @@ impl windows_core::RuntimeName for AppointmentCalendarForwardMeetingRequestEvent
 unsafe impl Send for AppointmentCalendarForwardMeetingRequestEventArgs {}
 unsafe impl Sync for AppointmentCalendarForwardMeetingRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarProposeNewTimeForMeetingRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarProposeNewTimeForMeetingRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarProposeNewTimeForMeetingRequest {
@@ -584,7 +584,7 @@ impl windows_core::RuntimeName for AppointmentCalendarProposeNewTimeForMeetingRe
 unsafe impl Send for AppointmentCalendarProposeNewTimeForMeetingRequest {}
 unsafe impl Sync for AppointmentCalendarProposeNewTimeForMeetingRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {
@@ -616,7 +616,7 @@ impl windows_core::RuntimeName for AppointmentCalendarProposeNewTimeForMeetingRe
 unsafe impl Send for AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {}
 unsafe impl Sync for AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarSyncManagerSyncRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarSyncManagerSyncRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarSyncManagerSyncRequest {
@@ -655,7 +655,7 @@ impl windows_core::RuntimeName for AppointmentCalendarSyncManagerSyncRequest {
 unsafe impl Send for AppointmentCalendarSyncManagerSyncRequest {}
 unsafe impl Sync for AppointmentCalendarSyncManagerSyncRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarSyncManagerSyncRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarSyncManagerSyncRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarSyncManagerSyncRequestEventArgs {
@@ -687,7 +687,7 @@ impl windows_core::RuntimeName for AppointmentCalendarSyncManagerSyncRequestEven
 unsafe impl Send for AppointmentCalendarSyncManagerSyncRequestEventArgs {}
 unsafe impl Sync for AppointmentCalendarSyncManagerSyncRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarUpdateMeetingResponseRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarUpdateMeetingResponseRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarUpdateMeetingResponseRequest {
@@ -768,7 +768,7 @@ impl windows_core::RuntimeName for AppointmentCalendarUpdateMeetingResponseReque
 unsafe impl Send for AppointmentCalendarUpdateMeetingResponseRequest {}
 unsafe impl Sync for AppointmentCalendarUpdateMeetingResponseRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarUpdateMeetingResponseRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarUpdateMeetingResponseRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarUpdateMeetingResponseRequestEventArgs {
@@ -800,7 +800,7 @@ impl windows_core::RuntimeName for AppointmentCalendarUpdateMeetingResponseReque
 unsafe impl Send for AppointmentCalendarUpdateMeetingResponseRequestEventArgs {}
 unsafe impl Sync for AppointmentCalendarUpdateMeetingResponseRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentDataProviderConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentDataProviderConnection, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentDataProviderConnection {
@@ -906,7 +906,7 @@ impl windows_core::RuntimeName for AppointmentDataProviderConnection {
 unsafe impl Send for AppointmentDataProviderConnection {}
 unsafe impl Sync for AppointmentDataProviderConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentDataProviderTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentDataProviderTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentDataProviderTriggerDetails {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
@@ -644,7 +644,7 @@ pub struct IFindAppointmentsOptions_Vtbl {
     pub SetMaxCount: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Appointment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Appointment, windows_core::IUnknown, windows_core::IInspectable);
 impl Appointment {
@@ -969,7 +969,7 @@ impl windows_core::RuntimeName for Appointment {
 unsafe impl Send for Appointment {}
 unsafe impl Sync for Appointment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendar, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendar {
@@ -1347,7 +1347,7 @@ impl windows_core::RuntimeName for AppointmentCalendar {
 unsafe impl Send for AppointmentCalendar {}
 unsafe impl Sync for AppointmentCalendar {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentCalendarSyncManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentCalendarSyncManager, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentCalendarSyncManager {
@@ -1419,7 +1419,7 @@ impl windows_core::RuntimeName for AppointmentCalendarSyncManager {
 unsafe impl Send for AppointmentCalendarSyncManager {}
 unsafe impl Sync for AppointmentCalendarSyncManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentConflictResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentConflictResult, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentConflictResult {
@@ -1451,7 +1451,7 @@ impl windows_core::RuntimeName for AppointmentConflictResult {
 unsafe impl Send for AppointmentConflictResult {}
 unsafe impl Sync for AppointmentConflictResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentException(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentException, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentException {
@@ -1491,7 +1491,7 @@ impl windows_core::RuntimeName for AppointmentException {
 unsafe impl Send for AppointmentException {}
 unsafe impl Sync for AppointmentException {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentInvitee(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentInvitee, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppointmentInvitee, IAppointmentParticipant);
@@ -1693,7 +1693,7 @@ impl windows_core::RuntimeName for AppointmentManager {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentManagerForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentManagerForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentManagerForUser {
@@ -1833,7 +1833,7 @@ impl windows_core::RuntimeName for AppointmentManagerForUser {
 unsafe impl Send for AppointmentManagerForUser {}
 unsafe impl Sync for AppointmentManagerForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentOrganizer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentOrganizer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppointmentOrganizer, IAppointmentParticipant);
@@ -2054,7 +2054,7 @@ impl windows_core::RuntimeName for AppointmentProperties {
     const NAME: &'static str = "Windows.ApplicationModel.Appointments.AppointmentProperties";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentRecurrence(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentRecurrence, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentRecurrence {
@@ -2198,7 +2198,7 @@ impl windows_core::RuntimeName for AppointmentRecurrence {
 unsafe impl Send for AppointmentRecurrence {}
 unsafe impl Sync for AppointmentRecurrence {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentStore, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentStore {
@@ -2423,7 +2423,7 @@ impl windows_core::RuntimeName for AppointmentStore {
 unsafe impl Send for AppointmentStore {}
 unsafe impl Sync for AppointmentStore {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentStoreChange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentStoreChange, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentStoreChange {
@@ -2462,7 +2462,7 @@ impl windows_core::RuntimeName for AppointmentStoreChange {
 unsafe impl Send for AppointmentStoreChange {}
 unsafe impl Sync for AppointmentStoreChange {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentStoreChangeReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentStoreChangeReader, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentStoreChangeReader {
@@ -2499,7 +2499,7 @@ impl windows_core::RuntimeName for AppointmentStoreChangeReader {
 unsafe impl Send for AppointmentStoreChangeReader {}
 unsafe impl Sync for AppointmentStoreChangeReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentStoreChangeTracker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentStoreChangeTracker, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentStoreChangeTracker {
@@ -2539,7 +2539,7 @@ impl windows_core::RuntimeName for AppointmentStoreChangeTracker {
 unsafe impl Send for AppointmentStoreChangeTracker {}
 unsafe impl Sync for AppointmentStoreChangeTracker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentStoreChangedDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentStoreChangedDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentStoreChangedDeferral {
@@ -2561,7 +2561,7 @@ impl windows_core::RuntimeName for AppointmentStoreChangedDeferral {
 unsafe impl Send for AppointmentStoreChangedDeferral {}
 unsafe impl Sync for AppointmentStoreChangedDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentStoreChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentStoreChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentStoreChangedEventArgs {
@@ -2586,7 +2586,7 @@ impl windows_core::RuntimeName for AppointmentStoreChangedEventArgs {
 unsafe impl Send for AppointmentStoreChangedEventArgs {}
 unsafe impl Sync for AppointmentStoreChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentStoreNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentStoreNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentStoreNotificationTriggerDetails {}
@@ -2603,7 +2603,7 @@ impl windows_core::RuntimeName for AppointmentStoreNotificationTriggerDetails {
 unsafe impl Send for AppointmentStoreNotificationTriggerDetails {}
 unsafe impl Sync for AppointmentStoreNotificationTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FindAppointmentsOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FindAppointmentsOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl FindAppointmentsOptions {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
@@ -1529,7 +1529,7 @@ pub struct IUserNotificationChangedTriggerFactory_Vtbl {
     Create: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivitySensorTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivitySensorTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ActivitySensorTrigger, IBackgroundTrigger);
@@ -1612,7 +1612,7 @@ impl windows_core::RuntimeName for AlarmApplicationManager {
     const NAME: &'static str = "Windows.ApplicationModel.Background.AlarmApplicationManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppBroadcastTrigger, IBackgroundTrigger);
@@ -1656,7 +1656,7 @@ impl windows_core::RuntimeName for AppBroadcastTrigger {
 unsafe impl Send for AppBroadcastTrigger {}
 unsafe impl Sync for AppBroadcastTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastTriggerProviderInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastTriggerProviderInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastTriggerProviderInfo {
@@ -1740,7 +1740,7 @@ impl windows_core::RuntimeName for AppBroadcastTriggerProviderInfo {
 unsafe impl Send for AppBroadcastTriggerProviderInfo {}
 unsafe impl Sync for AppBroadcastTriggerProviderInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ApplicationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ApplicationTrigger, IBackgroundTrigger);
@@ -1784,7 +1784,7 @@ impl windows_core::RuntimeName for ApplicationTrigger {
 unsafe impl Send for ApplicationTrigger {}
 unsafe impl Sync for ApplicationTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ApplicationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl ApplicationTriggerDetails {
@@ -1810,7 +1810,7 @@ impl windows_core::RuntimeName for ApplicationTriggerDetails {
 unsafe impl Send for ApplicationTriggerDetails {}
 unsafe impl Sync for ApplicationTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppointmentStoreNotificationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentStoreNotificationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppointmentStoreNotificationTrigger, IBackgroundTrigger);
@@ -1911,7 +1911,7 @@ impl windows_core::RuntimeName for BackgroundExecutionManager {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BackgroundExecutionManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTaskBuilder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTaskBuilder, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundTaskBuilder {
@@ -2017,7 +2017,7 @@ impl windows_core::RuntimeName for BackgroundTaskBuilder {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BackgroundTaskBuilder";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTaskCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTaskCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundTaskCompletedEventArgs {
@@ -2046,7 +2046,7 @@ impl windows_core::RuntimeName for BackgroundTaskCompletedEventArgs {
 unsafe impl Send for BackgroundTaskCompletedEventArgs {}
 unsafe impl Sync for BackgroundTaskCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTaskDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTaskDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundTaskDeferral {
@@ -2068,7 +2068,7 @@ impl windows_core::RuntimeName for BackgroundTaskDeferral {
 unsafe impl Send for BackgroundTaskDeferral {}
 unsafe impl Sync for BackgroundTaskDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTaskProgressEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTaskProgressEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundTaskProgressEventArgs {
@@ -2100,7 +2100,7 @@ impl windows_core::RuntimeName for BackgroundTaskProgressEventArgs {
 unsafe impl Send for BackgroundTaskProgressEventArgs {}
 unsafe impl Sync for BackgroundTaskProgressEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTaskRegistration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTaskRegistration, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BackgroundTaskRegistration, IBackgroundTaskRegistration, IBackgroundTaskRegistration2, IBackgroundTaskRegistration3);
@@ -2209,7 +2209,7 @@ impl windows_core::RuntimeName for BackgroundTaskRegistration {
 unsafe impl Send for BackgroundTaskRegistration {}
 unsafe impl Sync for BackgroundTaskRegistration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTaskRegistrationGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTaskRegistrationGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundTaskRegistrationGroup {
@@ -2298,7 +2298,7 @@ impl windows_core::RuntimeName for BackgroundWorkCost {
     const NAME: &'static str = "Windows.ApplicationModel.Background.BackgroundWorkCost";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementPublisherTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementPublisherTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BluetoothLEAdvertisementPublisherTrigger, IBackgroundTrigger);
@@ -2379,7 +2379,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementPublisherTrigger {
 unsafe impl Send for BluetoothLEAdvertisementPublisherTrigger {}
 unsafe impl Sync for BluetoothLEAdvertisementPublisherTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementWatcherTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementWatcherTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BluetoothLEAdvertisementWatcherTrigger, IBackgroundTrigger);
@@ -2476,7 +2476,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementWatcherTrigger {
 unsafe impl Send for BluetoothLEAdvertisementWatcherTrigger {}
 unsafe impl Sync for BluetoothLEAdvertisementWatcherTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CachedFileUpdaterTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CachedFileUpdaterTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CachedFileUpdaterTrigger, IBackgroundTrigger);
@@ -2502,7 +2502,7 @@ impl windows_core::RuntimeName for CachedFileUpdaterTrigger {
 unsafe impl Send for CachedFileUpdaterTrigger {}
 unsafe impl Sync for CachedFileUpdaterTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CachedFileUpdaterTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CachedFileUpdaterTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl CachedFileUpdaterTriggerDetails {
@@ -2543,7 +2543,7 @@ impl windows_core::RuntimeName for CachedFileUpdaterTriggerDetails {
 unsafe impl Send for CachedFileUpdaterTriggerDetails {}
 unsafe impl Sync for CachedFileUpdaterTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageNotificationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageNotificationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ChatMessageNotificationTrigger, IBackgroundTrigger);
@@ -2569,7 +2569,7 @@ impl windows_core::RuntimeName for ChatMessageNotificationTrigger {
 unsafe impl Send for ChatMessageNotificationTrigger {}
 unsafe impl Sync for ChatMessageNotificationTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageReceivedNotificationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageReceivedNotificationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ChatMessageReceivedNotificationTrigger, IBackgroundTrigger);
@@ -2595,7 +2595,7 @@ impl windows_core::RuntimeName for ChatMessageReceivedNotificationTrigger {
 unsafe impl Send for ChatMessageReceivedNotificationTrigger {}
 unsafe impl Sync for ChatMessageReceivedNotificationTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CommunicationBlockingAppSetAsActiveTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CommunicationBlockingAppSetAsActiveTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CommunicationBlockingAppSetAsActiveTrigger, IBackgroundTrigger);
@@ -2621,7 +2621,7 @@ impl windows_core::RuntimeName for CommunicationBlockingAppSetAsActiveTrigger {
 unsafe impl Send for CommunicationBlockingAppSetAsActiveTrigger {}
 unsafe impl Sync for CommunicationBlockingAppSetAsActiveTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactStoreNotificationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactStoreNotificationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactStoreNotificationTrigger, IBackgroundTrigger);
@@ -2647,7 +2647,7 @@ impl windows_core::RuntimeName for ContactStoreNotificationTrigger {
 unsafe impl Send for ContactStoreNotificationTrigger {}
 unsafe impl Sync for ContactStoreNotificationTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContentPrefetchTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContentPrefetchTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContentPrefetchTrigger, IBackgroundTrigger);
@@ -2689,7 +2689,7 @@ impl windows_core::RuntimeName for ContentPrefetchTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ContentPrefetchTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConversationalAgentTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConversationalAgentTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ConversationalAgentTrigger, IBackgroundTrigger);
@@ -2713,7 +2713,7 @@ impl windows_core::RuntimeName for ConversationalAgentTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.ConversationalAgentTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CustomSystemEventTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CustomSystemEventTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CustomSystemEventTrigger, IBackgroundTrigger);
@@ -2755,7 +2755,7 @@ impl windows_core::RuntimeName for CustomSystemEventTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.CustomSystemEventTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceConnectionChangeTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceConnectionChangeTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DeviceConnectionChangeTrigger, IBackgroundTrigger);
@@ -2811,7 +2811,7 @@ unsafe impl Send for DeviceConnectionChangeTrigger {}
 unsafe impl Sync for DeviceConnectionChangeTrigger {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceManufacturerNotificationTrigger(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(DeviceManufacturerNotificationTrigger, windows_core::IUnknown, windows_core::IInspectable);
@@ -2863,7 +2863,7 @@ impl windows_core::RuntimeName for DeviceManufacturerNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.DeviceManufacturerNotificationTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceServicingTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceServicingTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DeviceServicingTrigger, IBackgroundTrigger);
@@ -2903,7 +2903,7 @@ impl windows_core::RuntimeName for DeviceServicingTrigger {
 unsafe impl Send for DeviceServicingTrigger {}
 unsafe impl Sync for DeviceServicingTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceUseTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceUseTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DeviceUseTrigger, IBackgroundTrigger);
@@ -2943,7 +2943,7 @@ impl windows_core::RuntimeName for DeviceUseTrigger {
 unsafe impl Send for DeviceUseTrigger {}
 unsafe impl Sync for DeviceUseTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceWatcherTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceWatcherTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DeviceWatcherTrigger, IBackgroundTrigger);
@@ -2959,7 +2959,7 @@ impl windows_core::RuntimeName for DeviceWatcherTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.DeviceWatcherTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailStoreNotificationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailStoreNotificationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(EmailStoreNotificationTrigger, IBackgroundTrigger);
@@ -2985,7 +2985,7 @@ impl windows_core::RuntimeName for EmailStoreNotificationTrigger {
 unsafe impl Send for EmailStoreNotificationTrigger {}
 unsafe impl Sync for EmailStoreNotificationTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattCharacteristicNotificationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattCharacteristicNotificationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GattCharacteristicNotificationTrigger, IBackgroundTrigger);
@@ -3050,7 +3050,7 @@ impl windows_core::RuntimeName for GattCharacteristicNotificationTrigger {
 unsafe impl Send for GattCharacteristicNotificationTrigger {}
 unsafe impl Sync for GattCharacteristicNotificationTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattServiceProviderTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattServiceProviderTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GattServiceProviderTrigger, IBackgroundTrigger);
@@ -3111,7 +3111,7 @@ impl windows_core::RuntimeName for GattServiceProviderTrigger {
 unsafe impl Send for GattServiceProviderTrigger {}
 unsafe impl Sync for GattServiceProviderTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattServiceProviderTriggerResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattServiceProviderTriggerResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattServiceProviderTriggerResult {
@@ -3144,7 +3144,7 @@ impl windows_core::RuntimeName for GattServiceProviderTriggerResult {
 unsafe impl Send for GattServiceProviderTriggerResult {}
 unsafe impl Sync for GattServiceProviderTriggerResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GeovisitTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GeovisitTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GeovisitTrigger, IBackgroundTrigger);
@@ -3183,7 +3183,7 @@ impl windows_core::RuntimeName for GeovisitTrigger {
 unsafe impl Send for GeovisitTrigger {}
 unsafe impl Sync for GeovisitTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LocationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LocationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LocationTrigger, IBackgroundTrigger);
@@ -3220,7 +3220,7 @@ impl windows_core::RuntimeName for LocationTrigger {
 unsafe impl Send for LocationTrigger {}
 unsafe impl Sync for LocationTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MaintenanceTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MaintenanceTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MaintenanceTrigger, IBackgroundTrigger);
@@ -3262,7 +3262,7 @@ impl windows_core::RuntimeName for MaintenanceTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.MaintenanceTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaProcessingTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaProcessingTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaProcessingTrigger, IBackgroundTrigger);
@@ -3304,7 +3304,7 @@ impl windows_core::RuntimeName for MediaProcessingTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.MediaProcessingTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandDeviceServiceNotificationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandDeviceServiceNotificationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MobileBroadbandDeviceServiceNotificationTrigger, IBackgroundTrigger);
@@ -3330,7 +3330,7 @@ impl windows_core::RuntimeName for MobileBroadbandDeviceServiceNotificationTrigg
 unsafe impl Send for MobileBroadbandDeviceServiceNotificationTrigger {}
 unsafe impl Sync for MobileBroadbandDeviceServiceNotificationTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandPcoDataChangeTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandPcoDataChangeTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MobileBroadbandPcoDataChangeTrigger, IBackgroundTrigger);
@@ -3356,7 +3356,7 @@ impl windows_core::RuntimeName for MobileBroadbandPcoDataChangeTrigger {
 unsafe impl Send for MobileBroadbandPcoDataChangeTrigger {}
 unsafe impl Sync for MobileBroadbandPcoDataChangeTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandPinLockStateChangeTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandPinLockStateChangeTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MobileBroadbandPinLockStateChangeTrigger, IBackgroundTrigger);
@@ -3382,7 +3382,7 @@ impl windows_core::RuntimeName for MobileBroadbandPinLockStateChangeTrigger {
 unsafe impl Send for MobileBroadbandPinLockStateChangeTrigger {}
 unsafe impl Sync for MobileBroadbandPinLockStateChangeTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandRadioStateChangeTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandRadioStateChangeTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MobileBroadbandRadioStateChangeTrigger, IBackgroundTrigger);
@@ -3408,7 +3408,7 @@ impl windows_core::RuntimeName for MobileBroadbandRadioStateChangeTrigger {
 unsafe impl Send for MobileBroadbandRadioStateChangeTrigger {}
 unsafe impl Sync for MobileBroadbandRadioStateChangeTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandRegistrationStateChangeTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandRegistrationStateChangeTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MobileBroadbandRegistrationStateChangeTrigger, IBackgroundTrigger);
@@ -3434,7 +3434,7 @@ impl windows_core::RuntimeName for MobileBroadbandRegistrationStateChangeTrigger
 unsafe impl Send for MobileBroadbandRegistrationStateChangeTrigger {}
 unsafe impl Sync for MobileBroadbandRegistrationStateChangeTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkOperatorDataUsageTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkOperatorDataUsageTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(NetworkOperatorDataUsageTrigger, IBackgroundTrigger);
@@ -3460,7 +3460,7 @@ impl windows_core::RuntimeName for NetworkOperatorDataUsageTrigger {
 unsafe impl Send for NetworkOperatorDataUsageTrigger {}
 unsafe impl Sync for NetworkOperatorDataUsageTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkOperatorHotspotAuthenticationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkOperatorHotspotAuthenticationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(NetworkOperatorHotspotAuthenticationTrigger, IBackgroundTrigger);
@@ -3484,7 +3484,7 @@ impl windows_core::RuntimeName for NetworkOperatorHotspotAuthenticationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.NetworkOperatorHotspotAuthenticationTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkOperatorNotificationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkOperatorNotificationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(NetworkOperatorNotificationTrigger, IBackgroundTrigger);
@@ -3519,7 +3519,7 @@ impl windows_core::RuntimeName for NetworkOperatorNotificationTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.NetworkOperatorNotificationTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentAppCanMakePaymentTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentAppCanMakePaymentTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PaymentAppCanMakePaymentTrigger, IBackgroundTrigger);
@@ -3545,7 +3545,7 @@ impl windows_core::RuntimeName for PaymentAppCanMakePaymentTrigger {
 unsafe impl Send for PaymentAppCanMakePaymentTrigger {}
 unsafe impl Sync for PaymentAppCanMakePaymentTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PhoneTrigger, IBackgroundTrigger);
@@ -3591,7 +3591,7 @@ impl windows_core::RuntimeName for PhoneTrigger {
 unsafe impl Send for PhoneTrigger {}
 unsafe impl Sync for PhoneTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PushNotificationTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PushNotificationTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PushNotificationTrigger, IBackgroundTrigger);
@@ -3628,7 +3628,7 @@ impl windows_core::RuntimeName for PushNotificationTrigger {
 unsafe impl Send for PushNotificationTrigger {}
 unsafe impl Sync for PushNotificationTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RcsEndUserMessageAvailableTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RcsEndUserMessageAvailableTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RcsEndUserMessageAvailableTrigger, IBackgroundTrigger);
@@ -3654,7 +3654,7 @@ impl windows_core::RuntimeName for RcsEndUserMessageAvailableTrigger {
 unsafe impl Send for RcsEndUserMessageAvailableTrigger {}
 unsafe impl Sync for RcsEndUserMessageAvailableTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RfcommConnectionTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RfcommConnectionTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RfcommConnectionTrigger, IBackgroundTrigger);
@@ -3737,7 +3737,7 @@ unsafe impl Send for RfcommConnectionTrigger {}
 unsafe impl Sync for RfcommConnectionTrigger {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SecondaryAuthenticationFactorAuthenticationTrigger(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SecondaryAuthenticationFactorAuthenticationTrigger, windows_core::IUnknown, windows_core::IInspectable);
@@ -3767,7 +3767,7 @@ impl windows_core::RuntimeName for SecondaryAuthenticationFactorAuthenticationTr
     const NAME: &'static str = "Windows.ApplicationModel.Background.SecondaryAuthenticationFactorAuthenticationTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SensorDataThresholdTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SensorDataThresholdTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SensorDataThresholdTrigger, IBackgroundTrigger);
@@ -3801,7 +3801,7 @@ impl windows_core::RuntimeName for SensorDataThresholdTrigger {
 unsafe impl Send for SensorDataThresholdTrigger {}
 unsafe impl Sync for SensorDataThresholdTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SmartCardTrigger, IBackgroundTrigger);
@@ -3838,7 +3838,7 @@ impl windows_core::RuntimeName for SmartCardTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.SmartCardTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsMessageReceivedTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsMessageReceivedTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SmsMessageReceivedTrigger, IBackgroundTrigger);
@@ -3872,7 +3872,7 @@ impl windows_core::RuntimeName for SmsMessageReceivedTrigger {
 unsafe impl Send for SmsMessageReceivedTrigger {}
 unsafe impl Sync for SmsMessageReceivedTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SocketActivityTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SocketActivityTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SocketActivityTrigger, IBackgroundTrigger);
@@ -3905,7 +3905,7 @@ impl windows_core::RuntimeName for SocketActivityTrigger {
 unsafe impl Send for SocketActivityTrigger {}
 unsafe impl Sync for SocketActivityTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageLibraryChangeTrackerTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageLibraryChangeTrackerTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StorageLibraryChangeTrackerTrigger, IBackgroundTrigger);
@@ -3939,7 +3939,7 @@ impl windows_core::RuntimeName for StorageLibraryChangeTrackerTrigger {
 unsafe impl Send for StorageLibraryChangeTrackerTrigger {}
 unsafe impl Sync for StorageLibraryChangeTrackerTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageLibraryContentChangedTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageLibraryContentChangedTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StorageLibraryContentChangedTrigger, IBackgroundTrigger);
@@ -3981,7 +3981,7 @@ impl windows_core::RuntimeName for StorageLibraryContentChangedTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.StorageLibraryContentChangedTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemCondition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemCondition, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SystemCondition, IBackgroundCondition);
@@ -4016,7 +4016,7 @@ impl windows_core::RuntimeName for SystemCondition {
     const NAME: &'static str = "Windows.ApplicationModel.Background.SystemCondition";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SystemTrigger, IBackgroundTrigger);
@@ -4058,7 +4058,7 @@ impl windows_core::RuntimeName for SystemTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.SystemTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TetheringEntitlementCheckTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TetheringEntitlementCheckTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TetheringEntitlementCheckTrigger, IBackgroundTrigger);
@@ -4084,7 +4084,7 @@ impl windows_core::RuntimeName for TetheringEntitlementCheckTrigger {
 unsafe impl Send for TetheringEntitlementCheckTrigger {}
 unsafe impl Sync for TetheringEntitlementCheckTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimeTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimeTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TimeTrigger, IBackgroundTrigger);
@@ -4126,7 +4126,7 @@ impl windows_core::RuntimeName for TimeTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.TimeTrigger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastNotificationActionTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastNotificationActionTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ToastNotificationActionTrigger, IBackgroundTrigger);
@@ -4163,7 +4163,7 @@ impl windows_core::RuntimeName for ToastNotificationActionTrigger {
 unsafe impl Send for ToastNotificationActionTrigger {}
 unsafe impl Sync for ToastNotificationActionTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastNotificationHistoryChangedTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastNotificationHistoryChangedTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ToastNotificationHistoryChangedTrigger, IBackgroundTrigger);
@@ -4200,7 +4200,7 @@ impl windows_core::RuntimeName for ToastNotificationHistoryChangedTrigger {
 unsafe impl Send for ToastNotificationHistoryChangedTrigger {}
 unsafe impl Sync for ToastNotificationHistoryChangedTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserNotificationChangedTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserNotificationChangedTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UserNotificationChangedTrigger, IBackgroundTrigger);
@@ -4231,7 +4231,7 @@ impl windows_core::RuntimeName for UserNotificationChangedTrigger {
 unsafe impl Send for UserNotificationChangedTrigger {}
 unsafe impl Sync for UserNotificationChangedTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiOnDemandHotspotConnectTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiOnDemandHotspotConnectTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WiFiOnDemandHotspotConnectTrigger, IBackgroundTrigger);
@@ -4257,7 +4257,7 @@ impl windows_core::RuntimeName for WiFiOnDemandHotspotConnectTrigger {
 unsafe impl Send for WiFiOnDemandHotspotConnectTrigger {}
 unsafe impl Sync for WiFiOnDemandHotspotConnectTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiOnDemandHotspotUpdateMetadataTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiOnDemandHotspotUpdateMetadataTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WiFiOnDemandHotspotUpdateMetadataTrigger, IBackgroundTrigger);

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
@@ -96,7 +96,7 @@ pub struct IPhoneNewVoicemailMessageTriggerDetails_Vtbl {
     pub OperatorMessage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallBlockedTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallBlockedTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallBlockedTriggerDetails {
@@ -136,7 +136,7 @@ unsafe impl Send for PhoneCallBlockedTriggerDetails {}
 unsafe impl Sync for PhoneCallBlockedTriggerDetails {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallOriginDataRequestTriggerDetails(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PhoneCallOriginDataRequestTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
@@ -178,7 +178,7 @@ unsafe impl Send for PhoneCallOriginDataRequestTriggerDetails {}
 unsafe impl Sync for PhoneCallOriginDataRequestTriggerDetails {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneIncomingCallDismissedTriggerDetails(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PhoneIncomingCallDismissedTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
@@ -251,7 +251,7 @@ unsafe impl Send for PhoneIncomingCallDismissedTriggerDetails {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for PhoneIncomingCallDismissedTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneIncomingCallNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneIncomingCallNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneIncomingCallNotificationTriggerDetails {
@@ -283,7 +283,7 @@ impl windows_core::RuntimeName for PhoneIncomingCallNotificationTriggerDetails {
 unsafe impl Send for PhoneIncomingCallNotificationTriggerDetails {}
 unsafe impl Sync for PhoneIncomingCallNotificationTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneLineChangedTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneLineChangedTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneLineChangedTriggerDetails {
@@ -322,7 +322,7 @@ impl windows_core::RuntimeName for PhoneLineChangedTriggerDetails {
 unsafe impl Send for PhoneLineChangedTriggerDetails {}
 unsafe impl Sync for PhoneLineChangedTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneNewVoicemailMessageTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneNewVoicemailMessageTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneNewVoicemailMessageTriggerDetails {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/Provider/mod.rs
@@ -126,7 +126,7 @@ pub struct IPhoneCallOriginManagerStatics3_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallOrigin(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PhoneCallOrigin, windows_core::IUnknown, windows_core::IInspectable);

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
@@ -700,7 +700,7 @@ pub struct IVoipPhoneCall3_Vtbl {
     pub NotifyCallAccepted: unsafe extern "system" fn(*mut core::ffi::c_void, VoipPhoneCallMedia) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CallAnswerEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CallAnswerEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CallAnswerEventArgs {
@@ -725,7 +725,7 @@ impl windows_core::RuntimeName for CallAnswerEventArgs {
 unsafe impl Send for CallAnswerEventArgs {}
 unsafe impl Sync for CallAnswerEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CallRejectEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CallRejectEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CallRejectEventArgs {
@@ -750,7 +750,7 @@ impl windows_core::RuntimeName for CallRejectEventArgs {
 unsafe impl Send for CallRejectEventArgs {}
 unsafe impl Sync for CallRejectEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CallStateChangeEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CallStateChangeEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CallStateChangeEventArgs {
@@ -775,7 +775,7 @@ impl windows_core::RuntimeName for CallStateChangeEventArgs {
 unsafe impl Send for CallStateChangeEventArgs {}
 unsafe impl Sync for CallStateChangeEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockScreenCallEndCallDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockScreenCallEndCallDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl LockScreenCallEndCallDeferral {
@@ -797,7 +797,7 @@ impl windows_core::RuntimeName for LockScreenCallEndCallDeferral {
 unsafe impl Send for LockScreenCallEndCallDeferral {}
 unsafe impl Sync for LockScreenCallEndCallDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockScreenCallEndRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockScreenCallEndRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl LockScreenCallEndRequestedEventArgs {
@@ -829,7 +829,7 @@ impl windows_core::RuntimeName for LockScreenCallEndRequestedEventArgs {
 unsafe impl Send for LockScreenCallEndRequestedEventArgs {}
 unsafe impl Sync for LockScreenCallEndRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockScreenCallUI(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockScreenCallUI, windows_core::IUnknown, windows_core::IInspectable);
 impl LockScreenCallUI {
@@ -890,7 +890,7 @@ impl windows_core::RuntimeName for LockScreenCallUI {
 unsafe impl Send for LockScreenCallUI {}
 unsafe impl Sync for LockScreenCallUI {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MuteChangeEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MuteChangeEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MuteChangeEventArgs {
@@ -915,7 +915,7 @@ impl windows_core::RuntimeName for MuteChangeEventArgs {
 unsafe impl Send for MuteChangeEventArgs {}
 unsafe impl Sync for MuteChangeEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCall(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCall, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCall {
@@ -1193,7 +1193,7 @@ impl windows_core::RuntimeName for PhoneCallBlocking {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallBlocking";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallHistoryEntry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallHistoryEntry, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallHistoryEntry {
@@ -1414,7 +1414,7 @@ impl windows_core::RuntimeName for PhoneCallHistoryEntry {
 unsafe impl Send for PhoneCallHistoryEntry {}
 unsafe impl Sync for PhoneCallHistoryEntry {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallHistoryEntryAddress(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallHistoryEntryAddress, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallHistoryEntryAddress {
@@ -1494,7 +1494,7 @@ impl windows_core::RuntimeName for PhoneCallHistoryEntryAddress {
 unsafe impl Send for PhoneCallHistoryEntryAddress {}
 unsafe impl Sync for PhoneCallHistoryEntryAddress {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallHistoryEntryQueryOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallHistoryEntryQueryOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallHistoryEntryQueryOptions {
@@ -1538,7 +1538,7 @@ impl windows_core::RuntimeName for PhoneCallHistoryEntryQueryOptions {
 unsafe impl Send for PhoneCallHistoryEntryQueryOptions {}
 unsafe impl Sync for PhoneCallHistoryEntryQueryOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallHistoryEntryReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallHistoryEntryReader, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallHistoryEntryReader {
@@ -1596,7 +1596,7 @@ impl windows_core::RuntimeName for PhoneCallHistoryManager {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallHistoryManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallHistoryManagerForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallHistoryManagerForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallHistoryManagerForUser {
@@ -1629,7 +1629,7 @@ impl windows_core::RuntimeName for PhoneCallHistoryManagerForUser {
 unsafe impl Send for PhoneCallHistoryManagerForUser {}
 unsafe impl Sync for PhoneCallHistoryManagerForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallHistoryStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallHistoryStore, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallHistoryStore {
@@ -1759,7 +1759,7 @@ impl windows_core::RuntimeName for PhoneCallHistoryStore {
 unsafe impl Send for PhoneCallHistoryStore {}
 unsafe impl Sync for PhoneCallHistoryStore {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallInfo {
@@ -1871,7 +1871,7 @@ impl windows_core::RuntimeName for PhoneCallManager {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallStore, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallStore {
@@ -1910,7 +1910,7 @@ impl windows_core::RuntimeName for PhoneCallStore {
 unsafe impl Send for PhoneCallStore {}
 unsafe impl Sync for PhoneCallStore {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallVideoCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallVideoCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallVideoCapabilities {
@@ -1952,7 +1952,7 @@ impl windows_core::RuntimeName for PhoneCallVideoCapabilitiesManager {
     const NAME: &'static str = "Windows.ApplicationModel.Calls.PhoneCallVideoCapabilitiesManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallsResult {
@@ -1985,7 +1985,7 @@ impl windows_core::RuntimeName for PhoneCallsResult {
 unsafe impl Send for PhoneCallsResult {}
 unsafe impl Sync for PhoneCallsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneDialOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneDialOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneDialOptions {
@@ -2086,7 +2086,7 @@ impl windows_core::RuntimeName for PhoneDialOptions {
 unsafe impl Send for PhoneDialOptions {}
 unsafe impl Sync for PhoneDialOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneLine(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneLine, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneLine {
@@ -2272,7 +2272,7 @@ impl windows_core::RuntimeName for PhoneLine {
 unsafe impl Send for PhoneLine {}
 unsafe impl Sync for PhoneLine {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneLineCellularDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneLineCellularDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneLineCellularDetails {
@@ -2325,7 +2325,7 @@ impl windows_core::RuntimeName for PhoneLineCellularDetails {
 unsafe impl Send for PhoneLineCellularDetails {}
 unsafe impl Sync for PhoneLineCellularDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneLineConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneLineConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneLineConfiguration {
@@ -2358,7 +2358,7 @@ impl windows_core::RuntimeName for PhoneLineConfiguration {
 unsafe impl Send for PhoneLineConfiguration {}
 unsafe impl Sync for PhoneLineConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneLineDialResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneLineDialResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneLineDialResult {
@@ -2390,7 +2390,7 @@ impl windows_core::RuntimeName for PhoneLineDialResult {
 unsafe impl Send for PhoneLineDialResult {}
 unsafe impl Sync for PhoneLineDialResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneLineTransportDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneLineTransportDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneLineTransportDevice {
@@ -2540,7 +2540,7 @@ impl windows_core::RuntimeName for PhoneLineTransportDevice {
 unsafe impl Send for PhoneLineTransportDevice {}
 unsafe impl Sync for PhoneLineTransportDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneLineWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneLineWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneLineWatcher {
@@ -2643,7 +2643,7 @@ impl windows_core::RuntimeName for PhoneLineWatcher {
 unsafe impl Send for PhoneLineWatcher {}
 unsafe impl Sync for PhoneLineWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneLineWatcherEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneLineWatcherEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneLineWatcherEventArgs {
@@ -2668,7 +2668,7 @@ impl windows_core::RuntimeName for PhoneLineWatcherEventArgs {
 unsafe impl Send for PhoneLineWatcherEventArgs {}
 unsafe impl Sync for PhoneLineWatcherEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneVoicemail(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneVoicemail, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneVoicemail {
@@ -2714,7 +2714,7 @@ impl windows_core::RuntimeName for PhoneVoicemail {
 unsafe impl Send for PhoneVoicemail {}
 unsafe impl Sync for PhoneVoicemail {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoipCallCoordinator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoipCallCoordinator, windows_core::IUnknown, windows_core::IInspectable);
 impl VoipCallCoordinator {
@@ -2851,7 +2851,7 @@ impl windows_core::RuntimeName for VoipCallCoordinator {
 unsafe impl Send for VoipCallCoordinator {}
 unsafe impl Sync for VoipCallCoordinator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoipPhoneCall(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoipPhoneCall, windows_core::IUnknown, windows_core::IInspectable);
 impl VoipPhoneCall {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Chat/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Chat/mod.rs
@@ -765,7 +765,7 @@ pub struct IRemoteParticipantComposingChangedEventArgs_Vtbl {
     pub IsComposing: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatCapabilities {
@@ -858,7 +858,7 @@ impl windows_core::RuntimeName for ChatCapabilitiesManager {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatCapabilitiesManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatConversation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatConversation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ChatConversation, IChatItem);
@@ -1010,7 +1010,7 @@ impl windows_core::RuntimeName for ChatConversation {
 unsafe impl Send for ChatConversation {}
 unsafe impl Sync for ChatConversation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatConversationReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatConversationReader, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatConversationReader {
@@ -1044,7 +1044,7 @@ impl windows_core::RuntimeName for ChatConversationReader {
 unsafe impl Send for ChatConversationReader {}
 unsafe impl Sync for ChatConversationReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatConversationThreadingInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatConversationThreadingInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatConversationThreadingInfo {
@@ -1121,7 +1121,7 @@ impl windows_core::RuntimeName for ChatConversationThreadingInfo {
 unsafe impl Send for ChatConversationThreadingInfo {}
 unsafe impl Sync for ChatConversationThreadingInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ChatMessage, IChatItem);
@@ -1437,7 +1437,7 @@ impl windows_core::RuntimeName for ChatMessage {
 unsafe impl Send for ChatMessage {}
 unsafe impl Sync for ChatMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageAttachment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageAttachment, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageAttachment {
@@ -1574,7 +1574,7 @@ impl windows_core::RuntimeName for ChatMessageBlocking {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageBlocking";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageChange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageChange, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageChange {
@@ -1606,7 +1606,7 @@ impl windows_core::RuntimeName for ChatMessageChange {
 unsafe impl Send for ChatMessageChange {}
 unsafe impl Sync for ChatMessageChange {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageChangeReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageChangeReader, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageChangeReader {
@@ -1643,7 +1643,7 @@ impl windows_core::RuntimeName for ChatMessageChangeReader {
 unsafe impl Send for ChatMessageChangeReader {}
 unsafe impl Sync for ChatMessageChangeReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageChangeTracker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageChangeTracker, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageChangeTracker {
@@ -1676,7 +1676,7 @@ impl windows_core::RuntimeName for ChatMessageChangeTracker {
 unsafe impl Send for ChatMessageChangeTracker {}
 unsafe impl Sync for ChatMessageChangeTracker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageChangedDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageChangedDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageChangedDeferral {
@@ -1698,7 +1698,7 @@ impl windows_core::RuntimeName for ChatMessageChangedDeferral {
 unsafe impl Send for ChatMessageChangedDeferral {}
 unsafe impl Sync for ChatMessageChangedDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageChangedEventArgs {
@@ -1787,7 +1787,7 @@ impl windows_core::RuntimeName for ChatMessageManager {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.ChatMessageManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageNotificationTriggerDetails {
@@ -1840,7 +1840,7 @@ impl windows_core::RuntimeName for ChatMessageNotificationTriggerDetails {
 unsafe impl Send for ChatMessageNotificationTriggerDetails {}
 unsafe impl Sync for ChatMessageNotificationTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageReader, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageReader {
@@ -1874,7 +1874,7 @@ impl windows_core::RuntimeName for ChatMessageReader {
 unsafe impl Send for ChatMessageReader {}
 unsafe impl Sync for ChatMessageReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageStore, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageStore {
@@ -2137,7 +2137,7 @@ impl windows_core::RuntimeName for ChatMessageStore {
 unsafe impl Send for ChatMessageStore {}
 unsafe impl Sync for ChatMessageStore {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageStoreChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageStoreChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageStoreChangedEventArgs {
@@ -2169,7 +2169,7 @@ impl windows_core::RuntimeName for ChatMessageStoreChangedEventArgs {
 unsafe impl Send for ChatMessageStoreChangedEventArgs {}
 unsafe impl Sync for ChatMessageStoreChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageTransport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageTransport, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageTransport {
@@ -2236,7 +2236,7 @@ impl windows_core::RuntimeName for ChatMessageTransport {
 unsafe impl Send for ChatMessageTransport {}
 unsafe impl Sync for ChatMessageTransport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageTransportConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageTransportConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageTransportConfiguration {
@@ -2291,7 +2291,7 @@ impl windows_core::RuntimeName for ChatMessageTransportConfiguration {
 unsafe impl Send for ChatMessageTransportConfiguration {}
 unsafe impl Sync for ChatMessageTransportConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatMessageValidationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatMessageValidationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatMessageValidationResult {
@@ -2337,7 +2337,7 @@ impl windows_core::RuntimeName for ChatMessageValidationResult {
 unsafe impl Send for ChatMessageValidationResult {}
 unsafe impl Sync for ChatMessageValidationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatQueryOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatQueryOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatQueryOptions {
@@ -2373,7 +2373,7 @@ impl windows_core::RuntimeName for ChatQueryOptions {
 unsafe impl Send for ChatQueryOptions {}
 unsafe impl Sync for ChatQueryOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatRecipientDeliveryInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatRecipientDeliveryInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatRecipientDeliveryInfo {
@@ -2472,7 +2472,7 @@ impl windows_core::RuntimeName for ChatRecipientDeliveryInfo {
 unsafe impl Send for ChatRecipientDeliveryInfo {}
 unsafe impl Sync for ChatRecipientDeliveryInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatSearchReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatSearchReader, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatSearchReader {
@@ -2506,7 +2506,7 @@ impl windows_core::RuntimeName for ChatSearchReader {
 unsafe impl Send for ChatSearchReader {}
 unsafe impl Sync for ChatSearchReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatSyncConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatSyncConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatSyncConfiguration {
@@ -2546,7 +2546,7 @@ impl windows_core::RuntimeName for ChatSyncConfiguration {
 unsafe impl Send for ChatSyncConfiguration {}
 unsafe impl Sync for ChatSyncConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChatSyncManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChatSyncManager, windows_core::IUnknown, windows_core::IInspectable);
 impl ChatSyncManager {
@@ -2614,7 +2614,7 @@ impl windows_core::RuntimeName for ChatSyncManager {
 unsafe impl Send for ChatSyncManager {}
 unsafe impl Sync for ChatSyncManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RcsEndUserMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RcsEndUserMessage, windows_core::IUnknown, windows_core::IInspectable);
 impl RcsEndUserMessage {
@@ -2688,7 +2688,7 @@ impl windows_core::RuntimeName for RcsEndUserMessage {
 unsafe impl Send for RcsEndUserMessage {}
 unsafe impl Sync for RcsEndUserMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RcsEndUserMessageAction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RcsEndUserMessageAction, windows_core::IUnknown, windows_core::IInspectable);
 impl RcsEndUserMessageAction {
@@ -2713,7 +2713,7 @@ impl windows_core::RuntimeName for RcsEndUserMessageAction {
 unsafe impl Send for RcsEndUserMessageAction {}
 unsafe impl Sync for RcsEndUserMessageAction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RcsEndUserMessageAvailableEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RcsEndUserMessageAvailableEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RcsEndUserMessageAvailableEventArgs {
@@ -2745,7 +2745,7 @@ impl windows_core::RuntimeName for RcsEndUserMessageAvailableEventArgs {
 unsafe impl Send for RcsEndUserMessageAvailableEventArgs {}
 unsafe impl Sync for RcsEndUserMessageAvailableEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RcsEndUserMessageAvailableTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RcsEndUserMessageAvailableTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl RcsEndUserMessageAvailableTriggerDetails {
@@ -2777,7 +2777,7 @@ impl windows_core::RuntimeName for RcsEndUserMessageAvailableTriggerDetails {
 unsafe impl Send for RcsEndUserMessageAvailableTriggerDetails {}
 unsafe impl Sync for RcsEndUserMessageAvailableTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RcsEndUserMessageManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RcsEndUserMessageManager, windows_core::IUnknown, windows_core::IInspectable);
 impl RcsEndUserMessageManager {
@@ -2865,7 +2865,7 @@ impl windows_core::RuntimeName for RcsManager {
     const NAME: &'static str = "Windows.ApplicationModel.Chat.RcsManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RcsServiceKindSupportedChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RcsServiceKindSupportedChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RcsServiceKindSupportedChangedEventArgs {
@@ -2890,7 +2890,7 @@ impl windows_core::RuntimeName for RcsServiceKindSupportedChangedEventArgs {
 unsafe impl Send for RcsServiceKindSupportedChangedEventArgs {}
 unsafe impl Sync for RcsServiceKindSupportedChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RcsTransport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RcsTransport, windows_core::IUnknown, windows_core::IInspectable);
 impl RcsTransport {
@@ -2972,7 +2972,7 @@ impl windows_core::RuntimeName for RcsTransport {
 unsafe impl Send for RcsTransport {}
 unsafe impl Sync for RcsTransport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RcsTransportConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RcsTransportConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl RcsTransportConfiguration {
@@ -3032,7 +3032,7 @@ impl windows_core::RuntimeName for RcsTransportConfiguration {
 unsafe impl Send for RcsTransportConfiguration {}
 unsafe impl Sync for RcsTransportConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteParticipantComposingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteParticipantComposingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteParticipantComposingChangedEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/DataProvider/mod.rs
@@ -123,7 +123,7 @@ pub struct IContactListSyncManagerSyncRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactDataProviderConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactDataProviderConnection, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactDataProviderConnection {
@@ -201,7 +201,7 @@ impl windows_core::RuntimeName for ContactDataProviderConnection {
 unsafe impl Send for ContactDataProviderConnection {}
 unsafe impl Sync for ContactDataProviderConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactDataProviderTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactDataProviderTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactDataProviderTriggerDetails {
@@ -226,7 +226,7 @@ impl windows_core::RuntimeName for ContactDataProviderTriggerDetails {
 unsafe impl Send for ContactDataProviderTriggerDetails {}
 unsafe impl Sync for ContactDataProviderTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListCreateOrUpdateContactRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListCreateOrUpdateContactRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListCreateOrUpdateContactRequest {
@@ -275,7 +275,7 @@ impl windows_core::RuntimeName for ContactListCreateOrUpdateContactRequest {
 unsafe impl Send for ContactListCreateOrUpdateContactRequest {}
 unsafe impl Sync for ContactListCreateOrUpdateContactRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListCreateOrUpdateContactRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListCreateOrUpdateContactRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListCreateOrUpdateContactRequestEventArgs {
@@ -307,7 +307,7 @@ impl windows_core::RuntimeName for ContactListCreateOrUpdateContactRequestEventA
 unsafe impl Send for ContactListCreateOrUpdateContactRequestEventArgs {}
 unsafe impl Sync for ContactListCreateOrUpdateContactRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListDeleteContactRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListDeleteContactRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListDeleteContactRequest {
@@ -353,7 +353,7 @@ impl windows_core::RuntimeName for ContactListDeleteContactRequest {
 unsafe impl Send for ContactListDeleteContactRequest {}
 unsafe impl Sync for ContactListDeleteContactRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListDeleteContactRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListDeleteContactRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListDeleteContactRequestEventArgs {
@@ -385,7 +385,7 @@ impl windows_core::RuntimeName for ContactListDeleteContactRequestEventArgs {
 unsafe impl Send for ContactListDeleteContactRequestEventArgs {}
 unsafe impl Sync for ContactListDeleteContactRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListServerSearchReadBatchRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListServerSearchReadBatchRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListServerSearchReadBatchRequest {
@@ -455,7 +455,7 @@ impl windows_core::RuntimeName for ContactListServerSearchReadBatchRequest {
 unsafe impl Send for ContactListServerSearchReadBatchRequest {}
 unsafe impl Sync for ContactListServerSearchReadBatchRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListServerSearchReadBatchRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListServerSearchReadBatchRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListServerSearchReadBatchRequestEventArgs {
@@ -487,7 +487,7 @@ impl windows_core::RuntimeName for ContactListServerSearchReadBatchRequestEventA
 unsafe impl Send for ContactListServerSearchReadBatchRequestEventArgs {}
 unsafe impl Sync for ContactListServerSearchReadBatchRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListSyncManagerSyncRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListSyncManagerSyncRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListSyncManagerSyncRequest {
@@ -526,7 +526,7 @@ impl windows_core::RuntimeName for ContactListSyncManagerSyncRequest {
 unsafe impl Send for ContactListSyncManagerSyncRequest {}
 unsafe impl Sync for ContactListSyncManagerSyncRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListSyncManagerSyncRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListSyncManagerSyncRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListSyncManagerSyncRequestEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/Provider/mod.rs
@@ -42,7 +42,7 @@ pub struct IContactRemovedEventArgs_Vtbl {
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactPickerUI(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactPickerUI, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactPickerUI {
@@ -127,7 +127,7 @@ impl windows_core::RuntimeName for ContactPickerUI {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.Provider.ContactPickerUI";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactRemovedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactRemovedEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
@@ -1387,7 +1387,7 @@ pub struct IPinnedContactManagerStatics_Vtbl {
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AggregateContactManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AggregateContactManager, windows_core::IUnknown, windows_core::IInspectable);
 impl AggregateContactManager {
@@ -1455,7 +1455,7 @@ impl windows_core::RuntimeName for AggregateContactManager {
 unsafe impl Send for AggregateContactManager {}
 unsafe impl Sync for AggregateContactManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Contact(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Contact, windows_core::IUnknown, windows_core::IInspectable);
 impl Contact {
@@ -1855,7 +1855,7 @@ impl windows_core::RuntimeName for Contact {
 unsafe impl Send for Contact {}
 unsafe impl Sync for Contact {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactAddress(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactAddress, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactAddress {
@@ -1957,7 +1957,7 @@ impl windows_core::RuntimeName for ContactAddress {
 unsafe impl Send for ContactAddress {}
 unsafe impl Sync for ContactAddress {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactAnnotation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactAnnotation, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactAnnotation {
@@ -2055,7 +2055,7 @@ impl windows_core::RuntimeName for ContactAnnotation {
 unsafe impl Send for ContactAnnotation {}
 unsafe impl Sync for ContactAnnotation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactAnnotationList(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactAnnotationList, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactAnnotationList {
@@ -2144,7 +2144,7 @@ impl windows_core::RuntimeName for ContactAnnotationList {
 unsafe impl Send for ContactAnnotationList {}
 unsafe impl Sync for ContactAnnotationList {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactAnnotationStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactAnnotationStore, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactAnnotationStore {
@@ -2236,7 +2236,7 @@ impl windows_core::RuntimeName for ContactAnnotationStore {
 unsafe impl Send for ContactAnnotationStore {}
 unsafe impl Sync for ContactAnnotationStore {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactBatch(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactBatch, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactBatch {
@@ -2269,7 +2269,7 @@ impl windows_core::RuntimeName for ContactBatch {
 unsafe impl Send for ContactBatch {}
 unsafe impl Sync for ContactBatch {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactCardDelayedDataLoader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactCardDelayedDataLoader, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactCardDelayedDataLoader, super::super::Foundation::IClosable);
@@ -2299,7 +2299,7 @@ impl windows_core::RuntimeName for ContactCardDelayedDataLoader {
 unsafe impl Send for ContactCardDelayedDataLoader {}
 unsafe impl Sync for ContactCardDelayedDataLoader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactCardOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactCardOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactCardOptions {
@@ -2354,7 +2354,7 @@ impl windows_core::RuntimeName for ContactCardOptions {
 unsafe impl Send for ContactCardOptions {}
 unsafe impl Sync for ContactCardOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactChange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactChange, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactChange {
@@ -2386,7 +2386,7 @@ impl windows_core::RuntimeName for ContactChange {
 unsafe impl Send for ContactChange {}
 unsafe impl Sync for ContactChange {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactChangeReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactChangeReader, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactChangeReader {
@@ -2423,7 +2423,7 @@ impl windows_core::RuntimeName for ContactChangeReader {
 unsafe impl Send for ContactChangeReader {}
 unsafe impl Sync for ContactChangeReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactChangeTracker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactChangeTracker, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactChangeTracker {
@@ -2463,7 +2463,7 @@ impl windows_core::RuntimeName for ContactChangeTracker {
 unsafe impl Send for ContactChangeTracker {}
 unsafe impl Sync for ContactChangeTracker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactChangedDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactChangedDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactChangedDeferral {
@@ -2485,7 +2485,7 @@ impl windows_core::RuntimeName for ContactChangedDeferral {
 unsafe impl Send for ContactChangedDeferral {}
 unsafe impl Sync for ContactChangedDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactChangedEventArgs {
@@ -2510,7 +2510,7 @@ impl windows_core::RuntimeName for ContactChangedEventArgs {
 unsafe impl Send for ContactChangedEventArgs {}
 unsafe impl Sync for ContactChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactConnectedServiceAccount(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactConnectedServiceAccount, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactConnectedServiceAccount {
@@ -2557,7 +2557,7 @@ impl windows_core::RuntimeName for ContactConnectedServiceAccount {
 unsafe impl Send for ContactConnectedServiceAccount {}
 unsafe impl Sync for ContactConnectedServiceAccount {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactDate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactDate, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactDate {
@@ -2646,7 +2646,7 @@ impl windows_core::RuntimeName for ContactDate {
 unsafe impl Send for ContactDate {}
 unsafe impl Sync for ContactDate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactEmail(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactEmail, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactEmail {
@@ -2704,7 +2704,7 @@ impl windows_core::RuntimeName for ContactEmail {
 unsafe impl Send for ContactEmail {}
 unsafe impl Sync for ContactEmail {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactField(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactField, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactField, IContactField);
@@ -2774,7 +2774,7 @@ impl windows_core::RuntimeName for ContactField {
 unsafe impl Send for ContactField {}
 unsafe impl Sync for ContactField {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactFieldFactory(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactFieldFactory, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactFieldFactory, IContactFieldFactory, IContactInstantMessageFieldFactory, IContactLocationFieldFactory);
@@ -2866,7 +2866,7 @@ impl windows_core::RuntimeName for ContactFieldFactory {
 unsafe impl Send for ContactFieldFactory {}
 unsafe impl Sync for ContactFieldFactory {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactGroup {}
@@ -2883,7 +2883,7 @@ impl windows_core::RuntimeName for ContactGroup {
 unsafe impl Send for ContactGroup {}
 unsafe impl Sync for ContactGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactInformation {
@@ -2962,7 +2962,7 @@ impl windows_core::RuntimeName for ContactInformation {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactInformation";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactInstantMessageField(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactInstantMessageField, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactInstantMessageField, IContactField);
@@ -3063,7 +3063,7 @@ impl windows_core::RuntimeName for ContactInstantMessageField {
 unsafe impl Send for ContactInstantMessageField {}
 unsafe impl Sync for ContactInstantMessageField {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactJobInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactJobInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactJobInfo {
@@ -3217,7 +3217,7 @@ impl windows_core::RuntimeName for ContactLaunchActionVerbs {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactLaunchActionVerbs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactList(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactList, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactList {
@@ -3439,7 +3439,7 @@ impl windows_core::RuntimeName for ContactList {
 unsafe impl Send for ContactList {}
 unsafe impl Sync for ContactList {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListLimitedWriteOperations(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListLimitedWriteOperations, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListLimitedWriteOperations {
@@ -3474,7 +3474,7 @@ impl windows_core::RuntimeName for ContactListLimitedWriteOperations {
 unsafe impl Send for ContactListLimitedWriteOperations {}
 unsafe impl Sync for ContactListLimitedWriteOperations {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListSyncConstraints(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListSyncConstraints, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListSyncConstraints {
@@ -3881,7 +3881,7 @@ impl windows_core::RuntimeName for ContactListSyncConstraints {
 unsafe impl Send for ContactListSyncConstraints {}
 unsafe impl Sync for ContactListSyncConstraints {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactListSyncManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactListSyncManager, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactListSyncManager {
@@ -3953,7 +3953,7 @@ impl windows_core::RuntimeName for ContactListSyncManager {
 unsafe impl Send for ContactListSyncManager {}
 unsafe impl Sync for ContactListSyncManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactLocationField(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactLocationField, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactLocationField, IContactField);
@@ -4248,7 +4248,7 @@ impl windows_core::RuntimeName for ContactManager {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactManagerForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactManagerForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactManagerForUser {
@@ -4351,7 +4351,7 @@ impl windows_core::RuntimeName for ContactManagerForUser {
 unsafe impl Send for ContactManagerForUser {}
 unsafe impl Sync for ContactManagerForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactMatchReason(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactMatchReason, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactMatchReason {
@@ -4391,7 +4391,7 @@ impl windows_core::RuntimeName for ContactMatchReason {
 unsafe impl Send for ContactMatchReason {}
 unsafe impl Sync for ContactMatchReason {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactPanel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactPanel, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactPanel {
@@ -4457,7 +4457,7 @@ impl windows_core::RuntimeName for ContactPanel {
 unsafe impl Send for ContactPanel {}
 unsafe impl Sync for ContactPanel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactPanelClosingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactPanelClosingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactPanelClosingEventArgs {
@@ -4482,7 +4482,7 @@ impl windows_core::RuntimeName for ContactPanelClosingEventArgs {
 unsafe impl Send for ContactPanelClosingEventArgs {}
 unsafe impl Sync for ContactPanelClosingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactPanelLaunchFullAppRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactPanelLaunchFullAppRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactPanelLaunchFullAppRequestedEventArgs {
@@ -4511,7 +4511,7 @@ impl windows_core::RuntimeName for ContactPanelLaunchFullAppRequestedEventArgs {
 unsafe impl Send for ContactPanelLaunchFullAppRequestedEventArgs {}
 unsafe impl Sync for ContactPanelLaunchFullAppRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactPhone(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactPhone, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactPhone {
@@ -4569,7 +4569,7 @@ impl windows_core::RuntimeName for ContactPhone {
 unsafe impl Send for ContactPhone {}
 unsafe impl Sync for ContactPhone {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactPicker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactPicker, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactPicker {
@@ -4689,7 +4689,7 @@ impl windows_core::RuntimeName for ContactPicker {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.ContactPicker";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactQueryOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactQueryOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactQueryOptions {
@@ -4787,7 +4787,7 @@ impl windows_core::RuntimeName for ContactQueryOptions {
 unsafe impl Send for ContactQueryOptions {}
 unsafe impl Sync for ContactQueryOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactQueryTextSearch(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactQueryTextSearch, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactQueryTextSearch {
@@ -4838,7 +4838,7 @@ impl windows_core::RuntimeName for ContactQueryTextSearch {
 unsafe impl Send for ContactQueryTextSearch {}
 unsafe impl Sync for ContactQueryTextSearch {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactReader, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactReader {
@@ -4874,7 +4874,7 @@ impl windows_core::RuntimeName for ContactReader {
 unsafe impl Send for ContactReader {}
 unsafe impl Sync for ContactReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactSignificantOther(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactSignificantOther, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactSignificantOther {
@@ -4932,7 +4932,7 @@ impl windows_core::RuntimeName for ContactSignificantOther {
 unsafe impl Send for ContactSignificantOther {}
 unsafe impl Sync for ContactSignificantOther {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactStore, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactStore {
@@ -5061,7 +5061,7 @@ impl windows_core::RuntimeName for ContactStore {
 unsafe impl Send for ContactStore {}
 unsafe impl Sync for ContactStore {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactStoreNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactStoreNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactStoreNotificationTriggerDetails {}
@@ -5078,7 +5078,7 @@ impl windows_core::RuntimeName for ContactStoreNotificationTriggerDetails {
 unsafe impl Send for ContactStoreNotificationTriggerDetails {}
 unsafe impl Sync for ContactStoreNotificationTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactWebsite(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactWebsite, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactWebsite {
@@ -5139,7 +5139,7 @@ impl windows_core::RuntimeName for ContactWebsite {
 unsafe impl Send for ContactWebsite {}
 unsafe impl Sync for ContactWebsite {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FullContactCardOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FullContactCardOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl FullContactCardOptions {
@@ -5234,7 +5234,7 @@ impl windows_core::RuntimeName for KnownContactField {
     const NAME: &'static str = "Windows.ApplicationModel.Contacts.KnownContactField";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PinnedContactIdsQueryResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PinnedContactIdsQueryResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PinnedContactIdsQueryResult {
@@ -5260,7 +5260,7 @@ impl windows_core::RuntimeName for PinnedContactIdsQueryResult {
 unsafe impl Send for PinnedContactIdsQueryResult {}
 unsafe impl Sync for PinnedContactIdsQueryResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PinnedContactManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PinnedContactManager, windows_core::IUnknown, windows_core::IInspectable);
 impl PinnedContactManager {

--- a/crates/libs/windows/src/Windows/ApplicationModel/ConversationalAgent/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ConversationalAgent/mod.rs
@@ -359,7 +359,7 @@ pub struct IDetectionConfigurationAvailabilityInfo2_Vtbl {
     UnavailableSystemResources: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivationSignalDetectionConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivationSignalDetectionConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ActivationSignalDetectionConfiguration, super::super::Foundation::IClosable);
@@ -599,7 +599,7 @@ impl windows_core::RuntimeName for ActivationSignalDetectionConfiguration {
 unsafe impl Send for ActivationSignalDetectionConfiguration {}
 unsafe impl Sync for ActivationSignalDetectionConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivationSignalDetectionConfigurationCreationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivationSignalDetectionConfigurationCreationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ActivationSignalDetectionConfigurationCreationResult {
@@ -631,7 +631,7 @@ impl windows_core::RuntimeName for ActivationSignalDetectionConfigurationCreatio
 unsafe impl Send for ActivationSignalDetectionConfigurationCreationResult {}
 unsafe impl Sync for ActivationSignalDetectionConfigurationCreationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivationSignalDetector(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivationSignalDetector, windows_core::IUnknown, windows_core::IInspectable);
 impl ActivationSignalDetector {
@@ -813,7 +813,7 @@ impl windows_core::RuntimeName for ActivationSignalDetector {
 unsafe impl Send for ActivationSignalDetector {}
 unsafe impl Sync for ActivationSignalDetector {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConversationalAgentDetectorManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConversationalAgentDetectorManager, windows_core::IUnknown, windows_core::IInspectable);
 impl ConversationalAgentDetectorManager {
@@ -888,7 +888,7 @@ impl windows_core::RuntimeName for ConversationalAgentDetectorManager {
 unsafe impl Send for ConversationalAgentDetectorManager {}
 unsafe impl Sync for ConversationalAgentDetectorManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConversationalAgentSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConversationalAgentSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ConversationalAgentSession, super::super::Foundation::IClosable);
@@ -1217,7 +1217,7 @@ impl windows_core::RuntimeName for ConversationalAgentSession {
 unsafe impl Send for ConversationalAgentSession {}
 unsafe impl Sync for ConversationalAgentSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConversationalAgentSessionInterruptedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConversationalAgentSessionInterruptedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ConversationalAgentSessionInterruptedEventArgs {}
@@ -1234,7 +1234,7 @@ impl windows_core::RuntimeName for ConversationalAgentSessionInterruptedEventArg
 unsafe impl Send for ConversationalAgentSessionInterruptedEventArgs {}
 unsafe impl Sync for ConversationalAgentSessionInterruptedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConversationalAgentSignal(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConversationalAgentSignal, windows_core::IUnknown, windows_core::IInspectable);
 impl ConversationalAgentSignal {
@@ -1335,7 +1335,7 @@ impl windows_core::RuntimeName for ConversationalAgentSignal {
 unsafe impl Send for ConversationalAgentSignal {}
 unsafe impl Sync for ConversationalAgentSignal {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConversationalAgentSignalDetectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConversationalAgentSignalDetectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ConversationalAgentSignalDetectedEventArgs {}
@@ -1352,7 +1352,7 @@ impl windows_core::RuntimeName for ConversationalAgentSignalDetectedEventArgs {
 unsafe impl Send for ConversationalAgentSignalDetectedEventArgs {}
 unsafe impl Sync for ConversationalAgentSignalDetectedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConversationalAgentSystemStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConversationalAgentSystemStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ConversationalAgentSystemStateChangedEventArgs {
@@ -1377,7 +1377,7 @@ impl windows_core::RuntimeName for ConversationalAgentSystemStateChangedEventArg
 unsafe impl Send for ConversationalAgentSystemStateChangedEventArgs {}
 unsafe impl Sync for ConversationalAgentSystemStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DetectionConfigurationAvailabilityChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DetectionConfigurationAvailabilityChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DetectionConfigurationAvailabilityChangedEventArgs {
@@ -1402,7 +1402,7 @@ impl windows_core::RuntimeName for DetectionConfigurationAvailabilityChangedEven
 unsafe impl Send for DetectionConfigurationAvailabilityChangedEventArgs {}
 unsafe impl Sync for DetectionConfigurationAvailabilityChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DetectionConfigurationAvailabilityInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DetectionConfigurationAvailabilityInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl DetectionConfigurationAvailabilityInfo {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Core/mod.rs
@@ -366,7 +366,7 @@ pub struct IUnhandledErrorDetectedEventArgs_Vtbl {
     pub UnhandledError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppListEntry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppListEntry, windows_core::IUnknown, windows_core::IInspectable);
 impl AppListEntry {
@@ -652,7 +652,7 @@ impl windows_core::RuntimeName for CoreApplication {
     const NAME: &'static str = "Windows.ApplicationModel.Core.CoreApplication";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreApplicationView(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreApplicationView, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreApplicationView {
@@ -757,7 +757,7 @@ impl windows_core::RuntimeName for CoreApplicationView {
     const NAME: &'static str = "Windows.ApplicationModel.Core.CoreApplicationView";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreApplicationViewTitleBar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreApplicationViewTitleBar, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreApplicationViewTitleBar {
@@ -840,7 +840,7 @@ impl windows_core::RuntimeName for CoreApplicationViewTitleBar {
     const NAME: &'static str = "Windows.ApplicationModel.Core.CoreApplicationViewTitleBar";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HostedViewClosingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HostedViewClosingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HostedViewClosingEventArgs {
@@ -865,7 +865,7 @@ impl windows_core::RuntimeName for HostedViewClosingEventArgs {
 unsafe impl Send for HostedViewClosingEventArgs {}
 unsafe impl Sync for HostedViewClosingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UnhandledError(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UnhandledError, windows_core::IUnknown, windows_core::IInspectable);
 impl UnhandledError {
@@ -894,7 +894,7 @@ impl windows_core::RuntimeName for UnhandledError {
 unsafe impl Send for UnhandledError {}
 unsafe impl Sync for UnhandledError {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UnhandledErrorDetectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UnhandledErrorDetectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UnhandledErrorDetectedEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
@@ -168,7 +168,7 @@ pub struct ICoreDropOperationTargetRequestedEventArgs_Vtbl {
     pub SetTarget: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreDragDropManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreDragDropManager, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreDragDropManager {
@@ -222,7 +222,7 @@ impl windows_core::RuntimeName for CoreDragDropManager {
 unsafe impl Send for CoreDragDropManager {}
 unsafe impl Sync for CoreDragDropManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreDragInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreDragInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreDragInfo {
@@ -268,7 +268,7 @@ impl windows_core::RuntimeName for CoreDragInfo {
 unsafe impl Send for CoreDragInfo {}
 unsafe impl Sync for CoreDragInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreDragOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreDragOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreDragOperation {
@@ -349,7 +349,7 @@ impl windows_core::RuntimeName for CoreDragOperation {
 unsafe impl Send for CoreDragOperation {}
 unsafe impl Sync for CoreDragOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreDragUIOverride(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreDragUIOverride, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreDragUIOverride {
@@ -431,7 +431,7 @@ impl windows_core::RuntimeName for CoreDragUIOverride {
 unsafe impl Send for CoreDragUIOverride {}
 unsafe impl Sync for CoreDragUIOverride {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreDropOperationTargetRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreDropOperationTargetRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreDropOperationTargetRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/ShareTarget/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/ShareTarget/mod.rs
@@ -65,7 +65,7 @@ pub struct IShareOperation3_Vtbl {
     Contacts: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct QuickLink(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(QuickLink, windows_core::IUnknown, windows_core::IInspectable);
 impl QuickLink {
@@ -142,7 +142,7 @@ impl windows_core::RuntimeName for QuickLink {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.ShareTarget.QuickLink";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShareOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShareOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl ShareOperation {

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
@@ -794,7 +794,7 @@ impl windows_core::RuntimeName for Clipboard {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.Clipboard";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClipboardContentOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClipboardContentOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl ClipboardContentOptions {
@@ -857,7 +857,7 @@ impl windows_core::RuntimeName for ClipboardContentOptions {
 unsafe impl Send for ClipboardContentOptions {}
 unsafe impl Sync for ClipboardContentOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClipboardHistoryChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClipboardHistoryChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClipboardHistoryChangedEventArgs {}
@@ -874,7 +874,7 @@ impl windows_core::RuntimeName for ClipboardHistoryChangedEventArgs {
 unsafe impl Send for ClipboardHistoryChangedEventArgs {}
 unsafe impl Sync for ClipboardHistoryChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClipboardHistoryItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClipboardHistoryItem, windows_core::IUnknown, windows_core::IInspectable);
 impl ClipboardHistoryItem {
@@ -913,7 +913,7 @@ impl windows_core::RuntimeName for ClipboardHistoryItem {
 unsafe impl Send for ClipboardHistoryItem {}
 unsafe impl Sync for ClipboardHistoryItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClipboardHistoryItemsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClipboardHistoryItemsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ClipboardHistoryItemsResult {
@@ -946,7 +946,7 @@ impl windows_core::RuntimeName for ClipboardHistoryItemsResult {
 unsafe impl Send for ClipboardHistoryItemsResult {}
 unsafe impl Sync for ClipboardHistoryItemsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataPackage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataPackage, windows_core::IUnknown, windows_core::IInspectable);
 impl DataPackage {
@@ -1132,7 +1132,7 @@ impl windows_core::RuntimeName for DataPackage {
 unsafe impl Send for DataPackage {}
 unsafe impl Sync for DataPackage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataPackagePropertySet(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataPackagePropertySet, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -1390,7 +1390,7 @@ impl IntoIterator for &DataPackagePropertySet {
 unsafe impl Send for DataPackagePropertySet {}
 unsafe impl Sync for DataPackagePropertySet {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataPackagePropertySetView(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataPackagePropertySetView, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -1565,7 +1565,7 @@ impl IntoIterator for &DataPackagePropertySetView {
 unsafe impl Send for DataPackagePropertySetView {}
 unsafe impl Sync for DataPackagePropertySetView {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataPackageView(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataPackageView, windows_core::IUnknown, windows_core::IInspectable);
 impl DataPackageView {
@@ -1725,7 +1725,7 @@ impl windows_core::RuntimeName for DataPackageView {
 unsafe impl Send for DataPackageView {}
 unsafe impl Sync for DataPackageView {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataProviderDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataProviderDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl DataProviderDeferral {
@@ -1747,7 +1747,7 @@ impl windows_core::RuntimeName for DataProviderDeferral {
 unsafe impl Send for DataProviderDeferral {}
 unsafe impl Sync for DataProviderDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataProviderRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataProviderRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl DataProviderRequest {
@@ -1793,7 +1793,7 @@ impl windows_core::RuntimeName for DataProviderRequest {
 unsafe impl Send for DataProviderRequest {}
 unsafe impl Sync for DataProviderRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl DataRequest {
@@ -1843,7 +1843,7 @@ impl windows_core::RuntimeName for DataRequest {
 unsafe impl Send for DataRequest {}
 unsafe impl Sync for DataRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataRequestDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataRequestDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl DataRequestDeferral {
@@ -1865,7 +1865,7 @@ impl windows_core::RuntimeName for DataRequestDeferral {
 unsafe impl Send for DataRequestDeferral {}
 unsafe impl Sync for DataRequestDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DataRequestedEventArgs {
@@ -1890,7 +1890,7 @@ impl windows_core::RuntimeName for DataRequestedEventArgs {
 unsafe impl Send for DataRequestedEventArgs {}
 unsafe impl Sync for DataRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataTransferManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataTransferManager, windows_core::IUnknown, windows_core::IInspectable);
 impl DataTransferManager {
@@ -2007,7 +2007,7 @@ impl windows_core::RuntimeName for HtmlFormatHelper {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.HtmlFormatHelper";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OperationCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OperationCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl OperationCompletedEventArgs {
@@ -2039,7 +2039,7 @@ impl windows_core::RuntimeName for OperationCompletedEventArgs {
 unsafe impl Send for OperationCompletedEventArgs {}
 unsafe impl Sync for OperationCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShareCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShareCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ShareCompletedEventArgs {
@@ -2064,7 +2064,7 @@ impl windows_core::RuntimeName for ShareCompletedEventArgs {
 unsafe impl Send for ShareCompletedEventArgs {}
 unsafe impl Sync for ShareCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShareProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShareProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl ShareProvider {
@@ -2135,7 +2135,7 @@ impl windows_core::RuntimeName for ShareProvider {
 unsafe impl Send for ShareProvider {}
 unsafe impl Sync for ShareProvider {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShareProviderOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShareProviderOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl ShareProviderOperation {
@@ -2171,7 +2171,7 @@ impl windows_core::RuntimeName for ShareProviderOperation {
 unsafe impl Send for ShareProviderOperation {}
 unsafe impl Sync for ShareProviderOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShareProvidersRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShareProvidersRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ShareProvidersRequestedEventArgs {
@@ -2211,7 +2211,7 @@ impl windows_core::RuntimeName for ShareProvidersRequestedEventArgs {
 unsafe impl Send for ShareProvidersRequestedEventArgs {}
 unsafe impl Sync for ShareProvidersRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShareTargetInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShareTargetInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl ShareTargetInfo {
@@ -2243,7 +2243,7 @@ impl windows_core::RuntimeName for ShareTargetInfo {
 unsafe impl Send for ShareTargetInfo {}
 unsafe impl Sync for ShareTargetInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShareUIOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShareUIOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl ShareUIOptions {
@@ -2400,7 +2400,7 @@ impl windows_core::RuntimeName for StandardDataFormats {
     const NAME: &'static str = "Windows.ApplicationModel.DataTransfer.StandardDataFormats";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetApplicationChosenEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetApplicationChosenEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetApplicationChosenEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Email/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Email/DataProvider/mod.rs
@@ -412,7 +412,7 @@ pub struct IEmailMailboxValidateCertificatesRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailDataProviderConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailDataProviderConnection, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailDataProviderConnection {
@@ -644,7 +644,7 @@ impl windows_core::RuntimeName for EmailDataProviderConnection {
 unsafe impl Send for EmailDataProviderConnection {}
 unsafe impl Sync for EmailDataProviderConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailDataProviderTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailDataProviderTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailDataProviderTriggerDetails {
@@ -669,7 +669,7 @@ impl windows_core::RuntimeName for EmailDataProviderTriggerDetails {
 unsafe impl Send for EmailDataProviderTriggerDetails {}
 unsafe impl Sync for EmailDataProviderTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxCreateFolderRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxCreateFolderRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxCreateFolderRequest {
@@ -725,7 +725,7 @@ impl windows_core::RuntimeName for EmailMailboxCreateFolderRequest {
 unsafe impl Send for EmailMailboxCreateFolderRequest {}
 unsafe impl Sync for EmailMailboxCreateFolderRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxCreateFolderRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxCreateFolderRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxCreateFolderRequestEventArgs {
@@ -757,7 +757,7 @@ impl windows_core::RuntimeName for EmailMailboxCreateFolderRequestEventArgs {
 unsafe impl Send for EmailMailboxCreateFolderRequestEventArgs {}
 unsafe impl Sync for EmailMailboxCreateFolderRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxDeleteFolderRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxDeleteFolderRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxDeleteFolderRequest {
@@ -803,7 +803,7 @@ impl windows_core::RuntimeName for EmailMailboxDeleteFolderRequest {
 unsafe impl Send for EmailMailboxDeleteFolderRequest {}
 unsafe impl Sync for EmailMailboxDeleteFolderRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxDeleteFolderRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxDeleteFolderRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxDeleteFolderRequestEventArgs {
@@ -835,7 +835,7 @@ impl windows_core::RuntimeName for EmailMailboxDeleteFolderRequestEventArgs {
 unsafe impl Send for EmailMailboxDeleteFolderRequestEventArgs {}
 unsafe impl Sync for EmailMailboxDeleteFolderRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxDownloadAttachmentRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxDownloadAttachmentRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxDownloadAttachmentRequest {
@@ -888,7 +888,7 @@ impl windows_core::RuntimeName for EmailMailboxDownloadAttachmentRequest {
 unsafe impl Send for EmailMailboxDownloadAttachmentRequest {}
 unsafe impl Sync for EmailMailboxDownloadAttachmentRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxDownloadAttachmentRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxDownloadAttachmentRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxDownloadAttachmentRequestEventArgs {
@@ -920,7 +920,7 @@ impl windows_core::RuntimeName for EmailMailboxDownloadAttachmentRequestEventArg
 unsafe impl Send for EmailMailboxDownloadAttachmentRequestEventArgs {}
 unsafe impl Sync for EmailMailboxDownloadAttachmentRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxDownloadMessageRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxDownloadMessageRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxDownloadMessageRequest {
@@ -966,7 +966,7 @@ impl windows_core::RuntimeName for EmailMailboxDownloadMessageRequest {
 unsafe impl Send for EmailMailboxDownloadMessageRequest {}
 unsafe impl Sync for EmailMailboxDownloadMessageRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxDownloadMessageRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxDownloadMessageRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxDownloadMessageRequestEventArgs {
@@ -998,7 +998,7 @@ impl windows_core::RuntimeName for EmailMailboxDownloadMessageRequestEventArgs {
 unsafe impl Send for EmailMailboxDownloadMessageRequestEventArgs {}
 unsafe impl Sync for EmailMailboxDownloadMessageRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxEmptyFolderRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxEmptyFolderRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxEmptyFolderRequest {
@@ -1044,7 +1044,7 @@ impl windows_core::RuntimeName for EmailMailboxEmptyFolderRequest {
 unsafe impl Send for EmailMailboxEmptyFolderRequest {}
 unsafe impl Sync for EmailMailboxEmptyFolderRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxEmptyFolderRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxEmptyFolderRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxEmptyFolderRequestEventArgs {
@@ -1076,7 +1076,7 @@ impl windows_core::RuntimeName for EmailMailboxEmptyFolderRequestEventArgs {
 unsafe impl Send for EmailMailboxEmptyFolderRequestEventArgs {}
 unsafe impl Sync for EmailMailboxEmptyFolderRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxForwardMeetingRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxForwardMeetingRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxForwardMeetingRequest {
@@ -1158,7 +1158,7 @@ impl windows_core::RuntimeName for EmailMailboxForwardMeetingRequest {
 unsafe impl Send for EmailMailboxForwardMeetingRequest {}
 unsafe impl Sync for EmailMailboxForwardMeetingRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxForwardMeetingRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxForwardMeetingRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxForwardMeetingRequestEventArgs {
@@ -1190,7 +1190,7 @@ impl windows_core::RuntimeName for EmailMailboxForwardMeetingRequestEventArgs {
 unsafe impl Send for EmailMailboxForwardMeetingRequestEventArgs {}
 unsafe impl Sync for EmailMailboxForwardMeetingRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxGetAutoReplySettingsRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxGetAutoReplySettingsRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxGetAutoReplySettingsRequest {
@@ -1239,7 +1239,7 @@ impl windows_core::RuntimeName for EmailMailboxGetAutoReplySettingsRequest {
 unsafe impl Send for EmailMailboxGetAutoReplySettingsRequest {}
 unsafe impl Sync for EmailMailboxGetAutoReplySettingsRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxGetAutoReplySettingsRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxGetAutoReplySettingsRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxGetAutoReplySettingsRequestEventArgs {
@@ -1271,7 +1271,7 @@ impl windows_core::RuntimeName for EmailMailboxGetAutoReplySettingsRequestEventA
 unsafe impl Send for EmailMailboxGetAutoReplySettingsRequestEventArgs {}
 unsafe impl Sync for EmailMailboxGetAutoReplySettingsRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxMoveFolderRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxMoveFolderRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxMoveFolderRequest {
@@ -1331,7 +1331,7 @@ impl windows_core::RuntimeName for EmailMailboxMoveFolderRequest {
 unsafe impl Send for EmailMailboxMoveFolderRequest {}
 unsafe impl Sync for EmailMailboxMoveFolderRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxMoveFolderRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxMoveFolderRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxMoveFolderRequestEventArgs {
@@ -1363,7 +1363,7 @@ impl windows_core::RuntimeName for EmailMailboxMoveFolderRequestEventArgs {
 unsafe impl Send for EmailMailboxMoveFolderRequestEventArgs {}
 unsafe impl Sync for EmailMailboxMoveFolderRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxProposeNewTimeForMeetingRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxProposeNewTimeForMeetingRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxProposeNewTimeForMeetingRequest {
@@ -1437,7 +1437,7 @@ impl windows_core::RuntimeName for EmailMailboxProposeNewTimeForMeetingRequest {
 unsafe impl Send for EmailMailboxProposeNewTimeForMeetingRequest {}
 unsafe impl Sync for EmailMailboxProposeNewTimeForMeetingRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxProposeNewTimeForMeetingRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxProposeNewTimeForMeetingRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxProposeNewTimeForMeetingRequestEventArgs {
@@ -1469,7 +1469,7 @@ impl windows_core::RuntimeName for EmailMailboxProposeNewTimeForMeetingRequestEv
 unsafe impl Send for EmailMailboxProposeNewTimeForMeetingRequestEventArgs {}
 unsafe impl Sync for EmailMailboxProposeNewTimeForMeetingRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxResolveRecipientsRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxResolveRecipientsRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxResolveRecipientsRequest {
@@ -1520,7 +1520,7 @@ impl windows_core::RuntimeName for EmailMailboxResolveRecipientsRequest {
 unsafe impl Send for EmailMailboxResolveRecipientsRequest {}
 unsafe impl Sync for EmailMailboxResolveRecipientsRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxResolveRecipientsRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxResolveRecipientsRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxResolveRecipientsRequestEventArgs {
@@ -1552,7 +1552,7 @@ impl windows_core::RuntimeName for EmailMailboxResolveRecipientsRequestEventArgs
 unsafe impl Send for EmailMailboxResolveRecipientsRequestEventArgs {}
 unsafe impl Sync for EmailMailboxResolveRecipientsRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxServerSearchReadBatchRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxServerSearchReadBatchRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxServerSearchReadBatchRequest {
@@ -1629,7 +1629,7 @@ impl windows_core::RuntimeName for EmailMailboxServerSearchReadBatchRequest {
 unsafe impl Send for EmailMailboxServerSearchReadBatchRequest {}
 unsafe impl Sync for EmailMailboxServerSearchReadBatchRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxServerSearchReadBatchRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxServerSearchReadBatchRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxServerSearchReadBatchRequestEventArgs {
@@ -1661,7 +1661,7 @@ impl windows_core::RuntimeName for EmailMailboxServerSearchReadBatchRequestEvent
 unsafe impl Send for EmailMailboxServerSearchReadBatchRequestEventArgs {}
 unsafe impl Sync for EmailMailboxServerSearchReadBatchRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxSetAutoReplySettingsRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxSetAutoReplySettingsRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxSetAutoReplySettingsRequest {
@@ -1707,7 +1707,7 @@ impl windows_core::RuntimeName for EmailMailboxSetAutoReplySettingsRequest {
 unsafe impl Send for EmailMailboxSetAutoReplySettingsRequest {}
 unsafe impl Sync for EmailMailboxSetAutoReplySettingsRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxSetAutoReplySettingsRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxSetAutoReplySettingsRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxSetAutoReplySettingsRequestEventArgs {
@@ -1739,7 +1739,7 @@ impl windows_core::RuntimeName for EmailMailboxSetAutoReplySettingsRequestEventA
 unsafe impl Send for EmailMailboxSetAutoReplySettingsRequestEventArgs {}
 unsafe impl Sync for EmailMailboxSetAutoReplySettingsRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxSyncManagerSyncRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxSyncManagerSyncRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxSyncManagerSyncRequest {
@@ -1778,7 +1778,7 @@ impl windows_core::RuntimeName for EmailMailboxSyncManagerSyncRequest {
 unsafe impl Send for EmailMailboxSyncManagerSyncRequest {}
 unsafe impl Sync for EmailMailboxSyncManagerSyncRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxSyncManagerSyncRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxSyncManagerSyncRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxSyncManagerSyncRequestEventArgs {
@@ -1810,7 +1810,7 @@ impl windows_core::RuntimeName for EmailMailboxSyncManagerSyncRequestEventArgs {
 unsafe impl Send for EmailMailboxSyncManagerSyncRequestEventArgs {}
 unsafe impl Sync for EmailMailboxSyncManagerSyncRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxUpdateMeetingResponseRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxUpdateMeetingResponseRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxUpdateMeetingResponseRequest {
@@ -1884,7 +1884,7 @@ impl windows_core::RuntimeName for EmailMailboxUpdateMeetingResponseRequest {
 unsafe impl Send for EmailMailboxUpdateMeetingResponseRequest {}
 unsafe impl Sync for EmailMailboxUpdateMeetingResponseRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxUpdateMeetingResponseRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxUpdateMeetingResponseRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxUpdateMeetingResponseRequestEventArgs {
@@ -1916,7 +1916,7 @@ impl windows_core::RuntimeName for EmailMailboxUpdateMeetingResponseRequestEvent
 unsafe impl Send for EmailMailboxUpdateMeetingResponseRequestEventArgs {}
 unsafe impl Sync for EmailMailboxUpdateMeetingResponseRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxValidateCertificatesRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxValidateCertificatesRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxValidateCertificatesRequest {
@@ -1967,7 +1967,7 @@ impl windows_core::RuntimeName for EmailMailboxValidateCertificatesRequest {
 unsafe impl Send for EmailMailboxValidateCertificatesRequest {}
 unsafe impl Sync for EmailMailboxValidateCertificatesRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxValidateCertificatesRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxValidateCertificatesRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxValidateCertificatesRequestEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
@@ -918,7 +918,7 @@ pub struct IEmailStoreNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailAttachment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailAttachment, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailAttachment {
@@ -1080,7 +1080,7 @@ impl windows_core::RuntimeName for EmailAttachment {
 unsafe impl Send for EmailAttachment {}
 unsafe impl Sync for EmailAttachment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailConversation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailConversation, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailConversation {
@@ -1205,7 +1205,7 @@ impl windows_core::RuntimeName for EmailConversation {
 unsafe impl Send for EmailConversation {}
 unsafe impl Sync for EmailConversation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailConversationBatch(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailConversationBatch, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailConversationBatch {
@@ -1238,7 +1238,7 @@ impl windows_core::RuntimeName for EmailConversationBatch {
 unsafe impl Send for EmailConversationBatch {}
 unsafe impl Sync for EmailConversationBatch {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailConversationReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailConversationReader, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailConversationReader {
@@ -1263,7 +1263,7 @@ impl windows_core::RuntimeName for EmailConversationReader {
 unsafe impl Send for EmailConversationReader {}
 unsafe impl Sync for EmailConversationReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailFolder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailFolder, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailFolder {
@@ -1460,7 +1460,7 @@ impl windows_core::RuntimeName for EmailFolder {
 unsafe impl Send for EmailFolder {}
 unsafe impl Sync for EmailFolder {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailIrmInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailIrmInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailIrmInfo {
@@ -1634,7 +1634,7 @@ impl windows_core::RuntimeName for EmailIrmInfo {
 unsafe impl Send for EmailIrmInfo {}
 unsafe impl Sync for EmailIrmInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailIrmTemplate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailIrmTemplate, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailIrmTemplate {
@@ -1703,7 +1703,7 @@ impl windows_core::RuntimeName for EmailIrmTemplate {
 unsafe impl Send for EmailIrmTemplate {}
 unsafe impl Sync for EmailIrmTemplate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailItemCounts(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailItemCounts, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailItemCounts {
@@ -1749,7 +1749,7 @@ impl windows_core::RuntimeName for EmailItemCounts {
 unsafe impl Send for EmailItemCounts {}
 unsafe impl Sync for EmailItemCounts {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailbox(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailbox, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailbox {
@@ -2213,7 +2213,7 @@ impl windows_core::RuntimeName for EmailMailbox {
 unsafe impl Send for EmailMailbox {}
 unsafe impl Sync for EmailMailbox {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxAction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxAction, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxAction {
@@ -2245,7 +2245,7 @@ impl windows_core::RuntimeName for EmailMailboxAction {
 unsafe impl Send for EmailMailboxAction {}
 unsafe impl Sync for EmailMailboxAction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxAutoReply(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxAutoReply, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxAutoReply {
@@ -2285,7 +2285,7 @@ impl windows_core::RuntimeName for EmailMailboxAutoReply {
 unsafe impl Send for EmailMailboxAutoReply {}
 unsafe impl Sync for EmailMailboxAutoReply {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxAutoReplySettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxAutoReplySettings, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxAutoReplySettings {
@@ -2381,7 +2381,7 @@ impl windows_core::RuntimeName for EmailMailboxAutoReplySettings {
 unsafe impl Send for EmailMailboxAutoReplySettings {}
 unsafe impl Sync for EmailMailboxAutoReplySettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxCapabilities {
@@ -2553,7 +2553,7 @@ impl windows_core::RuntimeName for EmailMailboxCapabilities {
 unsafe impl Send for EmailMailboxCapabilities {}
 unsafe impl Sync for EmailMailboxCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxChange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxChange, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxChange {
@@ -2600,7 +2600,7 @@ impl windows_core::RuntimeName for EmailMailboxChange {
 unsafe impl Send for EmailMailboxChange {}
 unsafe impl Sync for EmailMailboxChange {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxChangeReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxChangeReader, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxChangeReader {
@@ -2637,7 +2637,7 @@ impl windows_core::RuntimeName for EmailMailboxChangeReader {
 unsafe impl Send for EmailMailboxChangeReader {}
 unsafe impl Sync for EmailMailboxChangeReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxChangeTracker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxChangeTracker, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxChangeTracker {
@@ -2677,7 +2677,7 @@ impl windows_core::RuntimeName for EmailMailboxChangeTracker {
 unsafe impl Send for EmailMailboxChangeTracker {}
 unsafe impl Sync for EmailMailboxChangeTracker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxChangedDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxChangedDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxChangedDeferral {
@@ -2699,7 +2699,7 @@ impl windows_core::RuntimeName for EmailMailboxChangedDeferral {
 unsafe impl Send for EmailMailboxChangedDeferral {}
 unsafe impl Sync for EmailMailboxChangedDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxChangedEventArgs {
@@ -2724,7 +2724,7 @@ impl windows_core::RuntimeName for EmailMailboxChangedEventArgs {
 unsafe impl Send for EmailMailboxChangedEventArgs {}
 unsafe impl Sync for EmailMailboxChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxCreateFolderResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxCreateFolderResult, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxCreateFolderResult {
@@ -2756,7 +2756,7 @@ impl windows_core::RuntimeName for EmailMailboxCreateFolderResult {
 unsafe impl Send for EmailMailboxCreateFolderResult {}
 unsafe impl Sync for EmailMailboxCreateFolderResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxPolicies(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxPolicies, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxPolicies {
@@ -2846,7 +2846,7 @@ impl windows_core::RuntimeName for EmailMailboxPolicies {
 unsafe impl Send for EmailMailboxPolicies {}
 unsafe impl Sync for EmailMailboxPolicies {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMailboxSyncManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMailboxSyncManager, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMailboxSyncManager {
@@ -2964,7 +2964,7 @@ impl windows_core::RuntimeName for EmailManager {
     const NAME: &'static str = "Windows.ApplicationModel.Email.EmailManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailManagerForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailManagerForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailManagerForUser {
@@ -3007,7 +3007,7 @@ impl windows_core::RuntimeName for EmailManagerForUser {
 unsafe impl Send for EmailManagerForUser {}
 unsafe impl Sync for EmailManagerForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMeetingInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMeetingInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMeetingInfo {
@@ -3199,7 +3199,7 @@ impl windows_core::RuntimeName for EmailMeetingInfo {
 unsafe impl Send for EmailMeetingInfo {}
 unsafe impl Sync for EmailMeetingInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMessage, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMessage {
@@ -3608,7 +3608,7 @@ impl windows_core::RuntimeName for EmailMessage {
 unsafe impl Send for EmailMessage {}
 unsafe impl Sync for EmailMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMessageBatch(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMessageBatch, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMessageBatch {
@@ -3641,7 +3641,7 @@ impl windows_core::RuntimeName for EmailMessageBatch {
 unsafe impl Send for EmailMessageBatch {}
 unsafe impl Sync for EmailMessageBatch {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailMessageReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailMessageReader, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailMessageReader {
@@ -3666,7 +3666,7 @@ impl windows_core::RuntimeName for EmailMessageReader {
 unsafe impl Send for EmailMessageReader {}
 unsafe impl Sync for EmailMessageReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailQueryOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailQueryOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailQueryOptions {
@@ -3756,7 +3756,7 @@ impl windows_core::RuntimeName for EmailQueryOptions {
 unsafe impl Send for EmailQueryOptions {}
 unsafe impl Sync for EmailQueryOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailQueryTextSearch(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailQueryTextSearch, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailQueryTextSearch {
@@ -3807,7 +3807,7 @@ impl windows_core::RuntimeName for EmailQueryTextSearch {
 unsafe impl Send for EmailQueryTextSearch {}
 unsafe impl Sync for EmailQueryTextSearch {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailRecipient(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailRecipient, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailRecipient {
@@ -3871,7 +3871,7 @@ impl windows_core::RuntimeName for EmailRecipient {
 unsafe impl Send for EmailRecipient {}
 unsafe impl Sync for EmailRecipient {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailRecipientResolutionResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailRecipientResolutionResult, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailRecipientResolutionResult {
@@ -3923,7 +3923,7 @@ impl windows_core::RuntimeName for EmailRecipientResolutionResult {
 unsafe impl Send for EmailRecipientResolutionResult {}
 unsafe impl Sync for EmailRecipientResolutionResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailStore, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailStore {
@@ -4025,7 +4025,7 @@ impl windows_core::RuntimeName for EmailStore {
 unsafe impl Send for EmailStore {}
 unsafe impl Sync for EmailStore {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailStoreNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailStoreNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailStoreNotificationTriggerDetails {}

--- a/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/Foreground/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/Foreground/mod.rs
@@ -23,7 +23,7 @@ pub struct IExtendedExecutionForegroundSession_Vtbl {
     pub SetReason: unsafe extern "system" fn(*mut core::ffi::c_void, ExtendedExecutionForegroundReason) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExtendedExecutionForegroundRevokedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ExtendedExecutionForegroundRevokedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ExtendedExecutionForegroundRevokedEventArgs {
@@ -48,7 +48,7 @@ impl windows_core::RuntimeName for ExtendedExecutionForegroundRevokedEventArgs {
 unsafe impl Send for ExtendedExecutionForegroundRevokedEventArgs {}
 unsafe impl Sync for ExtendedExecutionForegroundRevokedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExtendedExecutionForegroundSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ExtendedExecutionForegroundSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ExtendedExecutionForegroundSession, super::super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/mod.rs
@@ -27,7 +27,7 @@ pub struct IExtendedExecutionSession_Vtbl {
     pub RequestExtensionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExtendedExecutionRevokedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ExtendedExecutionRevokedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ExtendedExecutionRevokedEventArgs {
@@ -52,7 +52,7 @@ impl windows_core::RuntimeName for ExtendedExecutionRevokedEventArgs {
 unsafe impl Send for ExtendedExecutionRevokedEventArgs {}
 unsafe impl Sync for ExtendedExecutionRevokedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExtendedExecutionSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ExtendedExecutionSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ExtendedExecutionSession, super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/ApplicationModel/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Holographic/mod.rs
@@ -25,7 +25,7 @@ pub struct IHolographicKeyboardStatics_Vtbl {
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicKeyboard(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicKeyboard, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicKeyboard {

--- a/crates/libs/windows/src/Windows/ApplicationModel/LockScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/LockScreen/mod.rs
@@ -89,7 +89,7 @@ pub struct ILockScreenUnlockingEventArgs_Vtbl {
     pub Deadline: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockApplicationHost(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockApplicationHost, windows_core::IUnknown, windows_core::IInspectable);
 impl LockApplicationHost {
@@ -136,7 +136,7 @@ impl windows_core::RuntimeName for LockApplicationHost {
 unsafe impl Send for LockApplicationHost {}
 unsafe impl Sync for LockApplicationHost {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockScreenBadge(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockScreenBadge, windows_core::IUnknown, windows_core::IInspectable);
 impl LockScreenBadge {
@@ -188,7 +188,7 @@ impl windows_core::RuntimeName for LockScreenBadge {
 unsafe impl Send for LockScreenBadge {}
 unsafe impl Sync for LockScreenBadge {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockScreenInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockScreenInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl LockScreenInfo {
@@ -294,7 +294,7 @@ impl windows_core::RuntimeName for LockScreenInfo {
 unsafe impl Send for LockScreenInfo {}
 unsafe impl Sync for LockScreenInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockScreenUnlockingDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockScreenUnlockingDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl LockScreenUnlockingDeferral {
@@ -316,7 +316,7 @@ impl windows_core::RuntimeName for LockScreenUnlockingDeferral {
 unsafe impl Send for LockScreenUnlockingDeferral {}
 unsafe impl Sync for LockScreenUnlockingDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockScreenUnlockingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockScreenUnlockingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl LockScreenUnlockingEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Payments/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Payments/Provider/mod.rs
@@ -68,7 +68,7 @@ pub struct IPaymentTransactionStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentAppCanMakePaymentTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentAppCanMakePaymentTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentAppCanMakePaymentTriggerDetails {
@@ -100,7 +100,7 @@ impl windows_core::RuntimeName for PaymentAppCanMakePaymentTriggerDetails {
 unsafe impl Send for PaymentAppCanMakePaymentTriggerDetails {}
 unsafe impl Sync for PaymentAppCanMakePaymentTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentAppManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentAppManager, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentAppManager {
@@ -147,7 +147,7 @@ impl windows_core::RuntimeName for PaymentAppManager {
 unsafe impl Send for PaymentAppManager {}
 unsafe impl Sync for PaymentAppManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentTransaction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentTransaction, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentTransaction {
@@ -250,7 +250,7 @@ impl windows_core::RuntimeName for PaymentTransaction {
 unsafe impl Send for PaymentTransaction {}
 unsafe impl Sync for PaymentTransaction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentTransactionAcceptResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentTransactionAcceptResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentTransactionAcceptResult {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
@@ -444,7 +444,7 @@ pub struct IPaymentTokenFactory_Vtbl {
     pub CreateWithJsonDetails: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentAddress(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentAddress, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentAddress {
@@ -603,7 +603,7 @@ impl windows_core::RuntimeName for PaymentAddress {
 unsafe impl Send for PaymentAddress {}
 unsafe impl Sync for PaymentAddress {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentCanMakePaymentResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentCanMakePaymentResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentCanMakePaymentResult {
@@ -639,7 +639,7 @@ impl windows_core::RuntimeName for PaymentCanMakePaymentResult {
 unsafe impl Send for PaymentCanMakePaymentResult {}
 unsafe impl Sync for PaymentCanMakePaymentResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentCurrencyAmount(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentCurrencyAmount, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentCurrencyAmount {
@@ -707,7 +707,7 @@ impl windows_core::RuntimeName for PaymentCurrencyAmount {
 unsafe impl Send for PaymentCurrencyAmount {}
 unsafe impl Sync for PaymentCurrencyAmount {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentDetails {
@@ -819,7 +819,7 @@ impl windows_core::RuntimeName for PaymentDetails {
 unsafe impl Send for PaymentDetails {}
 unsafe impl Sync for PaymentDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentDetailsModifier(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentDetailsModifier, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentDetailsModifier {
@@ -907,7 +907,7 @@ impl windows_core::RuntimeName for PaymentDetailsModifier {
 unsafe impl Send for PaymentDetailsModifier {}
 unsafe impl Sync for PaymentDetailsModifier {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentItem, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentItem {
@@ -975,7 +975,7 @@ impl windows_core::RuntimeName for PaymentItem {
 unsafe impl Send for PaymentItem {}
 unsafe impl Sync for PaymentItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentMediator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentMediator, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentMediator {
@@ -1039,7 +1039,7 @@ impl windows_core::RuntimeName for PaymentMediator {
 unsafe impl Send for PaymentMediator {}
 unsafe impl Sync for PaymentMediator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentMerchantInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentMerchantInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentMerchantInfo {
@@ -1092,7 +1092,7 @@ impl windows_core::RuntimeName for PaymentMerchantInfo {
 unsafe impl Send for PaymentMerchantInfo {}
 unsafe impl Sync for PaymentMerchantInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentMethodData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentMethodData, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentMethodData {
@@ -1150,7 +1150,7 @@ impl windows_core::RuntimeName for PaymentMethodData {
 unsafe impl Send for PaymentMethodData {}
 unsafe impl Sync for PaymentMethodData {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentOptions {
@@ -1230,7 +1230,7 @@ impl windows_core::RuntimeName for PaymentOptions {
 unsafe impl Send for PaymentOptions {}
 unsafe impl Sync for PaymentOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentRequest {
@@ -1343,7 +1343,7 @@ impl windows_core::RuntimeName for PaymentRequest {
 unsafe impl Send for PaymentRequest {}
 unsafe impl Sync for PaymentRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentRequestChangedArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentRequestChangedArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentRequestChangedArgs {
@@ -1389,7 +1389,7 @@ impl windows_core::RuntimeName for PaymentRequestChangedArgs {
 unsafe impl Send for PaymentRequestChangedArgs {}
 unsafe impl Sync for PaymentRequestChangedArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentRequestChangedResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentRequestChangedResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentRequestChangedResult {
@@ -1463,7 +1463,7 @@ impl windows_core::RuntimeName for PaymentRequestChangedResult {
 unsafe impl Send for PaymentRequestChangedResult {}
 unsafe impl Sync for PaymentRequestChangedResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentRequestSubmitResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentRequestSubmitResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentRequestSubmitResult {
@@ -1495,7 +1495,7 @@ impl windows_core::RuntimeName for PaymentRequestSubmitResult {
 unsafe impl Send for PaymentRequestSubmitResult {}
 unsafe impl Sync for PaymentRequestSubmitResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentResponse(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentResponse, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentResponse {
@@ -1562,7 +1562,7 @@ impl windows_core::RuntimeName for PaymentResponse {
 unsafe impl Send for PaymentResponse {}
 unsafe impl Sync for PaymentResponse {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentShippingOption(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentShippingOption, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentShippingOption {
@@ -1659,7 +1659,7 @@ impl windows_core::RuntimeName for PaymentShippingOption {
 unsafe impl Send for PaymentShippingOption {}
 unsafe impl Sync for PaymentShippingOption {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PaymentToken(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PaymentToken, windows_core::IUnknown, windows_core::IInspectable);
 impl PaymentToken {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Preview/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Preview/Holographic/mod.rs
@@ -78,7 +78,7 @@ impl windows_core::RuntimeName for HolographicApplicationPreview {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicKeyboardPlacementOverridePreview(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(HolographicKeyboardPlacementOverridePreview, windows_core::IUnknown, windows_core::IInspectable);

--- a/crates/libs/windows/src/Windows/ApplicationModel/Preview/InkWorkspace/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Preview/InkWorkspace/mod.rs
@@ -20,7 +20,7 @@ pub struct IInkWorkspaceHostedAppManagerStatics_Vtbl {
     pub GetForCurrentApp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkWorkspaceHostedAppManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkWorkspaceHostedAppManager, windows_core::IUnknown, windows_core::IInspectable);
 impl InkWorkspaceHostedAppManager {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Preview/Notes/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Preview/Notes/mod.rs
@@ -87,7 +87,7 @@ pub struct INotesWindowManagerPreviewStatics_Vtbl {
     pub GetForCurrentApp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NotePlacementChangedPreviewEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NotePlacementChangedPreviewEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl NotePlacementChangedPreviewEventArgs {
@@ -112,7 +112,7 @@ impl windows_core::RuntimeName for NotePlacementChangedPreviewEventArgs {
 unsafe impl Send for NotePlacementChangedPreviewEventArgs {}
 unsafe impl Sync for NotePlacementChangedPreviewEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NoteVisibilityChangedPreviewEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NoteVisibilityChangedPreviewEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl NoteVisibilityChangedPreviewEventArgs {
@@ -144,7 +144,7 @@ impl windows_core::RuntimeName for NoteVisibilityChangedPreviewEventArgs {
 unsafe impl Send for NoteVisibilityChangedPreviewEventArgs {}
 unsafe impl Sync for NoteVisibilityChangedPreviewEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NotesWindowManagerPreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NotesWindowManagerPreview, windows_core::IUnknown, windows_core::IInspectable);
 impl NotesWindowManagerPreview {
@@ -303,7 +303,7 @@ impl windows_core::RuntimeName for NotesWindowManagerPreview {
 unsafe impl Send for NotesWindowManagerPreview {}
 unsafe impl Sync for NotesWindowManagerPreview {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NotesWindowManagerPreviewShowNoteOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NotesWindowManagerPreviewShowNoteOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl NotesWindowManagerPreviewShowNoteOptions {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/Core/mod.rs
@@ -216,7 +216,7 @@ pub struct IResourceQualifier_Vtbl {
     pub Score: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NamedResource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NamedResource, windows_core::IUnknown, windows_core::IInspectable);
 impl NamedResource {
@@ -285,7 +285,7 @@ impl windows_core::RuntimeName for NamedResource {
 unsafe impl Send for NamedResource {}
 unsafe impl Sync for NamedResource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceCandidate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ResourceCandidate, windows_core::IUnknown, windows_core::IInspectable);
 impl ResourceCandidate {
@@ -370,7 +370,7 @@ unsafe impl Send for ResourceCandidate {}
 unsafe impl Sync for ResourceCandidate {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceCandidateVectorView(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(ResourceCandidateVectorView, windows_core::IUnknown, windows_core::IInspectable);
@@ -456,7 +456,7 @@ unsafe impl Send for ResourceCandidateVectorView {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for ResourceCandidateVectorView {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ResourceContext, windows_core::IUnknown, windows_core::IInspectable);
 impl ResourceContext {
@@ -601,7 +601,7 @@ unsafe impl Send for ResourceContext {}
 unsafe impl Sync for ResourceContext {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceContextLanguagesVectorView(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(ResourceContextLanguagesVectorView, windows_core::IUnknown, windows_core::IInspectable);
@@ -684,7 +684,7 @@ unsafe impl Send for ResourceContextLanguagesVectorView {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for ResourceContextLanguagesVectorView {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ResourceManager, windows_core::IUnknown, windows_core::IInspectable);
 impl ResourceManager {
@@ -773,7 +773,7 @@ impl windows_core::RuntimeName for ResourceManager {
 unsafe impl Send for ResourceManager {}
 unsafe impl Sync for ResourceManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceMap(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ResourceMap, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -878,7 +878,7 @@ unsafe impl Send for ResourceMap {}
 unsafe impl Sync for ResourceMap {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceMapIterator(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(ResourceMapIterator, windows_core::IUnknown, windows_core::IInspectable);
@@ -938,7 +938,7 @@ unsafe impl Send for ResourceMapIterator {}
 unsafe impl Sync for ResourceMapIterator {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceMapMapView(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(ResourceMapMapView, windows_core::IUnknown, windows_core::IInspectable);
@@ -1019,7 +1019,7 @@ unsafe impl Send for ResourceMapMapView {}
 unsafe impl Sync for ResourceMapMapView {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceMapMapViewIterator(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(ResourceMapMapViewIterator, windows_core::IUnknown, windows_core::IInspectable);
@@ -1078,7 +1078,7 @@ unsafe impl Send for ResourceMapMapViewIterator {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for ResourceMapMapViewIterator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceQualifier(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ResourceQualifier, windows_core::IUnknown, windows_core::IInspectable);
 impl ResourceQualifier {
@@ -1132,7 +1132,7 @@ unsafe impl Send for ResourceQualifier {}
 unsafe impl Sync for ResourceQualifier {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceQualifierMapView(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(ResourceQualifierMapView, windows_core::IUnknown, windows_core::IInspectable);
@@ -1213,7 +1213,7 @@ unsafe impl Send for ResourceQualifierMapView {}
 unsafe impl Sync for ResourceQualifierMapView {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceQualifierObservableMap(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(ResourceQualifierObservableMap, windows_core::IUnknown, windows_core::IInspectable);
@@ -1331,7 +1331,7 @@ unsafe impl Send for ResourceQualifierObservableMap {}
 unsafe impl Sync for ResourceQualifierObservableMap {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceQualifierVectorView(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(ResourceQualifierVectorView, windows_core::IUnknown, windows_core::IInspectable);

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/Management/mod.rs
@@ -78,7 +78,7 @@ pub struct IResourceIndexerFactory2_Vtbl {
     CreateResourceIndexerWithExtension: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IndexedResourceCandidate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IndexedResourceCandidate, windows_core::IUnknown, windows_core::IInspectable);
 impl IndexedResourceCandidate {
@@ -140,7 +140,7 @@ impl windows_core::RuntimeName for IndexedResourceCandidate {
 unsafe impl Send for IndexedResourceCandidate {}
 unsafe impl Sync for IndexedResourceCandidate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IndexedResourceQualifier(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IndexedResourceQualifier, windows_core::IUnknown, windows_core::IInspectable);
 impl IndexedResourceQualifier {
@@ -173,7 +173,7 @@ unsafe impl Send for IndexedResourceQualifier {}
 unsafe impl Sync for IndexedResourceQualifier {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceIndexer(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(ResourceIndexer, windows_core::IUnknown, windows_core::IInspectable);

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/mod.rs
@@ -72,7 +72,7 @@ pub struct IResourceLoaderStatics4_Vtbl {
     pub GetDefaultPriPath: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceLoader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ResourceLoader, windows_core::IUnknown, windows_core::IInspectable);
 impl ResourceLoader {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Search/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Search/Core/mod.rs
@@ -63,7 +63,7 @@ pub struct ISearchSuggestionsRequestedEventArgs_Vtbl {
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RequestingFocusOnKeyboardInputEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RequestingFocusOnKeyboardInputEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RequestingFocusOnKeyboardInputEventArgs {}
@@ -80,7 +80,7 @@ impl windows_core::RuntimeName for RequestingFocusOnKeyboardInputEventArgs {
 unsafe impl Send for RequestingFocusOnKeyboardInputEventArgs {}
 unsafe impl Sync for RequestingFocusOnKeyboardInputEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchSuggestion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SearchSuggestion, windows_core::IUnknown, windows_core::IInspectable);
 impl SearchSuggestion {
@@ -139,7 +139,7 @@ impl windows_core::RuntimeName for SearchSuggestion {
     const NAME: &'static str = "Windows.ApplicationModel.Search.Core.SearchSuggestion";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchSuggestionManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SearchSuggestionManager, windows_core::IUnknown, windows_core::IInspectable);
 impl SearchSuggestionManager {
@@ -254,7 +254,7 @@ impl windows_core::RuntimeName for SearchSuggestionManager {
     const NAME: &'static str = "Windows.ApplicationModel.Search.Core.SearchSuggestionManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchSuggestionsRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SearchSuggestionsRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SearchSuggestionsRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Search/mod.rs
@@ -417,7 +417,7 @@ pub struct ISearchSuggestionsRequestDeferral_Vtbl {
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LocalContentSuggestionSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LocalContentSuggestionSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl LocalContentSuggestionSettings {
@@ -479,7 +479,7 @@ impl windows_core::RuntimeName for LocalContentSuggestionSettings {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchPane(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SearchPane, windows_core::IUnknown, windows_core::IInspectable);
@@ -706,7 +706,7 @@ impl windows_core::RuntimeName for SearchPane {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchPaneQueryChangedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SearchPaneQueryChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -757,7 +757,7 @@ unsafe impl Send for SearchPaneQueryChangedEventArgs {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for SearchPaneQueryChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchPaneQueryLinguisticDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SearchPaneQueryLinguisticDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl SearchPaneQueryLinguisticDetails {
@@ -798,7 +798,7 @@ unsafe impl Send for SearchPaneQueryLinguisticDetails {}
 unsafe impl Sync for SearchPaneQueryLinguisticDetails {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchPaneQuerySubmittedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SearchPaneQuerySubmittedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -848,7 +848,7 @@ unsafe impl Send for SearchPaneQuerySubmittedEventArgs {}
 unsafe impl Sync for SearchPaneQuerySubmittedEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchPaneResultSuggestionChosenEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SearchPaneResultSuggestionChosenEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -882,7 +882,7 @@ unsafe impl Send for SearchPaneResultSuggestionChosenEventArgs {}
 unsafe impl Sync for SearchPaneResultSuggestionChosenEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchPaneSuggestionsRequest(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SearchPaneSuggestionsRequest, windows_core::IUnknown, windows_core::IInspectable);
@@ -932,7 +932,7 @@ unsafe impl Send for SearchPaneSuggestionsRequest {}
 unsafe impl Sync for SearchPaneSuggestionsRequest {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchPaneSuggestionsRequestDeferral(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SearchPaneSuggestionsRequestDeferral, windows_core::IUnknown, windows_core::IInspectable);
@@ -963,7 +963,7 @@ unsafe impl Send for SearchPaneSuggestionsRequestDeferral {}
 unsafe impl Sync for SearchPaneSuggestionsRequestDeferral {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchPaneSuggestionsRequestedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SearchPaneSuggestionsRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1023,7 +1023,7 @@ unsafe impl Send for SearchPaneSuggestionsRequestedEventArgs {}
 unsafe impl Sync for SearchPaneSuggestionsRequestedEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchPaneVisibilityChangedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SearchPaneVisibilityChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1056,7 +1056,7 @@ unsafe impl Send for SearchPaneVisibilityChangedEventArgs {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for SearchPaneVisibilityChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchQueryLinguisticDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SearchQueryLinguisticDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl SearchQueryLinguisticDetails {
@@ -1111,7 +1111,7 @@ impl windows_core::RuntimeName for SearchQueryLinguisticDetails {
 unsafe impl Send for SearchQueryLinguisticDetails {}
 unsafe impl Sync for SearchQueryLinguisticDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchSuggestionCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SearchSuggestionCollection, windows_core::IUnknown, windows_core::IInspectable);
 impl SearchSuggestionCollection {
@@ -1160,7 +1160,7 @@ impl windows_core::RuntimeName for SearchSuggestionCollection {
 unsafe impl Send for SearchSuggestionCollection {}
 unsafe impl Sync for SearchSuggestionCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchSuggestionsRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SearchSuggestionsRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl SearchSuggestionsRequest {
@@ -1199,7 +1199,7 @@ impl windows_core::RuntimeName for SearchSuggestionsRequest {
 unsafe impl Send for SearchSuggestionsRequest {}
 unsafe impl Sync for SearchSuggestionsRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SearchSuggestionsRequestDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SearchSuggestionsRequestDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl SearchSuggestionsRequestDeferral {

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/mod.rs
@@ -285,7 +285,7 @@ pub struct IUserActivityVisualElements2_Vtbl {
     pub SetAttributionDisplayText: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserActivity(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserActivity, windows_core::IUnknown, windows_core::IInspectable);
 impl UserActivity {
@@ -462,7 +462,7 @@ impl windows_core::RuntimeName for UserActivity {
 unsafe impl Send for UserActivity {}
 unsafe impl Sync for UserActivity {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserActivityAttribution(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserActivityAttribution, windows_core::IUnknown, windows_core::IInspectable);
 impl UserActivityAttribution {
@@ -537,7 +537,7 @@ impl windows_core::RuntimeName for UserActivityAttribution {
 unsafe impl Send for UserActivityAttribution {}
 unsafe impl Sync for UserActivityAttribution {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserActivityChannel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserActivityChannel, windows_core::IUnknown, windows_core::IInspectable);
 impl UserActivityChannel {
@@ -636,7 +636,7 @@ impl windows_core::RuntimeName for UserActivityChannel {
 unsafe impl Send for UserActivityChannel {}
 unsafe impl Sync for UserActivityChannel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserActivityContentInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserActivityContentInfo, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UserActivityContentInfo, IUserActivityContentInfo);
@@ -673,7 +673,7 @@ impl windows_core::RuntimeName for UserActivityContentInfo {
 unsafe impl Send for UserActivityContentInfo {}
 unsafe impl Sync for UserActivityContentInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserActivityRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserActivityRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl UserActivityRequest {
@@ -698,7 +698,7 @@ impl windows_core::RuntimeName for UserActivityRequest {
 unsafe impl Send for UserActivityRequest {}
 unsafe impl Sync for UserActivityRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserActivityRequestManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserActivityRequestManager, windows_core::IUnknown, windows_core::IInspectable);
 impl UserActivityRequestManager {
@@ -739,7 +739,7 @@ impl windows_core::RuntimeName for UserActivityRequestManager {
     const NAME: &'static str = "Windows.ApplicationModel.UserActivities.UserActivityRequestManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserActivityRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserActivityRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserActivityRequestedEventArgs {
@@ -771,7 +771,7 @@ impl windows_core::RuntimeName for UserActivityRequestedEventArgs {
 unsafe impl Send for UserActivityRequestedEventArgs {}
 unsafe impl Sync for UserActivityRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserActivitySession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserActivitySession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UserActivitySession, super::super::Foundation::IClosable);
@@ -801,7 +801,7 @@ impl windows_core::RuntimeName for UserActivitySession {
 unsafe impl Send for UserActivitySession {}
 unsafe impl Sync for UserActivitySession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserActivitySessionHistoryItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserActivitySessionHistoryItem, windows_core::IUnknown, windows_core::IInspectable);
 impl UserActivitySessionHistoryItem {
@@ -840,7 +840,7 @@ impl windows_core::RuntimeName for UserActivitySessionHistoryItem {
 unsafe impl Send for UserActivitySessionHistoryItem {}
 unsafe impl Sync for UserActivitySessionHistoryItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserActivityVisualElements(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserActivityVisualElements, windows_core::IUnknown, windows_core::IInspectable);
 impl UserActivityVisualElements {

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/mod.rs
@@ -69,7 +69,7 @@ pub struct IUserDataAccountProviderSettingsOperation_Vtbl {
     pub ReportCompleted: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataAccountPartnerAccountInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataAccountPartnerAccountInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataAccountPartnerAccountInfo {
@@ -108,7 +108,7 @@ impl windows_core::RuntimeName for UserDataAccountPartnerAccountInfo {
 unsafe impl Send for UserDataAccountPartnerAccountInfo {}
 unsafe impl Sync for UserDataAccountPartnerAccountInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataAccountProviderAddAccountOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataAccountProviderAddAccountOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UserDataAccountProviderAddAccountOperation, IUserDataAccountProviderOperation);
@@ -153,7 +153,7 @@ impl windows_core::RuntimeName for UserDataAccountProviderAddAccountOperation {
 unsafe impl Send for UserDataAccountProviderAddAccountOperation {}
 unsafe impl Sync for UserDataAccountProviderAddAccountOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataAccountProviderResolveErrorsOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataAccountProviderResolveErrorsOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UserDataAccountProviderResolveErrorsOperation, IUserDataAccountProviderOperation);
@@ -190,7 +190,7 @@ impl windows_core::RuntimeName for UserDataAccountProviderResolveErrorsOperation
 unsafe impl Send for UserDataAccountProviderResolveErrorsOperation {}
 unsafe impl Sync for UserDataAccountProviderResolveErrorsOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataAccountProviderSettingsOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataAccountProviderSettingsOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UserDataAccountProviderSettingsOperation, IUserDataAccountProviderOperation);

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/SystemAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/SystemAccess/mod.rs
@@ -139,7 +139,7 @@ pub struct IUserDataAccountSystemAccessManagerStatics2_Vtbl {
     pub GetDeviceAccountConfigurationAsync: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceAccountConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceAccountConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceAccountConfiguration {

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
@@ -172,7 +172,7 @@ pub struct IUserDataAccountStoreChangedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataAccount(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataAccount, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataAccount {
@@ -424,7 +424,7 @@ impl windows_core::RuntimeName for UserDataAccountManager {
     const NAME: &'static str = "Windows.ApplicationModel.UserDataAccounts.UserDataAccountManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataAccountManagerForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataAccountManagerForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataAccountManagerForUser {
@@ -457,7 +457,7 @@ impl windows_core::RuntimeName for UserDataAccountManagerForUser {
 unsafe impl Send for UserDataAccountManagerForUser {}
 unsafe impl Sync for UserDataAccountManagerForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataAccountStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataAccountStore, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataAccountStore {
@@ -525,7 +525,7 @@ impl windows_core::RuntimeName for UserDataAccountStore {
 unsafe impl Send for UserDataAccountStore {}
 unsafe impl Sync for UserDataAccountStore {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataAccountStoreChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataAccountStoreChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataAccountStoreChangedEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/DataProvider/mod.rs
@@ -136,7 +136,7 @@ pub struct IUserDataTaskListSyncManagerSyncRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskDataProviderConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskDataProviderConnection, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskDataProviderConnection {
@@ -228,7 +228,7 @@ impl windows_core::RuntimeName for UserDataTaskDataProviderConnection {
 unsafe impl Send for UserDataTaskDataProviderConnection {}
 unsafe impl Sync for UserDataTaskDataProviderConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskDataProviderTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskDataProviderTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskDataProviderTriggerDetails {
@@ -253,7 +253,7 @@ impl windows_core::RuntimeName for UserDataTaskDataProviderTriggerDetails {
 unsafe impl Send for UserDataTaskDataProviderTriggerDetails {}
 unsafe impl Sync for UserDataTaskDataProviderTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListCompleteTaskRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListCompleteTaskRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListCompleteTaskRequest {
@@ -299,7 +299,7 @@ impl windows_core::RuntimeName for UserDataTaskListCompleteTaskRequest {
 unsafe impl Send for UserDataTaskListCompleteTaskRequest {}
 unsafe impl Sync for UserDataTaskListCompleteTaskRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListCompleteTaskRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListCompleteTaskRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListCompleteTaskRequestEventArgs {
@@ -331,7 +331,7 @@ impl windows_core::RuntimeName for UserDataTaskListCompleteTaskRequestEventArgs 
 unsafe impl Send for UserDataTaskListCompleteTaskRequestEventArgs {}
 unsafe impl Sync for UserDataTaskListCompleteTaskRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListCreateOrUpdateTaskRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListCreateOrUpdateTaskRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListCreateOrUpdateTaskRequest {
@@ -380,7 +380,7 @@ impl windows_core::RuntimeName for UserDataTaskListCreateOrUpdateTaskRequest {
 unsafe impl Send for UserDataTaskListCreateOrUpdateTaskRequest {}
 unsafe impl Sync for UserDataTaskListCreateOrUpdateTaskRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListCreateOrUpdateTaskRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListCreateOrUpdateTaskRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListCreateOrUpdateTaskRequestEventArgs {
@@ -412,7 +412,7 @@ impl windows_core::RuntimeName for UserDataTaskListCreateOrUpdateTaskRequestEven
 unsafe impl Send for UserDataTaskListCreateOrUpdateTaskRequestEventArgs {}
 unsafe impl Sync for UserDataTaskListCreateOrUpdateTaskRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListDeleteTaskRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListDeleteTaskRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListDeleteTaskRequest {
@@ -458,7 +458,7 @@ impl windows_core::RuntimeName for UserDataTaskListDeleteTaskRequest {
 unsafe impl Send for UserDataTaskListDeleteTaskRequest {}
 unsafe impl Sync for UserDataTaskListDeleteTaskRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListDeleteTaskRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListDeleteTaskRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListDeleteTaskRequestEventArgs {
@@ -490,7 +490,7 @@ impl windows_core::RuntimeName for UserDataTaskListDeleteTaskRequestEventArgs {
 unsafe impl Send for UserDataTaskListDeleteTaskRequestEventArgs {}
 unsafe impl Sync for UserDataTaskListDeleteTaskRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListSkipOccurrenceRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListSkipOccurrenceRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListSkipOccurrenceRequest {
@@ -536,7 +536,7 @@ impl windows_core::RuntimeName for UserDataTaskListSkipOccurrenceRequest {
 unsafe impl Send for UserDataTaskListSkipOccurrenceRequest {}
 unsafe impl Sync for UserDataTaskListSkipOccurrenceRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListSkipOccurrenceRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListSkipOccurrenceRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListSkipOccurrenceRequestEventArgs {
@@ -568,7 +568,7 @@ impl windows_core::RuntimeName for UserDataTaskListSkipOccurrenceRequestEventArg
 unsafe impl Send for UserDataTaskListSkipOccurrenceRequestEventArgs {}
 unsafe impl Sync for UserDataTaskListSkipOccurrenceRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListSyncManagerSyncRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListSyncManagerSyncRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListSyncManagerSyncRequest {
@@ -607,7 +607,7 @@ impl windows_core::RuntimeName for UserDataTaskListSyncManagerSyncRequest {
 unsafe impl Send for UserDataTaskListSyncManagerSyncRequest {}
 unsafe impl Sync for UserDataTaskListSyncManagerSyncRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListSyncManagerSyncRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListSyncManagerSyncRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListSyncManagerSyncRequestEventArgs {

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
@@ -206,7 +206,7 @@ pub struct IUserDataTaskStore_Vtbl {
     pub GetListAsync: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTask(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTask, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTask {
@@ -402,7 +402,7 @@ impl windows_core::RuntimeName for UserDataTask {
 unsafe impl Send for UserDataTask {}
 unsafe impl Sync for UserDataTask {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskBatch(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskBatch, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskBatch {
@@ -428,7 +428,7 @@ impl windows_core::RuntimeName for UserDataTaskBatch {
 unsafe impl Send for UserDataTaskBatch {}
 unsafe impl Sync for UserDataTaskBatch {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskList(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskList, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskList {
@@ -576,7 +576,7 @@ impl windows_core::RuntimeName for UserDataTaskList {
 unsafe impl Send for UserDataTaskList {}
 unsafe impl Sync for UserDataTaskList {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListLimitedWriteOperations(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListLimitedWriteOperations, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListLimitedWriteOperations {
@@ -625,7 +625,7 @@ impl windows_core::RuntimeName for UserDataTaskListLimitedWriteOperations {
 unsafe impl Send for UserDataTaskListLimitedWriteOperations {}
 unsafe impl Sync for UserDataTaskListLimitedWriteOperations {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskListSyncManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskListSyncManager, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskListSyncManager {
@@ -697,7 +697,7 @@ impl windows_core::RuntimeName for UserDataTaskListSyncManager {
 unsafe impl Send for UserDataTaskListSyncManager {}
 unsafe impl Sync for UserDataTaskListSyncManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskManager, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskManager {
@@ -751,7 +751,7 @@ impl windows_core::RuntimeName for UserDataTaskManager {
 unsafe impl Send for UserDataTaskManager {}
 unsafe impl Sync for UserDataTaskManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskQueryOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskQueryOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskQueryOptions {
@@ -798,7 +798,7 @@ impl windows_core::RuntimeName for UserDataTaskQueryOptions {
 unsafe impl Send for UserDataTaskQueryOptions {}
 unsafe impl Sync for UserDataTaskQueryOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskReader, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskReader {
@@ -823,7 +823,7 @@ impl windows_core::RuntimeName for UserDataTaskReader {
 unsafe impl Send for UserDataTaskReader {}
 unsafe impl Sync for UserDataTaskReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskRecurrenceProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskRecurrenceProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskRecurrenceProperties {
@@ -954,7 +954,7 @@ impl windows_core::RuntimeName for UserDataTaskRecurrenceProperties {
 unsafe impl Send for UserDataTaskRecurrenceProperties {}
 unsafe impl Sync for UserDataTaskRecurrenceProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskRegenerationProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskRegenerationProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskRegenerationProperties {
@@ -1029,7 +1029,7 @@ impl windows_core::RuntimeName for UserDataTaskRegenerationProperties {
 unsafe impl Send for UserDataTaskRegenerationProperties {}
 unsafe impl Sync for UserDataTaskRegenerationProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataTaskStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataTaskStore, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataTaskStore {

--- a/crates/libs/windows/src/Windows/ApplicationModel/VoiceCommands/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/VoiceCommands/mod.rs
@@ -185,7 +185,7 @@ pub struct IVoiceCommandUserMessage_Vtbl {
     pub SetSpokenMessage: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommand(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommand, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceCommand {
@@ -226,7 +226,7 @@ impl windows_core::RuntimeName for VoiceCommand {
 unsafe impl Send for VoiceCommand {}
 unsafe impl Sync for VoiceCommand {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommandCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommandCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceCommandCompletedEventArgs {
@@ -251,7 +251,7 @@ impl windows_core::RuntimeName for VoiceCommandCompletedEventArgs {
 unsafe impl Send for VoiceCommandCompletedEventArgs {}
 unsafe impl Sync for VoiceCommandCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommandConfirmationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommandConfirmationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceCommandConfirmationResult {
@@ -276,7 +276,7 @@ impl windows_core::RuntimeName for VoiceCommandConfirmationResult {
 unsafe impl Send for VoiceCommandConfirmationResult {}
 unsafe impl Sync for VoiceCommandConfirmationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommandContentTile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommandContentTile, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceCommandContentTile {
@@ -397,7 +397,7 @@ impl windows_core::RuntimeName for VoiceCommandContentTile {
 unsafe impl Send for VoiceCommandContentTile {}
 unsafe impl Sync for VoiceCommandContentTile {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommandDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommandDefinition, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceCommandDefinition {
@@ -468,7 +468,7 @@ impl windows_core::RuntimeName for VoiceCommandDefinitionManager {
     const NAME: &'static str = "Windows.ApplicationModel.VoiceCommands.VoiceCommandDefinitionManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommandDisambiguationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommandDisambiguationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceCommandDisambiguationResult {
@@ -493,7 +493,7 @@ impl windows_core::RuntimeName for VoiceCommandDisambiguationResult {
 unsafe impl Send for VoiceCommandDisambiguationResult {}
 unsafe impl Sync for VoiceCommandDisambiguationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommandResponse(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommandResponse, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceCommandResponse {
@@ -611,7 +611,7 @@ impl windows_core::RuntimeName for VoiceCommandResponse {
 unsafe impl Send for VoiceCommandResponse {}
 unsafe impl Sync for VoiceCommandResponse {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommandServiceConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommandServiceConnection, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceCommandServiceConnection {
@@ -733,7 +733,7 @@ impl windows_core::RuntimeName for VoiceCommandServiceConnection {
 unsafe impl Send for VoiceCommandServiceConnection {}
 unsafe impl Sync for VoiceCommandServiceConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommandUserMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommandUserMessage, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceCommandUserMessage {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Wallet/System/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Wallet/System/mod.rs
@@ -65,7 +65,7 @@ pub struct IWalletManagerSystemStatics_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WalletItemSystemStore(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(WalletItemSystemStore, windows_core::IUnknown, windows_core::IInspectable);

--- a/crates/libs/windows/src/Windows/ApplicationModel/Wallet/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Wallet/mod.rs
@@ -549,7 +549,7 @@ pub struct IWalletVerbFactory_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WalletBarcode(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(WalletBarcode, windows_core::IUnknown, windows_core::IInspectable);
@@ -622,7 +622,7 @@ unsafe impl Send for WalletBarcode {}
 unsafe impl Sync for WalletBarcode {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WalletItem(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(WalletItem, windows_core::IUnknown, windows_core::IInspectable);
@@ -1041,7 +1041,7 @@ unsafe impl Send for WalletItem {}
 unsafe impl Sync for WalletItem {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WalletItemCustomProperty(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(WalletItemCustomProperty, windows_core::IUnknown, windows_core::IInspectable);
@@ -1145,7 +1145,7 @@ unsafe impl Send for WalletItemCustomProperty {}
 unsafe impl Sync for WalletItemCustomProperty {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WalletItemStore(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(WalletItemStore, windows_core::IUnknown, windows_core::IInspectable);
@@ -1282,7 +1282,7 @@ impl windows_core::RuntimeName for WalletManager {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WalletRelevantLocation(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(WalletRelevantLocation, windows_core::IUnknown, windows_core::IInspectable);
@@ -1341,7 +1341,7 @@ unsafe impl Send for WalletRelevantLocation {}
 unsafe impl Sync for WalletRelevantLocation {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WalletTransaction(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(WalletTransaction, windows_core::IUnknown, windows_core::IInspectable);
@@ -1455,7 +1455,7 @@ unsafe impl Send for WalletTransaction {}
 unsafe impl Sync for WalletTransaction {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WalletVerb(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(WalletVerb, windows_core::IUnknown, windows_core::IInspectable);

--- a/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
@@ -933,7 +933,7 @@ pub struct ISuspendingOperation_Vtbl {
     pub Deadline: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppDisplayInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppDisplayInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AppDisplayInfo {
@@ -973,7 +973,7 @@ impl windows_core::RuntimeName for AppDisplayInfo {
 unsafe impl Send for AppDisplayInfo {}
 unsafe impl Sync for AppDisplayInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AppInfo {
@@ -1067,7 +1067,7 @@ impl windows_core::RuntimeName for AppInfo {
 unsafe impl Send for AppInfo {}
 unsafe impl Sync for AppInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppInstallerInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppInstallerInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AppInstallerInfo {
@@ -1201,7 +1201,7 @@ impl windows_core::RuntimeName for AppInstallerInfo {
 unsafe impl Send for AppInstallerInfo {}
 unsafe impl Sync for AppInstallerInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppInstance(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppInstance, windows_core::IUnknown, windows_core::IInspectable);
 impl AppInstance {
@@ -1313,7 +1313,7 @@ impl windows_core::RuntimeName for DesignMode {
     const NAME: &'static str = "Windows.ApplicationModel.DesignMode";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EnteredBackgroundEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EnteredBackgroundEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(EnteredBackgroundEventArgs, IEnteredBackgroundEventArgs);
@@ -1339,7 +1339,7 @@ impl windows_core::RuntimeName for EnteredBackgroundEventArgs {
 unsafe impl Send for EnteredBackgroundEventArgs {}
 unsafe impl Sync for EnteredBackgroundEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FindRelatedPackagesOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FindRelatedPackagesOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl FindRelatedPackagesOptions {
@@ -1423,7 +1423,7 @@ impl windows_core::RuntimeName for FindRelatedPackagesOptions {
 unsafe impl Send for FindRelatedPackagesOptions {}
 unsafe impl Sync for FindRelatedPackagesOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FullTrustProcessLaunchResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FullTrustProcessLaunchResult, windows_core::IUnknown, windows_core::IInspectable);
 impl FullTrustProcessLaunchResult {
@@ -1507,7 +1507,7 @@ impl windows_core::RuntimeName for FullTrustProcessLauncher {
     const NAME: &'static str = "Windows.ApplicationModel.FullTrustProcessLauncher";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LeavingBackgroundEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LeavingBackgroundEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LeavingBackgroundEventArgs, ILeavingBackgroundEventArgs);
@@ -1533,7 +1533,7 @@ impl windows_core::RuntimeName for LeavingBackgroundEventArgs {
 unsafe impl Send for LeavingBackgroundEventArgs {}
 unsafe impl Sync for LeavingBackgroundEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LimitedAccessFeatureRequestResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LimitedAccessFeatureRequestResult, windows_core::IUnknown, windows_core::IInspectable);
 impl LimitedAccessFeatureRequestResult {
@@ -1589,7 +1589,7 @@ impl windows_core::RuntimeName for LimitedAccessFeatures {
     const NAME: &'static str = "Windows.ApplicationModel.LimitedAccessFeatures";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Package(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Package, windows_core::IUnknown, windows_core::IInspectable);
 impl Package {
@@ -1940,7 +1940,7 @@ impl windows_core::RuntimeName for Package {
 unsafe impl Send for Package {}
 unsafe impl Sync for Package {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageCatalog(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageCatalog, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageCatalog {
@@ -2107,7 +2107,7 @@ impl windows_core::RuntimeName for PackageCatalog {
     const NAME: &'static str = "Windows.ApplicationModel.PackageCatalog";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageCatalogAddOptionalPackageResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageCatalogAddOptionalPackageResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageCatalogAddOptionalPackageResult {
@@ -2137,7 +2137,7 @@ impl windows_core::RuntimeName for PackageCatalogAddOptionalPackageResult {
     const NAME: &'static str = "Windows.ApplicationModel.PackageCatalogAddOptionalPackageResult";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageCatalogAddResourcePackageResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageCatalogAddResourcePackageResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageCatalogAddResourcePackageResult {
@@ -2176,7 +2176,7 @@ impl windows_core::RuntimeName for PackageCatalogAddResourcePackageResult {
 unsafe impl Send for PackageCatalogAddResourcePackageResult {}
 unsafe impl Sync for PackageCatalogAddResourcePackageResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageCatalogRemoveOptionalPackagesResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageCatalogRemoveOptionalPackagesResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageCatalogRemoveOptionalPackagesResult {
@@ -2207,7 +2207,7 @@ impl windows_core::RuntimeName for PackageCatalogRemoveOptionalPackagesResult {
     const NAME: &'static str = "Windows.ApplicationModel.PackageCatalogRemoveOptionalPackagesResult";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageCatalogRemoveResourcePackagesResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageCatalogRemoveResourcePackagesResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageCatalogRemoveResourcePackagesResult {
@@ -2240,7 +2240,7 @@ impl windows_core::RuntimeName for PackageCatalogRemoveResourcePackagesResult {
 unsafe impl Send for PackageCatalogRemoveResourcePackagesResult {}
 unsafe impl Sync for PackageCatalogRemoveResourcePackagesResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageContentGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageContentGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageContentGroup {
@@ -2297,7 +2297,7 @@ impl windows_core::RuntimeName for PackageContentGroup {
 unsafe impl Send for PackageContentGroup {}
 unsafe impl Sync for PackageContentGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageContentGroupStagingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageContentGroupStagingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageContentGroupStagingEventArgs {
@@ -2364,7 +2364,7 @@ impl windows_core::RuntimeName for PackageContentGroupStagingEventArgs {
 unsafe impl Send for PackageContentGroupStagingEventArgs {}
 unsafe impl Sync for PackageContentGroupStagingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageId(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageId, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageId {
@@ -2453,7 +2453,7 @@ impl windows_core::RuntimeName for PackageId {
 unsafe impl Send for PackageId {}
 unsafe impl Sync for PackageId {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageInstallingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageInstallingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageInstallingEventArgs {
@@ -2506,7 +2506,7 @@ impl windows_core::RuntimeName for PackageInstallingEventArgs {
 unsafe impl Send for PackageInstallingEventArgs {}
 unsafe impl Sync for PackageInstallingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageStagingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageStagingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageStagingEventArgs {
@@ -2559,7 +2559,7 @@ impl windows_core::RuntimeName for PackageStagingEventArgs {
 unsafe impl Send for PackageStagingEventArgs {}
 unsafe impl Sync for PackageStagingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageStatus(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageStatus, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageStatus {
@@ -2668,7 +2668,7 @@ impl windows_core::RuntimeName for PackageStatus {
 unsafe impl Send for PackageStatus {}
 unsafe impl Sync for PackageStatus {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageStatusChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageStatusChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageStatusChangedEventArgs {
@@ -2693,7 +2693,7 @@ impl windows_core::RuntimeName for PackageStatusChangedEventArgs {
 unsafe impl Send for PackageStatusChangedEventArgs {}
 unsafe impl Sync for PackageStatusChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageUninstallingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageUninstallingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageUninstallingEventArgs {
@@ -2746,7 +2746,7 @@ impl windows_core::RuntimeName for PackageUninstallingEventArgs {
 unsafe impl Send for PackageUninstallingEventArgs {}
 unsafe impl Sync for PackageUninstallingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageUpdateAvailabilityResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageUpdateAvailabilityResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageUpdateAvailabilityResult {
@@ -2778,7 +2778,7 @@ impl windows_core::RuntimeName for PackageUpdateAvailabilityResult {
 unsafe impl Send for PackageUpdateAvailabilityResult {}
 unsafe impl Sync for PackageUpdateAvailabilityResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageUpdatingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageUpdatingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageUpdatingEventArgs {
@@ -2838,7 +2838,7 @@ impl windows_core::RuntimeName for PackageUpdatingEventArgs {
 unsafe impl Send for PackageUpdatingEventArgs {}
 unsafe impl Sync for PackageUpdatingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StartupTask(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StartupTask, windows_core::IUnknown, windows_core::IInspectable);
 impl StartupTask {
@@ -2899,7 +2899,7 @@ impl windows_core::RuntimeName for StartupTask {
 unsafe impl Send for StartupTask {}
 unsafe impl Sync for StartupTask {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SuspendingDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SuspendingDeferral, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SuspendingDeferral, ISuspendingDeferral);
@@ -2922,7 +2922,7 @@ impl windows_core::RuntimeName for SuspendingDeferral {
 unsafe impl Send for SuspendingDeferral {}
 unsafe impl Sync for SuspendingDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SuspendingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SuspendingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SuspendingEventArgs, ISuspendingEventArgs);
@@ -2948,7 +2948,7 @@ impl windows_core::RuntimeName for SuspendingEventArgs {
 unsafe impl Send for SuspendingEventArgs {}
 unsafe impl Sync for SuspendingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SuspendingOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SuspendingOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SuspendingOperation, ISuspendingOperation);

--- a/crates/libs/windows/src/Windows/Data/Json/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Json/mod.rs
@@ -165,7 +165,7 @@ pub struct IJsonValueStatics2_Vtbl {
     pub CreateNullValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct JsonArray(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(JsonArray, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -428,7 +428,7 @@ impl windows_core::RuntimeName for JsonError {
     const NAME: &'static str = "Windows.Data.Json.JsonError";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct JsonObject(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(JsonObject, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -705,7 +705,7 @@ impl IntoIterator for &JsonObject {
 unsafe impl Send for JsonObject {}
 unsafe impl Sync for JsonObject {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct JsonValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(JsonValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(JsonValue, IJsonValue, super::super::Foundation::IStringable);

--- a/crates/libs/windows/src/Windows/Data/Pdf/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Pdf/mod.rs
@@ -95,7 +95,7 @@ pub struct IPdfPageRenderOptions_Vtbl {
     pub SetBitmapEncoderId: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PdfDocument(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PdfDocument, windows_core::IUnknown, windows_core::IInspectable);
 impl PdfDocument {
@@ -179,7 +179,7 @@ impl windows_core::RuntimeName for PdfDocument {
 unsafe impl Send for PdfDocument {}
 unsafe impl Sync for PdfDocument {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PdfPage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PdfPage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PdfPage, super::super::Foundation::IClosable);
@@ -267,7 +267,7 @@ impl windows_core::RuntimeName for PdfPage {
 unsafe impl Send for PdfPage {}
 unsafe impl Sync for PdfPage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PdfPageDimensions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PdfPageDimensions, windows_core::IUnknown, windows_core::IInspectable);
 impl PdfPageDimensions {
@@ -320,7 +320,7 @@ impl windows_core::RuntimeName for PdfPageDimensions {
 unsafe impl Send for PdfPageDimensions {}
 unsafe impl Sync for PdfPageDimensions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PdfPageRenderOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PdfPageRenderOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl PdfPageRenderOptions {

--- a/crates/libs/windows/src/Windows/Data/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Text/mod.rs
@@ -259,7 +259,7 @@ pub struct IWordsSegmenterFactory_Vtbl {
     pub CreateWithLanguage: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AlternateWordForm(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AlternateWordForm, windows_core::IUnknown, windows_core::IInspectable);
 impl AlternateWordForm {
@@ -298,7 +298,7 @@ impl windows_core::RuntimeName for AlternateWordForm {
 unsafe impl Send for AlternateWordForm {}
 unsafe impl Sync for AlternateWordForm {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SelectableWordSegment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SelectableWordSegment, windows_core::IUnknown, windows_core::IInspectable);
 impl SelectableWordSegment {
@@ -330,7 +330,7 @@ impl windows_core::RuntimeName for SelectableWordSegment {
 unsafe impl Send for SelectableWordSegment {}
 unsafe impl Sync for SelectableWordSegment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SelectableWordsSegmenter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SelectableWordsSegmenter, windows_core::IUnknown, windows_core::IInspectable);
 impl SelectableWordsSegmenter {
@@ -389,7 +389,7 @@ impl windows_core::RuntimeName for SelectableWordsSegmenter {
 unsafe impl Send for SelectableWordsSegmenter {}
 unsafe impl Sync for SelectableWordsSegmenter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SemanticTextQuery(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SemanticTextQuery, windows_core::IUnknown, windows_core::IInspectable);
 impl SemanticTextQuery {
@@ -440,7 +440,7 @@ impl windows_core::RuntimeName for SemanticTextQuery {
 unsafe impl Send for SemanticTextQuery {}
 unsafe impl Sync for SemanticTextQuery {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TextConversionGenerator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TextConversionGenerator, windows_core::IUnknown, windows_core::IInspectable);
 impl TextConversionGenerator {
@@ -499,7 +499,7 @@ impl windows_core::RuntimeName for TextConversionGenerator {
 unsafe impl Send for TextConversionGenerator {}
 unsafe impl Sync for TextConversionGenerator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TextPhoneme(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TextPhoneme, windows_core::IUnknown, windows_core::IInspectable);
 impl TextPhoneme {
@@ -531,7 +531,7 @@ impl windows_core::RuntimeName for TextPhoneme {
 unsafe impl Send for TextPhoneme {}
 unsafe impl Sync for TextPhoneme {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TextPredictionGenerator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TextPredictionGenerator, windows_core::IUnknown, windows_core::IInspectable);
 impl TextPredictionGenerator {
@@ -625,7 +625,7 @@ impl windows_core::RuntimeName for TextPredictionGenerator {
 unsafe impl Send for TextPredictionGenerator {}
 unsafe impl Sync for TextPredictionGenerator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TextReverseConversionGenerator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TextReverseConversionGenerator, windows_core::IUnknown, windows_core::IInspectable);
 impl TextReverseConversionGenerator {
@@ -793,7 +793,7 @@ impl windows_core::RuntimeName for UnicodeCharacters {
     const NAME: &'static str = "Windows.Data.Text.UnicodeCharacters";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WordSegment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WordSegment, windows_core::IUnknown, windows_core::IInspectable);
 impl WordSegment {
@@ -833,7 +833,7 @@ impl windows_core::RuntimeName for WordSegment {
 unsafe impl Send for WordSegment {}
 unsafe impl Sync for WordSegment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WordsSegmenter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WordsSegmenter, windows_core::IUnknown, windows_core::IInspectable);
 impl WordsSegmenter {

--- a/crates/libs/windows/src/Windows/Data/Xml/Dom/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Xml/Dom/mod.rs
@@ -1173,7 +1173,7 @@ pub struct IXmlText_Vtbl {
     pub SplitText: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DtdEntity(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DtdEntity, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DtdEntity, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer);
@@ -1437,7 +1437,7 @@ impl windows_core::RuntimeName for DtdEntity {
 unsafe impl Send for DtdEntity {}
 unsafe impl Sync for DtdEntity {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DtdNotation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DtdNotation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DtdNotation, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer);
@@ -1694,7 +1694,7 @@ impl windows_core::RuntimeName for DtdNotation {
 unsafe impl Send for DtdNotation {}
 unsafe impl Sync for DtdNotation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlAttribute(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlAttribute, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XmlAttribute, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer);
@@ -1962,7 +1962,7 @@ impl windows_core::RuntimeName for XmlAttribute {
 unsafe impl Send for XmlAttribute {}
 unsafe impl Sync for XmlAttribute {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlCDataSection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlCDataSection, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XmlCDataSection, IXmlCharacterData, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer, IXmlText);
@@ -2253,7 +2253,7 @@ impl windows_core::RuntimeName for XmlCDataSection {
 unsafe impl Send for XmlCDataSection {}
 unsafe impl Sync for XmlCDataSection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlComment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlComment, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XmlComment, IXmlCharacterData, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer);
@@ -2537,7 +2537,7 @@ impl windows_core::RuntimeName for XmlComment {
 unsafe impl Send for XmlComment {}
 unsafe impl Sync for XmlComment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlDocument(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlDocument, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XmlDocument, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer);
@@ -2999,7 +2999,7 @@ impl windows_core::RuntimeName for XmlDocument {
 unsafe impl Send for XmlDocument {}
 unsafe impl Sync for XmlDocument {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlDocumentFragment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlDocumentFragment, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XmlDocumentFragment, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer);
@@ -3242,7 +3242,7 @@ impl windows_core::RuntimeName for XmlDocumentFragment {
 unsafe impl Send for XmlDocumentFragment {}
 unsafe impl Sync for XmlDocumentFragment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlDocumentType(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlDocumentType, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XmlDocumentType, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer);
@@ -3506,7 +3506,7 @@ impl windows_core::RuntimeName for XmlDocumentType {
 unsafe impl Send for XmlDocumentType {}
 unsafe impl Sync for XmlDocumentType {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlDomImplementation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlDomImplementation, windows_core::IUnknown, windows_core::IInspectable);
 impl XmlDomImplementation {
@@ -3534,7 +3534,7 @@ impl windows_core::RuntimeName for XmlDomImplementation {
 unsafe impl Send for XmlDomImplementation {}
 unsafe impl Sync for XmlDomImplementation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlElement(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlElement, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XmlElement, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer);
@@ -3877,7 +3877,7 @@ impl windows_core::RuntimeName for XmlElement {
 unsafe impl Send for XmlElement {}
 unsafe impl Sync for XmlElement {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlEntityReference(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlEntityReference, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XmlEntityReference, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer);
@@ -4120,7 +4120,7 @@ impl windows_core::RuntimeName for XmlEntityReference {
 unsafe impl Send for XmlEntityReference {}
 unsafe impl Sync for XmlEntityReference {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlLoadSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlLoadSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl XmlLoadSettings {
@@ -4200,7 +4200,7 @@ impl windows_core::RuntimeName for XmlLoadSettings {
 unsafe impl Send for XmlLoadSettings {}
 unsafe impl Sync for XmlLoadSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlNamedNodeMap(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlNamedNodeMap, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -4347,7 +4347,7 @@ impl IntoIterator for &XmlNamedNodeMap {
 unsafe impl Send for XmlNamedNodeMap {}
 unsafe impl Sync for XmlNamedNodeMap {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlNodeList(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlNodeList, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -4440,7 +4440,7 @@ impl IntoIterator for &XmlNodeList {
 unsafe impl Send for XmlNodeList {}
 unsafe impl Sync for XmlNodeList {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlProcessingInstruction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlProcessingInstruction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XmlProcessingInstruction, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer);
@@ -4701,7 +4701,7 @@ impl windows_core::RuntimeName for XmlProcessingInstruction {
 unsafe impl Send for XmlProcessingInstruction {}
 unsafe impl Sync for XmlProcessingInstruction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XmlText(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XmlText, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XmlText, IXmlCharacterData, IXmlNode, IXmlNodeSelector, IXmlNodeSerializer, IXmlText);

--- a/crates/libs/windows/src/Windows/Data/Xml/Xsl/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Xml/Xsl/mod.rs
@@ -35,7 +35,7 @@ pub struct IXsltProcessorFactory_Vtbl {
     CreateInstance: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XsltProcessor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XsltProcessor, windows_core::IUnknown, windows_core::IInspectable);
 impl XsltProcessor {

--- a/crates/libs/windows/src/Windows/Devices/Adc/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Adc/mod.rs
@@ -49,7 +49,7 @@ pub struct IAdcControllerStatics2_Vtbl {
     pub GetDefaultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdcChannel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdcChannel, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AdcChannel, super::super::Foundation::IClosable);
@@ -93,7 +93,7 @@ impl windows_core::RuntimeName for AdcChannel {
 unsafe impl Send for AdcChannel {}
 unsafe impl Sync for AdcChannel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdcController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdcController, windows_core::IUnknown, windows_core::IInspectable);
 impl AdcController {

--- a/crates/libs/windows/src/Windows/Devices/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Background/mod.rs
@@ -20,7 +20,7 @@ pub struct IDeviceUseDetails_Vtbl {
     pub Arguments: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceServicingDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceServicingDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceServicingDetails {
@@ -59,7 +59,7 @@ impl windows_core::RuntimeName for DeviceServicingDetails {
 unsafe impl Send for DeviceServicingDetails {}
 unsafe impl Sync for DeviceServicingDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceUseDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceUseDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceUseDetails {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
@@ -306,7 +306,7 @@ pub struct IBluetoothLEManufacturerDataFactory_Vtbl {
     Create: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisement(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisement, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisement {
@@ -396,7 +396,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisement {
 unsafe impl Send for BluetoothLEAdvertisement {}
 unsafe impl Sync for BluetoothLEAdvertisement {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementBytePattern(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementBytePattern, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisementBytePattern {
@@ -474,7 +474,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementBytePattern {
 unsafe impl Send for BluetoothLEAdvertisementBytePattern {}
 unsafe impl Sync for BluetoothLEAdvertisementBytePattern {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementDataSection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementDataSection, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisementDataSection {
@@ -684,7 +684,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementDataTypes {
     const NAME: &'static str = "Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementDataTypes";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementFilter, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisementFilter {
@@ -731,7 +731,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementFilter {
 unsafe impl Send for BluetoothLEAdvertisementFilter {}
 unsafe impl Sync for BluetoothLEAdvertisementFilter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementPublisher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementPublisher, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisementPublisher {
@@ -853,7 +853,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementPublisher {
 unsafe impl Send for BluetoothLEAdvertisementPublisher {}
 unsafe impl Sync for BluetoothLEAdvertisementPublisher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementPublisherStatusChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementPublisherStatusChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisementPublisherStatusChangedEventArgs {
@@ -892,7 +892,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementPublisherStatusChange
 unsafe impl Send for BluetoothLEAdvertisementPublisherStatusChangedEventArgs {}
 unsafe impl Sync for BluetoothLEAdvertisementPublisherStatusChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisementReceivedEventArgs {
@@ -994,7 +994,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementReceivedEventArgs {
 unsafe impl Send for BluetoothLEAdvertisementReceivedEventArgs {}
 unsafe impl Sync for BluetoothLEAdvertisementReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisementWatcher {
@@ -1154,7 +1154,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementWatcher {
 unsafe impl Send for BluetoothLEAdvertisementWatcher {}
 unsafe impl Sync for BluetoothLEAdvertisementWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementWatcherStoppedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementWatcherStoppedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisementWatcherStoppedEventArgs {
@@ -1179,7 +1179,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementWatcherStoppedEventAr
 unsafe impl Send for BluetoothLEAdvertisementWatcherStoppedEventArgs {}
 unsafe impl Sync for BluetoothLEAdvertisementWatcherStoppedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEManufacturerData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEManufacturerData, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEManufacturerData {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Background/mod.rs
@@ -156,7 +156,7 @@ pub struct IRfcommOutboundConnectionInformation_Vtbl {
     SetRemoteServiceId: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementPublisherTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementPublisherTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisementPublisherTriggerDetails {
@@ -196,7 +196,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementPublisherTriggerDetai
 unsafe impl Send for BluetoothLEAdvertisementPublisherTriggerDetails {}
 unsafe impl Sync for BluetoothLEAdvertisementPublisherTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAdvertisementWatcherTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAdvertisementWatcherTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAdvertisementWatcherTriggerDetails {
@@ -236,7 +236,7 @@ impl windows_core::RuntimeName for BluetoothLEAdvertisementWatcherTriggerDetails
 unsafe impl Send for BluetoothLEAdvertisementWatcherTriggerDetails {}
 unsafe impl Sync for BluetoothLEAdvertisementWatcherTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattCharacteristicNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattCharacteristicNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl GattCharacteristicNotificationTriggerDetails {
@@ -292,7 +292,7 @@ impl windows_core::RuntimeName for GattCharacteristicNotificationTriggerDetails 
 unsafe impl Send for GattCharacteristicNotificationTriggerDetails {}
 unsafe impl Sync for GattCharacteristicNotificationTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattServiceProviderConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattServiceProviderConnection, windows_core::IUnknown, windows_core::IInspectable);
 impl GattServiceProviderConnection {
@@ -341,7 +341,7 @@ impl windows_core::RuntimeName for GattServiceProviderConnection {
 unsafe impl Send for GattServiceProviderConnection {}
 unsafe impl Sync for GattServiceProviderConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattServiceProviderTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattServiceProviderTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl GattServiceProviderTriggerDetails {
@@ -366,7 +366,7 @@ impl windows_core::RuntimeName for GattServiceProviderTriggerDetails {
 unsafe impl Send for GattServiceProviderTriggerDetails {}
 unsafe impl Sync for GattServiceProviderTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RfcommConnectionTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RfcommConnectionTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl RfcommConnectionTriggerDetails {
@@ -406,7 +406,7 @@ impl windows_core::RuntimeName for RfcommConnectionTriggerDetails {
 unsafe impl Send for RfcommConnectionTriggerDetails {}
 unsafe impl Sync for RfcommConnectionTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RfcommInboundConnectionInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RfcommInboundConnectionInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl RfcommInboundConnectionInformation {
@@ -467,7 +467,7 @@ impl windows_core::RuntimeName for RfcommInboundConnectionInformation {
 unsafe impl Send for RfcommInboundConnectionInformation {}
 unsafe impl Sync for RfcommInboundConnectionInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RfcommOutboundConnectionInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RfcommOutboundConnectionInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl RfcommOutboundConnectionInformation {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
@@ -947,7 +947,7 @@ pub struct IGattWriteResult_Vtbl {
     pub ProtocolError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattCharacteristic(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattCharacteristic, windows_core::IUnknown, windows_core::IInspectable);
 impl GattCharacteristic {
@@ -1670,7 +1670,7 @@ impl windows_core::RuntimeName for GattCharacteristicUuids {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristicUuids";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattCharacteristicsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattCharacteristicsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattCharacteristicsResult {
@@ -1710,7 +1710,7 @@ impl windows_core::RuntimeName for GattCharacteristicsResult {
 unsafe impl Send for GattCharacteristicsResult {}
 unsafe impl Sync for GattCharacteristicsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattClientNotificationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattClientNotificationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattClientNotificationResult {
@@ -1756,7 +1756,7 @@ impl windows_core::RuntimeName for GattClientNotificationResult {
 unsafe impl Send for GattClientNotificationResult {}
 unsafe impl Sync for GattClientNotificationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl GattDescriptor {
@@ -1894,7 +1894,7 @@ impl windows_core::RuntimeName for GattDescriptorUuids {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattDescriptorUuids";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattDescriptorsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattDescriptorsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattDescriptorsResult {
@@ -1934,7 +1934,7 @@ impl windows_core::RuntimeName for GattDescriptorsResult {
 unsafe impl Send for GattDescriptorsResult {}
 unsafe impl Sync for GattDescriptorsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattDeviceService(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattDeviceService, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GattDeviceService, super::super::super::Foundation::IClosable);
@@ -2197,7 +2197,7 @@ impl windows_core::RuntimeName for GattDeviceService {
 unsafe impl Send for GattDeviceService {}
 unsafe impl Sync for GattDeviceService {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattDeviceServicesResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattDeviceServicesResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattDeviceServicesResult {
@@ -2237,7 +2237,7 @@ impl windows_core::RuntimeName for GattDeviceServicesResult {
 unsafe impl Send for GattDeviceServicesResult {}
 unsafe impl Sync for GattDeviceServicesResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattLocalCharacteristic(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattLocalCharacteristic, windows_core::IUnknown, windows_core::IInspectable);
 impl GattLocalCharacteristic {
@@ -2397,7 +2397,7 @@ impl windows_core::RuntimeName for GattLocalCharacteristic {
 unsafe impl Send for GattLocalCharacteristic {}
 unsafe impl Sync for GattLocalCharacteristic {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattLocalCharacteristicParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattLocalCharacteristicParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl GattLocalCharacteristicParameters {
@@ -2490,7 +2490,7 @@ impl windows_core::RuntimeName for GattLocalCharacteristicParameters {
 unsafe impl Send for GattLocalCharacteristicParameters {}
 unsafe impl Sync for GattLocalCharacteristicParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattLocalCharacteristicResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattLocalCharacteristicResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattLocalCharacteristicResult {
@@ -2522,7 +2522,7 @@ impl windows_core::RuntimeName for GattLocalCharacteristicResult {
 unsafe impl Send for GattLocalCharacteristicResult {}
 unsafe impl Sync for GattLocalCharacteristicResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattLocalDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattLocalDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl GattLocalDescriptor {
@@ -2597,7 +2597,7 @@ impl windows_core::RuntimeName for GattLocalDescriptor {
 unsafe impl Send for GattLocalDescriptor {}
 unsafe impl Sync for GattLocalDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattLocalDescriptorParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattLocalDescriptorParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl GattLocalDescriptorParameters {
@@ -2660,7 +2660,7 @@ impl windows_core::RuntimeName for GattLocalDescriptorParameters {
 unsafe impl Send for GattLocalDescriptorParameters {}
 unsafe impl Sync for GattLocalDescriptorParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattLocalDescriptorResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattLocalDescriptorResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattLocalDescriptorResult {
@@ -2692,7 +2692,7 @@ impl windows_core::RuntimeName for GattLocalDescriptorResult {
 unsafe impl Send for GattLocalDescriptorResult {}
 unsafe impl Sync for GattLocalDescriptorResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattLocalService(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattLocalService, windows_core::IUnknown, windows_core::IInspectable);
 impl GattLocalService {
@@ -2735,7 +2735,7 @@ impl windows_core::RuntimeName for GattLocalService {
 unsafe impl Send for GattLocalService {}
 unsafe impl Sync for GattLocalService {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattPresentationFormat(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattPresentationFormat, windows_core::IUnknown, windows_core::IInspectable);
 impl GattPresentationFormat {
@@ -3096,7 +3096,7 @@ impl windows_core::RuntimeName for GattProtocolError {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattProtocolError";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattReadClientCharacteristicConfigurationDescriptorResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattReadClientCharacteristicConfigurationDescriptorResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattReadClientCharacteristicConfigurationDescriptorResult {
@@ -3135,7 +3135,7 @@ impl windows_core::RuntimeName for GattReadClientCharacteristicConfigurationDesc
 unsafe impl Send for GattReadClientCharacteristicConfigurationDescriptorResult {}
 unsafe impl Sync for GattReadClientCharacteristicConfigurationDescriptorResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattReadRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattReadRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl GattReadRequest {
@@ -3200,7 +3200,7 @@ impl windows_core::RuntimeName for GattReadRequest {
 unsafe impl Send for GattReadRequest {}
 unsafe impl Sync for GattReadRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattReadRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattReadRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GattReadRequestedEventArgs {
@@ -3239,7 +3239,7 @@ impl windows_core::RuntimeName for GattReadRequestedEventArgs {
 unsafe impl Send for GattReadRequestedEventArgs {}
 unsafe impl Sync for GattReadRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattReadResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattReadResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattReadResult {
@@ -3279,7 +3279,7 @@ impl windows_core::RuntimeName for GattReadResult {
 unsafe impl Send for GattReadResult {}
 unsafe impl Sync for GattReadResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattReliableWriteTransaction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattReliableWriteTransaction, windows_core::IUnknown, windows_core::IInspectable);
 impl GattReliableWriteTransaction {
@@ -3327,7 +3327,7 @@ impl windows_core::RuntimeName for GattReliableWriteTransaction {
 unsafe impl Send for GattReliableWriteTransaction {}
 unsafe impl Sync for GattReliableWriteTransaction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattRequestStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattRequestStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GattRequestStateChangedEventArgs {
@@ -3359,7 +3359,7 @@ impl windows_core::RuntimeName for GattRequestStateChangedEventArgs {
 unsafe impl Send for GattRequestStateChangedEventArgs {}
 unsafe impl Sync for GattRequestStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattServiceProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattServiceProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl GattServiceProvider {
@@ -3431,7 +3431,7 @@ impl windows_core::RuntimeName for GattServiceProvider {
 unsafe impl Send for GattServiceProvider {}
 unsafe impl Sync for GattServiceProvider {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattServiceProviderAdvertisementStatusChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattServiceProviderAdvertisementStatusChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GattServiceProviderAdvertisementStatusChangedEventArgs {
@@ -3463,7 +3463,7 @@ impl windows_core::RuntimeName for GattServiceProviderAdvertisementStatusChanged
 unsafe impl Send for GattServiceProviderAdvertisementStatusChangedEventArgs {}
 unsafe impl Sync for GattServiceProviderAdvertisementStatusChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattServiceProviderAdvertisingParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattServiceProviderAdvertisingParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl GattServiceProviderAdvertisingParameters {
@@ -3526,7 +3526,7 @@ impl windows_core::RuntimeName for GattServiceProviderAdvertisingParameters {
 unsafe impl Send for GattServiceProviderAdvertisingParameters {}
 unsafe impl Sync for GattServiceProviderAdvertisingParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattServiceProviderResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattServiceProviderResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattServiceProviderResult {
@@ -3706,7 +3706,7 @@ impl windows_core::RuntimeName for GattServiceUuids {
     const NAME: &'static str = "Windows.Devices.Bluetooth.GenericAttributeProfile.GattServiceUuids";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GattSession, super::super::super::Foundation::IClosable);
@@ -3810,7 +3810,7 @@ impl windows_core::RuntimeName for GattSession {
 unsafe impl Send for GattSession {}
 unsafe impl Sync for GattSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattSessionStatusChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattSessionStatusChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GattSessionStatusChangedEventArgs {
@@ -3842,7 +3842,7 @@ impl windows_core::RuntimeName for GattSessionStatusChangedEventArgs {
 unsafe impl Send for GattSessionStatusChangedEventArgs {}
 unsafe impl Sync for GattSessionStatusChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattSubscribedClient(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattSubscribedClient, windows_core::IUnknown, windows_core::IInspectable);
 impl GattSubscribedClient {
@@ -3888,7 +3888,7 @@ impl windows_core::RuntimeName for GattSubscribedClient {
 unsafe impl Send for GattSubscribedClient {}
 unsafe impl Sync for GattSubscribedClient {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattValueChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattValueChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GattValueChangedEventArgs {
@@ -3921,7 +3921,7 @@ impl windows_core::RuntimeName for GattValueChangedEventArgs {
 unsafe impl Send for GattValueChangedEventArgs {}
 unsafe impl Sync for GattValueChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattWriteRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattWriteRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl GattWriteRequest {
@@ -3990,7 +3990,7 @@ impl windows_core::RuntimeName for GattWriteRequest {
 unsafe impl Send for GattWriteRequest {}
 unsafe impl Sync for GattWriteRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattWriteRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattWriteRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GattWriteRequestedEventArgs {
@@ -4029,7 +4029,7 @@ impl windows_core::RuntimeName for GattWriteRequestedEventArgs {
 unsafe impl Send for GattWriteRequestedEventArgs {}
 unsafe impl Sync for GattWriteRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GattWriteResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GattWriteResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GattWriteResult {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Rfcomm/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Rfcomm/mod.rs
@@ -155,7 +155,7 @@ pub struct IRfcommServiceProviderStatics_Vtbl {
     pub CreateAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RfcommDeviceService(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RfcommDeviceService, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RfcommDeviceService, super::super::super::Foundation::IClosable);
@@ -318,7 +318,7 @@ impl windows_core::RuntimeName for RfcommDeviceService {
 unsafe impl Send for RfcommDeviceService {}
 unsafe impl Sync for RfcommDeviceService {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RfcommDeviceServicesResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RfcommDeviceServicesResult, windows_core::IUnknown, windows_core::IInspectable);
 impl RfcommDeviceServicesResult {
@@ -351,7 +351,7 @@ impl windows_core::RuntimeName for RfcommDeviceServicesResult {
 unsafe impl Send for RfcommDeviceServicesResult {}
 unsafe impl Sync for RfcommDeviceServicesResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RfcommServiceId(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RfcommServiceId, windows_core::IUnknown, windows_core::IInspectable);
 impl RfcommServiceId {
@@ -443,7 +443,7 @@ impl windows_core::RuntimeName for RfcommServiceId {
 unsafe impl Send for RfcommServiceId {}
 unsafe impl Sync for RfcommServiceId {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RfcommServiceProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RfcommServiceProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl RfcommServiceProvider {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
@@ -528,7 +528,7 @@ pub struct IBluetoothUuidHelperStatics_Vtbl {
     pub TryGetShortId: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothAdapter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothAdapter, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothAdapter {
@@ -654,7 +654,7 @@ impl windows_core::RuntimeName for BluetoothAdapter {
 unsafe impl Send for BluetoothAdapter {}
 unsafe impl Sync for BluetoothAdapter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothClassOfDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothClassOfDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothClassOfDevice {
@@ -717,7 +717,7 @@ impl windows_core::RuntimeName for BluetoothClassOfDevice {
 unsafe impl Send for BluetoothClassOfDevice {}
 unsafe impl Sync for BluetoothClassOfDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothDevice, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BluetoothDevice, super::super::Foundation::IClosable);
@@ -988,7 +988,7 @@ impl windows_core::RuntimeName for BluetoothDevice {
 unsafe impl Send for BluetoothDevice {}
 unsafe impl Sync for BluetoothDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothDeviceId(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothDeviceId, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothDeviceId {
@@ -1038,7 +1038,7 @@ impl windows_core::RuntimeName for BluetoothDeviceId {
 unsafe impl Send for BluetoothDeviceId {}
 unsafe impl Sync for BluetoothDeviceId {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEAppearance(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEAppearance, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEAppearance {
@@ -1416,7 +1416,7 @@ impl windows_core::RuntimeName for BluetoothLEAppearanceSubcategories {
     const NAME: &'static str = "Windows.Devices.Bluetooth.BluetoothLEAppearanceSubcategories";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEConnectionParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEConnectionParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEConnectionParameters {
@@ -1455,7 +1455,7 @@ impl windows_core::RuntimeName for BluetoothLEConnectionParameters {
 unsafe impl Send for BluetoothLEConnectionParameters {}
 unsafe impl Sync for BluetoothLEConnectionParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEConnectionPhy(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEConnectionPhy, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEConnectionPhy {
@@ -1487,7 +1487,7 @@ impl windows_core::RuntimeName for BluetoothLEConnectionPhy {
 unsafe impl Send for BluetoothLEConnectionPhy {}
 unsafe impl Sync for BluetoothLEConnectionPhy {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEConnectionPhyInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEConnectionPhyInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEConnectionPhyInfo {
@@ -1526,7 +1526,7 @@ impl windows_core::RuntimeName for BluetoothLEConnectionPhyInfo {
 unsafe impl Send for BluetoothLEConnectionPhyInfo {}
 unsafe impl Sync for BluetoothLEConnectionPhyInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEDevice, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BluetoothLEDevice, super::super::Foundation::IClosable);
@@ -1844,7 +1844,7 @@ impl windows_core::RuntimeName for BluetoothLEDevice {
 unsafe impl Send for BluetoothLEDevice {}
 unsafe impl Sync for BluetoothLEDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEPreferredConnectionParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEPreferredConnectionParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothLEPreferredConnectionParameters {
@@ -1913,7 +1913,7 @@ impl windows_core::RuntimeName for BluetoothLEPreferredConnectionParameters {
 unsafe impl Send for BluetoothLEPreferredConnectionParameters {}
 unsafe impl Sync for BluetoothLEPreferredConnectionParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothLEPreferredConnectionParametersRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothLEPreferredConnectionParametersRequest, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BluetoothLEPreferredConnectionParametersRequest, super::super::Foundation::IClosable);
@@ -1943,7 +1943,7 @@ impl windows_core::RuntimeName for BluetoothLEPreferredConnectionParametersReque
 unsafe impl Send for BluetoothLEPreferredConnectionParametersRequest {}
 unsafe impl Sync for BluetoothLEPreferredConnectionParametersRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BluetoothSignalStrengthFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BluetoothSignalStrengthFilter, windows_core::IUnknown, windows_core::IInspectable);
 impl BluetoothSignalStrengthFilter {

--- a/crates/libs/windows/src/Windows/Devices/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Custom/mod.rs
@@ -108,7 +108,7 @@ pub struct IKnownDeviceTypesStatics_Vtbl {
     pub Unknown: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CustomDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CustomDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl CustomDevice {
@@ -185,7 +185,7 @@ impl windows_core::RuntimeName for CustomDevice {
 unsafe impl Send for CustomDevice {}
 unsafe impl Sync for CustomDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IOControlCode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IOControlCode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(IOControlCode, IIOControlCode);

--- a/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
@@ -572,7 +572,7 @@ pub struct IDisplayWireFormatStatics_Vtbl {
     CreateWithProperties: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayAdapter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayAdapter, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayAdapter {
@@ -660,7 +660,7 @@ impl windows_core::RuntimeName for DisplayAdapter {
 unsafe impl Send for DisplayAdapter {}
 unsafe impl Sync for DisplayAdapter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayDevice {
@@ -754,7 +754,7 @@ impl windows_core::RuntimeName for DisplayDevice {
 unsafe impl Send for DisplayDevice {}
 unsafe impl Sync for DisplayDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayFence(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayFence, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayFence {}
@@ -771,7 +771,7 @@ impl windows_core::RuntimeName for DisplayFence {
 unsafe impl Send for DisplayFence {}
 unsafe impl Sync for DisplayFence {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayManager, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DisplayManager, super::super::super::Foundation::IClosable);
@@ -953,7 +953,7 @@ impl windows_core::RuntimeName for DisplayManager {
 unsafe impl Send for DisplayManager {}
 unsafe impl Sync for DisplayManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayManagerChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayManagerChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayManagerChangedEventArgs {
@@ -989,7 +989,7 @@ impl windows_core::RuntimeName for DisplayManagerChangedEventArgs {
 unsafe impl Send for DisplayManagerChangedEventArgs {}
 unsafe impl Sync for DisplayManagerChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayManagerDisabledEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayManagerDisabledEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayManagerDisabledEventArgs {
@@ -1025,7 +1025,7 @@ impl windows_core::RuntimeName for DisplayManagerDisabledEventArgs {
 unsafe impl Send for DisplayManagerDisabledEventArgs {}
 unsafe impl Sync for DisplayManagerDisabledEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayManagerEnabledEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayManagerEnabledEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayManagerEnabledEventArgs {
@@ -1061,7 +1061,7 @@ impl windows_core::RuntimeName for DisplayManagerEnabledEventArgs {
 unsafe impl Send for DisplayManagerEnabledEventArgs {}
 unsafe impl Sync for DisplayManagerEnabledEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayManagerPathsFailedOrInvalidatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayManagerPathsFailedOrInvalidatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayManagerPathsFailedOrInvalidatedEventArgs {
@@ -1097,7 +1097,7 @@ impl windows_core::RuntimeName for DisplayManagerPathsFailedOrInvalidatedEventAr
 unsafe impl Send for DisplayManagerPathsFailedOrInvalidatedEventArgs {}
 unsafe impl Sync for DisplayManagerPathsFailedOrInvalidatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayManagerResultWithState(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayManagerResultWithState, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayManagerResultWithState {
@@ -1136,7 +1136,7 @@ impl windows_core::RuntimeName for DisplayManagerResultWithState {
 unsafe impl Send for DisplayManagerResultWithState {}
 unsafe impl Sync for DisplayManagerResultWithState {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayModeInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayModeInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayModeInfo {
@@ -1233,7 +1233,7 @@ impl windows_core::RuntimeName for DisplayModeInfo {
 unsafe impl Send for DisplayModeInfo {}
 unsafe impl Sync for DisplayModeInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayPath(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayPath, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayPath {
@@ -1433,7 +1433,7 @@ impl windows_core::RuntimeName for DisplayPath {
 unsafe impl Send for DisplayPath {}
 unsafe impl Sync for DisplayPath {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayPrimaryDescription(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayPrimaryDescription, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayPrimaryDescription {
@@ -1531,7 +1531,7 @@ impl windows_core::RuntimeName for DisplayPrimaryDescription {
 unsafe impl Send for DisplayPrimaryDescription {}
 unsafe impl Sync for DisplayPrimaryDescription {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayScanout(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayScanout, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayScanout {}
@@ -1548,7 +1548,7 @@ impl windows_core::RuntimeName for DisplayScanout {
 unsafe impl Send for DisplayScanout {}
 unsafe impl Sync for DisplayScanout {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplaySource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplaySource, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplaySource {
@@ -1610,7 +1610,7 @@ impl windows_core::RuntimeName for DisplaySource {
 unsafe impl Send for DisplaySource {}
 unsafe impl Sync for DisplaySource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayState(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayState, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayState {
@@ -1746,7 +1746,7 @@ impl windows_core::RuntimeName for DisplayState {
 unsafe impl Send for DisplayState {}
 unsafe impl Sync for DisplayState {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayStateOperationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayStateOperationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayStateOperationResult {
@@ -1778,7 +1778,7 @@ impl windows_core::RuntimeName for DisplayStateOperationResult {
 unsafe impl Send for DisplayStateOperationResult {}
 unsafe impl Sync for DisplayStateOperationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplaySurface(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplaySurface, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplaySurface {}
@@ -1795,7 +1795,7 @@ impl windows_core::RuntimeName for DisplaySurface {
 unsafe impl Send for DisplaySurface {}
 unsafe impl Sync for DisplaySurface {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayTarget(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayTarget, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayTarget {
@@ -1918,7 +1918,7 @@ impl windows_core::RuntimeName for DisplayTarget {
 unsafe impl Send for DisplayTarget {}
 unsafe impl Sync for DisplayTarget {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayTask(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayTask, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayTask {
@@ -1957,7 +1957,7 @@ impl windows_core::RuntimeName for DisplayTask {
 unsafe impl Send for DisplayTask {}
 unsafe impl Sync for DisplayTask {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayTaskPool(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayTaskPool, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayTaskPool {
@@ -2000,7 +2000,7 @@ impl windows_core::RuntimeName for DisplayTaskPool {
 unsafe impl Send for DisplayTaskPool {}
 unsafe impl Sync for DisplayTaskPool {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayTaskResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayTaskResult, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayTaskResult {
@@ -2039,7 +2039,7 @@ impl windows_core::RuntimeName for DisplayTaskResult {
 unsafe impl Send for DisplayTaskResult {}
 unsafe impl Sync for DisplayTaskResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayView(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayView, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayView {
@@ -2096,7 +2096,7 @@ impl windows_core::RuntimeName for DisplayView {
 unsafe impl Send for DisplayView {}
 unsafe impl Sync for DisplayView {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayWireFormat(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayWireFormat, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayWireFormat {

--- a/crates/libs/windows/src/Windows/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/mod.rs
@@ -55,7 +55,7 @@ pub struct IDisplayMonitorStatics_Vtbl {
     pub FromInterfaceIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayMonitor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayMonitor, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayMonitor {

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/Pnp/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/Pnp/mod.rs
@@ -77,7 +77,7 @@ pub struct IPnpObjectWatcher_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PnpObject(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PnpObject, windows_core::IUnknown, windows_core::IInspectable);
 impl PnpObject {
@@ -180,7 +180,7 @@ unsafe impl Send for PnpObject {}
 unsafe impl Sync for PnpObject {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PnpObjectCollection(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(PnpObjectCollection, windows_core::IUnknown, windows_core::IInspectable);
@@ -266,7 +266,7 @@ unsafe impl Send for PnpObjectCollection {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for PnpObjectCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PnpObjectUpdate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PnpObjectUpdate, windows_core::IUnknown, windows_core::IInspectable);
 impl PnpObjectUpdate {
@@ -306,7 +306,7 @@ impl windows_core::RuntimeName for PnpObjectUpdate {
 unsafe impl Send for PnpObjectUpdate {}
 unsafe impl Sync for PnpObjectUpdate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PnpObjectWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PnpObjectWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl PnpObjectWatcher {

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
@@ -481,7 +481,7 @@ pub struct IEnclosureLocation2_Vtbl {
     pub RotationAngleInDegreesClockwise: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceAccessChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceAccessChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceAccessChangedEventArgs {
@@ -513,7 +513,7 @@ impl windows_core::RuntimeName for DeviceAccessChangedEventArgs {
 unsafe impl Send for DeviceAccessChangedEventArgs {}
 unsafe impl Sync for DeviceAccessChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceAccessInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceAccessInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceAccessInformation {
@@ -575,7 +575,7 @@ impl windows_core::RuntimeName for DeviceAccessInformation {
 unsafe impl Send for DeviceAccessInformation {}
 unsafe impl Sync for DeviceAccessInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceConnectionChangeTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceConnectionChangeTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceConnectionChangeTriggerDetails {
@@ -600,7 +600,7 @@ impl windows_core::RuntimeName for DeviceConnectionChangeTriggerDetails {
 unsafe impl Send for DeviceConnectionChangeTriggerDetails {}
 unsafe impl Sync for DeviceConnectionChangeTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceDisconnectButtonClickedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceDisconnectButtonClickedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceDisconnectButtonClickedEventArgs {
@@ -625,7 +625,7 @@ impl windows_core::RuntimeName for DeviceDisconnectButtonClickedEventArgs {
 unsafe impl Send for DeviceDisconnectButtonClickedEventArgs {}
 unsafe impl Sync for DeviceDisconnectButtonClickedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceInformation {
@@ -845,7 +845,7 @@ unsafe impl Send for DeviceInformation {}
 unsafe impl Sync for DeviceInformation {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceInformationCollection(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(DeviceInformationCollection, windows_core::IUnknown, windows_core::IInspectable);
@@ -931,7 +931,7 @@ unsafe impl Send for DeviceInformationCollection {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for DeviceInformationCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceInformationCustomPairing(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceInformationCustomPairing, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceInformationCustomPairing {
@@ -987,7 +987,7 @@ impl windows_core::RuntimeName for DeviceInformationCustomPairing {
 unsafe impl Send for DeviceInformationCustomPairing {}
 unsafe impl Sync for DeviceInformationCustomPairing {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceInformationPairing(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceInformationPairing, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceInformationPairing {
@@ -1086,7 +1086,7 @@ impl windows_core::RuntimeName for DeviceInformationPairing {
 unsafe impl Send for DeviceInformationPairing {}
 unsafe impl Sync for DeviceInformationPairing {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceInformationUpdate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceInformationUpdate, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceInformationUpdate {
@@ -1126,7 +1126,7 @@ impl windows_core::RuntimeName for DeviceInformationUpdate {
 unsafe impl Send for DeviceInformationUpdate {}
 unsafe impl Sync for DeviceInformationUpdate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DevicePairingRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DevicePairingRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DevicePairingRequestedEventArgs {
@@ -1188,7 +1188,7 @@ impl windows_core::RuntimeName for DevicePairingRequestedEventArgs {
 unsafe impl Send for DevicePairingRequestedEventArgs {}
 unsafe impl Sync for DevicePairingRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DevicePairingResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DevicePairingResult, windows_core::IUnknown, windows_core::IInspectable);
 impl DevicePairingResult {
@@ -1220,7 +1220,7 @@ impl windows_core::RuntimeName for DevicePairingResult {
 unsafe impl Send for DevicePairingResult {}
 unsafe impl Sync for DevicePairingResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DevicePicker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DevicePicker, windows_core::IUnknown, windows_core::IInspectable);
 impl DevicePicker {
@@ -1344,7 +1344,7 @@ impl windows_core::RuntimeName for DevicePicker {
 unsafe impl Send for DevicePicker {}
 unsafe impl Sync for DevicePicker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DevicePickerAppearance(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DevicePickerAppearance, windows_core::IUnknown, windows_core::IInspectable);
 impl DevicePickerAppearance {
@@ -1451,7 +1451,7 @@ impl windows_core::RuntimeName for DevicePickerAppearance {
 unsafe impl Send for DevicePickerAppearance {}
 unsafe impl Sync for DevicePickerAppearance {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DevicePickerFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DevicePickerFilter, windows_core::IUnknown, windows_core::IInspectable);
 impl DevicePickerFilter {
@@ -1485,7 +1485,7 @@ impl windows_core::RuntimeName for DevicePickerFilter {
 unsafe impl Send for DevicePickerFilter {}
 unsafe impl Sync for DevicePickerFilter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceSelectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceSelectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceSelectedEventArgs {
@@ -1511,7 +1511,7 @@ unsafe impl Send for DeviceSelectedEventArgs {}
 unsafe impl Sync for DeviceSelectedEventArgs {}
 #[cfg(feature = "Storage_Streams")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceThumbnail(windows_core::IUnknown);
 #[cfg(feature = "Storage_Streams")]
 windows_core::imp::interface_hierarchy!(DeviceThumbnail, windows_core::IUnknown, windows_core::IInspectable);
@@ -1646,7 +1646,7 @@ unsafe impl Send for DeviceThumbnail {}
 #[cfg(feature = "Storage_Streams")]
 unsafe impl Sync for DeviceThumbnail {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceUnpairingResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceUnpairingResult, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceUnpairingResult {
@@ -1671,7 +1671,7 @@ impl windows_core::RuntimeName for DeviceUnpairingResult {
 unsafe impl Send for DeviceUnpairingResult {}
 unsafe impl Sync for DeviceUnpairingResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceWatcher {
@@ -1785,7 +1785,7 @@ impl windows_core::RuntimeName for DeviceWatcher {
 unsafe impl Send for DeviceWatcher {}
 unsafe impl Sync for DeviceWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceWatcherEvent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceWatcherEvent, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceWatcherEvent {
@@ -1824,7 +1824,7 @@ impl windows_core::RuntimeName for DeviceWatcherEvent {
 unsafe impl Send for DeviceWatcherEvent {}
 unsafe impl Sync for DeviceWatcherEvent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceWatcherTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceWatcherTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceWatcherTriggerDetails {
@@ -1850,7 +1850,7 @@ impl windows_core::RuntimeName for DeviceWatcherTriggerDetails {
 unsafe impl Send for DeviceWatcherTriggerDetails {}
 unsafe impl Sync for DeviceWatcherTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EnclosureLocation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EnclosureLocation, windows_core::IUnknown, windows_core::IInspectable);
 impl EnclosureLocation {

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
@@ -69,7 +69,7 @@ pub struct IGeofenceStateChangeReport_Vtbl {
     pub RemovalReason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GeofenceRemovalReason) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Geofence(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Geofence, windows_core::IUnknown, windows_core::IInspectable);
 impl Geofence {
@@ -177,7 +177,7 @@ impl windows_core::RuntimeName for Geofence {
 unsafe impl Send for Geofence {}
 unsafe impl Sync for Geofence {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GeofenceMonitor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GeofenceMonitor, windows_core::IUnknown, windows_core::IInspectable);
 impl GeofenceMonitor {
@@ -264,7 +264,7 @@ impl windows_core::RuntimeName for GeofenceMonitor {
 unsafe impl Send for GeofenceMonitor {}
 unsafe impl Sync for GeofenceMonitor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GeofenceStateChangeReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GeofenceStateChangeReport, windows_core::IUnknown, windows_core::IInspectable);
 impl GeofenceStateChangeReport {

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/Provider/mod.rs
@@ -12,7 +12,7 @@ pub struct IGeolocationProvider_Vtbl {
     pub RemoveIsOverriddenChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GeolocationProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GeolocationProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl GeolocationProvider {

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/mod.rs
@@ -426,7 +426,7 @@ pub struct IVenueData_Vtbl {
     pub Level: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CivicAddress(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CivicAddress, windows_core::IUnknown, windows_core::IInspectable);
 impl CivicAddress {
@@ -479,7 +479,7 @@ impl windows_core::RuntimeName for CivicAddress {
 unsafe impl Send for CivicAddress {}
 unsafe impl Sync for CivicAddress {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GeoboundingBox(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GeoboundingBox, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GeoboundingBox, IGeoshape);
@@ -612,7 +612,7 @@ impl windows_core::RuntimeName for GeoboundingBox {
 unsafe impl Send for GeoboundingBox {}
 unsafe impl Sync for GeoboundingBox {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Geocircle(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Geocircle, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Geocircle, IGeoshape);
@@ -689,7 +689,7 @@ impl windows_core::RuntimeName for Geocircle {
 unsafe impl Send for Geocircle {}
 unsafe impl Sync for Geocircle {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Geocoordinate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Geocoordinate, windows_core::IUnknown, windows_core::IInspectable);
 impl Geocoordinate {
@@ -801,7 +801,7 @@ impl windows_core::RuntimeName for Geocoordinate {
 unsafe impl Send for Geocoordinate {}
 unsafe impl Sync for Geocoordinate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GeocoordinateSatelliteData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GeocoordinateSatelliteData, windows_core::IUnknown, windows_core::IInspectable);
 impl GeocoordinateSatelliteData {
@@ -854,7 +854,7 @@ impl windows_core::RuntimeName for GeocoordinateSatelliteData {
 unsafe impl Send for GeocoordinateSatelliteData {}
 unsafe impl Sync for GeocoordinateSatelliteData {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Geolocator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Geolocator, windows_core::IUnknown, windows_core::IInspectable);
 impl Geolocator {
@@ -1027,7 +1027,7 @@ impl windows_core::RuntimeName for Geolocator {
 unsafe impl Send for Geolocator {}
 unsafe impl Sync for Geolocator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Geopath(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Geopath, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Geopath, IGeoshape);
@@ -1110,7 +1110,7 @@ impl windows_core::RuntimeName for Geopath {
 unsafe impl Send for Geopath {}
 unsafe impl Sync for Geopath {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Geopoint(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Geopoint, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Geopoint, IGeoshape);
@@ -1180,7 +1180,7 @@ impl windows_core::RuntimeName for Geopoint {
 unsafe impl Send for Geopoint {}
 unsafe impl Sync for Geopoint {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Geoposition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Geoposition, windows_core::IUnknown, windows_core::IInspectable);
 impl Geoposition {
@@ -1219,7 +1219,7 @@ impl windows_core::RuntimeName for Geoposition {
 unsafe impl Send for Geoposition {}
 unsafe impl Sync for Geoposition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Geovisit(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Geovisit, windows_core::IUnknown, windows_core::IInspectable);
 impl Geovisit {
@@ -1258,7 +1258,7 @@ impl windows_core::RuntimeName for Geovisit {
 unsafe impl Send for Geovisit {}
 unsafe impl Sync for Geovisit {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GeovisitMonitor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GeovisitMonitor, windows_core::IUnknown, windows_core::IInspectable);
 impl GeovisitMonitor {
@@ -1323,7 +1323,7 @@ impl windows_core::RuntimeName for GeovisitMonitor {
 unsafe impl Send for GeovisitMonitor {}
 unsafe impl Sync for GeovisitMonitor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GeovisitStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GeovisitStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GeovisitStateChangedEventArgs {
@@ -1348,7 +1348,7 @@ impl windows_core::RuntimeName for GeovisitStateChangedEventArgs {
 unsafe impl Send for GeovisitStateChangedEventArgs {}
 unsafe impl Sync for GeovisitStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GeovisitTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GeovisitTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl GeovisitTriggerDetails {
@@ -1374,7 +1374,7 @@ impl windows_core::RuntimeName for GeovisitTriggerDetails {
 unsafe impl Send for GeovisitTriggerDetails {}
 unsafe impl Sync for GeovisitTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PositionChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PositionChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PositionChangedEventArgs {
@@ -1399,7 +1399,7 @@ impl windows_core::RuntimeName for PositionChangedEventArgs {
 unsafe impl Send for PositionChangedEventArgs {}
 unsafe impl Sync for PositionChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StatusChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StatusChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl StatusChangedEventArgs {
@@ -1424,7 +1424,7 @@ impl windows_core::RuntimeName for StatusChangedEventArgs {
 unsafe impl Send for StatusChangedEventArgs {}
 unsafe impl Sync for StatusChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VenueData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VenueData, windows_core::IUnknown, windows_core::IInspectable);
 impl VenueData {

--- a/crates/libs/windows/src/Windows/Devices/Gpio/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/Provider/mod.rs
@@ -175,7 +175,7 @@ pub struct IGpioProvider_Vtbl {
     GetControllers: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GpioPinProviderValueChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GpioPinProviderValueChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GpioPinProviderValueChangedEventArgs {

--- a/crates/libs/windows/src/Windows/Devices/Gpio/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/mod.rs
@@ -122,7 +122,7 @@ pub struct IGpioPinValueChangedEventArgs_Vtbl {
     pub Edge: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GpioPinEdge) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GpioChangeCounter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GpioChangeCounter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GpioChangeCounter, super::super::Foundation::IClosable);
@@ -199,7 +199,7 @@ impl windows_core::RuntimeName for GpioChangeCounter {
 unsafe impl Send for GpioChangeCounter {}
 unsafe impl Sync for GpioChangeCounter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GpioChangeReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GpioChangeReader, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GpioChangeReader, super::super::Foundation::IClosable);
@@ -332,7 +332,7 @@ impl windows_core::RuntimeName for GpioChangeReader {
 unsafe impl Send for GpioChangeReader {}
 unsafe impl Sync for GpioChangeReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GpioController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GpioController, windows_core::IUnknown, windows_core::IInspectable);
 impl GpioController {
@@ -410,7 +410,7 @@ impl windows_core::RuntimeName for GpioController {
 unsafe impl Send for GpioController {}
 unsafe impl Sync for GpioController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GpioPin(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GpioPin, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GpioPin, super::super::Foundation::IClosable);
@@ -501,7 +501,7 @@ impl windows_core::RuntimeName for GpioPin {
 unsafe impl Send for GpioPin {}
 unsafe impl Sync for GpioPin {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GpioPinValueChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GpioPinValueChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GpioPinValueChangedEventArgs {

--- a/crates/libs/windows/src/Windows/Devices/Haptics/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Haptics/mod.rs
@@ -194,7 +194,7 @@ impl windows_core::RuntimeName for KnownSimpleHapticsControllerWaveforms {
     const NAME: &'static str = "Windows.Devices.Haptics.KnownSimpleHapticsControllerWaveforms";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SimpleHapticsController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SimpleHapticsController, windows_core::IUnknown, windows_core::IInspectable);
 impl SimpleHapticsController {
@@ -287,7 +287,7 @@ impl windows_core::RuntimeName for SimpleHapticsController {
 unsafe impl Send for SimpleHapticsController {}
 unsafe impl Sync for SimpleHapticsController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SimpleHapticsControllerFeedback(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SimpleHapticsControllerFeedback, windows_core::IUnknown, windows_core::IInspectable);
 impl SimpleHapticsControllerFeedback {
@@ -319,7 +319,7 @@ impl windows_core::RuntimeName for SimpleHapticsControllerFeedback {
 unsafe impl Send for SimpleHapticsControllerFeedback {}
 unsafe impl Sync for SimpleHapticsControllerFeedback {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VibrationDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VibrationDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl VibrationDevice {

--- a/crates/libs/windows/src/Windows/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/HumanInterfaceDevice/mod.rs
@@ -218,7 +218,7 @@ pub struct IHidOutputReport_Vtbl {
     pub GetNumericControlByDescription: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidBooleanControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidBooleanControl, windows_core::IUnknown, windows_core::IInspectable);
 impl HidBooleanControl {
@@ -275,7 +275,7 @@ impl windows_core::RuntimeName for HidBooleanControl {
 unsafe impl Send for HidBooleanControl {}
 unsafe impl Sync for HidBooleanControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidBooleanControlDescription(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidBooleanControlDescription, windows_core::IUnknown, windows_core::IInspectable);
 impl HidBooleanControlDescription {
@@ -343,7 +343,7 @@ impl windows_core::RuntimeName for HidBooleanControlDescription {
 unsafe impl Send for HidBooleanControlDescription {}
 unsafe impl Sync for HidBooleanControlDescription {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidCollection, windows_core::IUnknown, windows_core::IInspectable);
 impl HidCollection {
@@ -389,7 +389,7 @@ impl windows_core::RuntimeName for HidCollection {
 unsafe impl Send for HidCollection {}
 unsafe impl Sync for HidCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidDevice, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HidDevice, super::super::Foundation::IClosable);
@@ -577,7 +577,7 @@ impl windows_core::RuntimeName for HidDevice {
 unsafe impl Send for HidDevice {}
 unsafe impl Sync for HidDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidFeatureReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidFeatureReport, windows_core::IUnknown, windows_core::IInspectable);
 impl HidFeatureReport {
@@ -652,7 +652,7 @@ impl windows_core::RuntimeName for HidFeatureReport {
 unsafe impl Send for HidFeatureReport {}
 unsafe impl Sync for HidFeatureReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidInputReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidInputReport, windows_core::IUnknown, windows_core::IInspectable);
 impl HidInputReport {
@@ -735,7 +735,7 @@ impl windows_core::RuntimeName for HidInputReport {
 unsafe impl Send for HidInputReport {}
 unsafe impl Sync for HidInputReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidInputReportReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidInputReportReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HidInputReportReceivedEventArgs {
@@ -760,7 +760,7 @@ impl windows_core::RuntimeName for HidInputReportReceivedEventArgs {
 unsafe impl Send for HidInputReportReceivedEventArgs {}
 unsafe impl Sync for HidInputReportReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidNumericControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidNumericControl, windows_core::IUnknown, windows_core::IInspectable);
 impl HidNumericControl {
@@ -835,7 +835,7 @@ impl windows_core::RuntimeName for HidNumericControl {
 unsafe impl Send for HidNumericControl {}
 unsafe impl Sync for HidNumericControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidNumericControlDescription(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidNumericControlDescription, windows_core::IUnknown, windows_core::IInspectable);
 impl HidNumericControlDescription {
@@ -966,7 +966,7 @@ impl windows_core::RuntimeName for HidNumericControlDescription {
 unsafe impl Send for HidNumericControlDescription {}
 unsafe impl Sync for HidNumericControlDescription {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidOutputReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidOutputReport, windows_core::IUnknown, windows_core::IInspectable);
 impl HidOutputReport {

--- a/crates/libs/windows/src/Windows/Devices/I2c/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/Provider/mod.rs
@@ -139,7 +139,7 @@ pub struct IProviderI2cConnectionSettings_Vtbl {
     pub SetSharingMode: unsafe extern "system" fn(*mut core::ffi::c_void, ProviderI2cSharingMode) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProviderI2cConnectionSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProviderI2cConnectionSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl ProviderI2cConnectionSettings {

--- a/crates/libs/windows/src/Windows/Devices/I2c/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/mod.rs
@@ -106,7 +106,7 @@ pub struct II2cDeviceStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct I2cConnectionSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(I2cConnectionSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl I2cConnectionSettings {
@@ -168,7 +168,7 @@ impl windows_core::RuntimeName for I2cConnectionSettings {
 unsafe impl Send for I2cConnectionSettings {}
 unsafe impl Sync for I2cConnectionSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct I2cController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(I2cController, windows_core::IUnknown, windows_core::IInspectable);
 impl I2cController {
@@ -217,7 +217,7 @@ impl windows_core::RuntimeName for I2cController {
 unsafe impl Send for I2cController {}
 unsafe impl Sync for I2cController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct I2cDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(I2cDevice, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(I2cDevice, super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/Devices/Input/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Input/Preview/mod.rs
@@ -142,7 +142,7 @@ pub struct IGazePointPreview_Vtbl {
     HidInputReport: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GazeDevicePreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GazeDevicePreview, windows_core::IUnknown, windows_core::IInspectable);
 impl GazeDevicePreview {
@@ -211,7 +211,7 @@ impl windows_core::RuntimeName for GazeDevicePreview {
 unsafe impl Send for GazeDevicePreview {}
 unsafe impl Sync for GazeDevicePreview {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GazeDeviceWatcherAddedPreviewEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GazeDeviceWatcherAddedPreviewEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GazeDeviceWatcherAddedPreviewEventArgs {
@@ -236,7 +236,7 @@ impl windows_core::RuntimeName for GazeDeviceWatcherAddedPreviewEventArgs {
 unsafe impl Send for GazeDeviceWatcherAddedPreviewEventArgs {}
 unsafe impl Sync for GazeDeviceWatcherAddedPreviewEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GazeDeviceWatcherPreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GazeDeviceWatcherPreview, windows_core::IUnknown, windows_core::IInspectable);
 impl GazeDeviceWatcherPreview {
@@ -318,7 +318,7 @@ impl windows_core::RuntimeName for GazeDeviceWatcherPreview {
 unsafe impl Send for GazeDeviceWatcherPreview {}
 unsafe impl Sync for GazeDeviceWatcherPreview {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GazeDeviceWatcherRemovedPreviewEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GazeDeviceWatcherRemovedPreviewEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GazeDeviceWatcherRemovedPreviewEventArgs {
@@ -343,7 +343,7 @@ impl windows_core::RuntimeName for GazeDeviceWatcherRemovedPreviewEventArgs {
 unsafe impl Send for GazeDeviceWatcherRemovedPreviewEventArgs {}
 unsafe impl Sync for GazeDeviceWatcherRemovedPreviewEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GazeDeviceWatcherUpdatedPreviewEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GazeDeviceWatcherUpdatedPreviewEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GazeDeviceWatcherUpdatedPreviewEventArgs {
@@ -368,7 +368,7 @@ impl windows_core::RuntimeName for GazeDeviceWatcherUpdatedPreviewEventArgs {
 unsafe impl Send for GazeDeviceWatcherUpdatedPreviewEventArgs {}
 unsafe impl Sync for GazeDeviceWatcherUpdatedPreviewEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GazeEnteredPreviewEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GazeEnteredPreviewEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GazeEnteredPreviewEventArgs {
@@ -404,7 +404,7 @@ impl windows_core::RuntimeName for GazeEnteredPreviewEventArgs {
 unsafe impl Send for GazeEnteredPreviewEventArgs {}
 unsafe impl Sync for GazeEnteredPreviewEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GazeExitedPreviewEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GazeExitedPreviewEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GazeExitedPreviewEventArgs {
@@ -440,7 +440,7 @@ impl windows_core::RuntimeName for GazeExitedPreviewEventArgs {
 unsafe impl Send for GazeExitedPreviewEventArgs {}
 unsafe impl Sync for GazeExitedPreviewEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GazeInputSourcePreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GazeInputSourcePreview, windows_core::IUnknown, windows_core::IInspectable);
 impl GazeInputSourcePreview {
@@ -517,7 +517,7 @@ impl windows_core::RuntimeName for GazeInputSourcePreview {
 unsafe impl Send for GazeInputSourcePreview {}
 unsafe impl Sync for GazeInputSourcePreview {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GazeMovedPreviewEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GazeMovedPreviewEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GazeMovedPreviewEventArgs {
@@ -561,7 +561,7 @@ impl windows_core::RuntimeName for GazeMovedPreviewEventArgs {
 unsafe impl Send for GazeMovedPreviewEventArgs {}
 unsafe impl Sync for GazeMovedPreviewEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GazePointPreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GazePointPreview, windows_core::IUnknown, windows_core::IInspectable);
 impl GazePointPreview {

--- a/crates/libs/windows/src/Windows/Devices/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Input/mod.rs
@@ -220,7 +220,7 @@ pub struct ITouchCapabilities_Vtbl {
     pub Contacts: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeyboardCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeyboardCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl KeyboardCapabilities {
@@ -252,7 +252,7 @@ impl windows_core::RuntimeName for KeyboardCapabilities {
 unsafe impl Send for KeyboardCapabilities {}
 unsafe impl Sync for KeyboardCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MouseCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MouseCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl MouseCapabilities {
@@ -312,7 +312,7 @@ impl windows_core::RuntimeName for MouseCapabilities {
 unsafe impl Send for MouseCapabilities {}
 unsafe impl Sync for MouseCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MouseDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MouseDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl MouseDevice {
@@ -353,7 +353,7 @@ impl windows_core::RuntimeName for MouseDevice {
     const NAME: &'static str = "Windows.Devices.Input.MouseDevice";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MouseEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MouseEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MouseEventArgs {
@@ -376,7 +376,7 @@ impl windows_core::RuntimeName for MouseEventArgs {
     const NAME: &'static str = "Windows.Devices.Input.MouseEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PenButtonListener(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenButtonListener, windows_core::IUnknown, windows_core::IInspectable);
 impl PenButtonListener {
@@ -468,7 +468,7 @@ impl windows_core::RuntimeName for PenButtonListener {
 unsafe impl Send for PenButtonListener {}
 unsafe impl Sync for PenButtonListener {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PenDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl PenDevice {
@@ -512,7 +512,7 @@ impl windows_core::RuntimeName for PenDevice {
 unsafe impl Send for PenDevice {}
 unsafe impl Sync for PenDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PenDockListener(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenDockListener, windows_core::IUnknown, windows_core::IInspectable);
 impl PenDockListener {
@@ -590,7 +590,7 @@ impl windows_core::RuntimeName for PenDockListener {
 unsafe impl Send for PenDockListener {}
 unsafe impl Sync for PenDockListener {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PenDockedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenDockedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PenDockedEventArgs {}
@@ -607,7 +607,7 @@ impl windows_core::RuntimeName for PenDockedEventArgs {
 unsafe impl Send for PenDockedEventArgs {}
 unsafe impl Sync for PenDockedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PenTailButtonClickedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenTailButtonClickedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PenTailButtonClickedEventArgs {}
@@ -624,7 +624,7 @@ impl windows_core::RuntimeName for PenTailButtonClickedEventArgs {
 unsafe impl Send for PenTailButtonClickedEventArgs {}
 unsafe impl Sync for PenTailButtonClickedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PenTailButtonDoubleClickedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenTailButtonDoubleClickedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PenTailButtonDoubleClickedEventArgs {}
@@ -641,7 +641,7 @@ impl windows_core::RuntimeName for PenTailButtonDoubleClickedEventArgs {
 unsafe impl Send for PenTailButtonDoubleClickedEventArgs {}
 unsafe impl Sync for PenTailButtonDoubleClickedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PenTailButtonLongPressedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenTailButtonLongPressedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PenTailButtonLongPressedEventArgs {}
@@ -658,7 +658,7 @@ impl windows_core::RuntimeName for PenTailButtonLongPressedEventArgs {
 unsafe impl Send for PenTailButtonLongPressedEventArgs {}
 unsafe impl Sync for PenTailButtonLongPressedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PenUndockedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenUndockedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PenUndockedEventArgs {}
@@ -675,7 +675,7 @@ impl windows_core::RuntimeName for PenUndockedEventArgs {
 unsafe impl Send for PenUndockedEventArgs {}
 unsafe impl Sync for PenUndockedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PointerDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PointerDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl PointerDevice {
@@ -759,7 +759,7 @@ impl windows_core::RuntimeName for PointerDevice {
     const NAME: &'static str = "Windows.Devices.Input.PointerDevice";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TouchCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TouchCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl TouchCapabilities {

--- a/crates/libs/windows/src/Windows/Devices/Lights/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/Effects/mod.rs
@@ -256,7 +256,7 @@ pub struct ILampArrayUpdateRequestedEventArgs_Vtbl {
     SetColorsForIndices: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampArrayBitmapEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampArrayBitmapEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LampArrayBitmapEffect, ILampArrayEffect);
@@ -354,7 +354,7 @@ impl windows_core::RuntimeName for LampArrayBitmapEffect {
 unsafe impl Send for LampArrayBitmapEffect {}
 unsafe impl Sync for LampArrayBitmapEffect {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampArrayBitmapRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampArrayBitmapRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl LampArrayBitmapRequestedEventArgs {
@@ -387,7 +387,7 @@ impl windows_core::RuntimeName for LampArrayBitmapRequestedEventArgs {
 unsafe impl Send for LampArrayBitmapRequestedEventArgs {}
 unsafe impl Sync for LampArrayBitmapRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampArrayBlinkEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampArrayBlinkEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LampArrayBlinkEffect, ILampArrayEffect);
@@ -521,7 +521,7 @@ impl windows_core::RuntimeName for LampArrayBlinkEffect {
 unsafe impl Send for LampArrayBlinkEffect {}
 unsafe impl Sync for LampArrayBlinkEffect {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampArrayColorRampEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampArrayColorRampEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LampArrayColorRampEffect, ILampArrayEffect);
@@ -611,7 +611,7 @@ impl windows_core::RuntimeName for LampArrayColorRampEffect {
 unsafe impl Send for LampArrayColorRampEffect {}
 unsafe impl Sync for LampArrayColorRampEffect {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampArrayCustomEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampArrayCustomEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LampArrayCustomEffect, ILampArrayEffect);
@@ -691,7 +691,7 @@ impl windows_core::RuntimeName for LampArrayCustomEffect {
 unsafe impl Send for LampArrayCustomEffect {}
 unsafe impl Sync for LampArrayCustomEffect {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampArrayEffectPlaylist(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampArrayEffectPlaylist, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -859,7 +859,7 @@ impl IntoIterator for &LampArrayEffectPlaylist {
 unsafe impl Send for LampArrayEffectPlaylist {}
 unsafe impl Sync for LampArrayEffectPlaylist {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampArraySolidEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampArraySolidEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LampArraySolidEffect, ILampArrayEffect);
@@ -949,7 +949,7 @@ impl windows_core::RuntimeName for LampArraySolidEffect {
 unsafe impl Send for LampArraySolidEffect {}
 unsafe impl Sync for LampArraySolidEffect {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampArrayUpdateRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampArrayUpdateRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl LampArrayUpdateRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
@@ -160,7 +160,7 @@ pub struct ILampStatics_Vtbl {
     pub GetDefaultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Lamp(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Lamp, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Lamp, super::super::Foundation::IClosable);
@@ -269,7 +269,7 @@ impl windows_core::RuntimeName for Lamp {
 unsafe impl Send for Lamp {}
 unsafe impl Sync for Lamp {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampArray(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampArray, windows_core::IUnknown, windows_core::IInspectable);
 impl LampArray {
@@ -494,7 +494,7 @@ impl windows_core::RuntimeName for LampArray {
 unsafe impl Send for LampArray {}
 unsafe impl Sync for LampArray {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampAvailabilityChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampAvailabilityChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl LampAvailabilityChangedEventArgs {
@@ -519,7 +519,7 @@ impl windows_core::RuntimeName for LampAvailabilityChangedEventArgs {
 unsafe impl Send for LampAvailabilityChangedEventArgs {}
 unsafe impl Sync for LampAvailabilityChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LampInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LampInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl LampInfo {

--- a/crates/libs/windows/src/Windows/Devices/Midi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Midi/mod.rs
@@ -369,7 +369,7 @@ pub struct IMidiTimeCodeMessageFactory_Vtbl {
     pub CreateMidiTimeCodeMessage: unsafe extern "system" fn(*mut core::ffi::c_void, u8, u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiActiveSensingMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiActiveSensingMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiActiveSensingMessage, IMidiMessage);
@@ -417,7 +417,7 @@ impl windows_core::RuntimeName for MidiActiveSensingMessage {
 unsafe impl Send for MidiActiveSensingMessage {}
 unsafe impl Sync for MidiActiveSensingMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiChannelPressureMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiChannelPressureMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiChannelPressureMessage, IMidiMessage);
@@ -483,7 +483,7 @@ impl windows_core::RuntimeName for MidiChannelPressureMessage {
 unsafe impl Send for MidiChannelPressureMessage {}
 unsafe impl Sync for MidiChannelPressureMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiContinueMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiContinueMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiContinueMessage, IMidiMessage);
@@ -531,7 +531,7 @@ impl windows_core::RuntimeName for MidiContinueMessage {
 unsafe impl Send for MidiContinueMessage {}
 unsafe impl Sync for MidiContinueMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiControlChangeMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiControlChangeMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiControlChangeMessage, IMidiMessage);
@@ -604,7 +604,7 @@ impl windows_core::RuntimeName for MidiControlChangeMessage {
 unsafe impl Send for MidiControlChangeMessage {}
 unsafe impl Sync for MidiControlChangeMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiInPort(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiInPort, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiInPort, super::super::Foundation::IClosable);
@@ -665,7 +665,7 @@ impl windows_core::RuntimeName for MidiInPort {
 unsafe impl Send for MidiInPort {}
 unsafe impl Sync for MidiInPort {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiMessageReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiMessageReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MidiMessageReceivedEventArgs {
@@ -690,7 +690,7 @@ impl windows_core::RuntimeName for MidiMessageReceivedEventArgs {
 unsafe impl Send for MidiMessageReceivedEventArgs {}
 unsafe impl Sync for MidiMessageReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiNoteOffMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiNoteOffMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiNoteOffMessage, IMidiMessage);
@@ -763,7 +763,7 @@ impl windows_core::RuntimeName for MidiNoteOffMessage {
 unsafe impl Send for MidiNoteOffMessage {}
 unsafe impl Sync for MidiNoteOffMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiNoteOnMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiNoteOnMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiNoteOnMessage, IMidiMessage);
@@ -836,7 +836,7 @@ impl windows_core::RuntimeName for MidiNoteOnMessage {
 unsafe impl Send for MidiNoteOnMessage {}
 unsafe impl Sync for MidiNoteOnMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiOutPort(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiOutPort, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiOutPort, super::super::Foundation::IClosable, IMidiOutPort);
@@ -898,7 +898,7 @@ impl windows_core::RuntimeName for MidiOutPort {
 unsafe impl Send for MidiOutPort {}
 unsafe impl Sync for MidiOutPort {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiPitchBendChangeMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiPitchBendChangeMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiPitchBendChangeMessage, IMidiMessage);
@@ -964,7 +964,7 @@ impl windows_core::RuntimeName for MidiPitchBendChangeMessage {
 unsafe impl Send for MidiPitchBendChangeMessage {}
 unsafe impl Sync for MidiPitchBendChangeMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiPolyphonicKeyPressureMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiPolyphonicKeyPressureMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiPolyphonicKeyPressureMessage, IMidiMessage);
@@ -1037,7 +1037,7 @@ impl windows_core::RuntimeName for MidiPolyphonicKeyPressureMessage {
 unsafe impl Send for MidiPolyphonicKeyPressureMessage {}
 unsafe impl Sync for MidiPolyphonicKeyPressureMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiProgramChangeMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiProgramChangeMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiProgramChangeMessage, IMidiMessage);
@@ -1103,7 +1103,7 @@ impl windows_core::RuntimeName for MidiProgramChangeMessage {
 unsafe impl Send for MidiProgramChangeMessage {}
 unsafe impl Sync for MidiProgramChangeMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiSongPositionPointerMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiSongPositionPointerMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiSongPositionPointerMessage, IMidiMessage);
@@ -1162,7 +1162,7 @@ impl windows_core::RuntimeName for MidiSongPositionPointerMessage {
 unsafe impl Send for MidiSongPositionPointerMessage {}
 unsafe impl Sync for MidiSongPositionPointerMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiSongSelectMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiSongSelectMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiSongSelectMessage, IMidiMessage);
@@ -1221,7 +1221,7 @@ impl windows_core::RuntimeName for MidiSongSelectMessage {
 unsafe impl Send for MidiSongSelectMessage {}
 unsafe impl Sync for MidiSongSelectMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiStartMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiStartMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiStartMessage, IMidiMessage);
@@ -1269,7 +1269,7 @@ impl windows_core::RuntimeName for MidiStartMessage {
 unsafe impl Send for MidiStartMessage {}
 unsafe impl Sync for MidiStartMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiStopMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiStopMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiStopMessage, IMidiMessage);
@@ -1317,7 +1317,7 @@ impl windows_core::RuntimeName for MidiStopMessage {
 unsafe impl Send for MidiStopMessage {}
 unsafe impl Sync for MidiStopMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiSynthesizer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiSynthesizer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiSynthesizer, super::super::Foundation::IClosable, IMidiOutPort);
@@ -1412,7 +1412,7 @@ impl windows_core::RuntimeName for MidiSynthesizer {
 unsafe impl Send for MidiSynthesizer {}
 unsafe impl Sync for MidiSynthesizer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiSystemExclusiveMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiSystemExclusiveMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiSystemExclusiveMessage, IMidiMessage);
@@ -1468,7 +1468,7 @@ impl windows_core::RuntimeName for MidiSystemExclusiveMessage {
 unsafe impl Send for MidiSystemExclusiveMessage {}
 unsafe impl Sync for MidiSystemExclusiveMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiSystemResetMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiSystemResetMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiSystemResetMessage, IMidiMessage);
@@ -1516,7 +1516,7 @@ impl windows_core::RuntimeName for MidiSystemResetMessage {
 unsafe impl Send for MidiSystemResetMessage {}
 unsafe impl Sync for MidiSystemResetMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiTimeCodeMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiTimeCodeMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiTimeCodeMessage, IMidiMessage);
@@ -1582,7 +1582,7 @@ impl windows_core::RuntimeName for MidiTimeCodeMessage {
 unsafe impl Send for MidiTimeCodeMessage {}
 unsafe impl Sync for MidiTimeCodeMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiTimingClockMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiTimingClockMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiTimingClockMessage, IMidiMessage);
@@ -1630,7 +1630,7 @@ impl windows_core::RuntimeName for MidiTimingClockMessage {
 unsafe impl Send for MidiTimingClockMessage {}
 unsafe impl Sync for MidiTimingClockMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MidiTuneRequestMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MidiTuneRequestMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MidiTuneRequestMessage, IMidiMessage);

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/Provider/mod.rs
@@ -369,7 +369,7 @@ pub struct IBarcodeSymbologyAttributesBuilder_Vtbl {
     pub CreateAttributes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerDisableScannerRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerDisableScannerRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerDisableScannerRequest {
@@ -415,7 +415,7 @@ impl windows_core::RuntimeName for BarcodeScannerDisableScannerRequest {
 unsafe impl Send for BarcodeScannerDisableScannerRequest {}
 unsafe impl Sync for BarcodeScannerDisableScannerRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerDisableScannerRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerDisableScannerRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerDisableScannerRequestEventArgs {
@@ -447,7 +447,7 @@ impl windows_core::RuntimeName for BarcodeScannerDisableScannerRequestEventArgs 
 unsafe impl Send for BarcodeScannerDisableScannerRequestEventArgs {}
 unsafe impl Sync for BarcodeScannerDisableScannerRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerEnableScannerRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerEnableScannerRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerEnableScannerRequest {
@@ -493,7 +493,7 @@ impl windows_core::RuntimeName for BarcodeScannerEnableScannerRequest {
 unsafe impl Send for BarcodeScannerEnableScannerRequest {}
 unsafe impl Sync for BarcodeScannerEnableScannerRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerEnableScannerRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerEnableScannerRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerEnableScannerRequestEventArgs {
@@ -525,7 +525,7 @@ impl windows_core::RuntimeName for BarcodeScannerEnableScannerRequestEventArgs {
 unsafe impl Send for BarcodeScannerEnableScannerRequestEventArgs {}
 unsafe impl Sync for BarcodeScannerEnableScannerRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerFrameReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerFrameReader, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BarcodeScannerFrameReader, super::super::super::Foundation::IClosable);
@@ -590,7 +590,7 @@ impl windows_core::RuntimeName for BarcodeScannerFrameReader {
 unsafe impl Send for BarcodeScannerFrameReader {}
 unsafe impl Sync for BarcodeScannerFrameReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerFrameReaderFrameArrivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerFrameReaderFrameArrivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerFrameReaderFrameArrivedEventArgs {
@@ -615,7 +615,7 @@ impl windows_core::RuntimeName for BarcodeScannerFrameReaderFrameArrivedEventArg
 unsafe impl Send for BarcodeScannerFrameReaderFrameArrivedEventArgs {}
 unsafe impl Sync for BarcodeScannerFrameReaderFrameArrivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerGetSymbologyAttributesRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerGetSymbologyAttributesRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerGetSymbologyAttributesRequest {
@@ -671,7 +671,7 @@ impl windows_core::RuntimeName for BarcodeScannerGetSymbologyAttributesRequest {
 unsafe impl Send for BarcodeScannerGetSymbologyAttributesRequest {}
 unsafe impl Sync for BarcodeScannerGetSymbologyAttributesRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerGetSymbologyAttributesRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerGetSymbologyAttributesRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerGetSymbologyAttributesRequestEventArgs {
@@ -703,7 +703,7 @@ impl windows_core::RuntimeName for BarcodeScannerGetSymbologyAttributesRequestEv
 unsafe impl Send for BarcodeScannerGetSymbologyAttributesRequestEventArgs {}
 unsafe impl Sync for BarcodeScannerGetSymbologyAttributesRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerHideVideoPreviewRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerHideVideoPreviewRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerHideVideoPreviewRequest {
@@ -749,7 +749,7 @@ impl windows_core::RuntimeName for BarcodeScannerHideVideoPreviewRequest {
 unsafe impl Send for BarcodeScannerHideVideoPreviewRequest {}
 unsafe impl Sync for BarcodeScannerHideVideoPreviewRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerHideVideoPreviewRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerHideVideoPreviewRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerHideVideoPreviewRequestEventArgs {
@@ -781,7 +781,7 @@ impl windows_core::RuntimeName for BarcodeScannerHideVideoPreviewRequestEventArg
 unsafe impl Send for BarcodeScannerHideVideoPreviewRequestEventArgs {}
 unsafe impl Sync for BarcodeScannerHideVideoPreviewRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerProviderConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerProviderConnection, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BarcodeScannerProviderConnection, super::super::super::Foundation::IClosable);
@@ -1036,7 +1036,7 @@ impl windows_core::RuntimeName for BarcodeScannerProviderConnection {
 unsafe impl Send for BarcodeScannerProviderConnection {}
 unsafe impl Sync for BarcodeScannerProviderConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerProviderTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerProviderTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerProviderTriggerDetails {
@@ -1061,7 +1061,7 @@ impl windows_core::RuntimeName for BarcodeScannerProviderTriggerDetails {
 unsafe impl Send for BarcodeScannerProviderTriggerDetails {}
 unsafe impl Sync for BarcodeScannerProviderTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerSetActiveSymbologiesRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerSetActiveSymbologiesRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerSetActiveSymbologiesRequest {
@@ -1115,7 +1115,7 @@ impl windows_core::RuntimeName for BarcodeScannerSetActiveSymbologiesRequest {
 unsafe impl Send for BarcodeScannerSetActiveSymbologiesRequest {}
 unsafe impl Sync for BarcodeScannerSetActiveSymbologiesRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerSetActiveSymbologiesRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerSetActiveSymbologiesRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerSetActiveSymbologiesRequestEventArgs {
@@ -1147,7 +1147,7 @@ impl windows_core::RuntimeName for BarcodeScannerSetActiveSymbologiesRequestEven
 unsafe impl Send for BarcodeScannerSetActiveSymbologiesRequestEventArgs {}
 unsafe impl Sync for BarcodeScannerSetActiveSymbologiesRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerSetSymbologyAttributesRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerSetSymbologyAttributesRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerSetSymbologyAttributesRequest {
@@ -1207,7 +1207,7 @@ impl windows_core::RuntimeName for BarcodeScannerSetSymbologyAttributesRequest {
 unsafe impl Send for BarcodeScannerSetSymbologyAttributesRequest {}
 unsafe impl Sync for BarcodeScannerSetSymbologyAttributesRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerSetSymbologyAttributesRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerSetSymbologyAttributesRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerSetSymbologyAttributesRequestEventArgs {
@@ -1239,7 +1239,7 @@ impl windows_core::RuntimeName for BarcodeScannerSetSymbologyAttributesRequestEv
 unsafe impl Send for BarcodeScannerSetSymbologyAttributesRequestEventArgs {}
 unsafe impl Sync for BarcodeScannerSetSymbologyAttributesRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerStartSoftwareTriggerRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerStartSoftwareTriggerRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerStartSoftwareTriggerRequest {
@@ -1285,7 +1285,7 @@ impl windows_core::RuntimeName for BarcodeScannerStartSoftwareTriggerRequest {
 unsafe impl Send for BarcodeScannerStartSoftwareTriggerRequest {}
 unsafe impl Sync for BarcodeScannerStartSoftwareTriggerRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerStartSoftwareTriggerRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerStartSoftwareTriggerRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerStartSoftwareTriggerRequestEventArgs {
@@ -1317,7 +1317,7 @@ impl windows_core::RuntimeName for BarcodeScannerStartSoftwareTriggerRequestEven
 unsafe impl Send for BarcodeScannerStartSoftwareTriggerRequestEventArgs {}
 unsafe impl Sync for BarcodeScannerStartSoftwareTriggerRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerStopSoftwareTriggerRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerStopSoftwareTriggerRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerStopSoftwareTriggerRequest {
@@ -1363,7 +1363,7 @@ impl windows_core::RuntimeName for BarcodeScannerStopSoftwareTriggerRequest {
 unsafe impl Send for BarcodeScannerStopSoftwareTriggerRequest {}
 unsafe impl Sync for BarcodeScannerStopSoftwareTriggerRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerStopSoftwareTriggerRequestEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerStopSoftwareTriggerRequestEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerStopSoftwareTriggerRequestEventArgs {
@@ -1395,7 +1395,7 @@ impl windows_core::RuntimeName for BarcodeScannerStopSoftwareTriggerRequestEvent
 unsafe impl Send for BarcodeScannerStopSoftwareTriggerRequestEventArgs {}
 unsafe impl Sync for BarcodeScannerStopSoftwareTriggerRequestEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerVideoFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerVideoFrame, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BarcodeScannerVideoFrame, super::super::super::Foundation::IClosable);
@@ -1448,7 +1448,7 @@ impl windows_core::RuntimeName for BarcodeScannerVideoFrame {
 unsafe impl Send for BarcodeScannerVideoFrame {}
 unsafe impl Sync for BarcodeScannerVideoFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeSymbologyAttributesBuilder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeSymbologyAttributesBuilder, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeSymbologyAttributesBuilder {

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
@@ -2234,7 +2234,7 @@ pub struct IUnifiedPosErrorDataFactory_Vtbl {
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, UnifiedPosErrorSeverity, UnifiedPosErrorReason, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScanner(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScanner, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BarcodeScanner, super::super::Foundation::IClosable);
@@ -2381,7 +2381,7 @@ impl windows_core::RuntimeName for BarcodeScanner {
 unsafe impl Send for BarcodeScanner {}
 unsafe impl Sync for BarcodeScanner {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerCapabilities {
@@ -2441,7 +2441,7 @@ impl windows_core::RuntimeName for BarcodeScannerCapabilities {
 unsafe impl Send for BarcodeScannerCapabilities {}
 unsafe impl Sync for BarcodeScannerCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerDataReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerDataReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerDataReceivedEventArgs {
@@ -2466,7 +2466,7 @@ impl windows_core::RuntimeName for BarcodeScannerDataReceivedEventArgs {
 unsafe impl Send for BarcodeScannerDataReceivedEventArgs {}
 unsafe impl Sync for BarcodeScannerDataReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerErrorOccurredEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerErrorOccurredEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerErrorOccurredEventArgs {
@@ -2505,7 +2505,7 @@ impl windows_core::RuntimeName for BarcodeScannerErrorOccurredEventArgs {
 unsafe impl Send for BarcodeScannerErrorOccurredEventArgs {}
 unsafe impl Sync for BarcodeScannerErrorOccurredEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerImagePreviewReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerImagePreviewReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerImagePreviewReceivedEventArgs {
@@ -2531,7 +2531,7 @@ impl windows_core::RuntimeName for BarcodeScannerImagePreviewReceivedEventArgs {
 unsafe impl Send for BarcodeScannerImagePreviewReceivedEventArgs {}
 unsafe impl Sync for BarcodeScannerImagePreviewReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerReport, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerReport {
@@ -2588,7 +2588,7 @@ impl windows_core::RuntimeName for BarcodeScannerReport {
 unsafe impl Send for BarcodeScannerReport {}
 unsafe impl Sync for BarcodeScannerReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeScannerStatusUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeScannerStatusUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeScannerStatusUpdatedEventArgs {
@@ -3206,7 +3206,7 @@ impl windows_core::RuntimeName for BarcodeSymbologies {
     const NAME: &'static str = "Windows.Devices.PointOfService.BarcodeSymbologies";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarcodeSymbologyAttributes(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarcodeSymbologyAttributes, windows_core::IUnknown, windows_core::IInspectable);
 impl BarcodeSymbologyAttributes {
@@ -3300,7 +3300,7 @@ impl windows_core::RuntimeName for BarcodeSymbologyAttributes {
 unsafe impl Send for BarcodeSymbologyAttributes {}
 unsafe impl Sync for BarcodeSymbologyAttributes {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CashDrawer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CashDrawer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CashDrawer, super::super::Foundation::IClosable);
@@ -3431,7 +3431,7 @@ impl windows_core::RuntimeName for CashDrawer {
 unsafe impl Send for CashDrawer {}
 unsafe impl Sync for CashDrawer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CashDrawerCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CashDrawerCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl CashDrawerCapabilities {
@@ -3491,7 +3491,7 @@ impl windows_core::RuntimeName for CashDrawerCapabilities {
 unsafe impl Send for CashDrawerCapabilities {}
 unsafe impl Sync for CashDrawerCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CashDrawerCloseAlarm(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CashDrawerCloseAlarm, windows_core::IUnknown, windows_core::IInspectable);
 impl CashDrawerCloseAlarm {
@@ -3574,7 +3574,7 @@ impl windows_core::RuntimeName for CashDrawerCloseAlarm {
 unsafe impl Send for CashDrawerCloseAlarm {}
 unsafe impl Sync for CashDrawerCloseAlarm {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CashDrawerClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CashDrawerClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CashDrawerClosedEventArgs, ICashDrawerEventSourceEventArgs);
@@ -3600,7 +3600,7 @@ impl windows_core::RuntimeName for CashDrawerClosedEventArgs {
 unsafe impl Send for CashDrawerClosedEventArgs {}
 unsafe impl Sync for CashDrawerClosedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CashDrawerEventSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CashDrawerEventSource, windows_core::IUnknown, windows_core::IInspectable);
 impl CashDrawerEventSource {
@@ -3646,7 +3646,7 @@ impl windows_core::RuntimeName for CashDrawerEventSource {
 unsafe impl Send for CashDrawerEventSource {}
 unsafe impl Sync for CashDrawerEventSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CashDrawerOpenedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CashDrawerOpenedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CashDrawerOpenedEventArgs, ICashDrawerEventSourceEventArgs);
@@ -3672,7 +3672,7 @@ impl windows_core::RuntimeName for CashDrawerOpenedEventArgs {
 unsafe impl Send for CashDrawerOpenedEventArgs {}
 unsafe impl Sync for CashDrawerOpenedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CashDrawerStatus(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CashDrawerStatus, windows_core::IUnknown, windows_core::IInspectable);
 impl CashDrawerStatus {
@@ -3704,7 +3704,7 @@ impl windows_core::RuntimeName for CashDrawerStatus {
 unsafe impl Send for CashDrawerStatus {}
 unsafe impl Sync for CashDrawerStatus {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CashDrawerStatusUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CashDrawerStatusUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CashDrawerStatusUpdatedEventArgs {
@@ -3729,7 +3729,7 @@ impl windows_core::RuntimeName for CashDrawerStatusUpdatedEventArgs {
 unsafe impl Send for CashDrawerStatusUpdatedEventArgs {}
 unsafe impl Sync for CashDrawerStatusUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedBarcodeScanner(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedBarcodeScanner, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ClaimedBarcodeScanner, super::super::Foundation::IClosable);
@@ -3997,7 +3997,7 @@ impl windows_core::RuntimeName for ClaimedBarcodeScanner {
 unsafe impl Send for ClaimedBarcodeScanner {}
 unsafe impl Sync for ClaimedBarcodeScanner {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedBarcodeScannerClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedBarcodeScannerClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClaimedBarcodeScannerClosedEventArgs {}
@@ -4014,7 +4014,7 @@ impl windows_core::RuntimeName for ClaimedBarcodeScannerClosedEventArgs {
 unsafe impl Send for ClaimedBarcodeScannerClosedEventArgs {}
 unsafe impl Sync for ClaimedBarcodeScannerClosedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedCashDrawer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedCashDrawer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ClaimedCashDrawer, super::super::Foundation::IClosable);
@@ -4143,7 +4143,7 @@ impl windows_core::RuntimeName for ClaimedCashDrawer {
 unsafe impl Send for ClaimedCashDrawer {}
 unsafe impl Sync for ClaimedCashDrawer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedCashDrawerClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedCashDrawerClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClaimedCashDrawerClosedEventArgs {}
@@ -4160,7 +4160,7 @@ impl windows_core::RuntimeName for ClaimedCashDrawerClosedEventArgs {
 unsafe impl Send for ClaimedCashDrawerClosedEventArgs {}
 unsafe impl Sync for ClaimedCashDrawerClosedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedJournalPrinter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedJournalPrinter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ClaimedJournalPrinter, ICommonClaimedPosPrinterStation);
@@ -4304,7 +4304,7 @@ impl windows_core::RuntimeName for ClaimedJournalPrinter {
 unsafe impl Send for ClaimedJournalPrinter {}
 unsafe impl Sync for ClaimedJournalPrinter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedLineDisplay(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedLineDisplay, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ClaimedLineDisplay, super::super::Foundation::IClosable);
@@ -4578,7 +4578,7 @@ impl windows_core::RuntimeName for ClaimedLineDisplay {
 unsafe impl Send for ClaimedLineDisplay {}
 unsafe impl Sync for ClaimedLineDisplay {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedLineDisplayClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedLineDisplayClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClaimedLineDisplayClosedEventArgs {}
@@ -4595,7 +4595,7 @@ impl windows_core::RuntimeName for ClaimedLineDisplayClosedEventArgs {
 unsafe impl Send for ClaimedLineDisplayClosedEventArgs {}
 unsafe impl Sync for ClaimedLineDisplayClosedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedMagneticStripeReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedMagneticStripeReader, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ClaimedMagneticStripeReader, super::super::Foundation::IClosable);
@@ -4851,7 +4851,7 @@ impl windows_core::RuntimeName for ClaimedMagneticStripeReader {
 unsafe impl Send for ClaimedMagneticStripeReader {}
 unsafe impl Sync for ClaimedMagneticStripeReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedMagneticStripeReaderClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedMagneticStripeReaderClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClaimedMagneticStripeReaderClosedEventArgs {}
@@ -4868,7 +4868,7 @@ impl windows_core::RuntimeName for ClaimedMagneticStripeReaderClosedEventArgs {
 unsafe impl Send for ClaimedMagneticStripeReaderClosedEventArgs {}
 unsafe impl Sync for ClaimedMagneticStripeReaderClosedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedPosPrinter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedPosPrinter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ClaimedPosPrinter, super::super::Foundation::IClosable);
@@ -5037,7 +5037,7 @@ impl windows_core::RuntimeName for ClaimedPosPrinter {
 unsafe impl Send for ClaimedPosPrinter {}
 unsafe impl Sync for ClaimedPosPrinter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedPosPrinterClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedPosPrinterClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClaimedPosPrinterClosedEventArgs {}
@@ -5054,7 +5054,7 @@ impl windows_core::RuntimeName for ClaimedPosPrinterClosedEventArgs {
 unsafe impl Send for ClaimedPosPrinterClosedEventArgs {}
 unsafe impl Sync for ClaimedPosPrinterClosedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedReceiptPrinter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedReceiptPrinter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ClaimedReceiptPrinter, ICommonClaimedPosPrinterStation);
@@ -5233,7 +5233,7 @@ impl windows_core::RuntimeName for ClaimedReceiptPrinter {
 unsafe impl Send for ClaimedReceiptPrinter {}
 unsafe impl Sync for ClaimedReceiptPrinter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClaimedSlipPrinter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedSlipPrinter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ClaimedSlipPrinter, ICommonClaimedPosPrinterStation);
@@ -5452,7 +5452,7 @@ impl windows_core::RuntimeName for ClaimedSlipPrinter {
 unsafe impl Send for ClaimedSlipPrinter {}
 unsafe impl Sync for ClaimedSlipPrinter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct JournalPrintJob(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(JournalPrintJob, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(JournalPrintJob, IPosPrinterJob);
@@ -5505,7 +5505,7 @@ impl windows_core::RuntimeName for JournalPrintJob {
 unsafe impl Send for JournalPrintJob {}
 unsafe impl Sync for JournalPrintJob {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct JournalPrinterCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(JournalPrinterCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(JournalPrinterCapabilities, ICommonPosPrintStationCapabilities);
@@ -5658,7 +5658,7 @@ impl windows_core::RuntimeName for JournalPrinterCapabilities {
 unsafe impl Send for JournalPrinterCapabilities {}
 unsafe impl Sync for JournalPrinterCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplay(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplay, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LineDisplay, super::super::Foundation::IClosable);
@@ -5784,7 +5784,7 @@ impl windows_core::RuntimeName for LineDisplay {
 unsafe impl Send for LineDisplay {}
 unsafe impl Sync for LineDisplay {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplayAttributes(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplayAttributes, windows_core::IUnknown, windows_core::IInspectable);
 impl LineDisplayAttributes {
@@ -5882,7 +5882,7 @@ impl windows_core::RuntimeName for LineDisplayAttributes {
 unsafe impl Send for LineDisplayAttributes {}
 unsafe impl Sync for LineDisplayAttributes {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplayCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplayCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl LineDisplayCapabilities {
@@ -6026,7 +6026,7 @@ impl windows_core::RuntimeName for LineDisplayCapabilities {
 unsafe impl Send for LineDisplayCapabilities {}
 unsafe impl Sync for LineDisplayCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplayCursor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplayCursor, windows_core::IUnknown, windows_core::IInspectable);
 impl LineDisplayCursor {
@@ -6110,7 +6110,7 @@ impl windows_core::RuntimeName for LineDisplayCursor {
 unsafe impl Send for LineDisplayCursor {}
 unsafe impl Sync for LineDisplayCursor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplayCursorAttributes(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplayCursorAttributes, windows_core::IUnknown, windows_core::IInspectable);
 impl LineDisplayCursorAttributes {
@@ -6172,7 +6172,7 @@ impl windows_core::RuntimeName for LineDisplayCursorAttributes {
 unsafe impl Send for LineDisplayCursorAttributes {}
 unsafe impl Sync for LineDisplayCursorAttributes {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplayCustomGlyphs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplayCustomGlyphs, windows_core::IUnknown, windows_core::IInspectable);
 impl LineDisplayCustomGlyphs {
@@ -6216,7 +6216,7 @@ impl windows_core::RuntimeName for LineDisplayCustomGlyphs {
 unsafe impl Send for LineDisplayCustomGlyphs {}
 unsafe impl Sync for LineDisplayCustomGlyphs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplayMarquee(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplayMarquee, windows_core::IUnknown, windows_core::IInspectable);
 impl LineDisplayMarquee {
@@ -6281,7 +6281,7 @@ impl windows_core::RuntimeName for LineDisplayMarquee {
 unsafe impl Send for LineDisplayMarquee {}
 unsafe impl Sync for LineDisplayMarquee {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplayStatisticsCategorySelector(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplayStatisticsCategorySelector, windows_core::IUnknown, windows_core::IInspectable);
 impl LineDisplayStatisticsCategorySelector {
@@ -6320,7 +6320,7 @@ impl windows_core::RuntimeName for LineDisplayStatisticsCategorySelector {
 unsafe impl Send for LineDisplayStatisticsCategorySelector {}
 unsafe impl Sync for LineDisplayStatisticsCategorySelector {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplayStatusUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplayStatusUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl LineDisplayStatusUpdatedEventArgs {
@@ -6345,7 +6345,7 @@ impl windows_core::RuntimeName for LineDisplayStatusUpdatedEventArgs {
 unsafe impl Send for LineDisplayStatusUpdatedEventArgs {}
 unsafe impl Sync for LineDisplayStatusUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplayStoredBitmap(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplayStoredBitmap, windows_core::IUnknown, windows_core::IInspectable);
 impl LineDisplayStoredBitmap {
@@ -6377,7 +6377,7 @@ impl windows_core::RuntimeName for LineDisplayStoredBitmap {
 unsafe impl Send for LineDisplayStoredBitmap {}
 unsafe impl Sync for LineDisplayStoredBitmap {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LineDisplayWindow(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LineDisplayWindow, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LineDisplayWindow, super::super::Foundation::IClosable);
@@ -6546,7 +6546,7 @@ impl windows_core::RuntimeName for LineDisplayWindow {
 unsafe impl Send for LineDisplayWindow {}
 unsafe impl Sync for LineDisplayWindow {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagneticStripeReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagneticStripeReader, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MagneticStripeReader, super::super::Foundation::IClosable);
@@ -6677,7 +6677,7 @@ impl windows_core::RuntimeName for MagneticStripeReader {
 unsafe impl Send for MagneticStripeReader {}
 unsafe impl Sync for MagneticStripeReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagneticStripeReaderAamvaCardDataReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagneticStripeReaderAamvaCardDataReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MagneticStripeReaderAamvaCardDataReceivedEventArgs {
@@ -6828,7 +6828,7 @@ impl windows_core::RuntimeName for MagneticStripeReaderAamvaCardDataReceivedEven
 unsafe impl Send for MagneticStripeReaderAamvaCardDataReceivedEventArgs {}
 unsafe impl Sync for MagneticStripeReaderAamvaCardDataReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagneticStripeReaderBankCardDataReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagneticStripeReaderBankCardDataReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MagneticStripeReaderBankCardDataReceivedEventArgs {
@@ -6909,7 +6909,7 @@ impl windows_core::RuntimeName for MagneticStripeReaderBankCardDataReceivedEvent
 unsafe impl Send for MagneticStripeReaderBankCardDataReceivedEventArgs {}
 unsafe impl Sync for MagneticStripeReaderBankCardDataReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagneticStripeReaderCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagneticStripeReaderCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl MagneticStripeReaderCapabilities {
@@ -7068,7 +7068,7 @@ impl windows_core::RuntimeName for MagneticStripeReaderEncryptionAlgorithms {
     const NAME: &'static str = "Windows.Devices.PointOfService.MagneticStripeReaderEncryptionAlgorithms";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagneticStripeReaderErrorOccurredEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagneticStripeReaderErrorOccurredEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MagneticStripeReaderErrorOccurredEventArgs {
@@ -7128,7 +7128,7 @@ impl windows_core::RuntimeName for MagneticStripeReaderErrorOccurredEventArgs {
 unsafe impl Send for MagneticStripeReaderErrorOccurredEventArgs {}
 unsafe impl Sync for MagneticStripeReaderErrorOccurredEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagneticStripeReaderReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagneticStripeReaderReport, windows_core::IUnknown, windows_core::IInspectable);
 impl MagneticStripeReaderReport {
@@ -7212,7 +7212,7 @@ impl windows_core::RuntimeName for MagneticStripeReaderReport {
 unsafe impl Send for MagneticStripeReaderReport {}
 unsafe impl Sync for MagneticStripeReaderReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagneticStripeReaderStatusUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagneticStripeReaderStatusUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MagneticStripeReaderStatusUpdatedEventArgs {
@@ -7244,7 +7244,7 @@ impl windows_core::RuntimeName for MagneticStripeReaderStatusUpdatedEventArgs {
 unsafe impl Send for MagneticStripeReaderStatusUpdatedEventArgs {}
 unsafe impl Sync for MagneticStripeReaderStatusUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagneticStripeReaderTrackData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagneticStripeReaderTrackData, windows_core::IUnknown, windows_core::IInspectable);
 impl MagneticStripeReaderTrackData {
@@ -7286,7 +7286,7 @@ impl windows_core::RuntimeName for MagneticStripeReaderTrackData {
 unsafe impl Send for MagneticStripeReaderTrackData {}
 unsafe impl Sync for MagneticStripeReaderTrackData {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {
@@ -7311,7 +7311,7 @@ impl windows_core::RuntimeName for MagneticStripeReaderVendorSpecificCardDataRec
 unsafe impl Send for MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {}
 unsafe impl Sync for MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PosPrinter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PosPrinter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PosPrinter, super::super::Foundation::IClosable);
@@ -7459,7 +7459,7 @@ impl windows_core::RuntimeName for PosPrinter {
 unsafe impl Send for PosPrinter {}
 unsafe impl Sync for PosPrinter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PosPrinterCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PosPrinterCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl PosPrinterCapabilities {
@@ -7576,7 +7576,7 @@ impl windows_core::RuntimeName for PosPrinterCharacterSetIds {
     const NAME: &'static str = "Windows.Devices.PointOfService.PosPrinterCharacterSetIds";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PosPrinterFontProperty(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PosPrinterFontProperty, windows_core::IUnknown, windows_core::IInspectable);
 impl PosPrinterFontProperty {
@@ -7616,7 +7616,7 @@ impl windows_core::RuntimeName for PosPrinterFontProperty {
 unsafe impl Send for PosPrinterFontProperty {}
 unsafe impl Sync for PosPrinterFontProperty {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PosPrinterPrintOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PosPrinterPrintOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl PosPrinterPrintOptions {
@@ -7784,7 +7784,7 @@ impl windows_core::RuntimeName for PosPrinterPrintOptions {
 unsafe impl Send for PosPrinterPrintOptions {}
 unsafe impl Sync for PosPrinterPrintOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PosPrinterReleaseDeviceRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PosPrinterReleaseDeviceRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PosPrinterReleaseDeviceRequestedEventArgs {}
@@ -7801,7 +7801,7 @@ impl windows_core::RuntimeName for PosPrinterReleaseDeviceRequestedEventArgs {
 unsafe impl Send for PosPrinterReleaseDeviceRequestedEventArgs {}
 unsafe impl Sync for PosPrinterReleaseDeviceRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PosPrinterStatus(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PosPrinterStatus, windows_core::IUnknown, windows_core::IInspectable);
 impl PosPrinterStatus {
@@ -7833,7 +7833,7 @@ impl windows_core::RuntimeName for PosPrinterStatus {
 unsafe impl Send for PosPrinterStatus {}
 unsafe impl Sync for PosPrinterStatus {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PosPrinterStatusUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PosPrinterStatusUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PosPrinterStatusUpdatedEventArgs {
@@ -7858,7 +7858,7 @@ impl windows_core::RuntimeName for PosPrinterStatusUpdatedEventArgs {
 unsafe impl Send for PosPrinterStatusUpdatedEventArgs {}
 unsafe impl Sync for PosPrinterStatusUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ReceiptPrintJob(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ReceiptPrintJob, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ReceiptPrintJob, IPosPrinterJob, IReceiptOrSlipJob);
@@ -8019,7 +8019,7 @@ impl windows_core::RuntimeName for ReceiptPrintJob {
 unsafe impl Send for ReceiptPrintJob {}
 unsafe impl Sync for ReceiptPrintJob {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ReceiptPrinterCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ReceiptPrinterCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ReceiptPrinterCapabilities, ICommonPosPrintStationCapabilities, ICommonReceiptSlipCapabilities);
@@ -8258,7 +8258,7 @@ impl windows_core::RuntimeName for ReceiptPrinterCapabilities {
 unsafe impl Send for ReceiptPrinterCapabilities {}
 unsafe impl Sync for ReceiptPrinterCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SlipPrintJob(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SlipPrintJob, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SlipPrintJob, IPosPrinterJob, IReceiptOrSlipJob);
@@ -8403,7 +8403,7 @@ impl windows_core::RuntimeName for SlipPrintJob {
 unsafe impl Send for SlipPrintJob {}
 unsafe impl Sync for SlipPrintJob {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SlipPrinterCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SlipPrinterCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SlipPrinterCapabilities, ICommonPosPrintStationCapabilities, ICommonReceiptSlipCapabilities);
@@ -8635,7 +8635,7 @@ impl windows_core::RuntimeName for SlipPrinterCapabilities {
 unsafe impl Send for SlipPrinterCapabilities {}
 unsafe impl Sync for SlipPrinterCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UnifiedPosErrorData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UnifiedPosErrorData, windows_core::IUnknown, windows_core::IInspectable);
 impl UnifiedPosErrorData {

--- a/crates/libs/windows/src/Windows/Devices/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Power/mod.rs
@@ -38,7 +38,7 @@ pub struct IBatteryStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Battery(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Battery, windows_core::IUnknown, windows_core::IInspectable);
 impl Battery {
@@ -107,7 +107,7 @@ impl windows_core::RuntimeName for Battery {
 unsafe impl Send for Battery {}
 unsafe impl Sync for Battery {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BatteryReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BatteryReport, windows_core::IUnknown, windows_core::IInspectable);
 impl BatteryReport {

--- a/crates/libs/windows/src/Windows/Devices/Printers/Extensions/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Printers/Extensions/mod.rs
@@ -105,7 +105,7 @@ pub struct IPrintTaskConfigurationSaveRequestedEventArgs_Vtbl {
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DWorkflow(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DWorkflow, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DWorkflow {
@@ -176,7 +176,7 @@ impl windows_core::RuntimeName for Print3DWorkflow {
 unsafe impl Send for Print3DWorkflow {}
 unsafe impl Sync for Print3DWorkflow {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DWorkflowPrintRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DWorkflowPrintRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DWorkflowPrintRequestedEventArgs {
@@ -216,7 +216,7 @@ impl windows_core::RuntimeName for Print3DWorkflowPrintRequestedEventArgs {
 unsafe impl Send for Print3DWorkflowPrintRequestedEventArgs {}
 unsafe impl Sync for Print3DWorkflowPrintRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DWorkflowPrinterChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DWorkflowPrinterChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DWorkflowPrinterChangedEventArgs {
@@ -258,7 +258,7 @@ impl windows_core::RuntimeName for PrintExtensionContext {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.PrintExtensionContext";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintNotificationEventDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintNotificationEventDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintNotificationEventDetails {
@@ -294,7 +294,7 @@ impl windows_core::RuntimeName for PrintNotificationEventDetails {
 unsafe impl Send for PrintNotificationEventDetails {}
 unsafe impl Sync for PrintNotificationEventDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskConfiguration {
@@ -331,7 +331,7 @@ impl windows_core::RuntimeName for PrintTaskConfiguration {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.PrintTaskConfiguration";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskConfigurationSaveRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskConfigurationSaveRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskConfigurationSaveRequest {
@@ -372,7 +372,7 @@ impl windows_core::RuntimeName for PrintTaskConfigurationSaveRequest {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.PrintTaskConfigurationSaveRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskConfigurationSaveRequestedDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskConfigurationSaveRequestedDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskConfigurationSaveRequestedDeferral {
@@ -392,7 +392,7 @@ impl windows_core::RuntimeName for PrintTaskConfigurationSaveRequestedDeferral {
     const NAME: &'static str = "Windows.Devices.Printers.Extensions.PrintTaskConfigurationSaveRequestedDeferral";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskConfigurationSaveRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskConfigurationSaveRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskConfigurationSaveRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/Devices/Printers/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Printers/mod.rs
@@ -409,7 +409,7 @@ pub struct IPrintSchema_Vtbl {
     MergeAndValidateWithDefaultPrintTicketAsync: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IppAttributeError(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IppAttributeError, windows_core::IUnknown, windows_core::IInspectable);
 impl IppAttributeError {
@@ -449,7 +449,7 @@ impl windows_core::RuntimeName for IppAttributeError {
 unsafe impl Send for IppAttributeError {}
 unsafe impl Sync for IppAttributeError {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IppAttributeValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IppAttributeValue, windows_core::IUnknown, windows_core::IInspectable);
 impl IppAttributeValue {
@@ -952,7 +952,7 @@ impl windows_core::RuntimeName for IppAttributeValue {
 unsafe impl Send for IppAttributeValue {}
 unsafe impl Sync for IppAttributeValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IppIntegerRange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IppIntegerRange, windows_core::IUnknown, windows_core::IInspectable);
 impl IppIntegerRange {
@@ -995,7 +995,7 @@ impl windows_core::RuntimeName for IppIntegerRange {
 unsafe impl Send for IppIntegerRange {}
 unsafe impl Sync for IppIntegerRange {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IppPrintDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IppPrintDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl IppPrintDevice {
@@ -1128,7 +1128,7 @@ impl windows_core::RuntimeName for IppPrintDevice {
 unsafe impl Send for IppPrintDevice {}
 unsafe impl Sync for IppPrintDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IppResolution(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IppResolution, windows_core::IUnknown, windows_core::IInspectable);
 impl IppResolution {
@@ -1178,7 +1178,7 @@ impl windows_core::RuntimeName for IppResolution {
 unsafe impl Send for IppResolution {}
 unsafe impl Sync for IppResolution {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IppSetAttributesResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IppSetAttributesResult, windows_core::IUnknown, windows_core::IInspectable);
 impl IppSetAttributesResult {
@@ -1211,7 +1211,7 @@ impl windows_core::RuntimeName for IppSetAttributesResult {
 unsafe impl Send for IppSetAttributesResult {}
 unsafe impl Sync for IppSetAttributesResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IppTextWithLanguage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IppTextWithLanguage, windows_core::IUnknown, windows_core::IInspectable);
 impl IppTextWithLanguage {
@@ -1254,7 +1254,7 @@ impl windows_core::RuntimeName for IppTextWithLanguage {
 unsafe impl Send for IppTextWithLanguage {}
 unsafe impl Sync for IppTextWithLanguage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PageConfigurationSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PageConfigurationSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl PageConfigurationSettings {
@@ -1301,7 +1301,7 @@ impl windows_core::RuntimeName for PageConfigurationSettings {
 unsafe impl Send for PageConfigurationSettings {}
 unsafe impl Sync for PageConfigurationSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PdlPassthroughProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PdlPassthroughProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl PdlPassthroughProvider {
@@ -1351,7 +1351,7 @@ impl windows_core::RuntimeName for PdlPassthroughProvider {
 unsafe impl Send for PdlPassthroughProvider {}
 unsafe impl Sync for PdlPassthroughProvider {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PdlPassthroughTarget(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PdlPassthroughTarget, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PdlPassthroughTarget, super::super::Foundation::IClosable);
@@ -1393,7 +1393,7 @@ impl windows_core::RuntimeName for PdlPassthroughTarget {
 unsafe impl Send for PdlPassthroughTarget {}
 unsafe impl Sync for PdlPassthroughTarget {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DDevice {
@@ -1435,7 +1435,7 @@ impl windows_core::RuntimeName for Print3DDevice {
 unsafe impl Send for Print3DDevice {}
 unsafe impl Sync for Print3DDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSchema(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSchema, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintSchema {

--- a/crates/libs/windows/src/Windows/Devices/Pwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Pwm/mod.rs
@@ -63,7 +63,7 @@ pub struct IPwmPin_Vtbl {
     pub IsStarted: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PwmController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PwmController, windows_core::IUnknown, windows_core::IInspectable);
 impl PwmController {
@@ -172,7 +172,7 @@ impl windows_core::RuntimeName for PwmController {
 unsafe impl Send for PwmController {}
 unsafe impl Sync for PwmController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PwmPin(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PwmPin, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PwmPin, super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/Devices/Radios/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Radios/mod.rs
@@ -28,7 +28,7 @@ pub struct IRadioStatics_Vtbl {
     pub RequestAccessAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Radio(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Radio, windows_core::IUnknown, windows_core::IInspectable);
 impl Radio {

--- a/crates/libs/windows/src/Windows/Devices/Scanners/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Scanners/mod.rs
@@ -397,7 +397,7 @@ pub struct IImageScannerStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageScanner(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageScanner, windows_core::IUnknown, windows_core::IInspectable);
 impl ImageScanner {
@@ -503,7 +503,7 @@ impl windows_core::RuntimeName for ImageScanner {
 unsafe impl Send for ImageScanner {}
 unsafe impl Sync for ImageScanner {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageScannerAutoConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageScannerAutoConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ImageScannerAutoConfiguration, IImageScannerFormatConfiguration);
@@ -547,7 +547,7 @@ impl windows_core::RuntimeName for ImageScannerAutoConfiguration {
 unsafe impl Send for ImageScannerAutoConfiguration {}
 unsafe impl Sync for ImageScannerAutoConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageScannerFeederConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageScannerFeederConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ImageScannerFeederConfiguration, IImageScannerFormatConfiguration, IImageScannerSourceConfiguration);
@@ -882,7 +882,7 @@ impl windows_core::RuntimeName for ImageScannerFeederConfiguration {
 unsafe impl Send for ImageScannerFeederConfiguration {}
 unsafe impl Sync for ImageScannerFeederConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageScannerFlatbedConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageScannerFlatbedConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ImageScannerFlatbedConfiguration, IImageScannerFormatConfiguration, IImageScannerSourceConfiguration);
@@ -1111,7 +1111,7 @@ impl windows_core::RuntimeName for ImageScannerFlatbedConfiguration {
 unsafe impl Send for ImageScannerFlatbedConfiguration {}
 unsafe impl Sync for ImageScannerFlatbedConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageScannerPreviewResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageScannerPreviewResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ImageScannerPreviewResult {
@@ -1143,7 +1143,7 @@ impl windows_core::RuntimeName for ImageScannerPreviewResult {
 unsafe impl Send for ImageScannerPreviewResult {}
 unsafe impl Sync for ImageScannerPreviewResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageScannerScanResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageScannerScanResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ImageScannerScanResult {

--- a/crates/libs/windows/src/Windows/Devices/Sensors/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sensors/Custom/mod.rs
@@ -66,7 +66,7 @@ pub struct ICustomSensorStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CustomSensor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CustomSensor, windows_core::IUnknown, windows_core::IInspectable);
 impl CustomSensor {
@@ -165,7 +165,7 @@ impl windows_core::RuntimeName for CustomSensor {
 unsafe impl Send for CustomSensor {}
 unsafe impl Sync for CustomSensor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CustomSensorReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CustomSensorReading, windows_core::IUnknown, windows_core::IInspectable);
 impl CustomSensorReading {
@@ -205,7 +205,7 @@ impl windows_core::RuntimeName for CustomSensorReading {
 unsafe impl Send for CustomSensorReading {}
 unsafe impl Sync for CustomSensorReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CustomSensorReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CustomSensorReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CustomSensorReadingChangedEventArgs {

--- a/crates/libs/windows/src/Windows/Devices/Sensors/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sensors/mod.rs
@@ -1776,7 +1776,7 @@ pub struct IWakeOnApproachOptions_Vtbl {
     pub SetDisableWhenBatterySaverOn: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Accelerometer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Accelerometer, windows_core::IUnknown, windows_core::IInspectable);
 impl Accelerometer {
@@ -1938,7 +1938,7 @@ impl windows_core::RuntimeName for Accelerometer {
 unsafe impl Send for Accelerometer {}
 unsafe impl Sync for Accelerometer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AccelerometerDataThreshold(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AccelerometerDataThreshold, windows_core::IUnknown, windows_core::IInspectable);
 impl AccelerometerDataThreshold {
@@ -1989,7 +1989,7 @@ impl windows_core::RuntimeName for AccelerometerDataThreshold {
 unsafe impl Send for AccelerometerDataThreshold {}
 unsafe impl Sync for AccelerometerDataThreshold {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AccelerometerReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AccelerometerReading, windows_core::IUnknown, windows_core::IInspectable);
 impl AccelerometerReading {
@@ -2050,7 +2050,7 @@ impl windows_core::RuntimeName for AccelerometerReading {
 unsafe impl Send for AccelerometerReading {}
 unsafe impl Sync for AccelerometerReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AccelerometerReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AccelerometerReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AccelerometerReadingChangedEventArgs {
@@ -2075,7 +2075,7 @@ impl windows_core::RuntimeName for AccelerometerReadingChangedEventArgs {
 unsafe impl Send for AccelerometerReadingChangedEventArgs {}
 unsafe impl Sync for AccelerometerReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AccelerometerShakenEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AccelerometerShakenEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AccelerometerShakenEventArgs {
@@ -2100,7 +2100,7 @@ impl windows_core::RuntimeName for AccelerometerShakenEventArgs {
 unsafe impl Send for AccelerometerShakenEventArgs {}
 unsafe impl Sync for AccelerometerShakenEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivitySensor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivitySensor, windows_core::IUnknown, windows_core::IInspectable);
 impl ActivitySensor {
@@ -2213,7 +2213,7 @@ impl windows_core::RuntimeName for ActivitySensor {
 unsafe impl Send for ActivitySensor {}
 unsafe impl Sync for ActivitySensor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivitySensorReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivitySensorReading, windows_core::IUnknown, windows_core::IInspectable);
 impl ActivitySensorReading {
@@ -2252,7 +2252,7 @@ impl windows_core::RuntimeName for ActivitySensorReading {
 unsafe impl Send for ActivitySensorReading {}
 unsafe impl Sync for ActivitySensorReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivitySensorReadingChangeReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivitySensorReadingChangeReport, windows_core::IUnknown, windows_core::IInspectable);
 impl ActivitySensorReadingChangeReport {
@@ -2277,7 +2277,7 @@ impl windows_core::RuntimeName for ActivitySensorReadingChangeReport {
 unsafe impl Send for ActivitySensorReadingChangeReport {}
 unsafe impl Sync for ActivitySensorReadingChangeReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivitySensorReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivitySensorReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ActivitySensorReadingChangedEventArgs {
@@ -2302,7 +2302,7 @@ impl windows_core::RuntimeName for ActivitySensorReadingChangedEventArgs {
 unsafe impl Send for ActivitySensorReadingChangedEventArgs {}
 unsafe impl Sync for ActivitySensorReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivitySensorTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivitySensorTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl ActivitySensorTriggerDetails {
@@ -2328,7 +2328,7 @@ impl windows_core::RuntimeName for ActivitySensorTriggerDetails {
 unsafe impl Send for ActivitySensorTriggerDetails {}
 unsafe impl Sync for ActivitySensorTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveDimmingOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveDimmingOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveDimmingOptions {
@@ -2357,7 +2357,7 @@ impl windows_core::RuntimeName for AdaptiveDimmingOptions {
 unsafe impl Send for AdaptiveDimmingOptions {}
 unsafe impl Sync for AdaptiveDimmingOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Altimeter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Altimeter, windows_core::IUnknown, windows_core::IInspectable);
 impl Altimeter {
@@ -2450,7 +2450,7 @@ impl windows_core::RuntimeName for Altimeter {
 unsafe impl Send for Altimeter {}
 unsafe impl Sync for Altimeter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AltimeterReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AltimeterReading, windows_core::IUnknown, windows_core::IInspectable);
 impl AltimeterReading {
@@ -2497,7 +2497,7 @@ impl windows_core::RuntimeName for AltimeterReading {
 unsafe impl Send for AltimeterReading {}
 unsafe impl Sync for AltimeterReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AltimeterReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AltimeterReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AltimeterReadingChangedEventArgs {
@@ -2522,7 +2522,7 @@ impl windows_core::RuntimeName for AltimeterReadingChangedEventArgs {
 unsafe impl Send for AltimeterReadingChangedEventArgs {}
 unsafe impl Sync for AltimeterReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Barometer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Barometer, windows_core::IUnknown, windows_core::IInspectable);
 impl Barometer {
@@ -2639,7 +2639,7 @@ impl windows_core::RuntimeName for Barometer {
 unsafe impl Send for Barometer {}
 unsafe impl Sync for Barometer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarometerDataThreshold(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarometerDataThreshold, windows_core::IUnknown, windows_core::IInspectable);
 impl BarometerDataThreshold {
@@ -2668,7 +2668,7 @@ impl windows_core::RuntimeName for BarometerDataThreshold {
 unsafe impl Send for BarometerDataThreshold {}
 unsafe impl Sync for BarometerDataThreshold {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarometerReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarometerReading, windows_core::IUnknown, windows_core::IInspectable);
 impl BarometerReading {
@@ -2715,7 +2715,7 @@ impl windows_core::RuntimeName for BarometerReading {
 unsafe impl Send for BarometerReading {}
 unsafe impl Sync for BarometerReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BarometerReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BarometerReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BarometerReadingChangedEventArgs {
@@ -2740,7 +2740,7 @@ impl windows_core::RuntimeName for BarometerReadingChangedEventArgs {
 unsafe impl Send for BarometerReadingChangedEventArgs {}
 unsafe impl Sync for BarometerReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Compass(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Compass, windows_core::IUnknown, windows_core::IInspectable);
 impl Compass {
@@ -2870,7 +2870,7 @@ impl windows_core::RuntimeName for Compass {
 unsafe impl Send for Compass {}
 unsafe impl Sync for Compass {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompassDataThreshold(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompassDataThreshold, windows_core::IUnknown, windows_core::IInspectable);
 impl CompassDataThreshold {
@@ -2899,7 +2899,7 @@ impl windows_core::RuntimeName for CompassDataThreshold {
 unsafe impl Send for CompassDataThreshold {}
 unsafe impl Sync for CompassDataThreshold {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompassReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompassReading, windows_core::IUnknown, windows_core::IInspectable);
 impl CompassReading {
@@ -2960,7 +2960,7 @@ impl windows_core::RuntimeName for CompassReading {
 unsafe impl Send for CompassReading {}
 unsafe impl Sync for CompassReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompassReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompassReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CompassReadingChangedEventArgs {
@@ -2985,7 +2985,7 @@ impl windows_core::RuntimeName for CompassReadingChangedEventArgs {
 unsafe impl Send for CompassReadingChangedEventArgs {}
 unsafe impl Sync for CompassReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Gyrometer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Gyrometer, windows_core::IUnknown, windows_core::IInspectable);
 impl Gyrometer {
@@ -3115,7 +3115,7 @@ impl windows_core::RuntimeName for Gyrometer {
 unsafe impl Send for Gyrometer {}
 unsafe impl Sync for Gyrometer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GyrometerDataThreshold(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GyrometerDataThreshold, windows_core::IUnknown, windows_core::IInspectable);
 impl GyrometerDataThreshold {
@@ -3166,7 +3166,7 @@ impl windows_core::RuntimeName for GyrometerDataThreshold {
 unsafe impl Send for GyrometerDataThreshold {}
 unsafe impl Sync for GyrometerDataThreshold {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GyrometerReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GyrometerReading, windows_core::IUnknown, windows_core::IInspectable);
 impl GyrometerReading {
@@ -3227,7 +3227,7 @@ impl windows_core::RuntimeName for GyrometerReading {
 unsafe impl Send for GyrometerReading {}
 unsafe impl Sync for GyrometerReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GyrometerReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GyrometerReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GyrometerReadingChangedEventArgs {
@@ -3252,7 +3252,7 @@ impl windows_core::RuntimeName for GyrometerReadingChangedEventArgs {
 unsafe impl Send for GyrometerReadingChangedEventArgs {}
 unsafe impl Sync for GyrometerReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HingeAngleReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HingeAngleReading, windows_core::IUnknown, windows_core::IInspectable);
 impl HingeAngleReading {
@@ -3292,7 +3292,7 @@ impl windows_core::RuntimeName for HingeAngleReading {
 unsafe impl Send for HingeAngleReading {}
 unsafe impl Sync for HingeAngleReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HingeAngleSensor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HingeAngleSensor, windows_core::IUnknown, windows_core::IInspectable);
 impl HingeAngleSensor {
@@ -3385,7 +3385,7 @@ impl windows_core::RuntimeName for HingeAngleSensor {
 unsafe impl Send for HingeAngleSensor {}
 unsafe impl Sync for HingeAngleSensor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HingeAngleSensorReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HingeAngleSensorReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HingeAngleSensorReadingChangedEventArgs {
@@ -3410,7 +3410,7 @@ impl windows_core::RuntimeName for HingeAngleSensorReadingChangedEventArgs {
 unsafe impl Send for HingeAngleSensorReadingChangedEventArgs {}
 unsafe impl Sync for HingeAngleSensorReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HumanPresenceFeatures(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HumanPresenceFeatures, windows_core::IUnknown, windows_core::IInspectable);
 impl HumanPresenceFeatures {
@@ -3472,7 +3472,7 @@ impl windows_core::RuntimeName for HumanPresenceFeatures {
 unsafe impl Send for HumanPresenceFeatures {}
 unsafe impl Sync for HumanPresenceFeatures {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HumanPresenceSensor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HumanPresenceSensor, windows_core::IUnknown, windows_core::IInspectable);
 impl HumanPresenceSensor {
@@ -3586,7 +3586,7 @@ impl windows_core::RuntimeName for HumanPresenceSensor {
 unsafe impl Send for HumanPresenceSensor {}
 unsafe impl Sync for HumanPresenceSensor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HumanPresenceSensorReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HumanPresenceSensorReading, windows_core::IUnknown, windows_core::IInspectable);
 impl HumanPresenceSensorReading {
@@ -3640,7 +3640,7 @@ impl windows_core::RuntimeName for HumanPresenceSensorReading {
 unsafe impl Send for HumanPresenceSensorReading {}
 unsafe impl Sync for HumanPresenceSensorReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HumanPresenceSensorReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HumanPresenceSensorReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HumanPresenceSensorReadingChangedEventArgs {
@@ -3665,7 +3665,7 @@ impl windows_core::RuntimeName for HumanPresenceSensorReadingChangedEventArgs {
 unsafe impl Send for HumanPresenceSensorReadingChangedEventArgs {}
 unsafe impl Sync for HumanPresenceSensorReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HumanPresenceSensorReadingUpdate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HumanPresenceSensorReadingUpdate, windows_core::IUnknown, windows_core::IInspectable);
 impl HumanPresenceSensorReadingUpdate {
@@ -3746,7 +3746,7 @@ impl windows_core::RuntimeName for HumanPresenceSensorReadingUpdate {
 unsafe impl Send for HumanPresenceSensorReadingUpdate {}
 unsafe impl Sync for HumanPresenceSensorReadingUpdate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HumanPresenceSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HumanPresenceSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl HumanPresenceSettings {
@@ -3944,7 +3944,7 @@ impl windows_core::RuntimeName for HumanPresenceSettings {
 unsafe impl Send for HumanPresenceSettings {}
 unsafe impl Sync for HumanPresenceSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Inclinometer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Inclinometer, windows_core::IUnknown, windows_core::IInspectable);
 impl Inclinometer {
@@ -4103,7 +4103,7 @@ impl windows_core::RuntimeName for Inclinometer {
 unsafe impl Send for Inclinometer {}
 unsafe impl Sync for Inclinometer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InclinometerDataThreshold(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InclinometerDataThreshold, windows_core::IUnknown, windows_core::IInspectable);
 impl InclinometerDataThreshold {
@@ -4154,7 +4154,7 @@ impl windows_core::RuntimeName for InclinometerDataThreshold {
 unsafe impl Send for InclinometerDataThreshold {}
 unsafe impl Sync for InclinometerDataThreshold {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InclinometerReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InclinometerReading, windows_core::IUnknown, windows_core::IInspectable);
 impl InclinometerReading {
@@ -4222,7 +4222,7 @@ impl windows_core::RuntimeName for InclinometerReading {
 unsafe impl Send for InclinometerReading {}
 unsafe impl Sync for InclinometerReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InclinometerReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InclinometerReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InclinometerReadingChangedEventArgs {
@@ -4247,7 +4247,7 @@ impl windows_core::RuntimeName for InclinometerReadingChangedEventArgs {
 unsafe impl Send for InclinometerReadingChangedEventArgs {}
 unsafe impl Sync for InclinometerReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LightSensor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LightSensor, windows_core::IUnknown, windows_core::IInspectable);
 impl LightSensor {
@@ -4364,7 +4364,7 @@ impl windows_core::RuntimeName for LightSensor {
 unsafe impl Send for LightSensor {}
 unsafe impl Sync for LightSensor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LightSensorDataThreshold(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LightSensorDataThreshold, windows_core::IUnknown, windows_core::IInspectable);
 impl LightSensorDataThreshold {
@@ -4404,7 +4404,7 @@ impl windows_core::RuntimeName for LightSensorDataThreshold {
 unsafe impl Send for LightSensorDataThreshold {}
 unsafe impl Sync for LightSensorDataThreshold {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LightSensorReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LightSensorReading, windows_core::IUnknown, windows_core::IInspectable);
 impl LightSensorReading {
@@ -4451,7 +4451,7 @@ impl windows_core::RuntimeName for LightSensorReading {
 unsafe impl Send for LightSensorReading {}
 unsafe impl Sync for LightSensorReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LightSensorReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LightSensorReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl LightSensorReadingChangedEventArgs {
@@ -4476,7 +4476,7 @@ impl windows_core::RuntimeName for LightSensorReadingChangedEventArgs {
 unsafe impl Send for LightSensorReadingChangedEventArgs {}
 unsafe impl Sync for LightSensorReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LockOnLeaveOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LockOnLeaveOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl LockOnLeaveOptions {
@@ -4505,7 +4505,7 @@ impl windows_core::RuntimeName for LockOnLeaveOptions {
 unsafe impl Send for LockOnLeaveOptions {}
 unsafe impl Sync for LockOnLeaveOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Magnetometer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Magnetometer, windows_core::IUnknown, windows_core::IInspectable);
 impl Magnetometer {
@@ -4635,7 +4635,7 @@ impl windows_core::RuntimeName for Magnetometer {
 unsafe impl Send for Magnetometer {}
 unsafe impl Sync for Magnetometer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagnetometerDataThreshold(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagnetometerDataThreshold, windows_core::IUnknown, windows_core::IInspectable);
 impl MagnetometerDataThreshold {
@@ -4686,7 +4686,7 @@ impl windows_core::RuntimeName for MagnetometerDataThreshold {
 unsafe impl Send for MagnetometerDataThreshold {}
 unsafe impl Sync for MagnetometerDataThreshold {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagnetometerReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagnetometerReading, windows_core::IUnknown, windows_core::IInspectable);
 impl MagnetometerReading {
@@ -4754,7 +4754,7 @@ impl windows_core::RuntimeName for MagnetometerReading {
 unsafe impl Send for MagnetometerReading {}
 unsafe impl Sync for MagnetometerReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MagnetometerReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MagnetometerReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MagnetometerReadingChangedEventArgs {
@@ -4779,7 +4779,7 @@ impl windows_core::RuntimeName for MagnetometerReadingChangedEventArgs {
 unsafe impl Send for MagnetometerReadingChangedEventArgs {}
 unsafe impl Sync for MagnetometerReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OrientationSensor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OrientationSensor, windows_core::IUnknown, windows_core::IInspectable);
 impl OrientationSensor {
@@ -4943,7 +4943,7 @@ impl windows_core::RuntimeName for OrientationSensor {
 unsafe impl Send for OrientationSensor {}
 unsafe impl Sync for OrientationSensor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OrientationSensorReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OrientationSensorReading, windows_core::IUnknown, windows_core::IInspectable);
 impl OrientationSensorReading {
@@ -5004,7 +5004,7 @@ impl windows_core::RuntimeName for OrientationSensorReading {
 unsafe impl Send for OrientationSensorReading {}
 unsafe impl Sync for OrientationSensorReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OrientationSensorReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OrientationSensorReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl OrientationSensorReadingChangedEventArgs {
@@ -5029,7 +5029,7 @@ impl windows_core::RuntimeName for OrientationSensorReadingChangedEventArgs {
 unsafe impl Send for OrientationSensorReadingChangedEventArgs {}
 unsafe impl Sync for OrientationSensorReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Pedometer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Pedometer, windows_core::IUnknown, windows_core::IInspectable);
 impl Pedometer {
@@ -5153,7 +5153,7 @@ impl windows_core::RuntimeName for Pedometer {
 unsafe impl Send for Pedometer {}
 unsafe impl Sync for Pedometer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PedometerDataThreshold(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PedometerDataThreshold, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PedometerDataThreshold, ISensorDataThreshold);
@@ -5186,7 +5186,7 @@ impl windows_core::RuntimeName for PedometerDataThreshold {
 unsafe impl Send for PedometerDataThreshold {}
 unsafe impl Sync for PedometerDataThreshold {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PedometerReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PedometerReading, windows_core::IUnknown, windows_core::IInspectable);
 impl PedometerReading {
@@ -5232,7 +5232,7 @@ impl windows_core::RuntimeName for PedometerReading {
 unsafe impl Send for PedometerReading {}
 unsafe impl Sync for PedometerReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PedometerReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PedometerReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PedometerReadingChangedEventArgs {
@@ -5257,7 +5257,7 @@ impl windows_core::RuntimeName for PedometerReadingChangedEventArgs {
 unsafe impl Send for PedometerReadingChangedEventArgs {}
 unsafe impl Sync for PedometerReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProximitySensor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProximitySensor, windows_core::IUnknown, windows_core::IInspectable);
 impl ProximitySensor {
@@ -5356,7 +5356,7 @@ impl windows_core::RuntimeName for ProximitySensor {
 unsafe impl Send for ProximitySensor {}
 unsafe impl Sync for ProximitySensor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProximitySensorDataThreshold(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProximitySensorDataThreshold, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ProximitySensorDataThreshold, ISensorDataThreshold);
@@ -5389,7 +5389,7 @@ impl windows_core::RuntimeName for ProximitySensorDataThreshold {
 unsafe impl Send for ProximitySensorDataThreshold {}
 unsafe impl Sync for ProximitySensorDataThreshold {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProximitySensorDisplayOnOffController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProximitySensorDisplayOnOffController, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ProximitySensorDisplayOnOffController, super::super::Foundation::IClosable);
@@ -5412,7 +5412,7 @@ impl windows_core::RuntimeName for ProximitySensorDisplayOnOffController {
 unsafe impl Send for ProximitySensorDisplayOnOffController {}
 unsafe impl Sync for ProximitySensorDisplayOnOffController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProximitySensorReading(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProximitySensorReading, windows_core::IUnknown, windows_core::IInspectable);
 impl ProximitySensorReading {
@@ -5451,7 +5451,7 @@ impl windows_core::RuntimeName for ProximitySensorReading {
 unsafe impl Send for ProximitySensorReading {}
 unsafe impl Sync for ProximitySensorReading {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProximitySensorReadingChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProximitySensorReadingChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ProximitySensorReadingChangedEventArgs {
@@ -5476,7 +5476,7 @@ impl windows_core::RuntimeName for ProximitySensorReadingChangedEventArgs {
 unsafe impl Send for ProximitySensorReadingChangedEventArgs {}
 unsafe impl Sync for ProximitySensorReadingChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SensorDataThresholdTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SensorDataThresholdTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl SensorDataThresholdTriggerDetails {
@@ -5508,7 +5508,7 @@ impl windows_core::RuntimeName for SensorDataThresholdTriggerDetails {
 unsafe impl Send for SensorDataThresholdTriggerDetails {}
 unsafe impl Sync for SensorDataThresholdTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SensorQuaternion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SensorQuaternion, windows_core::IUnknown, windows_core::IInspectable);
 impl SensorQuaternion {
@@ -5554,7 +5554,7 @@ impl windows_core::RuntimeName for SensorQuaternion {
 unsafe impl Send for SensorQuaternion {}
 unsafe impl Sync for SensorQuaternion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SensorRotationMatrix(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SensorRotationMatrix, windows_core::IUnknown, windows_core::IInspectable);
 impl SensorRotationMatrix {
@@ -5635,7 +5635,7 @@ impl windows_core::RuntimeName for SensorRotationMatrix {
 unsafe impl Send for SensorRotationMatrix {}
 unsafe impl Sync for SensorRotationMatrix {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SimpleOrientationSensor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SimpleOrientationSensor, windows_core::IUnknown, windows_core::IInspectable);
 impl SimpleOrientationSensor {
@@ -5722,7 +5722,7 @@ impl windows_core::RuntimeName for SimpleOrientationSensor {
 unsafe impl Send for SimpleOrientationSensor {}
 unsafe impl Sync for SimpleOrientationSensor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SimpleOrientationSensorOrientationChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SimpleOrientationSensorOrientationChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SimpleOrientationSensorOrientationChangedEventArgs {
@@ -5754,7 +5754,7 @@ impl windows_core::RuntimeName for SimpleOrientationSensorOrientationChangedEven
 unsafe impl Send for SimpleOrientationSensorOrientationChangedEventArgs {}
 unsafe impl Sync for SimpleOrientationSensorOrientationChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WakeOnApproachOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WakeOnApproachOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl WakeOnApproachOptions {

--- a/crates/libs/windows/src/Windows/Devices/SerialCommunication/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SerialCommunication/mod.rs
@@ -76,7 +76,7 @@ pub struct ISerialDeviceStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ErrorReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ErrorReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ErrorReceivedEventArgs {
@@ -101,7 +101,7 @@ impl windows_core::RuntimeName for ErrorReceivedEventArgs {
 unsafe impl Send for ErrorReceivedEventArgs {}
 unsafe impl Sync for ErrorReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PinChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PinChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PinChangedEventArgs {
@@ -126,7 +126,7 @@ impl windows_core::RuntimeName for PinChangedEventArgs {
 unsafe impl Send for PinChangedEventArgs {}
 unsafe impl Sync for PinChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SerialDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SerialDevice, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SerialDevice, super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
@@ -808,7 +808,7 @@ pub struct ISmartCardTriggerDetails3_Vtbl {
     pub SmartCard: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CardAddedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CardAddedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CardAddedEventArgs {
@@ -833,7 +833,7 @@ impl windows_core::RuntimeName for CardAddedEventArgs {
 unsafe impl Send for CardAddedEventArgs {}
 unsafe impl Sync for CardAddedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CardRemovedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CardRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CardRemovedEventArgs {
@@ -883,7 +883,7 @@ impl windows_core::RuntimeName for KnownSmartCardAppletIds {
     const NAME: &'static str = "Windows.Devices.SmartCards.KnownSmartCardAppletIds";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCard(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCard, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCard {
@@ -930,7 +930,7 @@ impl windows_core::RuntimeName for SmartCard {
 unsafe impl Send for SmartCard {}
 unsafe impl Sync for SmartCard {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardAppletIdGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardAppletIdGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardAppletIdGroup {
@@ -1079,7 +1079,7 @@ impl windows_core::RuntimeName for SmartCardAppletIdGroup {
 unsafe impl Send for SmartCardAppletIdGroup {}
 unsafe impl Sync for SmartCardAppletIdGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardAppletIdGroupRegistration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardAppletIdGroupRegistration, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardAppletIdGroupRegistration {
@@ -1154,7 +1154,7 @@ impl windows_core::RuntimeName for SmartCardAppletIdGroupRegistration {
 unsafe impl Send for SmartCardAppletIdGroupRegistration {}
 unsafe impl Sync for SmartCardAppletIdGroupRegistration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardAutomaticResponseApdu(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardAutomaticResponseApdu, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardAutomaticResponseApdu {
@@ -1302,7 +1302,7 @@ impl windows_core::RuntimeName for SmartCardAutomaticResponseApdu {
 unsafe impl Send for SmartCardAutomaticResponseApdu {}
 unsafe impl Sync for SmartCardAutomaticResponseApdu {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardChallengeContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardChallengeContext, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SmartCardChallengeContext, super::super::Foundation::IClosable);
@@ -1378,7 +1378,7 @@ impl windows_core::RuntimeName for SmartCardChallengeContext {
 unsafe impl Send for SmartCardChallengeContext {}
 unsafe impl Sync for SmartCardChallengeContext {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardConnection, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SmartCardConnection, super::super::Foundation::IClosable);
@@ -1412,7 +1412,7 @@ impl windows_core::RuntimeName for SmartCardConnection {
 unsafe impl Send for SmartCardConnection {}
 unsafe impl Sync for SmartCardConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardCryptogramGenerator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardCryptogramGenerator, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardCryptogramGenerator {
@@ -1590,7 +1590,7 @@ impl windows_core::RuntimeName for SmartCardCryptogramGenerator {
 unsafe impl Send for SmartCardCryptogramGenerator {}
 unsafe impl Sync for SmartCardCryptogramGenerator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {
@@ -1630,7 +1630,7 @@ impl windows_core::RuntimeName for SmartCardCryptogramGetAllCryptogramMaterialCh
 unsafe impl Send for SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {}
 unsafe impl Sync for SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {
@@ -1670,7 +1670,7 @@ impl windows_core::RuntimeName for SmartCardCryptogramGetAllCryptogramMaterialPa
 unsafe impl Send for SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {}
 unsafe impl Sync for SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {
@@ -1710,7 +1710,7 @@ impl windows_core::RuntimeName for SmartCardCryptogramGetAllCryptogramStorageKey
 unsafe impl Send for SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {}
 unsafe impl Sync for SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardCryptogramMaterialCharacteristics(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardCryptogramMaterialCharacteristics, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardCryptogramMaterialCharacteristics {
@@ -1794,7 +1794,7 @@ impl windows_core::RuntimeName for SmartCardCryptogramMaterialCharacteristics {
 unsafe impl Send for SmartCardCryptogramMaterialCharacteristics {}
 unsafe impl Sync for SmartCardCryptogramMaterialCharacteristics {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardCryptogramMaterialPackageCharacteristics(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardCryptogramMaterialPackageCharacteristics, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardCryptogramMaterialPackageCharacteristics {
@@ -1847,7 +1847,7 @@ impl windows_core::RuntimeName for SmartCardCryptogramMaterialPackageCharacteris
 unsafe impl Send for SmartCardCryptogramMaterialPackageCharacteristics {}
 unsafe impl Sync for SmartCardCryptogramMaterialPackageCharacteristics {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardCryptogramMaterialPossessionProof(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardCryptogramMaterialPossessionProof, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardCryptogramMaterialPossessionProof {
@@ -1880,7 +1880,7 @@ impl windows_core::RuntimeName for SmartCardCryptogramMaterialPossessionProof {
 unsafe impl Send for SmartCardCryptogramMaterialPossessionProof {}
 unsafe impl Sync for SmartCardCryptogramMaterialPossessionProof {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardCryptogramPlacementStep(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardCryptogramPlacementStep, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardCryptogramPlacementStep {
@@ -2012,7 +2012,7 @@ impl windows_core::RuntimeName for SmartCardCryptogramPlacementStep {
 unsafe impl Send for SmartCardCryptogramPlacementStep {}
 unsafe impl Sync for SmartCardCryptogramPlacementStep {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardCryptogramStorageKeyCharacteristics(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardCryptogramStorageKeyCharacteristics, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardCryptogramStorageKeyCharacteristics {
@@ -2065,7 +2065,7 @@ impl windows_core::RuntimeName for SmartCardCryptogramStorageKeyCharacteristics 
 unsafe impl Send for SmartCardCryptogramStorageKeyCharacteristics {}
 unsafe impl Sync for SmartCardCryptogramStorageKeyCharacteristics {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardCryptogramStorageKeyInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardCryptogramStorageKeyInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardCryptogramStorageKeyInfo {
@@ -2143,7 +2143,7 @@ impl windows_core::RuntimeName for SmartCardCryptogramStorageKeyInfo {
 unsafe impl Send for SmartCardCryptogramStorageKeyInfo {}
 unsafe impl Sync for SmartCardCryptogramStorageKeyInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardEmulator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardEmulator, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardEmulator {
@@ -2265,7 +2265,7 @@ impl windows_core::RuntimeName for SmartCardEmulator {
 unsafe impl Send for SmartCardEmulator {}
 unsafe impl Sync for SmartCardEmulator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardEmulatorApduReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardEmulatorApduReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardEmulatorApduReceivedEventArgs {
@@ -2360,7 +2360,7 @@ impl windows_core::RuntimeName for SmartCardEmulatorApduReceivedEventArgs {
 unsafe impl Send for SmartCardEmulatorApduReceivedEventArgs {}
 unsafe impl Sync for SmartCardEmulatorApduReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardEmulatorConnectionDeactivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardEmulatorConnectionDeactivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardEmulatorConnectionDeactivatedEventArgs {
@@ -2392,7 +2392,7 @@ impl windows_core::RuntimeName for SmartCardEmulatorConnectionDeactivatedEventAr
 unsafe impl Send for SmartCardEmulatorConnectionDeactivatedEventArgs {}
 unsafe impl Sync for SmartCardEmulatorConnectionDeactivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardEmulatorConnectionProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardEmulatorConnectionProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardEmulatorConnectionProperties {
@@ -2424,7 +2424,7 @@ impl windows_core::RuntimeName for SmartCardEmulatorConnectionProperties {
 unsafe impl Send for SmartCardEmulatorConnectionProperties {}
 unsafe impl Sync for SmartCardEmulatorConnectionProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardPinPolicy(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardPinPolicy, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardPinPolicy {
@@ -2515,7 +2515,7 @@ impl windows_core::RuntimeName for SmartCardPinPolicy {
 unsafe impl Send for SmartCardPinPolicy {}
 unsafe impl Sync for SmartCardPinPolicy {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardPinResetDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardPinResetDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardPinResetDeferral {
@@ -2537,7 +2537,7 @@ impl windows_core::RuntimeName for SmartCardPinResetDeferral {
 unsafe impl Send for SmartCardPinResetDeferral {}
 unsafe impl Sync for SmartCardPinResetDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardPinResetRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardPinResetRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardPinResetRequest {
@@ -2585,7 +2585,7 @@ impl windows_core::RuntimeName for SmartCardPinResetRequest {
 unsafe impl Send for SmartCardPinResetRequest {}
 unsafe impl Sync for SmartCardPinResetRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardProvisioning(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardProvisioning, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardProvisioning {
@@ -2727,7 +2727,7 @@ impl windows_core::RuntimeName for SmartCardProvisioning {
 unsafe impl Send for SmartCardProvisioning {}
 unsafe impl Sync for SmartCardProvisioning {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardReader, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardReader {
@@ -2832,7 +2832,7 @@ impl windows_core::RuntimeName for SmartCardReader {
 unsafe impl Send for SmartCardReader {}
 unsafe impl Sync for SmartCardReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmartCardTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmartCardTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl SmartCardTriggerDetails {

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -951,7 +951,7 @@ pub struct ISmsWapMessage_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeleteSmsMessageOperation(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(DeleteSmsMessageOperation, windows_core::IUnknown, windows_core::IInspectable);
@@ -1053,7 +1053,7 @@ impl std::future::Future for DeleteSmsMessageOperation {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeleteSmsMessagesOperation(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(DeleteSmsMessagesOperation, windows_core::IUnknown, windows_core::IInspectable);
@@ -1155,7 +1155,7 @@ impl std::future::Future for DeleteSmsMessagesOperation {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GetSmsDeviceOperation(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(GetSmsDeviceOperation, windows_core::IUnknown, windows_core::IInspectable);
@@ -1260,7 +1260,7 @@ impl std::future::Future for GetSmsDeviceOperation {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GetSmsMessageOperation(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(GetSmsMessageOperation, windows_core::IUnknown, windows_core::IInspectable);
@@ -1365,7 +1365,7 @@ impl std::future::Future for GetSmsMessageOperation {
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GetSmsMessagesOperation(windows_core::IUnknown);
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
 windows_core::imp::interface_hierarchy!(GetSmsMessagesOperation, windows_core::IUnknown, windows_core::IInspectable);
@@ -1489,7 +1489,7 @@ impl std::future::Future for GetSmsMessagesOperation {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SendSmsMessageOperation(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SendSmsMessageOperation, windows_core::IUnknown, windows_core::IInspectable);
@@ -1590,7 +1590,7 @@ impl std::future::Future for SendSmsMessageOperation {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsAppMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsAppMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SmsAppMessage, ISmsMessageBase);
@@ -1781,7 +1781,7 @@ unsafe impl Send for SmsAppMessage {}
 unsafe impl Sync for SmsAppMessage {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsBinaryMessage(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SmsBinaryMessage, windows_core::IUnknown, windows_core::IInspectable);
@@ -1855,7 +1855,7 @@ unsafe impl Send for SmsBinaryMessage {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for SmsBinaryMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsBroadcastMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsBroadcastMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SmsBroadcastMessage, ISmsMessageBase);
@@ -1980,7 +1980,7 @@ unsafe impl Send for SmsBroadcastMessage {}
 unsafe impl Sync for SmsBroadcastMessage {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsDevice(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SmsDevice, windows_core::IUnknown, windows_core::IInspectable);
@@ -2129,7 +2129,7 @@ impl windows_core::RuntimeName for SmsDevice {
     const NAME: &'static str = "Windows.Devices.Sms.SmsDevice";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsDevice2(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsDevice2, windows_core::IUnknown, windows_core::IInspectable);
 impl SmsDevice2 {
@@ -2255,7 +2255,7 @@ impl windows_core::RuntimeName for SmsDevice2 {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsDeviceMessageStore(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SmsDeviceMessageStore, windows_core::IUnknown, windows_core::IInspectable);
@@ -2316,7 +2316,7 @@ impl windows_core::RuntimeName for SmsDeviceMessageStore {
     const NAME: &'static str = "Windows.Devices.Sms.SmsDeviceMessageStore";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsFilterRule(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsFilterRule, windows_core::IUnknown, windows_core::IInspectable);
 impl SmsFilterRule {
@@ -2451,7 +2451,7 @@ impl windows_core::RuntimeName for SmsFilterRule {
 unsafe impl Send for SmsFilterRule {}
 unsafe impl Sync for SmsFilterRule {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsFilterRules(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsFilterRules, windows_core::IUnknown, windows_core::IInspectable);
 impl SmsFilterRules {
@@ -2496,7 +2496,7 @@ unsafe impl Send for SmsFilterRules {}
 unsafe impl Sync for SmsFilterRules {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsMessageReceivedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SmsMessageReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2533,7 +2533,7 @@ impl windows_core::RuntimeName for SmsMessageReceivedEventArgs {
     const NAME: &'static str = "Windows.Devices.Sms.SmsMessageReceivedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsMessageReceivedTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsMessageReceivedTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl SmsMessageReceivedTriggerDetails {
@@ -2608,7 +2608,7 @@ impl windows_core::RuntimeName for SmsMessageReceivedTriggerDetails {
 unsafe impl Send for SmsMessageReceivedTriggerDetails {}
 unsafe impl Sync for SmsMessageReceivedTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsMessageRegistration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsMessageRegistration, windows_core::IUnknown, windows_core::IInspectable);
 impl SmsMessageRegistration {
@@ -2671,7 +2671,7 @@ impl windows_core::RuntimeName for SmsMessageRegistration {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsReceivedEventDetails(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SmsReceivedEventDetails, windows_core::IUnknown, windows_core::IInspectable);
@@ -2728,7 +2728,7 @@ unsafe impl Send for SmsReceivedEventDetails {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for SmsReceivedEventDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsSendMessageResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsSendMessageResult, windows_core::IUnknown, windows_core::IInspectable);
 impl SmsSendMessageResult {
@@ -2796,7 +2796,7 @@ impl windows_core::RuntimeName for SmsSendMessageResult {
 unsafe impl Send for SmsSendMessageResult {}
 unsafe impl Sync for SmsSendMessageResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsStatusMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsStatusMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SmsStatusMessage, ISmsMessageBase);
@@ -2900,7 +2900,7 @@ unsafe impl Send for SmsStatusMessage {}
 unsafe impl Sync for SmsStatusMessage {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsTextMessage(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SmsTextMessage, windows_core::IUnknown, windows_core::IInspectable);
@@ -3063,7 +3063,7 @@ unsafe impl Send for SmsTextMessage {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for SmsTextMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsTextMessage2(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsTextMessage2, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SmsTextMessage2, ISmsMessageBase);
@@ -3218,7 +3218,7 @@ impl windows_core::RuntimeName for SmsTextMessage2 {
 unsafe impl Send for SmsTextMessage2 {}
 unsafe impl Sync for SmsTextMessage2 {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsVoicemailMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsVoicemailMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SmsVoicemailMessage, ISmsMessageBase);
@@ -3300,7 +3300,7 @@ impl windows_core::RuntimeName for SmsVoicemailMessage {
 unsafe impl Send for SmsVoicemailMessage {}
 unsafe impl Sync for SmsVoicemailMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SmsWapMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SmsWapMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SmsWapMessage, ISmsMessageBase);

--- a/crates/libs/windows/src/Windows/Devices/Spi/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/Provider/mod.rs
@@ -141,7 +141,7 @@ pub struct ISpiProvider_Vtbl {
     GetControllersAsync: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProviderSpiConnectionSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProviderSpiConnectionSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl ProviderSpiConnectionSettings {

--- a/crates/libs/windows/src/Windows/Devices/Spi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/mod.rs
@@ -131,7 +131,7 @@ pub struct ISpiDeviceStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpiBusInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpiBusInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl SpiBusInfo {
@@ -178,7 +178,7 @@ impl windows_core::RuntimeName for SpiBusInfo {
 unsafe impl Send for SpiBusInfo {}
 unsafe impl Sync for SpiBusInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpiConnectionSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpiConnectionSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl SpiConnectionSettings {
@@ -262,7 +262,7 @@ impl windows_core::RuntimeName for SpiConnectionSettings {
 unsafe impl Send for SpiConnectionSettings {}
 unsafe impl Sync for SpiConnectionSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpiController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpiController, windows_core::IUnknown, windows_core::IInspectable);
 impl SpiController {
@@ -311,7 +311,7 @@ impl windows_core::RuntimeName for SpiController {
 unsafe impl Send for SpiController {}
 unsafe impl Sync for SpiController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpiDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpiDevice, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpiDevice, super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
@@ -420,7 +420,7 @@ pub struct IUsbSetupPacketFactory_Vtbl {
     CreateWithEightByteBuffer: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbBulkInEndpointDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbBulkInEndpointDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbBulkInEndpointDescriptor {
@@ -459,7 +459,7 @@ impl windows_core::RuntimeName for UsbBulkInEndpointDescriptor {
 unsafe impl Send for UsbBulkInEndpointDescriptor {}
 unsafe impl Sync for UsbBulkInEndpointDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbBulkInPipe(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbBulkInPipe, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbBulkInPipe {
@@ -521,7 +521,7 @@ impl windows_core::RuntimeName for UsbBulkInPipe {
 unsafe impl Send for UsbBulkInPipe {}
 unsafe impl Sync for UsbBulkInPipe {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbBulkOutEndpointDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbBulkOutEndpointDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbBulkOutEndpointDescriptor {
@@ -560,7 +560,7 @@ impl windows_core::RuntimeName for UsbBulkOutEndpointDescriptor {
 unsafe impl Send for UsbBulkOutEndpointDescriptor {}
 unsafe impl Sync for UsbBulkOutEndpointDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbBulkOutPipe(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbBulkOutPipe, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbBulkOutPipe {
@@ -611,7 +611,7 @@ impl windows_core::RuntimeName for UsbBulkOutPipe {
 unsafe impl Send for UsbBulkOutPipe {}
 unsafe impl Sync for UsbBulkOutPipe {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbConfiguration {
@@ -652,7 +652,7 @@ impl windows_core::RuntimeName for UsbConfiguration {
 unsafe impl Send for UsbConfiguration {}
 unsafe impl Sync for UsbConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbConfigurationDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbConfigurationDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbConfigurationDescriptor {
@@ -721,7 +721,7 @@ impl windows_core::RuntimeName for UsbConfigurationDescriptor {
 unsafe impl Send for UsbConfigurationDescriptor {}
 unsafe impl Sync for UsbConfigurationDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbControlRequestType(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbControlRequestType, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbControlRequestType {
@@ -790,7 +790,7 @@ impl windows_core::RuntimeName for UsbControlRequestType {
 unsafe impl Send for UsbControlRequestType {}
 unsafe impl Sync for UsbControlRequestType {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbDescriptor {
@@ -830,7 +830,7 @@ impl windows_core::RuntimeName for UsbDescriptor {
 unsafe impl Send for UsbDescriptor {}
 unsafe impl Sync for UsbDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbDevice, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UsbDevice, super::super::Foundation::IClosable);
@@ -957,7 +957,7 @@ impl windows_core::RuntimeName for UsbDevice {
 unsafe impl Send for UsbDevice {}
 unsafe impl Sync for UsbDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbDeviceClass(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbDeviceClass, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbDeviceClass {
@@ -1021,7 +1021,7 @@ impl windows_core::RuntimeName for UsbDeviceClass {
 unsafe impl Send for UsbDeviceClass {}
 unsafe impl Sync for UsbDeviceClass {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbDeviceClasses(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbDeviceClasses, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbDeviceClasses {
@@ -1098,7 +1098,7 @@ impl windows_core::RuntimeName for UsbDeviceClasses {
 unsafe impl Send for UsbDeviceClasses {}
 unsafe impl Sync for UsbDeviceClasses {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbDeviceDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbDeviceDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbDeviceDescriptor {
@@ -1158,7 +1158,7 @@ impl windows_core::RuntimeName for UsbDeviceDescriptor {
 unsafe impl Send for UsbDeviceDescriptor {}
 unsafe impl Sync for UsbDeviceDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbEndpointDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbEndpointDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbEndpointDescriptor {
@@ -1248,7 +1248,7 @@ impl windows_core::RuntimeName for UsbEndpointDescriptor {
 unsafe impl Send for UsbEndpointDescriptor {}
 unsafe impl Sync for UsbEndpointDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbInterface(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbInterface, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbInterface {
@@ -1321,7 +1321,7 @@ impl windows_core::RuntimeName for UsbInterface {
 unsafe impl Send for UsbInterface {}
 unsafe impl Sync for UsbInterface {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbInterfaceDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbInterfaceDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbInterfaceDescriptor {
@@ -1397,7 +1397,7 @@ impl windows_core::RuntimeName for UsbInterfaceDescriptor {
 unsafe impl Send for UsbInterfaceDescriptor {}
 unsafe impl Sync for UsbInterfaceDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbInterfaceSetting(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbInterfaceSetting, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbInterfaceSetting {
@@ -1476,7 +1476,7 @@ impl windows_core::RuntimeName for UsbInterfaceSetting {
 unsafe impl Send for UsbInterfaceSetting {}
 unsafe impl Sync for UsbInterfaceSetting {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbInterruptInEndpointDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbInterruptInEndpointDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbInterruptInEndpointDescriptor {
@@ -1522,7 +1522,7 @@ impl windows_core::RuntimeName for UsbInterruptInEndpointDescriptor {
 unsafe impl Send for UsbInterruptInEndpointDescriptor {}
 unsafe impl Sync for UsbInterruptInEndpointDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbInterruptInEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbInterruptInEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbInterruptInEventArgs {
@@ -1548,7 +1548,7 @@ impl windows_core::RuntimeName for UsbInterruptInEventArgs {
 unsafe impl Send for UsbInterruptInEventArgs {}
 unsafe impl Sync for UsbInterruptInEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbInterruptInPipe(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbInterruptInPipe, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbInterruptInPipe {
@@ -1594,7 +1594,7 @@ impl windows_core::RuntimeName for UsbInterruptInPipe {
 unsafe impl Send for UsbInterruptInPipe {}
 unsafe impl Sync for UsbInterruptInPipe {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbInterruptOutEndpointDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbInterruptOutEndpointDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbInterruptOutEndpointDescriptor {
@@ -1640,7 +1640,7 @@ impl windows_core::RuntimeName for UsbInterruptOutEndpointDescriptor {
 unsafe impl Send for UsbInterruptOutEndpointDescriptor {}
 unsafe impl Sync for UsbInterruptOutEndpointDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbInterruptOutPipe(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbInterruptOutPipe, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbInterruptOutPipe {
@@ -1691,7 +1691,7 @@ impl windows_core::RuntimeName for UsbInterruptOutPipe {
 unsafe impl Send for UsbInterruptOutPipe {}
 unsafe impl Sync for UsbInterruptOutPipe {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UsbSetupPacket(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UsbSetupPacket, windows_core::IUnknown, windows_core::IInspectable);
 impl UsbSetupPacket {

--- a/crates/libs/windows/src/Windows/Devices/WiFi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFi/mod.rs
@@ -179,7 +179,7 @@ pub struct IWiFiWpsConfigurationResult_Vtbl {
     SupportedWpsKinds: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiAdapter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiAdapter, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiAdapter {
@@ -323,7 +323,7 @@ impl windows_core::RuntimeName for WiFiAdapter {
 unsafe impl Send for WiFiAdapter {}
 unsafe impl Sync for WiFiAdapter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiAvailableNetwork(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiAvailableNetwork, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiAvailableNetwork {
@@ -419,7 +419,7 @@ impl windows_core::RuntimeName for WiFiAvailableNetwork {
 unsafe impl Send for WiFiAvailableNetwork {}
 unsafe impl Sync for WiFiAvailableNetwork {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiConnectionResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiConnectionResult, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiConnectionResult {
@@ -444,7 +444,7 @@ impl windows_core::RuntimeName for WiFiConnectionResult {
 unsafe impl Send for WiFiConnectionResult {}
 unsafe impl Sync for WiFiConnectionResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiNetworkReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiNetworkReport, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiNetworkReport {
@@ -477,7 +477,7 @@ impl windows_core::RuntimeName for WiFiNetworkReport {
 unsafe impl Send for WiFiNetworkReport {}
 unsafe impl Sync for WiFiNetworkReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiOnDemandHotspotConnectTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiOnDemandHotspotConnectTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiOnDemandHotspotConnectTriggerDetails {
@@ -520,7 +520,7 @@ impl windows_core::RuntimeName for WiFiOnDemandHotspotConnectTriggerDetails {
 unsafe impl Send for WiFiOnDemandHotspotConnectTriggerDetails {}
 unsafe impl Sync for WiFiOnDemandHotspotConnectTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiOnDemandHotspotConnectionResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiOnDemandHotspotConnectionResult, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiOnDemandHotspotConnectionResult {
@@ -545,7 +545,7 @@ impl windows_core::RuntimeName for WiFiOnDemandHotspotConnectionResult {
 unsafe impl Send for WiFiOnDemandHotspotConnectionResult {}
 unsafe impl Sync for WiFiOnDemandHotspotConnectionResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiOnDemandHotspotNetwork(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiOnDemandHotspotNetwork, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiOnDemandHotspotNetwork {
@@ -595,7 +595,7 @@ impl windows_core::RuntimeName for WiFiOnDemandHotspotNetwork {
 unsafe impl Send for WiFiOnDemandHotspotNetwork {}
 unsafe impl Sync for WiFiOnDemandHotspotNetwork {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiOnDemandHotspotNetworkProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiOnDemandHotspotNetworkProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiOnDemandHotspotNetworkProperties {
@@ -701,7 +701,7 @@ impl windows_core::RuntimeName for WiFiOnDemandHotspotNetworkProperties {
 unsafe impl Send for WiFiOnDemandHotspotNetworkProperties {}
 unsafe impl Sync for WiFiOnDemandHotspotNetworkProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiWpsConfigurationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiWpsConfigurationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiWpsConfigurationResult {

--- a/crates/libs/windows/src/Windows/Devices/WiFiDirect/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFiDirect/Services/mod.rs
@@ -218,7 +218,7 @@ pub struct IWiFiDirectServiceStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectService(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectService, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectService {
@@ -348,7 +348,7 @@ impl windows_core::RuntimeName for WiFiDirectService {
 unsafe impl Send for WiFiDirectService {}
 unsafe impl Sync for WiFiDirectService {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectServiceAdvertiser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectServiceAdvertiser, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectServiceAdvertiser {
@@ -562,7 +562,7 @@ impl windows_core::RuntimeName for WiFiDirectServiceAdvertiser {
 unsafe impl Send for WiFiDirectServiceAdvertiser {}
 unsafe impl Sync for WiFiDirectServiceAdvertiser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectServiceAutoAcceptSessionConnectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectServiceAutoAcceptSessionConnectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectServiceAutoAcceptSessionConnectedEventArgs {
@@ -595,7 +595,7 @@ impl windows_core::RuntimeName for WiFiDirectServiceAutoAcceptSessionConnectedEv
 unsafe impl Send for WiFiDirectServiceAutoAcceptSessionConnectedEventArgs {}
 unsafe impl Sync for WiFiDirectServiceAutoAcceptSessionConnectedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectServiceProvisioningInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectServiceProvisioningInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectServiceProvisioningInfo {
@@ -627,7 +627,7 @@ impl windows_core::RuntimeName for WiFiDirectServiceProvisioningInfo {
 unsafe impl Send for WiFiDirectServiceProvisioningInfo {}
 unsafe impl Sync for WiFiDirectServiceProvisioningInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectServiceRemotePortAddedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectServiceRemotePortAddedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectServiceRemotePortAddedEventArgs {
@@ -660,7 +660,7 @@ impl windows_core::RuntimeName for WiFiDirectServiceRemotePortAddedEventArgs {
 unsafe impl Send for WiFiDirectServiceRemotePortAddedEventArgs {}
 unsafe impl Sync for WiFiDirectServiceRemotePortAddedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectServiceSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectServiceSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WiFiDirectServiceSession, super::super::super::Foundation::IClosable);
@@ -790,7 +790,7 @@ impl windows_core::RuntimeName for WiFiDirectServiceSession {
 unsafe impl Send for WiFiDirectServiceSession {}
 unsafe impl Sync for WiFiDirectServiceSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectServiceSessionDeferredEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectServiceSessionDeferredEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectServiceSessionDeferredEventArgs {
@@ -816,7 +816,7 @@ impl windows_core::RuntimeName for WiFiDirectServiceSessionDeferredEventArgs {
 unsafe impl Send for WiFiDirectServiceSessionDeferredEventArgs {}
 unsafe impl Sync for WiFiDirectServiceSessionDeferredEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectServiceSessionRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectServiceSessionRequest, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WiFiDirectServiceSessionRequest, super::super::super::Foundation::IClosable);
@@ -862,7 +862,7 @@ impl windows_core::RuntimeName for WiFiDirectServiceSessionRequest {
 unsafe impl Send for WiFiDirectServiceSessionRequest {}
 unsafe impl Sync for WiFiDirectServiceSessionRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectServiceSessionRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectServiceSessionRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectServiceSessionRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/Devices/WiFiDirect/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFiDirect/mod.rs
@@ -223,7 +223,7 @@ pub struct IWiFiDirectLegacySettings_Vtbl {
     SetPassphrase: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectAdvertisement(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectAdvertisement, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectAdvertisement {
@@ -294,7 +294,7 @@ impl windows_core::RuntimeName for WiFiDirectAdvertisement {
 unsafe impl Send for WiFiDirectAdvertisement {}
 unsafe impl Sync for WiFiDirectAdvertisement {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectAdvertisementPublisher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectAdvertisementPublisher, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectAdvertisementPublisher {
@@ -355,7 +355,7 @@ impl windows_core::RuntimeName for WiFiDirectAdvertisementPublisher {
 unsafe impl Send for WiFiDirectAdvertisementPublisher {}
 unsafe impl Sync for WiFiDirectAdvertisementPublisher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectAdvertisementPublisherStatusChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectAdvertisementPublisherStatusChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectAdvertisementPublisherStatusChangedEventArgs {
@@ -387,7 +387,7 @@ impl windows_core::RuntimeName for WiFiDirectAdvertisementPublisherStatusChanged
 unsafe impl Send for WiFiDirectAdvertisementPublisherStatusChangedEventArgs {}
 unsafe impl Sync for WiFiDirectAdvertisementPublisherStatusChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectConnectionListener(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectConnectionListener, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectConnectionListener {
@@ -426,7 +426,7 @@ impl windows_core::RuntimeName for WiFiDirectConnectionListener {
 unsafe impl Send for WiFiDirectConnectionListener {}
 unsafe impl Sync for WiFiDirectConnectionListener {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectConnectionParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectConnectionParameters, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Devices_Enumeration")]
@@ -495,7 +495,7 @@ impl windows_core::RuntimeName for WiFiDirectConnectionParameters {
 unsafe impl Send for WiFiDirectConnectionParameters {}
 unsafe impl Sync for WiFiDirectConnectionParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectConnectionRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectConnectionRequest, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WiFiDirectConnectionRequest, super::super::Foundation::IClosable);
@@ -526,7 +526,7 @@ impl windows_core::RuntimeName for WiFiDirectConnectionRequest {
 unsafe impl Send for WiFiDirectConnectionRequest {}
 unsafe impl Sync for WiFiDirectConnectionRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectConnectionRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectConnectionRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectConnectionRequestedEventArgs {
@@ -551,7 +551,7 @@ impl windows_core::RuntimeName for WiFiDirectConnectionRequestedEventArgs {
 unsafe impl Send for WiFiDirectConnectionRequestedEventArgs {}
 unsafe impl Sync for WiFiDirectConnectionRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectDevice, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WiFiDirectDevice, super::super::Foundation::IClosable);
@@ -647,7 +647,7 @@ impl windows_core::RuntimeName for WiFiDirectDevice {
 unsafe impl Send for WiFiDirectDevice {}
 unsafe impl Sync for WiFiDirectDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectInformationElement(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectInformationElement, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectInformationElement {
@@ -740,7 +740,7 @@ impl windows_core::RuntimeName for WiFiDirectInformationElement {
 unsafe impl Send for WiFiDirectInformationElement {}
 unsafe impl Sync for WiFiDirectInformationElement {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WiFiDirectLegacySettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WiFiDirectLegacySettings, windows_core::IUnknown, windows_core::IInspectable);
 impl WiFiDirectLegacySettings {

--- a/crates/libs/windows/src/Windows/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/mod.rs
@@ -164,7 +164,7 @@ pub struct ILowLevelDevicesControllerStatics_Vtbl {
     pub SetDefaultProvider: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LowLevelDevicesAggregateProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LowLevelDevicesAggregateProvider, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LowLevelDevicesAggregateProvider, ILowLevelDevicesAggregateProvider);
@@ -242,7 +242,7 @@ impl windows_core::RuntimeName for LowLevelDevicesAggregateProvider {
 unsafe impl Send for LowLevelDevicesAggregateProvider {}
 unsafe impl Sync for LowLevelDevicesAggregateProvider {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LowLevelDevicesController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LowLevelDevicesController, windows_core::IUnknown, windows_core::IInspectable);
 impl LowLevelDevicesController {

--- a/crates/libs/windows/src/Windows/Embedded/DeviceLockdown/mod.rs
+++ b/crates/libs/windows/src/Windows/Embedded/DeviceLockdown/mod.rs
@@ -59,7 +59,7 @@ impl windows_core::RuntimeName for DeviceLockdownProfile {
     const NAME: &'static str = "Windows.Embedded.DeviceLockdown.DeviceLockdownProfile";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeviceLockdownProfileInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeviceLockdownProfileInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl DeviceLockdownProfileInformation {

--- a/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
@@ -1,5 +1,5 @@
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IIterable<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -51,7 +51,7 @@ where
     pub T: core::marker::PhantomData<T>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IIterator<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -123,7 +123,7 @@ where
     pub T: core::marker::PhantomData<T>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IKeyValuePair<K, V>(windows_core::IUnknown, core::marker::PhantomData<K>, core::marker::PhantomData<V>)
 where
     K: windows_core::RuntimeType + 'static,
@@ -172,7 +172,7 @@ where
     pub V: core::marker::PhantomData<V>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IMap<K, V>(windows_core::IUnknown, core::marker::PhantomData<K>, core::marker::PhantomData<V>)
 where
     K: windows_core::RuntimeType + 'static,
@@ -292,7 +292,7 @@ where
     pub V: core::marker::PhantomData<V>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IMapChangedEventArgs<K>(windows_core::IUnknown, core::marker::PhantomData<K>)
 where
     K: windows_core::RuntimeType + 'static;
@@ -338,7 +338,7 @@ where
     pub K: core::marker::PhantomData<K>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IMapView<K, V>(windows_core::IUnknown, core::marker::PhantomData<K>, core::marker::PhantomData<V>)
 where
     K: windows_core::RuntimeType + 'static,
@@ -430,7 +430,7 @@ where
     pub V: core::marker::PhantomData<V>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IObservableMap<K, V>(windows_core::IUnknown, core::marker::PhantomData<K>, core::marker::PhantomData<V>)
 where
     K: windows_core::RuntimeType + 'static,
@@ -562,7 +562,7 @@ where
     pub V: core::marker::PhantomData<V>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IObservableVector<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -809,7 +809,7 @@ pub struct IPropertySet_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IVector<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -1001,7 +1001,7 @@ pub struct IVectorChangedEventArgs_Vtbl {
     pub Index: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IVectorView<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -1108,7 +1108,7 @@ where
     pub T: core::marker::PhantomData<T>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PropertySet(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PropertySet, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PropertySet, IIterable < IKeyValuePair < windows_core::HSTRING , windows_core::IInspectable > >, IMap < windows_core::HSTRING , windows_core::IInspectable >, IObservableMap < windows_core::HSTRING , windows_core::IInspectable >, IPropertySet);
@@ -1215,7 +1215,7 @@ impl IntoIterator for &PropertySet {
 unsafe impl Send for PropertySet {}
 unsafe impl Sync for PropertySet {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StringMap(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StringMap, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StringMap, IIterable < IKeyValuePair < windows_core::HSTRING , windows_core::HSTRING > >, IMap < windows_core::HSTRING , windows_core::HSTRING >, IObservableMap < windows_core::HSTRING , windows_core::HSTRING >);
@@ -1319,7 +1319,7 @@ impl IntoIterator for &StringMap {
 unsafe impl Send for StringMap {}
 unsafe impl Sync for StringMap {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ValueSet(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ValueSet, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ValueSet, IIterable < IKeyValuePair < windows_core::HSTRING , windows_core::IInspectable > >, IMap < windows_core::HSTRING , windows_core::IInspectable >, IObservableMap < windows_core::HSTRING , windows_core::IInspectable >, IPropertySet);
@@ -1446,7 +1446,7 @@ impl windows_core::RuntimeType for CollectionChange {
     const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::from_slice(b"enum(Windows.Foundation.Collections.CollectionChange;i4)");
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MapChangedEventHandler<K, V>(windows_core::IUnknown, core::marker::PhantomData<K>, core::marker::PhantomData<V>)
 where
     K: windows_core::RuntimeType + 'static,
@@ -1531,7 +1531,7 @@ where
     pub V: core::marker::PhantomData<V>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VectorChangedEventHandler<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;

--- a/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
@@ -722,7 +722,7 @@ impl windows_core::RuntimeName for AsyncCausalityTracer {
     const NAME: &'static str = "Windows.Foundation.Diagnostics.AsyncCausalityTracer";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ErrorDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ErrorDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl ErrorDetails {
@@ -772,7 +772,7 @@ impl windows_core::RuntimeName for ErrorDetails {
 unsafe impl Send for ErrorDetails {}
 unsafe impl Sync for ErrorDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileLoggingSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileLoggingSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FileLoggingSession, super::IClosable, IFileLoggingSession);
@@ -856,7 +856,7 @@ impl windows_core::RuntimeName for FileLoggingSession {
 unsafe impl Send for FileLoggingSession {}
 unsafe impl Sync for FileLoggingSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LogFileGeneratedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LogFileGeneratedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl LogFileGeneratedEventArgs {
@@ -882,7 +882,7 @@ impl windows_core::RuntimeName for LogFileGeneratedEventArgs {
 unsafe impl Send for LogFileGeneratedEventArgs {}
 unsafe impl Sync for LogFileGeneratedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LoggingActivity(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LoggingActivity, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LoggingActivity, super::IClosable, ILoggingTarget);
@@ -1053,7 +1053,7 @@ impl windows_core::RuntimeName for LoggingActivity {
 unsafe impl Send for LoggingActivity {}
 unsafe impl Sync for LoggingActivity {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LoggingChannel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LoggingChannel, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LoggingChannel, super::IClosable, ILoggingChannel, ILoggingTarget);
@@ -1254,7 +1254,7 @@ impl windows_core::RuntimeName for LoggingChannel {
 unsafe impl Send for LoggingChannel {}
 unsafe impl Sync for LoggingChannel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LoggingChannelOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LoggingChannelOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl LoggingChannelOptions {
@@ -1301,7 +1301,7 @@ impl windows_core::RuntimeName for LoggingChannelOptions {
 unsafe impl Send for LoggingChannelOptions {}
 unsafe impl Sync for LoggingChannelOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LoggingFields(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LoggingFields, windows_core::IUnknown, windows_core::IInspectable);
 impl LoggingFields {
@@ -1786,7 +1786,7 @@ impl windows_core::RuntimeName for LoggingFields {
 unsafe impl Send for LoggingFields {}
 unsafe impl Sync for LoggingFields {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LoggingOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LoggingOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl LoggingOptions {
@@ -1888,7 +1888,7 @@ impl windows_core::RuntimeName for LoggingOptions {
 unsafe impl Send for LoggingOptions {}
 unsafe impl Sync for LoggingOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LoggingSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LoggingSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LoggingSession, super::IClosable, ILoggingSession);
@@ -1961,7 +1961,7 @@ impl windows_core::RuntimeName for LoggingSession {
 unsafe impl Send for LoggingSession {}
 unsafe impl Sync for LoggingSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RuntimeBrokerErrorSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RuntimeBrokerErrorSettings, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RuntimeBrokerErrorSettings, IErrorReportingSettings);
@@ -1998,7 +1998,7 @@ impl windows_core::RuntimeName for RuntimeBrokerErrorSettings {
 unsafe impl Send for RuntimeBrokerErrorSettings {}
 unsafe impl Sync for RuntimeBrokerErrorSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TracingStatusChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TracingStatusChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TracingStatusChangedEventArgs {

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -106,7 +106,7 @@ pub struct IAsyncAction_Vtbl {
     pub GetResults: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IAsyncActionWithProgress<TProgress>(windows_core::IUnknown, core::marker::PhantomData<TProgress>)
 where
     TProgress: windows_core::RuntimeType + 'static;
@@ -287,7 +287,7 @@ pub struct IAsyncInfo_Vtbl {
     pub Close: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IAsyncOperation<TResult>(windows_core::IUnknown, core::marker::PhantomData<TResult>)
 where
     TResult: windows_core::RuntimeType + 'static;
@@ -404,7 +404,7 @@ where
     pub TResult: core::marker::PhantomData<TResult>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IAsyncOperationWithProgress<TResult, TProgress>(windows_core::IUnknown, core::marker::PhantomData<TResult>, core::marker::PhantomData<TProgress>)
 where
     TResult: windows_core::RuntimeType + 'static,
@@ -1020,7 +1020,7 @@ pub struct IPropertyValueStatics_Vtbl {
     pub CreateRectArray: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const Rect, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IReference<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -1277,7 +1277,7 @@ where
     pub T: core::marker::PhantomData<T>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IReferenceArray<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -1665,7 +1665,7 @@ pub struct IWwwFormUrlDecoderRuntimeClassFactory_Vtbl {
     pub CreateWwwFormUrlDecoder: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Deferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Deferral, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Deferral, IClosable);
@@ -1735,7 +1735,7 @@ impl windows_core::RuntimeName for GuidHelper {
     const NAME: &'static str = "Windows.Foundation.GuidHelper";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MemoryBuffer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MemoryBuffer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MemoryBuffer, IClosable, IMemoryBuffer);
@@ -2024,7 +2024,7 @@ impl windows_core::RuntimeName for PropertyValue {
     const NAME: &'static str = "Windows.Foundation.PropertyValue";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Uri(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Uri, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Uri, IStringable);
@@ -2220,7 +2220,7 @@ impl windows_core::RuntimeName for Uri {
 unsafe impl Send for Uri {}
 unsafe impl Sync for Uri {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WwwFormUrlDecoder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WwwFormUrlDecoder, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -2317,7 +2317,7 @@ impl IntoIterator for &WwwFormUrlDecoder {
 unsafe impl Send for WwwFormUrlDecoder {}
 unsafe impl Sync for WwwFormUrlDecoder {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WwwFormUrlDecoderEntry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WwwFormUrlDecoderEntry, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WwwFormUrlDecoderEntry, IWwwFormUrlDecoderEntry);
@@ -2588,7 +2588,7 @@ pub struct AsyncActionCompletedHandler_Vtbl {
     pub Invoke: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, AsyncStatus) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AsyncActionProgressHandler<TProgress>(windows_core::IUnknown, core::marker::PhantomData<TProgress>)
 where
     TProgress: windows_core::RuntimeType + 'static;
@@ -2668,7 +2668,7 @@ where
     pub TProgress: core::marker::PhantomData<TProgress>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AsyncActionWithProgressCompletedHandler<TProgress>(windows_core::IUnknown, core::marker::PhantomData<TProgress>)
 where
     TProgress: windows_core::RuntimeType + 'static;
@@ -2747,7 +2747,7 @@ where
     pub TProgress: core::marker::PhantomData<TProgress>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AsyncOperationCompletedHandler<TResult>(windows_core::IUnknown, core::marker::PhantomData<TResult>)
 where
     TResult: windows_core::RuntimeType + 'static;
@@ -2826,7 +2826,7 @@ where
     pub TResult: core::marker::PhantomData<TResult>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AsyncOperationProgressHandler<TResult, TProgress>(windows_core::IUnknown, core::marker::PhantomData<TResult>, core::marker::PhantomData<TProgress>)
 where
     TResult: windows_core::RuntimeType + 'static,
@@ -2911,7 +2911,7 @@ where
     pub TProgress: core::marker::PhantomData<TProgress>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AsyncOperationWithProgressCompletedHandler<TResult, TProgress>(windows_core::IUnknown, core::marker::PhantomData<TResult>, core::marker::PhantomData<TProgress>)
 where
     TResult: windows_core::RuntimeType + 'static,
@@ -3052,7 +3052,7 @@ pub struct DeferralCompletedHandler_Vtbl {
     pub Invoke: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EventHandler<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -3132,7 +3132,7 @@ where
     pub T: core::marker::PhantomData<T>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TypedEventHandler<TSender, TResult>(windows_core::IUnknown, core::marker::PhantomData<TSender>, core::marker::PhantomData<TResult>)
 where
     TSender: windows_core::RuntimeType + 'static,

--- a/crates/libs/windows/src/Windows/Gaming/Input/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/Custom/mod.rs
@@ -336,7 +336,7 @@ impl windows_core::RuntimeName for GameControllerFactoryManager {
     const NAME: &'static str = "Windows.Gaming.Input.Custom.GameControllerFactoryManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GipFirmwareUpdateResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GipFirmwareUpdateResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GipFirmwareUpdateResult {
@@ -375,7 +375,7 @@ impl windows_core::RuntimeName for GipFirmwareUpdateResult {
 unsafe impl Send for GipFirmwareUpdateResult {}
 unsafe impl Sync for GipFirmwareUpdateResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GipGameControllerProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GipGameControllerProvider, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GipGameControllerProvider, IGameControllerProvider);
@@ -448,7 +448,7 @@ impl windows_core::RuntimeName for GipGameControllerProvider {
 unsafe impl Send for GipGameControllerProvider {}
 unsafe impl Sync for GipGameControllerProvider {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HidGameControllerProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HidGameControllerProvider, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HidGameControllerProvider, IGameControllerProvider);
@@ -528,7 +528,7 @@ impl windows_core::RuntimeName for HidGameControllerProvider {
 unsafe impl Send for HidGameControllerProvider {}
 unsafe impl Sync for HidGameControllerProvider {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XusbGameControllerProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XusbGameControllerProvider, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(XusbGameControllerProvider, IGameControllerProvider);

--- a/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
@@ -148,7 +148,7 @@ pub struct IRampForceEffect_Vtbl {
     SetParametersWithEnvelope: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConditionForceEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConditionForceEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ConditionForceEffect, IForceFeedbackEffect);
@@ -216,7 +216,7 @@ impl windows_core::RuntimeName for ConditionForceEffect {
 unsafe impl Send for ConditionForceEffect {}
 unsafe impl Sync for ConditionForceEffect {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConstantForceEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConstantForceEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ConstantForceEffect, IForceFeedbackEffect);
@@ -278,7 +278,7 @@ impl windows_core::RuntimeName for ConstantForceEffect {
 unsafe impl Send for ConstantForceEffect {}
 unsafe impl Sync for ConstantForceEffect {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ForceFeedbackMotor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ForceFeedbackMotor, windows_core::IUnknown, windows_core::IInspectable);
 impl ForceFeedbackMotor {
@@ -381,7 +381,7 @@ impl windows_core::RuntimeName for ForceFeedbackMotor {
 unsafe impl Send for ForceFeedbackMotor {}
 unsafe impl Sync for ForceFeedbackMotor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PeriodicForceEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PeriodicForceEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PeriodicForceEffect, IForceFeedbackEffect);
@@ -454,7 +454,7 @@ impl windows_core::RuntimeName for PeriodicForceEffect {
 unsafe impl Send for PeriodicForceEffect {}
 unsafe impl Sync for PeriodicForceEffect {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RampForceEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RampForceEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RampForceEffect, IForceFeedbackEffect);

--- a/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
@@ -380,7 +380,7 @@ pub struct IUINavigationControllerStatics2_Vtbl {
     pub FromGameController: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ArcadeStick(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ArcadeStick, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ArcadeStick, IGameController, IGameControllerBatteryInfo);
@@ -536,7 +536,7 @@ impl windows_core::RuntimeName for ArcadeStick {
 unsafe impl Send for ArcadeStick {}
 unsafe impl Sync for ArcadeStick {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FlightStick(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FlightStick, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FlightStick, IGameController, IGameControllerBatteryInfo);
@@ -694,7 +694,7 @@ impl windows_core::RuntimeName for FlightStick {
 unsafe impl Send for FlightStick {}
 unsafe impl Sync for FlightStick {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Gamepad(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Gamepad, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Gamepad, IGameController, IGameControllerBatteryInfo);
@@ -861,7 +861,7 @@ impl windows_core::RuntimeName for Gamepad {
 unsafe impl Send for Gamepad {}
 unsafe impl Sync for Gamepad {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Headset(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Headset, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Headset, IGameControllerBatteryInfo);
@@ -902,7 +902,7 @@ impl windows_core::RuntimeName for Headset {
 unsafe impl Send for Headset {}
 unsafe impl Sync for Headset {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RacingWheel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RacingWheel, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RacingWheel, IGameController, IGameControllerBatteryInfo);
@@ -1101,7 +1101,7 @@ impl windows_core::RuntimeName for RacingWheel {
 unsafe impl Send for RacingWheel {}
 unsafe impl Sync for RacingWheel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RawGameController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RawGameController, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RawGameController, IGameController, IGameControllerBatteryInfo);
@@ -1324,7 +1324,7 @@ impl windows_core::RuntimeName for RawGameController {
 unsafe impl Send for RawGameController {}
 unsafe impl Sync for RawGameController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UINavigationController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UINavigationController, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UINavigationController, IGameController, IGameControllerBatteryInfo);

--- a/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
@@ -261,7 +261,7 @@ impl windows_core::RuntimeName for GameList {
     const NAME: &'static str = "Windows.Gaming.Preview.GamesEnumeration.GameList";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameListEntry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameListEntry, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GameListEntry, IGameListEntry);
@@ -382,7 +382,7 @@ impl windows_core::RuntimeName for GameListEntry {
 unsafe impl Send for GameListEntry {}
 unsafe impl Sync for GameListEntry {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameModeConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameModeConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl GameModeConfiguration {
@@ -521,7 +521,7 @@ impl windows_core::RuntimeName for GameModeConfiguration {
 unsafe impl Send for GameModeConfiguration {}
 unsafe impl Sync for GameModeConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameModeUserConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameModeUserConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl GameModeUserConfiguration {

--- a/crates/libs/windows/src/Windows/Gaming/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/UI/mod.rs
@@ -120,7 +120,7 @@ impl windows_core::RuntimeName for GameBar {
     const NAME: &'static str = "Windows.Gaming.UI.GameBar";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameChatMessageReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameChatMessageReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GameChatMessageReceivedEventArgs {
@@ -173,7 +173,7 @@ impl windows_core::RuntimeName for GameChatMessageReceivedEventArgs {
 unsafe impl Send for GameChatMessageReceivedEventArgs {}
 unsafe impl Sync for GameChatMessageReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameChatOverlay(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameChatOverlay, windows_core::IUnknown, windows_core::IInspectable);
 impl GameChatOverlay {
@@ -217,7 +217,7 @@ impl windows_core::RuntimeName for GameChatOverlay {
 unsafe impl Send for GameChatOverlay {}
 unsafe impl Sync for GameChatOverlay {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameChatOverlayMessageSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameChatOverlayMessageSource, windows_core::IUnknown, windows_core::IInspectable);
 impl GameChatOverlayMessageSource {
@@ -260,7 +260,7 @@ impl windows_core::RuntimeName for GameChatOverlayMessageSource {
 unsafe impl Send for GameChatOverlayMessageSource {}
 unsafe impl Sync for GameChatOverlayMessageSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameUIProviderActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameUIProviderActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]

--- a/crates/libs/windows/src/Windows/Gaming/XboxLive/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/XboxLive/Storage/mod.rs
@@ -166,7 +166,7 @@ pub struct IGameSaveProviderStatics_Vtbl {
     GetSyncOnDemandForUserAsync: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveBlobGetResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveBlobGetResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveBlobGetResult {
@@ -199,7 +199,7 @@ impl windows_core::RuntimeName for GameSaveBlobGetResult {
 unsafe impl Send for GameSaveBlobGetResult {}
 unsafe impl Sync for GameSaveBlobGetResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveBlobInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveBlobInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveBlobInfo {
@@ -231,7 +231,7 @@ impl windows_core::RuntimeName for GameSaveBlobInfo {
 unsafe impl Send for GameSaveBlobInfo {}
 unsafe impl Sync for GameSaveBlobInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveBlobInfoGetResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveBlobInfoGetResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveBlobInfoGetResult {
@@ -264,7 +264,7 @@ impl windows_core::RuntimeName for GameSaveBlobInfoGetResult {
 unsafe impl Send for GameSaveBlobInfoGetResult {}
 unsafe impl Sync for GameSaveBlobInfoGetResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveBlobInfoQuery(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveBlobInfoQuery, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveBlobInfoQuery {
@@ -303,7 +303,7 @@ impl windows_core::RuntimeName for GameSaveBlobInfoQuery {
 unsafe impl Send for GameSaveBlobInfoQuery {}
 unsafe impl Sync for GameSaveBlobInfoQuery {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveContainer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveContainer, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveContainer {
@@ -388,7 +388,7 @@ impl windows_core::RuntimeName for GameSaveContainer {
 unsafe impl Send for GameSaveContainer {}
 unsafe impl Sync for GameSaveContainer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveContainerInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveContainerInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveContainerInfo {
@@ -441,7 +441,7 @@ impl windows_core::RuntimeName for GameSaveContainerInfo {
 unsafe impl Send for GameSaveContainerInfo {}
 unsafe impl Sync for GameSaveContainerInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveContainerInfoGetResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveContainerInfoGetResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveContainerInfoGetResult {
@@ -474,7 +474,7 @@ impl windows_core::RuntimeName for GameSaveContainerInfoGetResult {
 unsafe impl Send for GameSaveContainerInfoGetResult {}
 unsafe impl Sync for GameSaveContainerInfoGetResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveContainerInfoQuery(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveContainerInfoQuery, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveContainerInfoQuery {
@@ -513,7 +513,7 @@ impl windows_core::RuntimeName for GameSaveContainerInfoQuery {
 unsafe impl Send for GameSaveContainerInfoQuery {}
 unsafe impl Sync for GameSaveContainerInfoQuery {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveOperationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveOperationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveOperationResult {
@@ -538,7 +538,7 @@ impl windows_core::RuntimeName for GameSaveOperationResult {
 unsafe impl Send for GameSaveOperationResult {}
 unsafe impl Sync for GameSaveOperationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveProvider {
@@ -632,7 +632,7 @@ impl windows_core::RuntimeName for GameSaveProvider {
 unsafe impl Send for GameSaveProvider {}
 unsafe impl Sync for GameSaveProvider {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameSaveProviderGetResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameSaveProviderGetResult, windows_core::IUnknown, windows_core::IInspectable);
 impl GameSaveProviderGetResult {

--- a/crates/libs/windows/src/Windows/Globalization/Collation/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/Collation/mod.rs
@@ -27,7 +27,7 @@ pub struct ICharacterGroupingsFactory_Vtbl {
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CharacterGrouping(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CharacterGrouping, windows_core::IUnknown, windows_core::IInspectable);
 impl CharacterGrouping {
@@ -59,7 +59,7 @@ impl windows_core::RuntimeName for CharacterGrouping {
 unsafe impl Send for CharacterGrouping {}
 unsafe impl Sync for CharacterGrouping {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CharacterGroupings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CharacterGroupings, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]

--- a/crates/libs/windows/src/Windows/Globalization/DateTimeFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/DateTimeFormatting/mod.rs
@@ -79,7 +79,7 @@ pub struct IDateTimeFormatterStatics_Vtbl {
     pub ShortTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DateTimeFormatter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DateTimeFormatter, windows_core::IUnknown, windows_core::IInspectable);
 impl DateTimeFormatter {

--- a/crates/libs/windows/src/Windows/Globalization/Fonts/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/Fonts/mod.rs
@@ -49,7 +49,7 @@ pub struct ILanguageFontGroupFactory_Vtbl {
     pub CreateLanguageFontGroup: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LanguageFont(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LanguageFont, windows_core::IUnknown, windows_core::IInspectable);
 impl LanguageFont {
@@ -105,7 +105,7 @@ impl windows_core::RuntimeName for LanguageFont {
 unsafe impl Send for LanguageFont {}
 unsafe impl Sync for LanguageFont {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LanguageFontGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LanguageFontGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl LanguageFontGroup {

--- a/crates/libs/windows/src/Windows/Globalization/NumberFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/NumberFormatting/mod.rs
@@ -523,7 +523,7 @@ pub struct ISignificantDigitsOption_Vtbl {
     pub SetSignificantDigits: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CurrencyFormatter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CurrencyFormatter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CurrencyFormatter, INumberFormatter, INumberFormatter2, INumberFormatterOptions, INumberParser, INumberRounderOption, ISignedZeroOption, ISignificantDigitsOption);
@@ -773,7 +773,7 @@ impl windows_core::RuntimeName for CurrencyFormatter {
 unsafe impl Send for CurrencyFormatter {}
 unsafe impl Sync for CurrencyFormatter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DecimalFormatter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DecimalFormatter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DecimalFormatter, INumberFormatter, INumberFormatter2, INumberFormatterOptions, INumberParser, INumberRounderOption, ISignedZeroOption, ISignificantDigitsOption);
@@ -997,7 +997,7 @@ impl windows_core::RuntimeName for DecimalFormatter {
 unsafe impl Send for DecimalFormatter {}
 unsafe impl Sync for DecimalFormatter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IncrementNumberRounder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IncrementNumberRounder, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(IncrementNumberRounder, INumberRounder);
@@ -1087,7 +1087,7 @@ impl windows_core::RuntimeName for IncrementNumberRounder {
 unsafe impl Send for IncrementNumberRounder {}
 unsafe impl Sync for IncrementNumberRounder {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NumeralSystemTranslator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NumeralSystemTranslator, windows_core::IUnknown, windows_core::IInspectable);
 impl NumeralSystemTranslator {
@@ -1160,7 +1160,7 @@ impl windows_core::RuntimeName for NumeralSystemTranslator {
 unsafe impl Send for NumeralSystemTranslator {}
 unsafe impl Sync for NumeralSystemTranslator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PercentFormatter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PercentFormatter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PercentFormatter, INumberFormatter, INumberFormatter2, INumberFormatterOptions, INumberParser, INumberRounderOption, ISignedZeroOption, ISignificantDigitsOption);
@@ -1384,7 +1384,7 @@ impl windows_core::RuntimeName for PercentFormatter {
 unsafe impl Send for PercentFormatter {}
 unsafe impl Sync for PercentFormatter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PermilleFormatter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PermilleFormatter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PermilleFormatter, INumberFormatter, INumberFormatter2, INumberFormatterOptions, INumberParser, INumberRounderOption, ISignedZeroOption, ISignificantDigitsOption);
@@ -1608,7 +1608,7 @@ impl windows_core::RuntimeName for PermilleFormatter {
 unsafe impl Send for PermilleFormatter {}
 unsafe impl Sync for PermilleFormatter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SignificantDigitsNumberRounder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SignificantDigitsNumberRounder, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SignificantDigitsNumberRounder, INumberRounder);

--- a/crates/libs/windows/src/Windows/Globalization/PhoneNumberFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/PhoneNumberFormatting/mod.rs
@@ -59,7 +59,7 @@ pub struct IPhoneNumberInfoStatics_Vtbl {
     pub TryParseWithRegion: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut PhoneNumberParseResult) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneNumberFormatter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneNumberFormatter, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneNumberFormatter {
@@ -151,7 +151,7 @@ impl windows_core::RuntimeName for PhoneNumberFormatter {
 unsafe impl Send for PhoneNumberFormatter {}
 unsafe impl Sync for PhoneNumberFormatter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneNumberInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneNumberInfo, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PhoneNumberInfo, super::super::Foundation::IStringable);

--- a/crates/libs/windows/src/Windows/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/mod.rs
@@ -700,7 +700,7 @@ impl windows_core::RuntimeName for ApplicationLanguages {
     const NAME: &'static str = "Windows.Globalization.ApplicationLanguages";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Calendar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Calendar, windows_core::IUnknown, windows_core::IInspectable);
 impl Calendar {
@@ -1536,7 +1536,7 @@ impl windows_core::RuntimeName for ClockIdentifiers {
     const NAME: &'static str = "Windows.Globalization.ClockIdentifiers";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CurrencyAmount(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CurrencyAmount, windows_core::IUnknown, windows_core::IInspectable);
 impl CurrencyAmount {
@@ -2572,7 +2572,7 @@ impl windows_core::RuntimeName for CurrencyIdentifiers {
     const NAME: &'static str = "Windows.Globalization.CurrencyIdentifiers";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GeographicRegion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GeographicRegion, windows_core::IUnknown, windows_core::IInspectable);
 impl GeographicRegion {
@@ -2669,7 +2669,7 @@ impl windows_core::RuntimeName for GeographicRegion {
 unsafe impl Send for GeographicRegion {}
 unsafe impl Sync for GeographicRegion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct JapanesePhoneme(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(JapanesePhoneme, windows_core::IUnknown, windows_core::IInspectable);
 impl JapanesePhoneme {
@@ -2731,7 +2731,7 @@ impl windows_core::RuntimeName for JapanesePhoneticAnalyzer {
     const NAME: &'static str = "Windows.Globalization.JapanesePhoneticAnalyzer";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Language(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Language, windows_core::IUnknown, windows_core::IInspectable);
 impl Language {

--- a/crates/libs/windows/src/Windows/Graphics/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Capture/mod.rs
@@ -153,7 +153,7 @@ pub struct IGraphicsCaptureSessionStatics_Vtbl {
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Direct3D11CaptureFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Direct3D11CaptureFrame, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Direct3D11CaptureFrame, super::super::Foundation::IClosable);
@@ -198,7 +198,7 @@ impl windows_core::RuntimeName for Direct3D11CaptureFrame {
 unsafe impl Send for Direct3D11CaptureFrame {}
 unsafe impl Sync for Direct3D11CaptureFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Direct3D11CaptureFramePool(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Direct3D11CaptureFramePool, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Direct3D11CaptureFramePool, super::super::Foundation::IClosable);
@@ -316,7 +316,7 @@ impl windows_core::RuntimeName for GraphicsCaptureAccess {
     const NAME: &'static str = "Windows.Graphics.Capture.GraphicsCaptureAccess";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GraphicsCaptureItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GraphicsCaptureItem, windows_core::IUnknown, windows_core::IInspectable);
 impl GraphicsCaptureItem {
@@ -395,7 +395,7 @@ impl windows_core::RuntimeName for GraphicsCaptureItem {
 unsafe impl Send for GraphicsCaptureItem {}
 unsafe impl Sync for GraphicsCaptureItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GraphicsCapturePicker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GraphicsCapturePicker, windows_core::IUnknown, windows_core::IInspectable);
 impl GraphicsCapturePicker {
@@ -427,7 +427,7 @@ impl windows_core::RuntimeName for GraphicsCapturePicker {
 unsafe impl Send for GraphicsCapturePicker {}
 unsafe impl Sync for GraphicsCapturePicker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GraphicsCaptureSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GraphicsCaptureSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(GraphicsCaptureSession, super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/Graphics/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/Core/mod.rs
@@ -55,7 +55,7 @@ pub struct IHdmiDisplayMode2_Vtbl {
     pub IsDolbyVisionLowLatencySupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HdmiDisplayInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HdmiDisplayInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl HdmiDisplayInformation {
@@ -150,7 +150,7 @@ impl windows_core::RuntimeName for HdmiDisplayInformation {
 unsafe impl Send for HdmiDisplayInformation {}
 unsafe impl Sync for HdmiDisplayInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HdmiDisplayMode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HdmiDisplayMode, windows_core::IUnknown, windows_core::IInspectable);
 impl HdmiDisplayMode {

--- a/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
@@ -326,7 +326,7 @@ pub struct IDisplayServicesStatics_Vtbl {
     pub FindAll: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut *mut super::DisplayId) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdvancedColorInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdvancedColorInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AdvancedColorInfo {
@@ -421,7 +421,7 @@ impl windows_core::RuntimeName for AdvancedColorInfo {
 unsafe impl Send for AdvancedColorInfo {}
 unsafe impl Sync for AdvancedColorInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BrightnessOverride(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BrightnessOverride, windows_core::IUnknown, windows_core::IInspectable);
 impl BrightnessOverride {
@@ -551,7 +551,7 @@ impl windows_core::RuntimeName for BrightnessOverride {
 unsafe impl Send for BrightnessOverride {}
 unsafe impl Sync for BrightnessOverride {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BrightnessOverrideSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BrightnessOverrideSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl BrightnessOverrideSettings {
@@ -606,7 +606,7 @@ impl windows_core::RuntimeName for BrightnessOverrideSettings {
 unsafe impl Send for BrightnessOverrideSettings {}
 unsafe impl Sync for BrightnessOverrideSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ColorOverrideSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ColorOverrideSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl ColorOverrideSettings {
@@ -642,7 +642,7 @@ impl windows_core::RuntimeName for ColorOverrideSettings {
 unsafe impl Send for ColorOverrideSettings {}
 unsafe impl Sync for ColorOverrideSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayEnhancementOverride(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayEnhancementOverride, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayEnhancementOverride {
@@ -770,7 +770,7 @@ impl windows_core::RuntimeName for DisplayEnhancementOverride {
 unsafe impl Send for DisplayEnhancementOverride {}
 unsafe impl Sync for DisplayEnhancementOverride {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayEnhancementOverrideCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayEnhancementOverrideCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayEnhancementOverrideCapabilities {
@@ -810,7 +810,7 @@ impl windows_core::RuntimeName for DisplayEnhancementOverrideCapabilities {
 unsafe impl Send for DisplayEnhancementOverrideCapabilities {}
 unsafe impl Sync for DisplayEnhancementOverrideCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayEnhancementOverrideCapabilitiesChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayEnhancementOverrideCapabilitiesChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayEnhancementOverrideCapabilitiesChangedEventArgs {
@@ -835,7 +835,7 @@ impl windows_core::RuntimeName for DisplayEnhancementOverrideCapabilitiesChanged
 unsafe impl Send for DisplayEnhancementOverrideCapabilitiesChangedEventArgs {}
 unsafe impl Sync for DisplayEnhancementOverrideCapabilitiesChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayInformation {
@@ -1185,7 +1185,7 @@ impl windows_core::RuntimeName for DisplayProperties {
     const NAME: &'static str = "Windows.Graphics.Display.DisplayProperties";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayServices(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayServices, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayServices {

--- a/crates/libs/windows/src/Windows/Graphics/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Holographic/mod.rs
@@ -579,7 +579,7 @@ pub struct IHolographicViewConfiguration2_Vtbl {
     SupportedDepthReprojectionMethods: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicCamera(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicCamera, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicCamera {
@@ -716,7 +716,7 @@ impl windows_core::RuntimeName for HolographicCamera {
 unsafe impl Send for HolographicCamera {}
 unsafe impl Sync for HolographicCamera {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicCameraPose(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicCameraPose, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicCameraPose {
@@ -820,7 +820,7 @@ impl windows_core::RuntimeName for HolographicCameraPose {
 unsafe impl Send for HolographicCameraPose {}
 unsafe impl Sync for HolographicCameraPose {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicCameraRenderingParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicCameraRenderingParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicCameraRenderingParameters {
@@ -919,7 +919,7 @@ impl windows_core::RuntimeName for HolographicCameraRenderingParameters {
 unsafe impl Send for HolographicCameraRenderingParameters {}
 unsafe impl Sync for HolographicCameraRenderingParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicCameraViewportParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicCameraViewportParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicCameraViewportParameters {
@@ -953,7 +953,7 @@ impl windows_core::RuntimeName for HolographicCameraViewportParameters {
 unsafe impl Send for HolographicCameraViewportParameters {}
 unsafe impl Sync for HolographicCameraViewportParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicDisplay(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicDisplay, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicDisplay {
@@ -1039,7 +1039,7 @@ impl windows_core::RuntimeName for HolographicDisplay {
 unsafe impl Send for HolographicDisplay {}
 unsafe impl Sync for HolographicDisplay {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicFrame, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicFrame {
@@ -1136,7 +1136,7 @@ impl windows_core::RuntimeName for HolographicFrame {
 unsafe impl Send for HolographicFrame {}
 unsafe impl Sync for HolographicFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicFramePrediction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicFramePrediction, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicFramePrediction {
@@ -1171,7 +1171,7 @@ unsafe impl Send for HolographicFramePrediction {}
 unsafe impl Sync for HolographicFramePrediction {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicFramePresentationMonitor(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(HolographicFramePresentationMonitor, windows_core::IUnknown, windows_core::IInspectable);
@@ -1211,7 +1211,7 @@ unsafe impl Send for HolographicFramePresentationMonitor {}
 unsafe impl Sync for HolographicFramePresentationMonitor {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicFramePresentationReport(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(HolographicFramePresentationReport, windows_core::IUnknown, windows_core::IInspectable);
@@ -1276,7 +1276,7 @@ unsafe impl Send for HolographicFramePresentationReport {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for HolographicFramePresentationReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicFrameRenderingReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicFrameRenderingReport, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicFrameRenderingReport {
@@ -1329,7 +1329,7 @@ impl windows_core::RuntimeName for HolographicFrameRenderingReport {
 unsafe impl Send for HolographicFrameRenderingReport {}
 unsafe impl Sync for HolographicFrameRenderingReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicFrameScanoutMonitor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicFrameScanoutMonitor, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HolographicFrameScanoutMonitor, super::super::Foundation::IClosable);
@@ -1360,7 +1360,7 @@ impl windows_core::RuntimeName for HolographicFrameScanoutMonitor {
 unsafe impl Send for HolographicFrameScanoutMonitor {}
 unsafe impl Sync for HolographicFrameScanoutMonitor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicFrameScanoutReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicFrameScanoutReport, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicFrameScanoutReport {
@@ -1413,7 +1413,7 @@ impl windows_core::RuntimeName for HolographicFrameScanoutReport {
 unsafe impl Send for HolographicFrameScanoutReport {}
 unsafe impl Sync for HolographicFrameScanoutReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicQuadLayer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicQuadLayer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HolographicQuadLayer, super::super::Foundation::IClosable);
@@ -1469,7 +1469,7 @@ impl windows_core::RuntimeName for HolographicQuadLayer {
 unsafe impl Send for HolographicQuadLayer {}
 unsafe impl Sync for HolographicQuadLayer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicQuadLayerUpdateParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicQuadLayerUpdateParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicQuadLayerUpdateParameters {
@@ -1536,7 +1536,7 @@ impl windows_core::RuntimeName for HolographicQuadLayerUpdateParameters {
 unsafe impl Send for HolographicQuadLayerUpdateParameters {}
 unsafe impl Sync for HolographicQuadLayerUpdateParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicSpace(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicSpace, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicSpace {
@@ -1703,7 +1703,7 @@ impl windows_core::RuntimeName for HolographicSpace {
 unsafe impl Send for HolographicSpace {}
 unsafe impl Sync for HolographicSpace {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicSpaceCameraAddedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicSpaceCameraAddedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicSpaceCameraAddedEventArgs {
@@ -1735,7 +1735,7 @@ impl windows_core::RuntimeName for HolographicSpaceCameraAddedEventArgs {
 unsafe impl Send for HolographicSpaceCameraAddedEventArgs {}
 unsafe impl Sync for HolographicSpaceCameraAddedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicSpaceCameraRemovedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicSpaceCameraRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicSpaceCameraRemovedEventArgs {
@@ -1760,7 +1760,7 @@ impl windows_core::RuntimeName for HolographicSpaceCameraRemovedEventArgs {
 unsafe impl Send for HolographicSpaceCameraRemovedEventArgs {}
 unsafe impl Sync for HolographicSpaceCameraRemovedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HolographicViewConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HolographicViewConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl HolographicViewConfiguration {

--- a/crates/libs/windows/src/Windows/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Imaging/mod.rs
@@ -564,7 +564,7 @@ pub struct ISoftwareBitmapStatics_Vtbl {
     CreateCopyWithAlphaFromSurfaceAsync: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BitmapBuffer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BitmapBuffer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BitmapBuffer, super::super::Foundation::IClosable, super::super::Foundation::IMemoryBuffer);
@@ -608,7 +608,7 @@ impl windows_core::RuntimeName for BitmapBuffer {
 unsafe impl Send for BitmapBuffer {}
 unsafe impl Sync for BitmapBuffer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BitmapCodecInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BitmapCodecInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl BitmapCodecInformation {
@@ -656,7 +656,7 @@ impl windows_core::RuntimeName for BitmapCodecInformation {
 unsafe impl Send for BitmapCodecInformation {}
 unsafe impl Sync for BitmapCodecInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BitmapDecoder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BitmapDecoder, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BitmapDecoder, IBitmapFrame, IBitmapFrameWithSoftwareBitmap);
@@ -914,7 +914,7 @@ impl windows_core::RuntimeName for BitmapDecoder {
 unsafe impl Send for BitmapDecoder {}
 unsafe impl Sync for BitmapDecoder {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BitmapEncoder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BitmapEncoder, windows_core::IUnknown, windows_core::IInspectable);
 impl BitmapEncoder {
@@ -1129,7 +1129,7 @@ impl windows_core::RuntimeName for BitmapEncoder {
 unsafe impl Send for BitmapEncoder {}
 unsafe impl Sync for BitmapEncoder {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BitmapFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BitmapFrame, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BitmapFrame, IBitmapFrame, IBitmapFrameWithSoftwareBitmap);
@@ -1260,7 +1260,7 @@ impl windows_core::RuntimeName for BitmapFrame {
 unsafe impl Send for BitmapFrame {}
 unsafe impl Sync for BitmapFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BitmapProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BitmapProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BitmapProperties, IBitmapPropertiesView);
@@ -1301,7 +1301,7 @@ impl windows_core::RuntimeName for BitmapProperties {
 unsafe impl Send for BitmapProperties {}
 unsafe impl Sync for BitmapProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BitmapPropertiesView(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BitmapPropertiesView, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BitmapPropertiesView, IBitmapPropertiesView);
@@ -1332,7 +1332,7 @@ unsafe impl Send for BitmapPropertiesView {}
 unsafe impl Sync for BitmapPropertiesView {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BitmapPropertySet(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(BitmapPropertySet, windows_core::IUnknown, windows_core::IInspectable);
@@ -1443,7 +1443,7 @@ unsafe impl Send for BitmapPropertySet {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for BitmapPropertySet {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BitmapTransform(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BitmapTransform, windows_core::IUnknown, windows_core::IInspectable);
 impl BitmapTransform {
@@ -1534,7 +1534,7 @@ impl windows_core::RuntimeName for BitmapTransform {
 unsafe impl Send for BitmapTransform {}
 unsafe impl Sync for BitmapTransform {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BitmapTypedValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BitmapTypedValue, windows_core::IUnknown, windows_core::IInspectable);
 impl BitmapTypedValue {
@@ -1581,7 +1581,7 @@ unsafe impl Send for BitmapTypedValue {}
 unsafe impl Sync for BitmapTypedValue {}
 #[cfg(feature = "Storage_Streams")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageStream(windows_core::IUnknown);
 #[cfg(feature = "Storage_Streams")]
 windows_core::imp::interface_hierarchy!(ImageStream, windows_core::IUnknown, windows_core::IInspectable);
@@ -1716,7 +1716,7 @@ unsafe impl Send for ImageStream {}
 #[cfg(feature = "Storage_Streams")]
 unsafe impl Sync for ImageStream {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PixelDataProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PixelDataProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl PixelDataProvider {
@@ -1741,7 +1741,7 @@ impl windows_core::RuntimeName for PixelDataProvider {
 unsafe impl Send for PixelDataProvider {}
 unsafe impl Sync for PixelDataProvider {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SoftwareBitmap(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SoftwareBitmap, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SoftwareBitmap, super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
@@ -689,7 +689,7 @@ pub struct IPrintTextOptionDetails_Vtbl {
     pub MaxCharacters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintBindingOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintBindingOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintBindingOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -791,7 +791,7 @@ impl windows_core::RuntimeName for PrintBindingOptionDetails {
 unsafe impl Send for PrintBindingOptionDetails {}
 unsafe impl Sync for PrintBindingOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintBorderingOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintBorderingOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintBorderingOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -893,7 +893,7 @@ impl windows_core::RuntimeName for PrintBorderingOptionDetails {
 unsafe impl Send for PrintBorderingOptionDetails {}
 unsafe impl Sync for PrintBorderingOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintCollationOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintCollationOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintCollationOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -995,7 +995,7 @@ impl windows_core::RuntimeName for PrintCollationOptionDetails {
 unsafe impl Send for PrintCollationOptionDetails {}
 unsafe impl Sync for PrintCollationOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintColorModeOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintColorModeOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintColorModeOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -1097,7 +1097,7 @@ impl windows_core::RuntimeName for PrintColorModeOptionDetails {
 unsafe impl Send for PrintColorModeOptionDetails {}
 unsafe impl Sync for PrintColorModeOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintCopiesOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintCopiesOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintCopiesOptionDetails, IPrintNumberOptionDetails, IPrintOptionDetails);
@@ -1205,7 +1205,7 @@ impl windows_core::RuntimeName for PrintCopiesOptionDetails {
 unsafe impl Send for PrintCopiesOptionDetails {}
 unsafe impl Sync for PrintCopiesOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintCustomItemDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintCustomItemDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintCustomItemDetails {
@@ -1241,7 +1241,7 @@ impl windows_core::RuntimeName for PrintCustomItemDetails {
 unsafe impl Send for PrintCustomItemDetails {}
 unsafe impl Sync for PrintCustomItemDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintCustomItemListOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintCustomItemListOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintCustomItemListOptionDetails, IPrintCustomOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -1366,7 +1366,7 @@ impl windows_core::RuntimeName for PrintCustomItemListOptionDetails {
 unsafe impl Send for PrintCustomItemListOptionDetails {}
 unsafe impl Sync for PrintCustomItemListOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintCustomTextOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintCustomTextOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintCustomTextOptionDetails, IPrintCustomOptionDetails, IPrintOptionDetails);
@@ -1482,7 +1482,7 @@ impl windows_core::RuntimeName for PrintCustomTextOptionDetails {
 unsafe impl Send for PrintCustomTextOptionDetails {}
 unsafe impl Sync for PrintCustomTextOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintCustomToggleOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintCustomToggleOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintCustomToggleOptionDetails, IPrintCustomOptionDetails, IPrintOptionDetails);
@@ -1587,7 +1587,7 @@ impl windows_core::RuntimeName for PrintCustomToggleOptionDetails {
 unsafe impl Send for PrintCustomToggleOptionDetails {}
 unsafe impl Sync for PrintCustomToggleOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintDuplexOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintDuplexOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintDuplexOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -1689,7 +1689,7 @@ impl windows_core::RuntimeName for PrintDuplexOptionDetails {
 unsafe impl Send for PrintDuplexOptionDetails {}
 unsafe impl Sync for PrintDuplexOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintHolePunchOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintHolePunchOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintHolePunchOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -1791,7 +1791,7 @@ impl windows_core::RuntimeName for PrintHolePunchOptionDetails {
 unsafe impl Send for PrintHolePunchOptionDetails {}
 unsafe impl Sync for PrintHolePunchOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintMediaSizeOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintMediaSizeOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintMediaSizeOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -1893,7 +1893,7 @@ impl windows_core::RuntimeName for PrintMediaSizeOptionDetails {
 unsafe impl Send for PrintMediaSizeOptionDetails {}
 unsafe impl Sync for PrintMediaSizeOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintMediaTypeOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintMediaTypeOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintMediaTypeOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -1995,7 +1995,7 @@ impl windows_core::RuntimeName for PrintMediaTypeOptionDetails {
 unsafe impl Send for PrintMediaTypeOptionDetails {}
 unsafe impl Sync for PrintMediaTypeOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintOrientationOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintOrientationOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintOrientationOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -2097,7 +2097,7 @@ impl windows_core::RuntimeName for PrintOrientationOptionDetails {
 unsafe impl Send for PrintOrientationOptionDetails {}
 unsafe impl Sync for PrintOrientationOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintPageRangeOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintPageRangeOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintPageRangeOptionDetails, IPrintOptionDetails);
@@ -2191,7 +2191,7 @@ impl windows_core::RuntimeName for PrintPageRangeOptionDetails {
 unsafe impl Send for PrintPageRangeOptionDetails {}
 unsafe impl Sync for PrintPageRangeOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintQualityOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintQualityOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintQualityOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -2293,7 +2293,7 @@ impl windows_core::RuntimeName for PrintQualityOptionDetails {
 unsafe impl Send for PrintQualityOptionDetails {}
 unsafe impl Sync for PrintQualityOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintStapleOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintStapleOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintStapleOptionDetails, IPrintItemListOptionDetails, IPrintOptionDetails);
@@ -2395,7 +2395,7 @@ impl windows_core::RuntimeName for PrintStapleOptionDetails {
 unsafe impl Send for PrintStapleOptionDetails {}
 unsafe impl Sync for PrintStapleOptionDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskOptionChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskOptionChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskOptionChangedEventArgs {
@@ -2420,7 +2420,7 @@ impl windows_core::RuntimeName for PrintTaskOptionChangedEventArgs {
 unsafe impl Send for PrintTaskOptionChangedEventArgs {}
 unsafe impl Sync for PrintTaskOptionChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskOptionDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskOptionDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintTaskOptionDetails, super::IPrintTaskOptionsCore, super::IPrintTaskOptionsCoreUIConfiguration);

--- a/crates/libs/windows/src/Windows/Graphics/Printing/PrintSupport/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/PrintSupport/mod.rs
@@ -197,7 +197,7 @@ pub struct IPrintSupportSettingsUISession_Vtbl {
     pub SessionInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSupportExtensionSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSupportExtensionSession, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintSupportExtensionSession {
@@ -269,7 +269,7 @@ impl windows_core::RuntimeName for PrintSupportExtensionSession {
 unsafe impl Send for PrintSupportExtensionSession {}
 unsafe impl Sync for PrintSupportExtensionSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSupportExtensionTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSupportExtensionTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintSupportExtensionTriggerDetails {
@@ -294,7 +294,7 @@ impl windows_core::RuntimeName for PrintSupportExtensionTriggerDetails {
 unsafe impl Send for PrintSupportExtensionTriggerDetails {}
 unsafe impl Sync for PrintSupportExtensionTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSupportPrintDeviceCapabilitiesChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSupportPrintDeviceCapabilitiesChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintSupportPrintDeviceCapabilitiesChangedEventArgs {
@@ -373,7 +373,7 @@ impl windows_core::RuntimeName for PrintSupportPrintDeviceCapabilitiesChangedEve
 unsafe impl Send for PrintSupportPrintDeviceCapabilitiesChangedEventArgs {}
 unsafe impl Sync for PrintSupportPrintDeviceCapabilitiesChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSupportPrintDeviceCapabilitiesUpdatePolicy(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSupportPrintDeviceCapabilitiesUpdatePolicy, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintSupportPrintDeviceCapabilitiesUpdatePolicy {
@@ -408,7 +408,7 @@ impl windows_core::RuntimeName for PrintSupportPrintDeviceCapabilitiesUpdatePoli
 unsafe impl Send for PrintSupportPrintDeviceCapabilitiesUpdatePolicy {}
 unsafe impl Sync for PrintSupportPrintDeviceCapabilitiesUpdatePolicy {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSupportPrintTicketElement(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSupportPrintTicketElement, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintSupportPrintTicketElement {
@@ -455,7 +455,7 @@ impl windows_core::RuntimeName for PrintSupportPrintTicketElement {
 unsafe impl Send for PrintSupportPrintTicketElement {}
 unsafe impl Sync for PrintSupportPrintTicketElement {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSupportPrintTicketValidationRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSupportPrintTicketValidationRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintSupportPrintTicketValidationRequestedEventArgs {
@@ -492,7 +492,7 @@ impl windows_core::RuntimeName for PrintSupportPrintTicketValidationRequestedEve
 unsafe impl Send for PrintSupportPrintTicketValidationRequestedEventArgs {}
 unsafe impl Sync for PrintSupportPrintTicketValidationRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSupportPrinterSelectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSupportPrinterSelectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintSupportPrinterSelectedEventArgs {
@@ -572,7 +572,7 @@ impl windows_core::RuntimeName for PrintSupportPrinterSelectedEventArgs {
 unsafe impl Send for PrintSupportPrinterSelectedEventArgs {}
 unsafe impl Sync for PrintSupportPrinterSelectedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSupportSessionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSupportSessionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintSupportSessionInfo {
@@ -606,7 +606,7 @@ impl windows_core::RuntimeName for PrintSupportSessionInfo {
 unsafe impl Send for PrintSupportSessionInfo {}
 unsafe impl Sync for PrintSupportSessionInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSupportSettingsActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSupportSettingsActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
@@ -672,7 +672,7 @@ impl windows_core::RuntimeName for PrintSupportSettingsActivatedEventArgs {
 unsafe impl Send for PrintSupportSettingsActivatedEventArgs {}
 unsafe impl Sync for PrintSupportSettingsActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintSupportSettingsUISession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintSupportSettingsUISession, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintSupportSettingsUISession {

--- a/crates/libs/windows/src/Windows/Graphics/Printing/PrintTicket/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/PrintTicket/mod.rs
@@ -170,7 +170,7 @@ pub struct IWorkflowPrintTicketValidationResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTicketCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTicketCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTicketCapabilities {
@@ -329,7 +329,7 @@ impl windows_core::RuntimeName for PrintTicketCapabilities {
 unsafe impl Send for PrintTicketCapabilities {}
 unsafe impl Sync for PrintTicketCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTicketFeature(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTicketFeature, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTicketFeature {
@@ -412,7 +412,7 @@ impl windows_core::RuntimeName for PrintTicketFeature {
 unsafe impl Send for PrintTicketFeature {}
 unsafe impl Sync for PrintTicketFeature {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTicketOption(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTicketOption, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTicketOption {
@@ -489,7 +489,7 @@ impl windows_core::RuntimeName for PrintTicketOption {
 unsafe impl Send for PrintTicketOption {}
 unsafe impl Sync for PrintTicketOption {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTicketParameterDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTicketParameterDefinition, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTicketParameterDefinition {
@@ -557,7 +557,7 @@ impl windows_core::RuntimeName for PrintTicketParameterDefinition {
 unsafe impl Send for PrintTicketParameterDefinition {}
 unsafe impl Sync for PrintTicketParameterDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTicketParameterInitializer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTicketParameterInitializer, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTicketParameterInitializer {
@@ -611,7 +611,7 @@ impl windows_core::RuntimeName for PrintTicketParameterInitializer {
 unsafe impl Send for PrintTicketParameterInitializer {}
 unsafe impl Sync for PrintTicketParameterInitializer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTicketValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTicketValue, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTicketValue {
@@ -650,7 +650,7 @@ impl windows_core::RuntimeName for PrintTicketValue {
 unsafe impl Send for PrintTicketValue {}
 unsafe impl Sync for PrintTicketValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WorkflowPrintTicket(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WorkflowPrintTicket, windows_core::IUnknown, windows_core::IInspectable);
 impl WorkflowPrintTicket {
@@ -854,7 +854,7 @@ impl windows_core::RuntimeName for WorkflowPrintTicket {
 unsafe impl Send for WorkflowPrintTicket {}
 unsafe impl Sync for WorkflowPrintTicket {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WorkflowPrintTicketValidationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WorkflowPrintTicketValidationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl WorkflowPrintTicketValidationResult {

--- a/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
@@ -426,7 +426,7 @@ pub struct IPrintWorkflowXpsDataAvailableEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowBackgroundSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowBackgroundSession, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowBackgroundSession {
@@ -483,7 +483,7 @@ impl windows_core::RuntimeName for PrintWorkflowBackgroundSession {
 unsafe impl Send for PrintWorkflowBackgroundSession {}
 unsafe impl Sync for PrintWorkflowBackgroundSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowBackgroundSetupRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowBackgroundSetupRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowBackgroundSetupRequestedEventArgs {
@@ -527,7 +527,7 @@ impl windows_core::RuntimeName for PrintWorkflowBackgroundSetupRequestedEventArg
 unsafe impl Send for PrintWorkflowBackgroundSetupRequestedEventArgs {}
 unsafe impl Sync for PrintWorkflowBackgroundSetupRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowConfiguration {
@@ -570,7 +570,7 @@ impl windows_core::RuntimeName for PrintWorkflowConfiguration {
 unsafe impl Send for PrintWorkflowConfiguration {}
 unsafe impl Sync for PrintWorkflowConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowForegroundSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowForegroundSession, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowForegroundSession {
@@ -627,7 +627,7 @@ impl windows_core::RuntimeName for PrintWorkflowForegroundSession {
 unsafe impl Send for PrintWorkflowForegroundSession {}
 unsafe impl Sync for PrintWorkflowForegroundSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowForegroundSetupRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowForegroundSetupRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowForegroundSetupRequestedEventArgs {
@@ -667,7 +667,7 @@ impl windows_core::RuntimeName for PrintWorkflowForegroundSetupRequestedEventArg
 unsafe impl Send for PrintWorkflowForegroundSetupRequestedEventArgs {}
 unsafe impl Sync for PrintWorkflowForegroundSetupRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowJobActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowJobActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
@@ -726,7 +726,7 @@ impl windows_core::RuntimeName for PrintWorkflowJobActivatedEventArgs {
 unsafe impl Send for PrintWorkflowJobActivatedEventArgs {}
 unsafe impl Sync for PrintWorkflowJobActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowJobBackgroundSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowJobBackgroundSession, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowJobBackgroundSession {
@@ -783,7 +783,7 @@ impl windows_core::RuntimeName for PrintWorkflowJobBackgroundSession {
 unsafe impl Send for PrintWorkflowJobBackgroundSession {}
 unsafe impl Sync for PrintWorkflowJobBackgroundSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowJobNotificationEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowJobNotificationEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowJobNotificationEventArgs {
@@ -822,7 +822,7 @@ impl windows_core::RuntimeName for PrintWorkflowJobNotificationEventArgs {
 unsafe impl Send for PrintWorkflowJobNotificationEventArgs {}
 unsafe impl Sync for PrintWorkflowJobNotificationEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowJobStartingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowJobStartingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowJobStartingEventArgs {
@@ -866,7 +866,7 @@ impl windows_core::RuntimeName for PrintWorkflowJobStartingEventArgs {
 unsafe impl Send for PrintWorkflowJobStartingEventArgs {}
 unsafe impl Sync for PrintWorkflowJobStartingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowJobTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowJobTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowJobTriggerDetails {
@@ -891,7 +891,7 @@ impl windows_core::RuntimeName for PrintWorkflowJobTriggerDetails {
 unsafe impl Send for PrintWorkflowJobTriggerDetails {}
 unsafe impl Sync for PrintWorkflowJobTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowJobUISession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowJobUISession, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowJobUISession {
@@ -948,7 +948,7 @@ impl windows_core::RuntimeName for PrintWorkflowJobUISession {
 unsafe impl Send for PrintWorkflowJobUISession {}
 unsafe impl Sync for PrintWorkflowJobUISession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowObjectModelSourceFileContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowObjectModelSourceFileContent, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowObjectModelSourceFileContent {
@@ -981,7 +981,7 @@ impl windows_core::RuntimeName for PrintWorkflowObjectModelSourceFileContent {
 unsafe impl Send for PrintWorkflowObjectModelSourceFileContent {}
 unsafe impl Sync for PrintWorkflowObjectModelSourceFileContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowObjectModelTargetPackage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowObjectModelTargetPackage, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowObjectModelTargetPackage {}
@@ -998,7 +998,7 @@ impl windows_core::RuntimeName for PrintWorkflowObjectModelTargetPackage {
 unsafe impl Send for PrintWorkflowObjectModelTargetPackage {}
 unsafe impl Sync for PrintWorkflowObjectModelTargetPackage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowPdlConverter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowPdlConverter, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowPdlConverter {
@@ -1042,7 +1042,7 @@ impl windows_core::RuntimeName for PrintWorkflowPdlConverter {
 unsafe impl Send for PrintWorkflowPdlConverter {}
 unsafe impl Sync for PrintWorkflowPdlConverter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowPdlDataAvailableEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowPdlDataAvailableEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowPdlDataAvailableEventArgs {
@@ -1088,7 +1088,7 @@ impl windows_core::RuntimeName for PrintWorkflowPdlDataAvailableEventArgs {
 unsafe impl Send for PrintWorkflowPdlDataAvailableEventArgs {}
 unsafe impl Sync for PrintWorkflowPdlDataAvailableEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowPdlModificationRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowPdlModificationRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowPdlModificationRequestedEventArgs {
@@ -1201,7 +1201,7 @@ impl windows_core::RuntimeName for PrintWorkflowPdlModificationRequestedEventArg
 unsafe impl Send for PrintWorkflowPdlModificationRequestedEventArgs {}
 unsafe impl Sync for PrintWorkflowPdlModificationRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowPdlSourceContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowPdlSourceContent, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowPdlSourceContent {
@@ -1242,7 +1242,7 @@ impl windows_core::RuntimeName for PrintWorkflowPdlSourceContent {
 unsafe impl Send for PrintWorkflowPdlSourceContent {}
 unsafe impl Sync for PrintWorkflowPdlSourceContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowPdlTargetStream(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowPdlTargetStream, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowPdlTargetStream {
@@ -1272,7 +1272,7 @@ impl windows_core::RuntimeName for PrintWorkflowPdlTargetStream {
 unsafe impl Send for PrintWorkflowPdlTargetStream {}
 unsafe impl Sync for PrintWorkflowPdlTargetStream {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowPrinterJob(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowPrinterJob, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowPrinterJob {
@@ -1364,7 +1364,7 @@ impl windows_core::RuntimeName for PrintWorkflowPrinterJob {
 unsafe impl Send for PrintWorkflowPrinterJob {}
 unsafe impl Sync for PrintWorkflowPrinterJob {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowSourceContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowSourceContent, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowSourceContent {
@@ -1404,7 +1404,7 @@ impl windows_core::RuntimeName for PrintWorkflowSourceContent {
 unsafe impl Send for PrintWorkflowSourceContent {}
 unsafe impl Sync for PrintWorkflowSourceContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowSpoolStreamContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowSpoolStreamContent, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowSpoolStreamContent {
@@ -1430,7 +1430,7 @@ impl windows_core::RuntimeName for PrintWorkflowSpoolStreamContent {
 unsafe impl Send for PrintWorkflowSpoolStreamContent {}
 unsafe impl Sync for PrintWorkflowSpoolStreamContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowStreamTarget(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowStreamTarget, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowStreamTarget {
@@ -1456,7 +1456,7 @@ impl windows_core::RuntimeName for PrintWorkflowStreamTarget {
 unsafe impl Send for PrintWorkflowStreamTarget {}
 unsafe impl Sync for PrintWorkflowStreamTarget {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowSubmittedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowSubmittedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowSubmittedEventArgs {
@@ -1499,7 +1499,7 @@ impl windows_core::RuntimeName for PrintWorkflowSubmittedEventArgs {
 unsafe impl Send for PrintWorkflowSubmittedEventArgs {}
 unsafe impl Sync for PrintWorkflowSubmittedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowSubmittedOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowSubmittedOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowSubmittedOperation {
@@ -1535,7 +1535,7 @@ impl windows_core::RuntimeName for PrintWorkflowSubmittedOperation {
 unsafe impl Send for PrintWorkflowSubmittedOperation {}
 unsafe impl Sync for PrintWorkflowSubmittedOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowTarget(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowTarget, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowTarget {
@@ -1567,7 +1567,7 @@ impl windows_core::RuntimeName for PrintWorkflowTarget {
 unsafe impl Send for PrintWorkflowTarget {}
 unsafe impl Sync for PrintWorkflowTarget {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowTriggerDetails {
@@ -1592,7 +1592,7 @@ impl windows_core::RuntimeName for PrintWorkflowTriggerDetails {
 unsafe impl Send for PrintWorkflowTriggerDetails {}
 unsafe impl Sync for PrintWorkflowTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowUIActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowUIActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
@@ -1651,7 +1651,7 @@ impl windows_core::RuntimeName for PrintWorkflowUIActivatedEventArgs {
 unsafe impl Send for PrintWorkflowUIActivatedEventArgs {}
 unsafe impl Sync for PrintWorkflowUIActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowUILauncher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowUILauncher, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowUILauncher {
@@ -1683,7 +1683,7 @@ impl windows_core::RuntimeName for PrintWorkflowUILauncher {
 unsafe impl Send for PrintWorkflowUILauncher {}
 unsafe impl Sync for PrintWorkflowUILauncher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintWorkflowXpsDataAvailableEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowXpsDataAvailableEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowXpsDataAvailableEventArgs {

--- a/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
@@ -511,7 +511,7 @@ pub struct IStandardPrintTaskOptionsStatic3_Vtbl {
     pub CustomPageRanges: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintManager, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintManager {
@@ -571,7 +571,7 @@ impl windows_core::RuntimeName for PrintManager {
 unsafe impl Send for PrintManager {}
 unsafe impl Sync for PrintManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintPageInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintPageInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintPageInfo {
@@ -651,7 +651,7 @@ impl windows_core::RuntimeName for PrintPageInfo {
 unsafe impl Send for PrintPageInfo {}
 unsafe impl Sync for PrintPageInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintPageRange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintPageRange, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintPageRange {
@@ -700,7 +700,7 @@ impl windows_core::RuntimeName for PrintPageRange {
 unsafe impl Send for PrintPageRange {}
 unsafe impl Sync for PrintPageRange {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintPageRangeOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintPageRangeOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintPageRangeOptions {
@@ -751,7 +751,7 @@ impl windows_core::RuntimeName for PrintPageRangeOptions {
 unsafe impl Send for PrintPageRangeOptions {}
 unsafe impl Sync for PrintPageRangeOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTask(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTask, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTask {
@@ -880,7 +880,7 @@ impl windows_core::RuntimeName for PrintTask {
 unsafe impl Send for PrintTask {}
 unsafe impl Sync for PrintTask {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskCompletedEventArgs {
@@ -905,7 +905,7 @@ impl windows_core::RuntimeName for PrintTaskCompletedEventArgs {
 unsafe impl Send for PrintTaskCompletedEventArgs {}
 unsafe impl Sync for PrintTaskCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskOptions, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PrintTaskOptions, IPrintTaskOptionsCore, IPrintTaskOptionsCoreProperties, IPrintTaskOptionsCoreUIConfiguration);
@@ -1111,7 +1111,7 @@ impl windows_core::RuntimeName for PrintTaskOptions {
 unsafe impl Send for PrintTaskOptions {}
 unsafe impl Sync for PrintTaskOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskProgressingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskProgressingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskProgressingEventArgs {
@@ -1136,7 +1136,7 @@ impl windows_core::RuntimeName for PrintTaskProgressingEventArgs {
 unsafe impl Send for PrintTaskProgressingEventArgs {}
 unsafe impl Sync for PrintTaskProgressingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskRequest {
@@ -1178,7 +1178,7 @@ impl windows_core::RuntimeName for PrintTaskRequest {
 unsafe impl Send for PrintTaskRequest {}
 unsafe impl Sync for PrintTaskRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskRequestedDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskRequestedDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskRequestedDeferral {
@@ -1200,7 +1200,7 @@ impl windows_core::RuntimeName for PrintTaskRequestedDeferral {
 unsafe impl Send for PrintTaskRequestedDeferral {}
 unsafe impl Sync for PrintTaskRequestedDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskRequestedEventArgs {
@@ -1225,7 +1225,7 @@ impl windows_core::RuntimeName for PrintTaskRequestedEventArgs {
 unsafe impl Send for PrintTaskRequestedEventArgs {}
 unsafe impl Sync for PrintTaskRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskSourceRequestedArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskSourceRequestedArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskSourceRequestedArgs {
@@ -1264,7 +1264,7 @@ impl windows_core::RuntimeName for PrintTaskSourceRequestedArgs {
 unsafe impl Send for PrintTaskSourceRequestedArgs {}
 unsafe impl Sync for PrintTaskSourceRequestedArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrintTaskSourceRequestedDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintTaskSourceRequestedDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintTaskSourceRequestedDeferral {

--- a/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
@@ -597,7 +597,7 @@ pub struct IPrinting3DTextureResource_Vtbl {
     pub SetName: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DManager, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DManager {
@@ -646,7 +646,7 @@ impl windows_core::RuntimeName for Print3DManager {
 unsafe impl Send for Print3DManager {}
 unsafe impl Sync for Print3DManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DTask(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DTask, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DTask {
@@ -713,7 +713,7 @@ impl windows_core::RuntimeName for Print3DTask {
 unsafe impl Send for Print3DTask {}
 unsafe impl Sync for Print3DTask {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DTaskCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DTaskCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DTaskCompletedEventArgs {
@@ -745,7 +745,7 @@ impl windows_core::RuntimeName for Print3DTaskCompletedEventArgs {
 unsafe impl Send for Print3DTaskCompletedEventArgs {}
 unsafe impl Sync for Print3DTaskCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DTaskRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DTaskRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DTaskRequest {
@@ -773,7 +773,7 @@ impl windows_core::RuntimeName for Print3DTaskRequest {
 unsafe impl Send for Print3DTaskRequest {}
 unsafe impl Sync for Print3DTaskRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DTaskRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DTaskRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DTaskRequestedEventArgs {
@@ -798,7 +798,7 @@ impl windows_core::RuntimeName for Print3DTaskRequestedEventArgs {
 unsafe impl Send for Print3DTaskRequestedEventArgs {}
 unsafe impl Sync for Print3DTaskRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DTaskSourceChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DTaskSourceChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DTaskSourceChangedEventArgs {
@@ -823,7 +823,7 @@ impl windows_core::RuntimeName for Print3DTaskSourceChangedEventArgs {
 unsafe impl Send for Print3DTaskSourceChangedEventArgs {}
 unsafe impl Sync for Print3DTaskSourceChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Print3DTaskSourceRequestedArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Print3DTaskSourceRequestedArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl Print3DTaskSourceRequestedArgs {
@@ -848,7 +848,7 @@ impl windows_core::RuntimeName for Print3DTaskSourceRequestedArgs {
 unsafe impl Send for Print3DTaskSourceRequestedArgs {}
 unsafe impl Sync for Print3DTaskSourceRequestedArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3D3MFPackage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3D3MFPackage, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3D3MFPackage {
@@ -982,7 +982,7 @@ impl windows_core::RuntimeName for Printing3D3MFPackage {
 unsafe impl Send for Printing3D3MFPackage {}
 unsafe impl Sync for Printing3D3MFPackage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DBaseMaterial(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DBaseMaterial, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DBaseMaterial {
@@ -1049,7 +1049,7 @@ impl windows_core::RuntimeName for Printing3DBaseMaterial {
 unsafe impl Send for Printing3DBaseMaterial {}
 unsafe impl Sync for Printing3DBaseMaterial {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DBaseMaterialGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DBaseMaterialGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DBaseMaterialGroup {
@@ -1093,7 +1093,7 @@ impl windows_core::RuntimeName for Printing3DBaseMaterialGroup {
 unsafe impl Send for Printing3DBaseMaterialGroup {}
 unsafe impl Sync for Printing3DBaseMaterialGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DColorMaterial(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DColorMaterial, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DColorMaterial {
@@ -1142,7 +1142,7 @@ impl windows_core::RuntimeName for Printing3DColorMaterial {
 unsafe impl Send for Printing3DColorMaterial {}
 unsafe impl Sync for Printing3DColorMaterial {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DColorMaterialGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DColorMaterialGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DColorMaterialGroup {
@@ -1186,7 +1186,7 @@ impl windows_core::RuntimeName for Printing3DColorMaterialGroup {
 unsafe impl Send for Printing3DColorMaterialGroup {}
 unsafe impl Sync for Printing3DColorMaterialGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DComponent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DComponent, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DComponent {
@@ -1280,7 +1280,7 @@ impl windows_core::RuntimeName for Printing3DComponent {
 unsafe impl Send for Printing3DComponent {}
 unsafe impl Sync for Printing3DComponent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DComponentWithMatrix(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DComponentWithMatrix, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DComponentWithMatrix {
@@ -1332,7 +1332,7 @@ impl windows_core::RuntimeName for Printing3DComponentWithMatrix {
 unsafe impl Send for Printing3DComponentWithMatrix {}
 unsafe impl Sync for Printing3DComponentWithMatrix {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DCompositeMaterial(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DCompositeMaterial, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DCompositeMaterial {
@@ -1365,7 +1365,7 @@ impl windows_core::RuntimeName for Printing3DCompositeMaterial {
 unsafe impl Send for Printing3DCompositeMaterial {}
 unsafe impl Sync for Printing3DCompositeMaterial {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DCompositeMaterialGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DCompositeMaterialGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DCompositeMaterialGroup {
@@ -1431,7 +1431,7 @@ impl windows_core::RuntimeName for Printing3DCompositeMaterialGroup {
 unsafe impl Send for Printing3DCompositeMaterialGroup {}
 unsafe impl Sync for Printing3DCompositeMaterialGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DFaceReductionOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DFaceReductionOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DFaceReductionOptions {
@@ -1489,7 +1489,7 @@ impl windows_core::RuntimeName for Printing3DFaceReductionOptions {
 unsafe impl Send for Printing3DFaceReductionOptions {}
 unsafe impl Sync for Printing3DFaceReductionOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DMaterial(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DMaterial, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DMaterial {
@@ -1554,7 +1554,7 @@ impl windows_core::RuntimeName for Printing3DMaterial {
 unsafe impl Send for Printing3DMaterial {}
 unsafe impl Sync for Printing3DMaterial {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DMesh(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DMesh, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DMesh {
@@ -1716,7 +1716,7 @@ impl windows_core::RuntimeName for Printing3DMesh {
 unsafe impl Send for Printing3DMesh {}
 unsafe impl Sync for Printing3DMesh {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DMeshVerificationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DMeshVerificationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DMeshVerificationResult {
@@ -1757,7 +1757,7 @@ impl windows_core::RuntimeName for Printing3DMeshVerificationResult {
 unsafe impl Send for Printing3DMeshVerificationResult {}
 unsafe impl Sync for Printing3DMeshVerificationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DModel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DModel, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DModel {
@@ -1934,7 +1934,7 @@ impl windows_core::RuntimeName for Printing3DModel {
 unsafe impl Send for Printing3DModel {}
 unsafe impl Sync for Printing3DModel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DModelTexture(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DModelTexture, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DModelTexture {
@@ -1995,7 +1995,7 @@ impl windows_core::RuntimeName for Printing3DModelTexture {
 unsafe impl Send for Printing3DModelTexture {}
 unsafe impl Sync for Printing3DModelTexture {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DMultiplePropertyMaterial(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DMultiplePropertyMaterial, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DMultiplePropertyMaterial {
@@ -2028,7 +2028,7 @@ impl windows_core::RuntimeName for Printing3DMultiplePropertyMaterial {
 unsafe impl Send for Printing3DMultiplePropertyMaterial {}
 unsafe impl Sync for Printing3DMultiplePropertyMaterial {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DMultiplePropertyMaterialGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DMultiplePropertyMaterialGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DMultiplePropertyMaterialGroup {
@@ -2080,7 +2080,7 @@ impl windows_core::RuntimeName for Printing3DMultiplePropertyMaterialGroup {
 unsafe impl Send for Printing3DMultiplePropertyMaterialGroup {}
 unsafe impl Sync for Printing3DMultiplePropertyMaterialGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DTexture2CoordMaterial(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DTexture2CoordMaterial, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DTexture2CoordMaterial {
@@ -2141,7 +2141,7 @@ impl windows_core::RuntimeName for Printing3DTexture2CoordMaterial {
 unsafe impl Send for Printing3DTexture2CoordMaterial {}
 unsafe impl Sync for Printing3DTexture2CoordMaterial {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DTexture2CoordMaterialGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DTexture2CoordMaterialGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DTexture2CoordMaterialGroup {
@@ -2199,7 +2199,7 @@ impl windows_core::RuntimeName for Printing3DTexture2CoordMaterialGroup {
 unsafe impl Send for Printing3DTexture2CoordMaterialGroup {}
 unsafe impl Sync for Printing3DTexture2CoordMaterialGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Printing3DTextureResource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Printing3DTextureResource, windows_core::IUnknown, windows_core::IInspectable);
 impl Printing3DTextureResource {

--- a/crates/libs/windows/src/Windows/Management/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Core/mod.rs
@@ -19,7 +19,7 @@ pub struct IApplicationDataManagerStatics_Vtbl {
     CreateForPackageFamily: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationDataManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ApplicationDataManager, windows_core::IUnknown, windows_core::IInspectable);
 impl ApplicationDataManager {

--- a/crates/libs/windows/src/Windows/Management/Deployment/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Deployment/Preview/mod.rs
@@ -35,7 +35,7 @@ impl windows_core::RuntimeName for ClassicAppManager {
     const NAME: &'static str = "Windows.Management.Deployment.Preview.ClassicAppManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InstalledClassicAppInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InstalledClassicAppInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl InstalledClassicAppInfo {

--- a/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
@@ -785,7 +785,7 @@ pub struct IUpdateSharedPackageContainerResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AddPackageOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AddPackageOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl AddPackageOptions {
@@ -1010,7 +1010,7 @@ impl windows_core::RuntimeName for AddPackageOptions {
 unsafe impl Send for AddPackageOptions {}
 unsafe impl Sync for AddPackageOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppInstallerManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppInstallerManager, windows_core::IUnknown, windows_core::IInspectable);
 impl AppInstallerManager {
@@ -1060,7 +1060,7 @@ impl windows_core::RuntimeName for AppInstallerManager {
 unsafe impl Send for AppInstallerManager {}
 unsafe impl Sync for AppInstallerManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AutoUpdateSettingsOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AutoUpdateSettingsOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl AutoUpdateSettingsOptions {
@@ -1236,7 +1236,7 @@ impl windows_core::RuntimeName for AutoUpdateSettingsOptions {
 unsafe impl Send for AutoUpdateSettingsOptions {}
 unsafe impl Sync for AutoUpdateSettingsOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CreateSharedPackageContainerOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CreateSharedPackageContainerOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl CreateSharedPackageContainerOptions {
@@ -1291,7 +1291,7 @@ impl windows_core::RuntimeName for CreateSharedPackageContainerOptions {
 unsafe impl Send for CreateSharedPackageContainerOptions {}
 unsafe impl Sync for CreateSharedPackageContainerOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CreateSharedPackageContainerResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CreateSharedPackageContainerResult, windows_core::IUnknown, windows_core::IInspectable);
 impl CreateSharedPackageContainerResult {
@@ -1330,7 +1330,7 @@ impl windows_core::RuntimeName for CreateSharedPackageContainerResult {
 unsafe impl Send for CreateSharedPackageContainerResult {}
 unsafe impl Sync for CreateSharedPackageContainerResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeleteSharedPackageContainerOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeleteSharedPackageContainerOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl DeleteSharedPackageContainerOptions {
@@ -1377,7 +1377,7 @@ impl windows_core::RuntimeName for DeleteSharedPackageContainerOptions {
 unsafe impl Send for DeleteSharedPackageContainerOptions {}
 unsafe impl Sync for DeleteSharedPackageContainerOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeleteSharedPackageContainerResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeleteSharedPackageContainerResult, windows_core::IUnknown, windows_core::IInspectable);
 impl DeleteSharedPackageContainerResult {
@@ -1409,7 +1409,7 @@ impl windows_core::RuntimeName for DeleteSharedPackageContainerResult {
 unsafe impl Send for DeleteSharedPackageContainerResult {}
 unsafe impl Sync for DeleteSharedPackageContainerResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeploymentResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DeploymentResult, windows_core::IUnknown, windows_core::IInspectable);
 impl DeploymentResult {
@@ -1455,7 +1455,7 @@ impl windows_core::RuntimeName for DeploymentResult {
 unsafe impl Send for DeploymentResult {}
 unsafe impl Sync for DeploymentResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FindSharedPackageContainerOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FindSharedPackageContainerOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl FindSharedPackageContainerOptions {
@@ -1502,7 +1502,7 @@ impl windows_core::RuntimeName for FindSharedPackageContainerOptions {
 unsafe impl Send for FindSharedPackageContainerOptions {}
 unsafe impl Sync for FindSharedPackageContainerOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageAllUserProvisioningOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageAllUserProvisioningOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageAllUserProvisioningOptions {
@@ -1543,7 +1543,7 @@ impl windows_core::RuntimeName for PackageAllUserProvisioningOptions {
 unsafe impl Send for PackageAllUserProvisioningOptions {}
 unsafe impl Sync for PackageAllUserProvisioningOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageManager, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageManager {
@@ -2152,7 +2152,7 @@ impl windows_core::RuntimeName for PackageManager {
 unsafe impl Send for PackageManager {}
 unsafe impl Sync for PackageManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageManagerDebugSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageManagerDebugSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageManagerDebugSettings {
@@ -2192,7 +2192,7 @@ impl windows_core::RuntimeName for PackageManagerDebugSettings {
 unsafe impl Send for PackageManagerDebugSettings {}
 unsafe impl Sync for PackageManagerDebugSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageUserInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageUserInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageUserInformation {
@@ -2224,7 +2224,7 @@ impl windows_core::RuntimeName for PackageUserInformation {
 unsafe impl Send for PackageUserInformation {}
 unsafe impl Sync for PackageUserInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageVolume(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageVolume, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageVolume {
@@ -2417,7 +2417,7 @@ impl windows_core::RuntimeName for PackageVolume {
 unsafe impl Send for PackageVolume {}
 unsafe impl Sync for PackageVolume {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RegisterPackageOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RegisterPackageOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl RegisterPackageOptions {
@@ -2582,7 +2582,7 @@ impl windows_core::RuntimeName for RegisterPackageOptions {
 unsafe impl Send for RegisterPackageOptions {}
 unsafe impl Sync for RegisterPackageOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SharedPackageContainer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SharedPackageContainer, windows_core::IUnknown, windows_core::IInspectable);
 impl SharedPackageContainer {
@@ -2639,7 +2639,7 @@ impl windows_core::RuntimeName for SharedPackageContainer {
 unsafe impl Send for SharedPackageContainer {}
 unsafe impl Sync for SharedPackageContainer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SharedPackageContainerManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SharedPackageContainerManager, windows_core::IUnknown, windows_core::IInspectable);
 impl SharedPackageContainerManager {
@@ -2726,7 +2726,7 @@ impl windows_core::RuntimeName for SharedPackageContainerManager {
 unsafe impl Send for SharedPackageContainerManager {}
 unsafe impl Sync for SharedPackageContainerManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SharedPackageContainerMember(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SharedPackageContainerMember, windows_core::IUnknown, windows_core::IInspectable);
 impl SharedPackageContainerMember {
@@ -2762,7 +2762,7 @@ impl windows_core::RuntimeName for SharedPackageContainerMember {
 unsafe impl Send for SharedPackageContainerMember {}
 unsafe impl Sync for SharedPackageContainerMember {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StagePackageOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StagePackageOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl StagePackageOptions {
@@ -2932,7 +2932,7 @@ impl windows_core::RuntimeName for StagePackageOptions {
 unsafe impl Send for StagePackageOptions {}
 unsafe impl Sync for StagePackageOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UpdateSharedPackageContainerOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UpdateSharedPackageContainerOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl UpdateSharedPackageContainerOptions {
@@ -2979,7 +2979,7 @@ impl windows_core::RuntimeName for UpdateSharedPackageContainerOptions {
 unsafe impl Send for UpdateSharedPackageContainerOptions {}
 unsafe impl Sync for UpdateSharedPackageContainerOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UpdateSharedPackageContainerResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UpdateSharedPackageContainerResult, windows_core::IUnknown, windows_core::IInspectable);
 impl UpdateSharedPackageContainerResult {

--- a/crates/libs/windows/src/Windows/Management/Policies/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Policies/mod.rs
@@ -66,7 +66,7 @@ impl windows_core::RuntimeName for NamedPolicy {
     const NAME: &'static str = "Windows.Management.Policies.NamedPolicy";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NamedPolicyData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NamedPolicyData, windows_core::IUnknown, windows_core::IInspectable);
 impl NamedPolicyData {

--- a/crates/libs/windows/src/Windows/Management/Update/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Update/mod.rs
@@ -295,7 +295,7 @@ pub struct IWindowsUpdateScanCompletedEventArgs_Vtbl {
     Updates: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PreviewBuildsManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PreviewBuildsManager, windows_core::IUnknown, windows_core::IInspectable);
 impl PreviewBuildsManager {
@@ -355,7 +355,7 @@ impl windows_core::RuntimeName for PreviewBuildsManager {
 unsafe impl Send for PreviewBuildsManager {}
 unsafe impl Sync for PreviewBuildsManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PreviewBuildsState(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PreviewBuildsState, windows_core::IUnknown, windows_core::IInspectable);
 impl PreviewBuildsState {
@@ -381,7 +381,7 @@ impl windows_core::RuntimeName for PreviewBuildsState {
 unsafe impl Send for PreviewBuildsState {}
 unsafe impl Sync for PreviewBuildsState {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdate, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdate {
@@ -564,7 +564,7 @@ impl windows_core::RuntimeName for WindowsUpdate {
 unsafe impl Send for WindowsUpdate {}
 unsafe impl Sync for WindowsUpdate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateActionCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateActionCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateActionCompletedEventArgs {
@@ -610,7 +610,7 @@ impl windows_core::RuntimeName for WindowsUpdateActionCompletedEventArgs {
 unsafe impl Send for WindowsUpdateActionCompletedEventArgs {}
 unsafe impl Sync for WindowsUpdateActionCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateActionProgress(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateActionProgress, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateActionProgress {
@@ -642,7 +642,7 @@ impl windows_core::RuntimeName for WindowsUpdateActionProgress {
 unsafe impl Send for WindowsUpdateActionProgress {}
 unsafe impl Sync for WindowsUpdateActionProgress {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateActionResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateActionResult, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateActionResult {
@@ -688,7 +688,7 @@ impl windows_core::RuntimeName for WindowsUpdateActionResult {
 unsafe impl Send for WindowsUpdateActionResult {}
 unsafe impl Sync for WindowsUpdateActionResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateAdministrator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateAdministrator, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateAdministrator {
@@ -778,7 +778,7 @@ impl windows_core::RuntimeName for WindowsUpdateAdministrator {
 unsafe impl Send for WindowsUpdateAdministrator {}
 unsafe impl Sync for WindowsUpdateAdministrator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateApprovalData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateApprovalData, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateApprovalData {
@@ -873,7 +873,7 @@ impl windows_core::RuntimeName for WindowsUpdateApprovalData {
 unsafe impl Send for WindowsUpdateApprovalData {}
 unsafe impl Sync for WindowsUpdateApprovalData {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateAttentionRequiredInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateAttentionRequiredInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateAttentionRequiredInfo {
@@ -905,7 +905,7 @@ impl windows_core::RuntimeName for WindowsUpdateAttentionRequiredInfo {
 unsafe impl Send for WindowsUpdateAttentionRequiredInfo {}
 unsafe impl Sync for WindowsUpdateAttentionRequiredInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateAttentionRequiredReasonChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateAttentionRequiredReasonChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateAttentionRequiredReasonChangedEventArgs {
@@ -937,7 +937,7 @@ impl windows_core::RuntimeName for WindowsUpdateAttentionRequiredReasonChangedEv
 unsafe impl Send for WindowsUpdateAttentionRequiredReasonChangedEventArgs {}
 unsafe impl Sync for WindowsUpdateAttentionRequiredReasonChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateGetAdministratorResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateGetAdministratorResult, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateGetAdministratorResult {
@@ -969,7 +969,7 @@ impl windows_core::RuntimeName for WindowsUpdateGetAdministratorResult {
 unsafe impl Send for WindowsUpdateGetAdministratorResult {}
 unsafe impl Sync for WindowsUpdateGetAdministratorResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateItem, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateItem {
@@ -1043,7 +1043,7 @@ impl windows_core::RuntimeName for WindowsUpdateItem {
 unsafe impl Send for WindowsUpdateItem {}
 unsafe impl Sync for WindowsUpdateItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateManager, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateManager {
@@ -1205,7 +1205,7 @@ impl windows_core::RuntimeName for WindowsUpdateManager {
 unsafe impl Send for WindowsUpdateManager {}
 unsafe impl Sync for WindowsUpdateManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateProgressChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateProgressChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateProgressChangedEventArgs {
@@ -1237,7 +1237,7 @@ impl windows_core::RuntimeName for WindowsUpdateProgressChangedEventArgs {
 unsafe impl Send for WindowsUpdateProgressChangedEventArgs {}
 unsafe impl Sync for WindowsUpdateProgressChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateRestartRequestOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateRestartRequestOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateRestartRequestOptions {
@@ -1356,7 +1356,7 @@ impl windows_core::RuntimeName for WindowsUpdateRestartRequestOptions {
 unsafe impl Send for WindowsUpdateRestartRequestOptions {}
 unsafe impl Sync for WindowsUpdateRestartRequestOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowsUpdateScanCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowsUpdateScanCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowsUpdateScanCompletedEventArgs {

--- a/crates/libs/windows/src/Windows/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/mod.rs
@@ -67,7 +67,7 @@ pub struct IMdmSessionManagerStatics_Vtbl {
     pub GetSessionById: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MdmAlert(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MdmAlert, windows_core::IUnknown, windows_core::IInspectable);
 impl MdmAlert {
@@ -163,7 +163,7 @@ impl windows_core::RuntimeName for MdmAlert {
     const NAME: &'static str = "Windows.Management.MdmAlert";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MdmSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MdmSession, windows_core::IUnknown, windows_core::IInspectable);
 impl MdmSession {

--- a/crates/libs/windows/src/Windows/Media/AppBroadcasting/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/AppBroadcasting/mod.rs
@@ -59,7 +59,7 @@ pub struct IAppBroadcastingUIStatics_Vtbl {
     GetForUser: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastingMonitor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastingMonitor, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastingMonitor {
@@ -105,7 +105,7 @@ impl windows_core::RuntimeName for AppBroadcastingMonitor {
 unsafe impl Send for AppBroadcastingMonitor {}
 unsafe impl Sync for AppBroadcastingMonitor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastingStatus(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastingStatus, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastingStatus {
@@ -137,7 +137,7 @@ impl windows_core::RuntimeName for AppBroadcastingStatus {
 unsafe impl Send for AppBroadcastingStatus {}
 unsafe impl Sync for AppBroadcastingStatus {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastingStatusDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastingStatusDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastingStatusDetails {
@@ -211,7 +211,7 @@ impl windows_core::RuntimeName for AppBroadcastingStatusDetails {
 unsafe impl Send for AppBroadcastingStatusDetails {}
 unsafe impl Sync for AppBroadcastingStatusDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastingUI(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastingUI, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastingUI {

--- a/crates/libs/windows/src/Windows/Media/AppRecording/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/AppRecording/mod.rs
@@ -101,7 +101,7 @@ pub struct IAppRecordingStatusDetails_Vtbl {
     pub IsDisabledBySystem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppRecordingManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppRecordingManager, windows_core::IUnknown, windows_core::IInspectable);
 impl AppRecordingManager {
@@ -179,7 +179,7 @@ impl windows_core::RuntimeName for AppRecordingManager {
 unsafe impl Send for AppRecordingManager {}
 unsafe impl Sync for AppRecordingManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppRecordingResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppRecordingResult, windows_core::IUnknown, windows_core::IInspectable);
 impl AppRecordingResult {
@@ -225,7 +225,7 @@ impl windows_core::RuntimeName for AppRecordingResult {
 unsafe impl Send for AppRecordingResult {}
 unsafe impl Sync for AppRecordingResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppRecordingSaveScreenshotResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppRecordingSaveScreenshotResult, windows_core::IUnknown, windows_core::IInspectable);
 impl AppRecordingSaveScreenshotResult {
@@ -265,7 +265,7 @@ impl windows_core::RuntimeName for AppRecordingSaveScreenshotResult {
 unsafe impl Send for AppRecordingSaveScreenshotResult {}
 unsafe impl Sync for AppRecordingSaveScreenshotResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppRecordingSavedScreenshotInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppRecordingSavedScreenshotInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AppRecordingSavedScreenshotInfo {
@@ -298,7 +298,7 @@ impl windows_core::RuntimeName for AppRecordingSavedScreenshotInfo {
 unsafe impl Send for AppRecordingSavedScreenshotInfo {}
 unsafe impl Sync for AppRecordingSavedScreenshotInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppRecordingStatus(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppRecordingStatus, windows_core::IUnknown, windows_core::IInspectable);
 impl AppRecordingStatus {
@@ -344,7 +344,7 @@ impl windows_core::RuntimeName for AppRecordingStatus {
 unsafe impl Send for AppRecordingStatus {}
 unsafe impl Sync for AppRecordingStatus {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppRecordingStatusDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppRecordingStatusDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl AppRecordingStatusDetails {

--- a/crates/libs/windows/src/Windows/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Audio/mod.rs
@@ -1372,7 +1372,7 @@ pub struct ISpatialAudioFormatSubtypeStatics2_Vtbl {
     pub DTSXForHomeTheater: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioDeviceInputNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioDeviceInputNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioDeviceInputNode, IAudioInputNode, IAudioInputNode2, IAudioNode, super::super::Foundation::IClosable);
@@ -1505,7 +1505,7 @@ impl windows_core::RuntimeName for AudioDeviceInputNode {
 unsafe impl Send for AudioDeviceInputNode {}
 unsafe impl Sync for AudioDeviceInputNode {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioDeviceOutputNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioDeviceOutputNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioDeviceOutputNode, IAudioNode, IAudioNodeWithListener, super::super::Foundation::IClosable);
@@ -1616,7 +1616,7 @@ impl windows_core::RuntimeName for AudioDeviceOutputNode {
 unsafe impl Send for AudioDeviceOutputNode {}
 unsafe impl Sync for AudioDeviceOutputNode {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioFileInputNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioFileInputNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioFileInputNode, IAudioInputNode, IAudioInputNode2, IAudioNode, super::super::Foundation::IClosable);
@@ -1834,7 +1834,7 @@ impl windows_core::RuntimeName for AudioFileInputNode {
 unsafe impl Send for AudioFileInputNode {}
 unsafe impl Sync for AudioFileInputNode {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioFileOutputNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioFileOutputNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioFileOutputNode, IAudioNode, super::super::Foundation::IClosable);
@@ -1947,7 +1947,7 @@ impl windows_core::RuntimeName for AudioFileOutputNode {
 unsafe impl Send for AudioFileOutputNode {}
 unsafe impl Sync for AudioFileOutputNode {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioFrameCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioFrameCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioFrameCompletedEventArgs {
@@ -1972,7 +1972,7 @@ impl windows_core::RuntimeName for AudioFrameCompletedEventArgs {
 unsafe impl Send for AudioFrameCompletedEventArgs {}
 unsafe impl Sync for AudioFrameCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioFrameInputNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioFrameInputNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioFrameInputNode, IAudioInputNode, IAudioInputNode2, IAudioNode, super::super::Foundation::IClosable);
@@ -2154,7 +2154,7 @@ impl windows_core::RuntimeName for AudioFrameInputNode {
 unsafe impl Send for AudioFrameInputNode {}
 unsafe impl Sync for AudioFrameInputNode {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioFrameOutputNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioFrameOutputNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioFrameOutputNode, IAudioNode, super::super::Foundation::IClosable);
@@ -2250,7 +2250,7 @@ impl windows_core::RuntimeName for AudioFrameOutputNode {
 unsafe impl Send for AudioFrameOutputNode {}
 unsafe impl Sync for AudioFrameOutputNode {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioGraph(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioGraph, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioGraph, super::super::Foundation::IClosable);
@@ -2590,7 +2590,7 @@ impl windows_core::RuntimeName for AudioGraph {
 unsafe impl Send for AudioGraph {}
 unsafe impl Sync for AudioGraph {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioGraphBatchUpdater(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioGraphBatchUpdater, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioGraphBatchUpdater, super::super::Foundation::IClosable);
@@ -2613,7 +2613,7 @@ impl windows_core::RuntimeName for AudioGraphBatchUpdater {
 unsafe impl Send for AudioGraphBatchUpdater {}
 unsafe impl Sync for AudioGraphBatchUpdater {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioGraphConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioGraphConnection, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioGraphConnection {
@@ -2649,7 +2649,7 @@ impl windows_core::RuntimeName for AudioGraphConnection {
 unsafe impl Send for AudioGraphConnection {}
 unsafe impl Sync for AudioGraphConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioGraphSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioGraphSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioGraphSettings {
@@ -2768,7 +2768,7 @@ impl windows_core::RuntimeName for AudioGraphSettings {
 unsafe impl Send for AudioGraphSettings {}
 unsafe impl Sync for AudioGraphSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioGraphUnrecoverableErrorOccurredEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioGraphUnrecoverableErrorOccurredEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioGraphUnrecoverableErrorOccurredEventArgs {
@@ -2793,7 +2793,7 @@ impl windows_core::RuntimeName for AudioGraphUnrecoverableErrorOccurredEventArgs
 unsafe impl Send for AudioGraphUnrecoverableErrorOccurredEventArgs {}
 unsafe impl Sync for AudioGraphUnrecoverableErrorOccurredEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioNodeEmitter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioNodeEmitter, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioNodeEmitter {
@@ -2937,7 +2937,7 @@ impl windows_core::RuntimeName for AudioNodeEmitter {
 unsafe impl Send for AudioNodeEmitter {}
 unsafe impl Sync for AudioNodeEmitter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioNodeEmitterConeProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioNodeEmitterConeProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioNodeEmitterConeProperties {
@@ -2976,7 +2976,7 @@ impl windows_core::RuntimeName for AudioNodeEmitterConeProperties {
 unsafe impl Send for AudioNodeEmitterConeProperties {}
 unsafe impl Sync for AudioNodeEmitterConeProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioNodeEmitterDecayModel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioNodeEmitterDecayModel, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioNodeEmitterDecayModel {
@@ -3039,7 +3039,7 @@ impl windows_core::RuntimeName for AudioNodeEmitterDecayModel {
 unsafe impl Send for AudioNodeEmitterDecayModel {}
 unsafe impl Sync for AudioNodeEmitterDecayModel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioNodeEmitterNaturalDecayModelProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioNodeEmitterNaturalDecayModelProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioNodeEmitterNaturalDecayModelProperties {
@@ -3071,7 +3071,7 @@ impl windows_core::RuntimeName for AudioNodeEmitterNaturalDecayModelProperties {
 unsafe impl Send for AudioNodeEmitterNaturalDecayModelProperties {}
 unsafe impl Sync for AudioNodeEmitterNaturalDecayModelProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioNodeEmitterShape(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioNodeEmitterShape, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioNodeEmitterShape {
@@ -3120,7 +3120,7 @@ impl windows_core::RuntimeName for AudioNodeEmitterShape {
 unsafe impl Send for AudioNodeEmitterShape {}
 unsafe impl Sync for AudioNodeEmitterShape {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioNodeListener(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioNodeListener, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioNodeListener {
@@ -3195,7 +3195,7 @@ impl windows_core::RuntimeName for AudioNodeListener {
 unsafe impl Send for AudioNodeListener {}
 unsafe impl Sync for AudioNodeListener {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioPlaybackConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioPlaybackConnection, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioPlaybackConnection, super::super::Foundation::IClosable);
@@ -3288,7 +3288,7 @@ impl windows_core::RuntimeName for AudioPlaybackConnection {
 unsafe impl Send for AudioPlaybackConnection {}
 unsafe impl Sync for AudioPlaybackConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioPlaybackConnectionOpenResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioPlaybackConnectionOpenResult, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioPlaybackConnectionOpenResult {
@@ -3320,7 +3320,7 @@ impl windows_core::RuntimeName for AudioPlaybackConnectionOpenResult {
 unsafe impl Send for AudioPlaybackConnectionOpenResult {}
 unsafe impl Sync for AudioPlaybackConnectionOpenResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioStateMonitor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioStateMonitor, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioStateMonitor {
@@ -3418,7 +3418,7 @@ impl windows_core::RuntimeName for AudioStateMonitor {
 unsafe impl Send for AudioStateMonitor {}
 unsafe impl Sync for AudioStateMonitor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioSubmixNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioSubmixNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioSubmixNode, IAudioInputNode, IAudioInputNode2, IAudioNode, super::super::Foundation::IClosable);
@@ -3543,7 +3543,7 @@ impl windows_core::RuntimeName for AudioSubmixNode {
 unsafe impl Send for AudioSubmixNode {}
 unsafe impl Sync for AudioSubmixNode {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CreateAudioDeviceInputNodeResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CreateAudioDeviceInputNodeResult, windows_core::IUnknown, windows_core::IInspectable);
 impl CreateAudioDeviceInputNodeResult {
@@ -3582,7 +3582,7 @@ impl windows_core::RuntimeName for CreateAudioDeviceInputNodeResult {
 unsafe impl Send for CreateAudioDeviceInputNodeResult {}
 unsafe impl Sync for CreateAudioDeviceInputNodeResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CreateAudioDeviceOutputNodeResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CreateAudioDeviceOutputNodeResult, windows_core::IUnknown, windows_core::IInspectable);
 impl CreateAudioDeviceOutputNodeResult {
@@ -3621,7 +3621,7 @@ impl windows_core::RuntimeName for CreateAudioDeviceOutputNodeResult {
 unsafe impl Send for CreateAudioDeviceOutputNodeResult {}
 unsafe impl Sync for CreateAudioDeviceOutputNodeResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CreateAudioFileInputNodeResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CreateAudioFileInputNodeResult, windows_core::IUnknown, windows_core::IInspectable);
 impl CreateAudioFileInputNodeResult {
@@ -3660,7 +3660,7 @@ impl windows_core::RuntimeName for CreateAudioFileInputNodeResult {
 unsafe impl Send for CreateAudioFileInputNodeResult {}
 unsafe impl Sync for CreateAudioFileInputNodeResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CreateAudioFileOutputNodeResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CreateAudioFileOutputNodeResult, windows_core::IUnknown, windows_core::IInspectable);
 impl CreateAudioFileOutputNodeResult {
@@ -3699,7 +3699,7 @@ impl windows_core::RuntimeName for CreateAudioFileOutputNodeResult {
 unsafe impl Send for CreateAudioFileOutputNodeResult {}
 unsafe impl Sync for CreateAudioFileOutputNodeResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CreateAudioGraphResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CreateAudioGraphResult, windows_core::IUnknown, windows_core::IInspectable);
 impl CreateAudioGraphResult {
@@ -3738,7 +3738,7 @@ impl windows_core::RuntimeName for CreateAudioGraphResult {
 unsafe impl Send for CreateAudioGraphResult {}
 unsafe impl Sync for CreateAudioGraphResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CreateMediaSourceAudioInputNodeResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CreateMediaSourceAudioInputNodeResult, windows_core::IUnknown, windows_core::IInspectable);
 impl CreateMediaSourceAudioInputNodeResult {
@@ -3777,7 +3777,7 @@ impl windows_core::RuntimeName for CreateMediaSourceAudioInputNodeResult {
 unsafe impl Send for CreateMediaSourceAudioInputNodeResult {}
 unsafe impl Sync for CreateMediaSourceAudioInputNodeResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EchoEffectDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EchoEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Media_Effects")]
@@ -3860,7 +3860,7 @@ impl windows_core::RuntimeName for EchoEffectDefinition {
 unsafe impl Send for EchoEffectDefinition {}
 unsafe impl Sync for EchoEffectDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EqualizerBand(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EqualizerBand, windows_core::IUnknown, windows_core::IInspectable);
 impl EqualizerBand {
@@ -3911,7 +3911,7 @@ impl windows_core::RuntimeName for EqualizerBand {
 unsafe impl Send for EqualizerBand {}
 unsafe impl Sync for EqualizerBand {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EqualizerEffectDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EqualizerEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Media_Effects")]
@@ -3969,7 +3969,7 @@ impl windows_core::RuntimeName for EqualizerEffectDefinition {
 unsafe impl Send for EqualizerEffectDefinition {}
 unsafe impl Sync for EqualizerEffectDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameInputNodeQuantumStartedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameInputNodeQuantumStartedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameInputNodeQuantumStartedEventArgs {
@@ -3994,7 +3994,7 @@ impl windows_core::RuntimeName for FrameInputNodeQuantumStartedEventArgs {
 unsafe impl Send for FrameInputNodeQuantumStartedEventArgs {}
 unsafe impl Sync for FrameInputNodeQuantumStartedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LimiterEffectDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LimiterEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Media_Effects")]
@@ -4066,7 +4066,7 @@ impl windows_core::RuntimeName for LimiterEffectDefinition {
 unsafe impl Send for LimiterEffectDefinition {}
 unsafe impl Sync for LimiterEffectDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaSourceAudioInputNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaSourceAudioInputNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaSourceAudioInputNode, IAudioInputNode, IAudioInputNode2, IAudioNode, super::super::Foundation::IClosable);
@@ -4284,7 +4284,7 @@ impl windows_core::RuntimeName for MediaSourceAudioInputNode {
 unsafe impl Send for MediaSourceAudioInputNode {}
 unsafe impl Sync for MediaSourceAudioInputNode {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ReverbEffectDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ReverbEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Media_Effects")]
@@ -4587,7 +4587,7 @@ impl windows_core::RuntimeName for ReverbEffectDefinition {
 unsafe impl Send for ReverbEffectDefinition {}
 unsafe impl Sync for ReverbEffectDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SetDefaultSpatialAudioFormatResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SetDefaultSpatialAudioFormatResult, windows_core::IUnknown, windows_core::IInspectable);
 impl SetDefaultSpatialAudioFormatResult {
@@ -4612,7 +4612,7 @@ impl windows_core::RuntimeName for SetDefaultSpatialAudioFormatResult {
 unsafe impl Send for SetDefaultSpatialAudioFormatResult {}
 unsafe impl Sync for SetDefaultSpatialAudioFormatResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialAudioDeviceConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialAudioDeviceConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialAudioDeviceConfiguration {
@@ -4697,7 +4697,7 @@ impl windows_core::RuntimeName for SpatialAudioDeviceConfiguration {
 unsafe impl Send for SpatialAudioDeviceConfiguration {}
 unsafe impl Sync for SpatialAudioDeviceConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialAudioFormatConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialAudioFormatConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialAudioFormatConfiguration {

--- a/crates/libs/windows/src/Windows/Media/Capture/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/Core/mod.rs
@@ -35,7 +35,7 @@ pub struct IVariablePhotoSequenceCapture2_Vtbl {
     pub UpdateSettingsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VariablePhotoCapturedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VariablePhotoCapturedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl VariablePhotoCapturedEventArgs {
@@ -81,7 +81,7 @@ impl windows_core::RuntimeName for VariablePhotoCapturedEventArgs {
 unsafe impl Send for VariablePhotoCapturedEventArgs {}
 unsafe impl Sync for VariablePhotoCapturedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VariablePhotoSequenceCapture(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VariablePhotoSequenceCapture, windows_core::IUnknown, windows_core::IInspectable);
 impl VariablePhotoSequenceCapture {

--- a/crates/libs/windows/src/Windows/Media/Capture/Frames/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/Frames/mod.rs
@@ -396,7 +396,7 @@ pub struct IVideoMediaFrameFormat_Vtbl {
     pub Height: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioMediaFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioMediaFrame, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioMediaFrame {
@@ -436,7 +436,7 @@ impl windows_core::RuntimeName for AudioMediaFrame {
 unsafe impl Send for AudioMediaFrame {}
 unsafe impl Sync for AudioMediaFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BufferMediaFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BufferMediaFrame, windows_core::IUnknown, windows_core::IInspectable);
 impl BufferMediaFrame {
@@ -469,7 +469,7 @@ impl windows_core::RuntimeName for BufferMediaFrame {
 unsafe impl Send for BufferMediaFrame {}
 unsafe impl Sync for BufferMediaFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DepthMediaFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DepthMediaFrame, windows_core::IUnknown, windows_core::IInspectable);
 impl DepthMediaFrame {
@@ -534,7 +534,7 @@ impl windows_core::RuntimeName for DepthMediaFrame {
 unsafe impl Send for DepthMediaFrame {}
 unsafe impl Sync for DepthMediaFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DepthMediaFrameFormat(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DepthMediaFrameFormat, windows_core::IUnknown, windows_core::IInspectable);
 impl DepthMediaFrameFormat {
@@ -566,7 +566,7 @@ impl windows_core::RuntimeName for DepthMediaFrameFormat {
 unsafe impl Send for DepthMediaFrameFormat {}
 unsafe impl Sync for DepthMediaFrameFormat {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InfraredMediaFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InfraredMediaFrame, windows_core::IUnknown, windows_core::IInspectable);
 impl InfraredMediaFrame {
@@ -605,7 +605,7 @@ impl windows_core::RuntimeName for InfraredMediaFrame {
 unsafe impl Send for InfraredMediaFrame {}
 unsafe impl Sync for InfraredMediaFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaFrameArrivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaFrameArrivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaFrameArrivedEventArgs {}
@@ -622,7 +622,7 @@ impl windows_core::RuntimeName for MediaFrameArrivedEventArgs {
 unsafe impl Send for MediaFrameArrivedEventArgs {}
 unsafe impl Sync for MediaFrameArrivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaFrameFormat(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaFrameFormat, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaFrameFormat {
@@ -685,7 +685,7 @@ impl windows_core::RuntimeName for MediaFrameFormat {
 unsafe impl Send for MediaFrameFormat {}
 unsafe impl Sync for MediaFrameFormat {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaFrameReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaFrameReader, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaFrameReader, super::super::super::Foundation::IClosable);
@@ -754,7 +754,7 @@ impl windows_core::RuntimeName for MediaFrameReader {
 unsafe impl Send for MediaFrameReader {}
 unsafe impl Sync for MediaFrameReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaFrameReference(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaFrameReference, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaFrameReference, super::super::super::Foundation::IClosable);
@@ -842,7 +842,7 @@ impl windows_core::RuntimeName for MediaFrameReference {
 unsafe impl Send for MediaFrameReference {}
 unsafe impl Sync for MediaFrameReference {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaFrameSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaFrameSource, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaFrameSource {
@@ -924,7 +924,7 @@ impl windows_core::RuntimeName for MediaFrameSource {
 unsafe impl Send for MediaFrameSource {}
 unsafe impl Sync for MediaFrameSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaFrameSourceController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaFrameSourceController, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaFrameSourceController {
@@ -992,7 +992,7 @@ impl windows_core::RuntimeName for MediaFrameSourceController {
 unsafe impl Send for MediaFrameSourceController {}
 unsafe impl Sync for MediaFrameSourceController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaFrameSourceGetPropertyResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaFrameSourceGetPropertyResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaFrameSourceGetPropertyResult {
@@ -1024,7 +1024,7 @@ impl windows_core::RuntimeName for MediaFrameSourceGetPropertyResult {
 unsafe impl Send for MediaFrameSourceGetPropertyResult {}
 unsafe impl Sync for MediaFrameSourceGetPropertyResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaFrameSourceGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaFrameSourceGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaFrameSourceGroup {
@@ -1088,7 +1088,7 @@ impl windows_core::RuntimeName for MediaFrameSourceGroup {
 unsafe impl Send for MediaFrameSourceGroup {}
 unsafe impl Sync for MediaFrameSourceGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaFrameSourceInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaFrameSourceInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaFrameSourceInfo {
@@ -1191,7 +1191,7 @@ impl windows_core::RuntimeName for MediaFrameSourceInfo {
 unsafe impl Send for MediaFrameSourceInfo {}
 unsafe impl Sync for MediaFrameSourceInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MultiSourceMediaFrameArrivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MultiSourceMediaFrameArrivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MultiSourceMediaFrameArrivedEventArgs {}
@@ -1208,7 +1208,7 @@ impl windows_core::RuntimeName for MultiSourceMediaFrameArrivedEventArgs {
 unsafe impl Send for MultiSourceMediaFrameArrivedEventArgs {}
 unsafe impl Sync for MultiSourceMediaFrameArrivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MultiSourceMediaFrameReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MultiSourceMediaFrameReader, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MultiSourceMediaFrameReader, super::super::super::Foundation::IClosable);
@@ -1277,7 +1277,7 @@ impl windows_core::RuntimeName for MultiSourceMediaFrameReader {
 unsafe impl Send for MultiSourceMediaFrameReader {}
 unsafe impl Sync for MultiSourceMediaFrameReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MultiSourceMediaFrameReference(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MultiSourceMediaFrameReference, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MultiSourceMediaFrameReference, super::super::super::Foundation::IClosable);
@@ -1307,7 +1307,7 @@ impl windows_core::RuntimeName for MultiSourceMediaFrameReference {
 unsafe impl Send for MultiSourceMediaFrameReference {}
 unsafe impl Sync for MultiSourceMediaFrameReference {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoMediaFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoMediaFrame, windows_core::IUnknown, windows_core::IInspectable);
 impl VideoMediaFrame {
@@ -1384,7 +1384,7 @@ impl windows_core::RuntimeName for VideoMediaFrame {
 unsafe impl Send for VideoMediaFrame {}
 unsafe impl Sync for VideoMediaFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoMediaFrameFormat(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoMediaFrameFormat, windows_core::IUnknown, windows_core::IInspectable);
 impl VideoMediaFrameFormat {

--- a/crates/libs/windows/src/Windows/Media/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/mod.rs
@@ -1856,7 +1856,7 @@ pub struct IVideoStreamConfiguration_Vtbl {
     OutputProperties: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdvancedCapturedPhoto(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdvancedCapturedPhoto, windows_core::IUnknown, windows_core::IInspectable);
 impl AdvancedCapturedPhoto {
@@ -1903,7 +1903,7 @@ impl windows_core::RuntimeName for AdvancedCapturedPhoto {
 unsafe impl Send for AdvancedCapturedPhoto {}
 unsafe impl Sync for AdvancedCapturedPhoto {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdvancedPhotoCapture(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdvancedPhotoCapture, windows_core::IUnknown, windows_core::IInspectable);
 impl AdvancedPhotoCapture {
@@ -1973,7 +1973,7 @@ impl windows_core::RuntimeName for AdvancedPhotoCapture {
 unsafe impl Send for AdvancedPhotoCapture {}
 unsafe impl Sync for AdvancedPhotoCapture {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastBackgroundService(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastBackgroundService, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastBackgroundService {
@@ -2146,7 +2146,7 @@ impl windows_core::RuntimeName for AppBroadcastBackgroundService {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastBackgroundService";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastBackgroundServiceSignInInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastBackgroundServiceSignInInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastBackgroundServiceSignInInfo {
@@ -2244,7 +2244,7 @@ impl windows_core::RuntimeName for AppBroadcastBackgroundServiceSignInInfo {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastBackgroundServiceSignInInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastBackgroundServiceStreamInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastBackgroundServiceStreamInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastBackgroundServiceStreamInfo {
@@ -2353,7 +2353,7 @@ impl windows_core::RuntimeName for AppBroadcastBackgroundServiceStreamInfo {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastBackgroundServiceStreamInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastCameraCaptureStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastCameraCaptureStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastCameraCaptureStateChangedEventArgs {
@@ -2385,7 +2385,7 @@ impl windows_core::RuntimeName for AppBroadcastCameraCaptureStateChangedEventArg
 unsafe impl Send for AppBroadcastCameraCaptureStateChangedEventArgs {}
 unsafe impl Sync for AppBroadcastCameraCaptureStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastGlobalSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastGlobalSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastGlobalSettings {
@@ -2539,7 +2539,7 @@ impl windows_core::RuntimeName for AppBroadcastGlobalSettings {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastGlobalSettings";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastHeartbeatRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastHeartbeatRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastHeartbeatRequestedEventArgs {
@@ -2601,7 +2601,7 @@ impl windows_core::RuntimeName for AppBroadcastManager {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastMicrophoneCaptureStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastMicrophoneCaptureStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastMicrophoneCaptureStateChangedEventArgs {
@@ -2633,7 +2633,7 @@ impl windows_core::RuntimeName for AppBroadcastMicrophoneCaptureStateChangedEven
 unsafe impl Send for AppBroadcastMicrophoneCaptureStateChangedEventArgs {}
 unsafe impl Sync for AppBroadcastMicrophoneCaptureStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastPlugIn(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastPlugIn, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastPlugIn {
@@ -2680,7 +2680,7 @@ impl windows_core::RuntimeName for AppBroadcastPlugIn {
 unsafe impl Send for AppBroadcastPlugIn {}
 unsafe impl Sync for AppBroadcastPlugIn {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastPlugInManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastPlugInManager, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastPlugInManager {
@@ -2748,7 +2748,7 @@ impl windows_core::RuntimeName for AppBroadcastPlugInManager {
 unsafe impl Send for AppBroadcastPlugInManager {}
 unsafe impl Sync for AppBroadcastPlugInManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastPlugInStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastPlugInStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastPlugInStateChangedEventArgs {
@@ -2773,7 +2773,7 @@ impl windows_core::RuntimeName for AppBroadcastPlugInStateChangedEventArgs {
 unsafe impl Send for AppBroadcastPlugInStateChangedEventArgs {}
 unsafe impl Sync for AppBroadcastPlugInStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastPreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastPreview, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastPreview {
@@ -2830,7 +2830,7 @@ impl windows_core::RuntimeName for AppBroadcastPreview {
 unsafe impl Send for AppBroadcastPreview {}
 unsafe impl Sync for AppBroadcastPreview {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastPreviewStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastPreviewStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastPreviewStateChangedEventArgs {
@@ -2862,7 +2862,7 @@ impl windows_core::RuntimeName for AppBroadcastPreviewStateChangedEventArgs {
 unsafe impl Send for AppBroadcastPreviewStateChangedEventArgs {}
 unsafe impl Sync for AppBroadcastPreviewStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastPreviewStreamReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastPreviewStreamReader, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastPreviewStreamReader {
@@ -2938,7 +2938,7 @@ impl windows_core::RuntimeName for AppBroadcastPreviewStreamReader {
 unsafe impl Send for AppBroadcastPreviewStreamReader {}
 unsafe impl Sync for AppBroadcastPreviewStreamReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastPreviewStreamVideoFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastPreviewStreamVideoFrame, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastPreviewStreamVideoFrame {
@@ -2971,7 +2971,7 @@ impl windows_core::RuntimeName for AppBroadcastPreviewStreamVideoFrame {
 unsafe impl Send for AppBroadcastPreviewStreamVideoFrame {}
 unsafe impl Sync for AppBroadcastPreviewStreamVideoFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastPreviewStreamVideoHeader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastPreviewStreamVideoHeader, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastPreviewStreamVideoHeader {
@@ -3017,7 +3017,7 @@ impl windows_core::RuntimeName for AppBroadcastPreviewStreamVideoHeader {
 unsafe impl Send for AppBroadcastPreviewStreamVideoHeader {}
 unsafe impl Sync for AppBroadcastPreviewStreamVideoHeader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastProviderSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastProviderSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastProviderSettings {
@@ -3110,7 +3110,7 @@ impl windows_core::RuntimeName for AppBroadcastProviderSettings {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastProviderSettings";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastServices(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastServices, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastServices {
@@ -3215,7 +3215,7 @@ impl windows_core::RuntimeName for AppBroadcastServices {
 unsafe impl Send for AppBroadcastServices {}
 unsafe impl Sync for AppBroadcastServices {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastSignInStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastSignInStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastSignInStateChangedEventArgs {
@@ -3245,7 +3245,7 @@ impl windows_core::RuntimeName for AppBroadcastSignInStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastSignInStateChangedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastState(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastState, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastState {
@@ -3495,7 +3495,7 @@ impl windows_core::RuntimeName for AppBroadcastState {
 unsafe impl Send for AppBroadcastState {}
 unsafe impl Sync for AppBroadcastState {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastStreamAudioFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastStreamAudioFrame, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastStreamAudioFrame {
@@ -3526,7 +3526,7 @@ impl windows_core::RuntimeName for AppBroadcastStreamAudioFrame {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamAudioFrame";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastStreamAudioHeader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastStreamAudioHeader, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastStreamAudioHeader {
@@ -3577,7 +3577,7 @@ impl windows_core::RuntimeName for AppBroadcastStreamAudioHeader {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamAudioHeader";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastStreamReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastStreamReader, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastStreamReader {
@@ -3685,7 +3685,7 @@ impl windows_core::RuntimeName for AppBroadcastStreamReader {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamReader";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastStreamStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastStreamStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastStreamStateChangedEventArgs {
@@ -3708,7 +3708,7 @@ impl windows_core::RuntimeName for AppBroadcastStreamStateChangedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamStateChangedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastStreamVideoFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastStreamVideoFrame, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastStreamVideoFrame {
@@ -3739,7 +3739,7 @@ impl windows_core::RuntimeName for AppBroadcastStreamVideoFrame {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamVideoFrame";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastStreamVideoHeader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastStreamVideoHeader, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastStreamVideoHeader {
@@ -3797,7 +3797,7 @@ impl windows_core::RuntimeName for AppBroadcastStreamVideoHeader {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastStreamVideoHeader";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastTriggerDetails {
@@ -3820,7 +3820,7 @@ impl windows_core::RuntimeName for AppBroadcastTriggerDetails {
     const NAME: &'static str = "Windows.Media.Capture.AppBroadcastTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppBroadcastViewerCountChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppBroadcastViewerCountChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppBroadcastViewerCountChangedEventArgs {
@@ -3845,7 +3845,7 @@ impl windows_core::RuntimeName for AppBroadcastViewerCountChangedEventArgs {
 unsafe impl Send for AppBroadcastViewerCountChangedEventArgs {}
 unsafe impl Sync for AppBroadcastViewerCountChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCapture(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCapture, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCapture {
@@ -3911,7 +3911,7 @@ impl windows_core::RuntimeName for AppCapture {
     const NAME: &'static str = "Windows.Media.Capture.AppCapture";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCaptureAlternateShortcutKeys(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCaptureAlternateShortcutKeys, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCaptureAlternateShortcutKeys {
@@ -4135,7 +4135,7 @@ impl windows_core::RuntimeName for AppCaptureAlternateShortcutKeys {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureAlternateShortcutKeys";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCaptureDurationGeneratedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCaptureDurationGeneratedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCaptureDurationGeneratedEventArgs {
@@ -4160,7 +4160,7 @@ impl windows_core::RuntimeName for AppCaptureDurationGeneratedEventArgs {
 unsafe impl Send for AppCaptureDurationGeneratedEventArgs {}
 unsafe impl Sync for AppCaptureDurationGeneratedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCaptureFileGeneratedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCaptureFileGeneratedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCaptureFileGeneratedEventArgs {
@@ -4209,7 +4209,7 @@ impl windows_core::RuntimeName for AppCaptureManager {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCaptureMetadataWriter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCaptureMetadataWriter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AppCaptureMetadataWriter, super::super::Foundation::IClosable);
@@ -4292,7 +4292,7 @@ impl windows_core::RuntimeName for AppCaptureMetadataWriter {
 unsafe impl Send for AppCaptureMetadataWriter {}
 unsafe impl Sync for AppCaptureMetadataWriter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCaptureMicrophoneCaptureStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCaptureMicrophoneCaptureStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCaptureMicrophoneCaptureStateChangedEventArgs {
@@ -4324,7 +4324,7 @@ impl windows_core::RuntimeName for AppCaptureMicrophoneCaptureStateChangedEventA
 unsafe impl Send for AppCaptureMicrophoneCaptureStateChangedEventArgs {}
 unsafe impl Sync for AppCaptureMicrophoneCaptureStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCaptureRecordOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCaptureRecordOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCaptureRecordOperation {
@@ -4424,7 +4424,7 @@ impl windows_core::RuntimeName for AppCaptureRecordOperation {
 unsafe impl Send for AppCaptureRecordOperation {}
 unsafe impl Sync for AppCaptureRecordOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCaptureRecordingStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCaptureRecordingStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCaptureRecordingStateChangedEventArgs {
@@ -4456,7 +4456,7 @@ impl windows_core::RuntimeName for AppCaptureRecordingStateChangedEventArgs {
 unsafe impl Send for AppCaptureRecordingStateChangedEventArgs {}
 unsafe impl Sync for AppCaptureRecordingStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCaptureServices(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCaptureServices, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCaptureServices {
@@ -4502,7 +4502,7 @@ impl windows_core::RuntimeName for AppCaptureServices {
 unsafe impl Send for AppCaptureServices {}
 unsafe impl Sync for AppCaptureServices {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCaptureSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCaptureSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCaptureSettings {
@@ -4823,7 +4823,7 @@ impl windows_core::RuntimeName for AppCaptureSettings {
     const NAME: &'static str = "Windows.Media.Capture.AppCaptureSettings";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCaptureState(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCaptureState, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCaptureState {
@@ -4912,7 +4912,7 @@ impl windows_core::RuntimeName for AppCaptureState {
 unsafe impl Send for AppCaptureState {}
 unsafe impl Sync for AppCaptureState {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CameraCaptureUI(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CameraCaptureUI, windows_core::IUnknown, windows_core::IInspectable);
 impl CameraCaptureUI {
@@ -4957,7 +4957,7 @@ impl windows_core::RuntimeName for CameraCaptureUI {
     const NAME: &'static str = "Windows.Media.Capture.CameraCaptureUI";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CameraCaptureUIPhotoCaptureSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CameraCaptureUIPhotoCaptureSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl CameraCaptureUIPhotoCaptureSettings {
@@ -5030,7 +5030,7 @@ impl windows_core::RuntimeName for CameraCaptureUIPhotoCaptureSettings {
 unsafe impl Send for CameraCaptureUIPhotoCaptureSettings {}
 unsafe impl Sync for CameraCaptureUIPhotoCaptureSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CameraCaptureUIVideoCaptureSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CameraCaptureUIVideoCaptureSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl CameraCaptureUIVideoCaptureSettings {
@@ -5109,7 +5109,7 @@ impl windows_core::RuntimeName for CameraOptionsUI {
     const NAME: &'static str = "Windows.Media.Capture.CameraOptionsUI";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CapturedFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CapturedFrame, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Storage_Streams")]
@@ -5274,7 +5274,7 @@ impl windows_core::RuntimeName for CapturedFrame {
 unsafe impl Send for CapturedFrame {}
 unsafe impl Sync for CapturedFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CapturedFrameControlValues(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CapturedFrameControlValues, windows_core::IUnknown, windows_core::IInspectable);
 impl CapturedFrameControlValues {
@@ -5393,7 +5393,7 @@ impl windows_core::RuntimeName for CapturedFrameControlValues {
 unsafe impl Send for CapturedFrameControlValues {}
 unsafe impl Sync for CapturedFrameControlValues {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CapturedPhoto(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CapturedPhoto, windows_core::IUnknown, windows_core::IInspectable);
 impl CapturedPhoto {
@@ -5425,7 +5425,7 @@ impl windows_core::RuntimeName for CapturedPhoto {
 unsafe impl Send for CapturedPhoto {}
 unsafe impl Sync for CapturedPhoto {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameBarServices(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameBarServices, windows_core::IUnknown, windows_core::IInspectable);
 impl GameBarServices {
@@ -5500,7 +5500,7 @@ impl windows_core::RuntimeName for GameBarServices {
 unsafe impl Send for GameBarServices {}
 unsafe impl Sync for GameBarServices {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameBarServicesCommandEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameBarServicesCommandEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GameBarServicesCommandEventArgs {
@@ -5532,7 +5532,7 @@ impl windows_core::RuntimeName for GameBarServicesCommandEventArgs {
 unsafe impl Send for GameBarServicesCommandEventArgs {}
 unsafe impl Sync for GameBarServicesCommandEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameBarServicesManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameBarServicesManager, windows_core::IUnknown, windows_core::IInspectable);
 impl GameBarServicesManager {
@@ -5575,7 +5575,7 @@ impl windows_core::RuntimeName for GameBarServicesManager {
 unsafe impl Send for GameBarServicesManager {}
 unsafe impl Sync for GameBarServicesManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameBarServicesManagerGameBarServicesCreatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameBarServicesManagerGameBarServicesCreatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GameBarServicesManagerGameBarServicesCreatedEventArgs {
@@ -5600,7 +5600,7 @@ impl windows_core::RuntimeName for GameBarServicesManagerGameBarServicesCreatedE
 unsafe impl Send for GameBarServicesManagerGameBarServicesCreatedEventArgs {}
 unsafe impl Sync for GameBarServicesManagerGameBarServicesCreatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameBarServicesTargetInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameBarServicesTargetInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl GameBarServicesTargetInfo {
@@ -5646,7 +5646,7 @@ impl windows_core::RuntimeName for GameBarServicesTargetInfo {
 unsafe impl Send for GameBarServicesTargetInfo {}
 unsafe impl Sync for GameBarServicesTargetInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LowLagMediaRecording(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LowLagMediaRecording, windows_core::IUnknown, windows_core::IInspectable);
 impl LowLagMediaRecording {
@@ -5713,7 +5713,7 @@ impl windows_core::RuntimeName for LowLagMediaRecording {
     const NAME: &'static str = "Windows.Media.Capture.LowLagMediaRecording";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LowLagPhotoCapture(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LowLagPhotoCapture, windows_core::IUnknown, windows_core::IInspectable);
 impl LowLagPhotoCapture {
@@ -5743,7 +5743,7 @@ impl windows_core::RuntimeName for LowLagPhotoCapture {
     const NAME: &'static str = "Windows.Media.Capture.LowLagPhotoCapture";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LowLagPhotoSequenceCapture(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LowLagPhotoSequenceCapture, windows_core::IUnknown, windows_core::IInspectable);
 impl LowLagPhotoSequenceCapture {
@@ -5794,7 +5794,7 @@ impl windows_core::RuntimeName for LowLagPhotoSequenceCapture {
     const NAME: &'static str = "Windows.Media.Capture.LowLagPhotoSequenceCapture";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCapture(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCapture, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaCapture, super::super::Foundation::IClosable);
@@ -6435,7 +6435,7 @@ impl windows_core::RuntimeName for MediaCapture {
     const NAME: &'static str = "Windows.Media.Capture.MediaCapture";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCaptureDeviceExclusiveControlStatusChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCaptureDeviceExclusiveControlStatusChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaCaptureDeviceExclusiveControlStatusChangedEventArgs {
@@ -6467,7 +6467,7 @@ impl windows_core::RuntimeName for MediaCaptureDeviceExclusiveControlStatusChang
 unsafe impl Send for MediaCaptureDeviceExclusiveControlStatusChangedEventArgs {}
 unsafe impl Sync for MediaCaptureDeviceExclusiveControlStatusChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCaptureFailedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCaptureFailedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaCaptureFailedEventArgs {
@@ -6497,7 +6497,7 @@ impl windows_core::RuntimeName for MediaCaptureFailedEventArgs {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureFailedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCaptureFocusChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCaptureFocusChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaCaptureFocusChangedEventArgs {
@@ -6523,7 +6523,7 @@ impl windows_core::RuntimeName for MediaCaptureFocusChangedEventArgs {
 unsafe impl Send for MediaCaptureFocusChangedEventArgs {}
 unsafe impl Sync for MediaCaptureFocusChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCaptureInitializationSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCaptureInitializationSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaCaptureInitializationSettings {
@@ -6781,7 +6781,7 @@ impl windows_core::RuntimeName for MediaCaptureInitializationSettings {
 unsafe impl Send for MediaCaptureInitializationSettings {}
 unsafe impl Sync for MediaCaptureInitializationSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCapturePauseResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCapturePauseResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaCapturePauseResult, super::super::Foundation::IClosable);
@@ -6816,7 +6816,7 @@ impl windows_core::RuntimeName for MediaCapturePauseResult {
     const NAME: &'static str = "Windows.Media.Capture.MediaCapturePauseResult";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCaptureRelativePanelWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCaptureRelativePanelWatcher, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaCaptureRelativePanelWatcher, super::super::Foundation::IClosable);
@@ -6869,7 +6869,7 @@ impl windows_core::RuntimeName for MediaCaptureRelativePanelWatcher {
 unsafe impl Send for MediaCaptureRelativePanelWatcher {}
 unsafe impl Sync for MediaCaptureRelativePanelWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCaptureSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCaptureSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaCaptureSettings {
@@ -6984,7 +6984,7 @@ impl windows_core::RuntimeName for MediaCaptureSettings {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureSettings";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCaptureStopResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCaptureStopResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaCaptureStopResult, super::super::Foundation::IClosable);
@@ -7019,7 +7019,7 @@ impl windows_core::RuntimeName for MediaCaptureStopResult {
     const NAME: &'static str = "Windows.Media.Capture.MediaCaptureStopResult";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCaptureVideoProfile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCaptureVideoProfile, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaCaptureVideoProfile {
@@ -7099,7 +7099,7 @@ impl windows_core::RuntimeName for MediaCaptureVideoProfile {
 unsafe impl Send for MediaCaptureVideoProfile {}
 unsafe impl Sync for MediaCaptureVideoProfile {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCaptureVideoProfileMediaDescription(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCaptureVideoProfileMediaDescription, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaCaptureVideoProfileMediaDescription {
@@ -7169,7 +7169,7 @@ impl windows_core::RuntimeName for MediaCaptureVideoProfileMediaDescription {
 unsafe impl Send for MediaCaptureVideoProfileMediaDescription {}
 unsafe impl Sync for MediaCaptureVideoProfileMediaDescription {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OptionalReferencePhotoCapturedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OptionalReferencePhotoCapturedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl OptionalReferencePhotoCapturedEventArgs {
@@ -7201,7 +7201,7 @@ impl windows_core::RuntimeName for OptionalReferencePhotoCapturedEventArgs {
 unsafe impl Send for OptionalReferencePhotoCapturedEventArgs {}
 unsafe impl Sync for OptionalReferencePhotoCapturedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoCapturedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoCapturedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoCapturedEventArgs {
@@ -7240,7 +7240,7 @@ impl windows_core::RuntimeName for PhotoCapturedEventArgs {
 unsafe impl Send for PhotoCapturedEventArgs {}
 unsafe impl Sync for PhotoCapturedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoConfirmationCapturedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoConfirmationCapturedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoConfirmationCapturedEventArgs {
@@ -7272,7 +7272,7 @@ impl windows_core::RuntimeName for PhotoConfirmationCapturedEventArgs {
 unsafe impl Send for PhotoConfirmationCapturedEventArgs {}
 unsafe impl Sync for PhotoConfirmationCapturedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ScreenCapture(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ScreenCapture, windows_core::IUnknown, windows_core::IInspectable);
 impl ScreenCapture {
@@ -7345,7 +7345,7 @@ impl windows_core::RuntimeName for ScreenCapture {
 unsafe impl Send for ScreenCapture {}
 unsafe impl Sync for ScreenCapture {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SourceSuspensionChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SourceSuspensionChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SourceSuspensionChangedEventArgs {
@@ -7377,7 +7377,7 @@ impl windows_core::RuntimeName for SourceSuspensionChangedEventArgs {
 unsafe impl Send for SourceSuspensionChangedEventArgs {}
 unsafe impl Sync for SourceSuspensionChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoStreamConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoStreamConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl VideoStreamConfiguration {

--- a/crates/libs/windows/src/Windows/Media/Casting/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Casting/mod.rs
@@ -118,7 +118,7 @@ pub struct ICastingSource_Vtbl {
     pub SetPreferredSourceUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CastingConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CastingConnection, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CastingConnection, super::super::Foundation::IClosable);
@@ -214,7 +214,7 @@ impl windows_core::RuntimeName for CastingConnection {
 unsafe impl Send for CastingConnection {}
 unsafe impl Sync for CastingConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CastingConnectionErrorOccurredEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CastingConnectionErrorOccurredEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CastingConnectionErrorOccurredEventArgs {
@@ -246,7 +246,7 @@ impl windows_core::RuntimeName for CastingConnectionErrorOccurredEventArgs {
 unsafe impl Send for CastingConnectionErrorOccurredEventArgs {}
 unsafe impl Sync for CastingConnectionErrorOccurredEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CastingDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CastingDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl CastingDevice {
@@ -336,7 +336,7 @@ impl windows_core::RuntimeName for CastingDevice {
 unsafe impl Send for CastingDevice {}
 unsafe impl Sync for CastingDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CastingDevicePicker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CastingDevicePicker, windows_core::IUnknown, windows_core::IInspectable);
 impl CastingDevicePicker {
@@ -417,7 +417,7 @@ impl windows_core::RuntimeName for CastingDevicePicker {
 unsafe impl Send for CastingDevicePicker {}
 unsafe impl Sync for CastingDevicePicker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CastingDevicePickerFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CastingDevicePickerFilter, windows_core::IUnknown, windows_core::IInspectable);
 impl CastingDevicePickerFilter {
@@ -476,7 +476,7 @@ impl windows_core::RuntimeName for CastingDevicePickerFilter {
 unsafe impl Send for CastingDevicePickerFilter {}
 unsafe impl Sync for CastingDevicePickerFilter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CastingDeviceSelectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CastingDeviceSelectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CastingDeviceSelectedEventArgs {
@@ -501,7 +501,7 @@ impl windows_core::RuntimeName for CastingDeviceSelectedEventArgs {
 unsafe impl Send for CastingDeviceSelectedEventArgs {}
 unsafe impl Sync for CastingDeviceSelectedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CastingSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CastingSource, windows_core::IUnknown, windows_core::IInspectable);
 impl CastingSource {

--- a/crates/libs/windows/src/Windows/Media/ContentRestrictions/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/ContentRestrictions/mod.rs
@@ -71,7 +71,7 @@ pub struct IRatedContentRestrictionsFactory_Vtbl {
     pub CreateWithMaxAgeRating: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContentRestrictionsBrowsePolicy(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContentRestrictionsBrowsePolicy, windows_core::IUnknown, windows_core::IInspectable);
 impl ContentRestrictionsBrowsePolicy {
@@ -110,7 +110,7 @@ impl windows_core::RuntimeName for ContentRestrictionsBrowsePolicy {
 unsafe impl Send for ContentRestrictionsBrowsePolicy {}
 unsafe impl Sync for ContentRestrictionsBrowsePolicy {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RatedContentDescription(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RatedContentDescription, windows_core::IUnknown, windows_core::IInspectable);
 impl RatedContentDescription {
@@ -204,7 +204,7 @@ impl windows_core::RuntimeName for RatedContentDescription {
 unsafe impl Send for RatedContentDescription {}
 unsafe impl Sync for RatedContentDescription {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RatedContentRestrictions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RatedContentRestrictions, windows_core::IUnknown, windows_core::IInspectable);
 impl RatedContentRestrictions {

--- a/crates/libs/windows/src/Windows/Media/Control/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Control/mod.rs
@@ -173,7 +173,7 @@ pub struct ITimelinePropertiesChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CurrentSessionChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CurrentSessionChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CurrentSessionChangedEventArgs {}
@@ -190,7 +190,7 @@ impl windows_core::RuntimeName for CurrentSessionChangedEventArgs {
 unsafe impl Send for CurrentSessionChangedEventArgs {}
 unsafe impl Sync for CurrentSessionChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GlobalSystemMediaTransportControlsSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GlobalSystemMediaTransportControlsSession, windows_core::IUnknown, windows_core::IInspectable);
 impl GlobalSystemMediaTransportControlsSession {
@@ -383,7 +383,7 @@ impl windows_core::RuntimeName for GlobalSystemMediaTransportControlsSession {
 unsafe impl Send for GlobalSystemMediaTransportControlsSession {}
 unsafe impl Sync for GlobalSystemMediaTransportControlsSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GlobalSystemMediaTransportControlsSessionManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GlobalSystemMediaTransportControlsSessionManager, windows_core::IUnknown, windows_core::IInspectable);
 impl GlobalSystemMediaTransportControlsSessionManager {
@@ -455,7 +455,7 @@ impl windows_core::RuntimeName for GlobalSystemMediaTransportControlsSessionMana
 unsafe impl Send for GlobalSystemMediaTransportControlsSessionManager {}
 unsafe impl Sync for GlobalSystemMediaTransportControlsSessionManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GlobalSystemMediaTransportControlsSessionMediaProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GlobalSystemMediaTransportControlsSessionMediaProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl GlobalSystemMediaTransportControlsSessionMediaProperties {
@@ -545,7 +545,7 @@ impl windows_core::RuntimeName for GlobalSystemMediaTransportControlsSessionMedi
 unsafe impl Send for GlobalSystemMediaTransportControlsSessionMediaProperties {}
 unsafe impl Sync for GlobalSystemMediaTransportControlsSessionMediaProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GlobalSystemMediaTransportControlsSessionPlaybackControls(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GlobalSystemMediaTransportControlsSessionPlaybackControls, windows_core::IUnknown, windows_core::IInspectable);
 impl GlobalSystemMediaTransportControlsSessionPlaybackControls {
@@ -668,7 +668,7 @@ impl windows_core::RuntimeName for GlobalSystemMediaTransportControlsSessionPlay
 unsafe impl Send for GlobalSystemMediaTransportControlsSessionPlaybackControls {}
 unsafe impl Sync for GlobalSystemMediaTransportControlsSessionPlaybackControls {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GlobalSystemMediaTransportControlsSessionPlaybackInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GlobalSystemMediaTransportControlsSessionPlaybackInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl GlobalSystemMediaTransportControlsSessionPlaybackInfo {
@@ -728,7 +728,7 @@ impl windows_core::RuntimeName for GlobalSystemMediaTransportControlsSessionPlay
 unsafe impl Send for GlobalSystemMediaTransportControlsSessionPlaybackInfo {}
 unsafe impl Sync for GlobalSystemMediaTransportControlsSessionPlaybackInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GlobalSystemMediaTransportControlsSessionTimelineProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GlobalSystemMediaTransportControlsSessionTimelineProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl GlobalSystemMediaTransportControlsSessionTimelineProperties {
@@ -788,7 +788,7 @@ impl windows_core::RuntimeName for GlobalSystemMediaTransportControlsSessionTime
 unsafe impl Send for GlobalSystemMediaTransportControlsSessionTimelineProperties {}
 unsafe impl Sync for GlobalSystemMediaTransportControlsSessionTimelineProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPropertiesChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPropertiesChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPropertiesChangedEventArgs {}
@@ -805,7 +805,7 @@ impl windows_core::RuntimeName for MediaPropertiesChangedEventArgs {
 unsafe impl Send for MediaPropertiesChangedEventArgs {}
 unsafe impl Sync for MediaPropertiesChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlaybackInfoChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlaybackInfoChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PlaybackInfoChangedEventArgs {}
@@ -822,7 +822,7 @@ impl windows_core::RuntimeName for PlaybackInfoChangedEventArgs {
 unsafe impl Send for PlaybackInfoChangedEventArgs {}
 unsafe impl Sync for PlaybackInfoChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SessionsChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SessionsChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SessionsChangedEventArgs {}
@@ -839,7 +839,7 @@ impl windows_core::RuntimeName for SessionsChangedEventArgs {
 unsafe impl Send for SessionsChangedEventArgs {}
 unsafe impl Sync for SessionsChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimelinePropertiesChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimelinePropertiesChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TimelinePropertiesChangedEventArgs {}

--- a/crates/libs/windows/src/Windows/Media/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Core/mod.rs
@@ -1800,7 +1800,7 @@ pub struct IVideoTrackSupportInfo_Vtbl {
     pub MediaSourceStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MediaSourceStatus) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioStreamDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioStreamDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioStreamDescriptor, IMediaStreamDescriptor, IMediaStreamDescriptor2);
@@ -1917,7 +1917,7 @@ impl windows_core::RuntimeName for AudioStreamDescriptor {
 unsafe impl Send for AudioStreamDescriptor {}
 unsafe impl Sync for AudioStreamDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioTrack(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioTrack, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioTrack, IMediaTrack);
@@ -2012,7 +2012,7 @@ impl windows_core::RuntimeName for AudioTrack {
 unsafe impl Send for AudioTrack {}
 unsafe impl Sync for AudioTrack {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioTrackOpenFailedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioTrackOpenFailedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioTrackOpenFailedEventArgs {
@@ -2037,7 +2037,7 @@ impl windows_core::RuntimeName for AudioTrackOpenFailedEventArgs {
 unsafe impl Send for AudioTrackOpenFailedEventArgs {}
 unsafe impl Sync for AudioTrackOpenFailedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioTrackSupportInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioTrackSupportInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioTrackSupportInfo {
@@ -2083,7 +2083,7 @@ impl windows_core::RuntimeName for AudioTrackSupportInfo {
 unsafe impl Send for AudioTrackSupportInfo {}
 unsafe impl Sync for AudioTrackSupportInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChapterCue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChapterCue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ChapterCue, IMediaCue);
@@ -2153,7 +2153,7 @@ impl windows_core::RuntimeName for ChapterCue {
 unsafe impl Send for ChapterCue {}
 unsafe impl Sync for ChapterCue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CodecInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CodecInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl CodecInfo {
@@ -2207,7 +2207,7 @@ impl windows_core::RuntimeName for CodecInfo {
 unsafe impl Send for CodecInfo {}
 unsafe impl Sync for CodecInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CodecQuery(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CodecQuery, windows_core::IUnknown, windows_core::IInspectable);
 impl CodecQuery {
@@ -2557,7 +2557,7 @@ impl windows_core::RuntimeName for CodecSubtypes {
     const NAME: &'static str = "Windows.Media.Core.CodecSubtypes";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataCue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataCue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DataCue, IMediaCue);
@@ -2640,7 +2640,7 @@ impl windows_core::RuntimeName for DataCue {
 unsafe impl Send for DataCue {}
 unsafe impl Sync for DataCue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FaceDetectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FaceDetectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl FaceDetectedEventArgs {
@@ -2665,7 +2665,7 @@ impl windows_core::RuntimeName for FaceDetectedEventArgs {
 unsafe impl Send for FaceDetectedEventArgs {}
 unsafe impl Sync for FaceDetectedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FaceDetectionEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FaceDetectionEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FaceDetectionEffect, super::IMediaExtension);
@@ -2729,7 +2729,7 @@ unsafe impl Send for FaceDetectionEffect {}
 unsafe impl Sync for FaceDetectionEffect {}
 #[cfg(feature = "Media_Effects")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FaceDetectionEffectDefinition(windows_core::IUnknown);
 #[cfg(feature = "Media_Effects")]
 windows_core::imp::interface_hierarchy!(FaceDetectionEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
@@ -2801,7 +2801,7 @@ unsafe impl Send for FaceDetectionEffectDefinition {}
 #[cfg(feature = "Media_Effects")]
 unsafe impl Sync for FaceDetectionEffectDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FaceDetectionEffectFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FaceDetectionEffectFrame, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FaceDetectionEffectFrame, super::super::Foundation::IClosable, super::IMediaFrame);
@@ -2907,7 +2907,7 @@ impl windows_core::RuntimeName for FaceDetectionEffectFrame {
 unsafe impl Send for FaceDetectionEffectFrame {}
 unsafe impl Sync for FaceDetectionEffectFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HighDynamicRangeControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HighDynamicRangeControl, windows_core::IUnknown, windows_core::IInspectable);
 impl HighDynamicRangeControl {
@@ -2936,7 +2936,7 @@ impl windows_core::RuntimeName for HighDynamicRangeControl {
 unsafe impl Send for HighDynamicRangeControl {}
 unsafe impl Sync for HighDynamicRangeControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HighDynamicRangeOutput(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HighDynamicRangeOutput, windows_core::IUnknown, windows_core::IInspectable);
 impl HighDynamicRangeOutput {
@@ -2969,7 +2969,7 @@ impl windows_core::RuntimeName for HighDynamicRangeOutput {
 unsafe impl Send for HighDynamicRangeOutput {}
 unsafe impl Sync for HighDynamicRangeOutput {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageCue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageCue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ImageCue, IMediaCue);
@@ -3066,7 +3066,7 @@ impl windows_core::RuntimeName for ImageCue {
 unsafe impl Send for ImageCue {}
 unsafe impl Sync for ImageCue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InitializeMediaStreamSourceRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InitializeMediaStreamSourceRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InitializeMediaStreamSourceRequestedEventArgs {
@@ -3140,7 +3140,7 @@ impl windows_core::RuntimeName for LowLightFusion {
     const NAME: &'static str = "Windows.Media.Core.LowLightFusion";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LowLightFusionResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LowLightFusionResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LowLightFusionResult, super::super::Foundation::IClosable);
@@ -3171,7 +3171,7 @@ impl windows_core::RuntimeName for LowLightFusionResult {
 unsafe impl Send for LowLightFusionResult {}
 unsafe impl Sync for LowLightFusionResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaBinder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaBinder, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaBinder {
@@ -3228,7 +3228,7 @@ impl windows_core::RuntimeName for MediaBinder {
 unsafe impl Send for MediaBinder {}
 unsafe impl Sync for MediaBinder {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaBindingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaBindingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaBindingEventArgs {
@@ -3321,7 +3321,7 @@ impl windows_core::RuntimeName for MediaBindingEventArgs {
 unsafe impl Send for MediaBindingEventArgs {}
 unsafe impl Sync for MediaBindingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaCueEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaCueEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaCueEventArgs {
@@ -3346,7 +3346,7 @@ impl windows_core::RuntimeName for MediaCueEventArgs {
 unsafe impl Send for MediaCueEventArgs {}
 unsafe impl Sync for MediaCueEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaSource, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Media_Playback")]
@@ -3616,7 +3616,7 @@ impl windows_core::RuntimeName for MediaSource {
 unsafe impl Send for MediaSource {}
 unsafe impl Sync for MediaSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaSourceAppServiceConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaSourceAppServiceConnection, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaSourceAppServiceConnection {
@@ -3665,7 +3665,7 @@ impl windows_core::RuntimeName for MediaSourceAppServiceConnection {
     const NAME: &'static str = "Windows.Media.Core.MediaSourceAppServiceConnection";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaSourceError(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaSourceError, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaSourceError {
@@ -3690,7 +3690,7 @@ impl windows_core::RuntimeName for MediaSourceError {
 unsafe impl Send for MediaSourceError {}
 unsafe impl Sync for MediaSourceError {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaSourceOpenOperationCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaSourceOpenOperationCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaSourceOpenOperationCompletedEventArgs {
@@ -3715,7 +3715,7 @@ impl windows_core::RuntimeName for MediaSourceOpenOperationCompletedEventArgs {
 unsafe impl Send for MediaSourceOpenOperationCompletedEventArgs {}
 unsafe impl Sync for MediaSourceOpenOperationCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaSourceStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaSourceStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaSourceStateChangedEventArgs {
@@ -3747,7 +3747,7 @@ impl windows_core::RuntimeName for MediaSourceStateChangedEventArgs {
 unsafe impl Send for MediaSourceStateChangedEventArgs {}
 unsafe impl Sync for MediaSourceStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSample(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSample, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSample {
@@ -3902,7 +3902,7 @@ unsafe impl Send for MediaStreamSample {}
 unsafe impl Sync for MediaStreamSample {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSamplePropertySet(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(MediaStreamSamplePropertySet, windows_core::IUnknown, windows_core::IInspectable);
@@ -4006,7 +4006,7 @@ unsafe impl Send for MediaStreamSamplePropertySet {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for MediaStreamSamplePropertySet {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSampleProtectionProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSampleProtectionProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSampleProtectionProperties {
@@ -4048,7 +4048,7 @@ impl windows_core::RuntimeName for MediaStreamSampleProtectionProperties {
 unsafe impl Send for MediaStreamSampleProtectionProperties {}
 unsafe impl Sync for MediaStreamSampleProtectionProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSource, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaStreamSource, IMediaSource);
@@ -4303,7 +4303,7 @@ impl windows_core::RuntimeName for MediaStreamSource {
 unsafe impl Send for MediaStreamSource {}
 unsafe impl Sync for MediaStreamSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceClosedEventArgs {
@@ -4328,7 +4328,7 @@ impl windows_core::RuntimeName for MediaStreamSourceClosedEventArgs {
 unsafe impl Send for MediaStreamSourceClosedEventArgs {}
 unsafe impl Sync for MediaStreamSourceClosedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceClosedRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceClosedRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceClosedRequest {
@@ -4353,7 +4353,7 @@ impl windows_core::RuntimeName for MediaStreamSourceClosedRequest {
 unsafe impl Send for MediaStreamSourceClosedRequest {}
 unsafe impl Sync for MediaStreamSourceClosedRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceSampleRenderedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceSampleRenderedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceSampleRenderedEventArgs {
@@ -4378,7 +4378,7 @@ impl windows_core::RuntimeName for MediaStreamSourceSampleRenderedEventArgs {
 unsafe impl Send for MediaStreamSourceSampleRenderedEventArgs {}
 unsafe impl Sync for MediaStreamSourceSampleRenderedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceSampleRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceSampleRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceSampleRequest {
@@ -4428,7 +4428,7 @@ impl windows_core::RuntimeName for MediaStreamSourceSampleRequest {
 unsafe impl Send for MediaStreamSourceSampleRequest {}
 unsafe impl Sync for MediaStreamSourceSampleRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceSampleRequestDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceSampleRequestDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceSampleRequestDeferral {
@@ -4450,7 +4450,7 @@ impl windows_core::RuntimeName for MediaStreamSourceSampleRequestDeferral {
 unsafe impl Send for MediaStreamSourceSampleRequestDeferral {}
 unsafe impl Sync for MediaStreamSourceSampleRequestDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceSampleRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceSampleRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceSampleRequestedEventArgs {
@@ -4475,7 +4475,7 @@ impl windows_core::RuntimeName for MediaStreamSourceSampleRequestedEventArgs {
 unsafe impl Send for MediaStreamSourceSampleRequestedEventArgs {}
 unsafe impl Sync for MediaStreamSourceSampleRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceStartingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceStartingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceStartingEventArgs {
@@ -4500,7 +4500,7 @@ impl windows_core::RuntimeName for MediaStreamSourceStartingEventArgs {
 unsafe impl Send for MediaStreamSourceStartingEventArgs {}
 unsafe impl Sync for MediaStreamSourceStartingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceStartingRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceStartingRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceStartingRequest {
@@ -4536,7 +4536,7 @@ impl windows_core::RuntimeName for MediaStreamSourceStartingRequest {
 unsafe impl Send for MediaStreamSourceStartingRequest {}
 unsafe impl Sync for MediaStreamSourceStartingRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceStartingRequestDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceStartingRequestDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceStartingRequestDeferral {
@@ -4558,7 +4558,7 @@ impl windows_core::RuntimeName for MediaStreamSourceStartingRequestDeferral {
 unsafe impl Send for MediaStreamSourceStartingRequestDeferral {}
 unsafe impl Sync for MediaStreamSourceStartingRequestDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceSwitchStreamsRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceSwitchStreamsRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceSwitchStreamsRequest {
@@ -4597,7 +4597,7 @@ impl windows_core::RuntimeName for MediaStreamSourceSwitchStreamsRequest {
 unsafe impl Send for MediaStreamSourceSwitchStreamsRequest {}
 unsafe impl Sync for MediaStreamSourceSwitchStreamsRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceSwitchStreamsRequestDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceSwitchStreamsRequestDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceSwitchStreamsRequestDeferral {
@@ -4619,7 +4619,7 @@ impl windows_core::RuntimeName for MediaStreamSourceSwitchStreamsRequestDeferral
 unsafe impl Send for MediaStreamSourceSwitchStreamsRequestDeferral {}
 unsafe impl Sync for MediaStreamSourceSwitchStreamsRequestDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaStreamSourceSwitchStreamsRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaStreamSourceSwitchStreamsRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaStreamSourceSwitchStreamsRequestedEventArgs {
@@ -4644,7 +4644,7 @@ impl windows_core::RuntimeName for MediaStreamSourceSwitchStreamsRequestedEventA
 unsafe impl Send for MediaStreamSourceSwitchStreamsRequestedEventArgs {}
 unsafe impl Sync for MediaStreamSourceSwitchStreamsRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MseSourceBuffer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MseSourceBuffer, windows_core::IUnknown, windows_core::IInspectable);
 impl MseSourceBuffer {
@@ -4829,7 +4829,7 @@ impl windows_core::RuntimeName for MseSourceBuffer {
 unsafe impl Send for MseSourceBuffer {}
 unsafe impl Sync for MseSourceBuffer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MseSourceBufferList(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MseSourceBufferList, windows_core::IUnknown, windows_core::IInspectable);
 impl MseSourceBufferList {
@@ -4883,7 +4883,7 @@ impl windows_core::RuntimeName for MseSourceBufferList {
 unsafe impl Send for MseSourceBufferList {}
 unsafe impl Sync for MseSourceBufferList {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MseStreamSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MseStreamSource, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MseStreamSource, IMediaSource);
@@ -5029,7 +5029,7 @@ impl windows_core::RuntimeName for MseStreamSource {
 unsafe impl Send for MseStreamSource {}
 unsafe impl Sync for MseStreamSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneAnalysisEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneAnalysisEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneAnalysisEffect, super::IMediaExtension);
@@ -5089,7 +5089,7 @@ unsafe impl Send for SceneAnalysisEffect {}
 unsafe impl Sync for SceneAnalysisEffect {}
 #[cfg(feature = "Media_Effects")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneAnalysisEffectDefinition(windows_core::IUnknown);
 #[cfg(feature = "Media_Effects")]
 windows_core::imp::interface_hierarchy!(SceneAnalysisEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
@@ -5139,7 +5139,7 @@ unsafe impl Send for SceneAnalysisEffectDefinition {}
 #[cfg(feature = "Media_Effects")]
 unsafe impl Sync for SceneAnalysisEffectDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneAnalysisEffectFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneAnalysisEffectFrame, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneAnalysisEffectFrame, super::super::Foundation::IClosable, super::IMediaFrame);
@@ -5259,7 +5259,7 @@ impl windows_core::RuntimeName for SceneAnalysisEffectFrame {
 unsafe impl Send for SceneAnalysisEffectFrame {}
 unsafe impl Sync for SceneAnalysisEffectFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneAnalyzedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneAnalyzedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SceneAnalyzedEventArgs {
@@ -5284,7 +5284,7 @@ impl windows_core::RuntimeName for SceneAnalyzedEventArgs {
 unsafe impl Send for SceneAnalyzedEventArgs {}
 unsafe impl Sync for SceneAnalyzedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechCue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechCue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpeechCue, IMediaCue);
@@ -5382,7 +5382,7 @@ impl windows_core::RuntimeName for SpeechCue {
 unsafe impl Send for SpeechCue {}
 unsafe impl Sync for SpeechCue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedMetadataStreamDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedMetadataStreamDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TimedMetadataStreamDescriptor, IMediaStreamDescriptor, IMediaStreamDescriptor2);
@@ -5471,7 +5471,7 @@ impl windows_core::RuntimeName for TimedMetadataStreamDescriptor {
 unsafe impl Send for TimedMetadataStreamDescriptor {}
 unsafe impl Sync for TimedMetadataStreamDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedMetadataTrack(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedMetadataTrack, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TimedMetadataTrack, IMediaTrack);
@@ -5634,7 +5634,7 @@ impl windows_core::RuntimeName for TimedMetadataTrack {
 unsafe impl Send for TimedMetadataTrack {}
 unsafe impl Sync for TimedMetadataTrack {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedMetadataTrackError(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedMetadataTrackError, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedMetadataTrackError {
@@ -5666,7 +5666,7 @@ impl windows_core::RuntimeName for TimedMetadataTrackError {
 unsafe impl Send for TimedMetadataTrackError {}
 unsafe impl Sync for TimedMetadataTrackError {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedMetadataTrackFailedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedMetadataTrackFailedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedMetadataTrackFailedEventArgs {
@@ -5691,7 +5691,7 @@ impl windows_core::RuntimeName for TimedMetadataTrackFailedEventArgs {
 unsafe impl Send for TimedMetadataTrackFailedEventArgs {}
 unsafe impl Sync for TimedMetadataTrackFailedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedTextBouten(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedTextBouten, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedTextBouten {
@@ -5744,7 +5744,7 @@ impl windows_core::RuntimeName for TimedTextBouten {
 unsafe impl Send for TimedTextBouten {}
 unsafe impl Sync for TimedTextBouten {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedTextCue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedTextCue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TimedTextCue, IMediaCue);
@@ -5839,7 +5839,7 @@ impl windows_core::RuntimeName for TimedTextCue {
 unsafe impl Send for TimedTextCue {}
 unsafe impl Sync for TimedTextCue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedTextLine(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedTextLine, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedTextLine {
@@ -5883,7 +5883,7 @@ impl windows_core::RuntimeName for TimedTextLine {
 unsafe impl Send for TimedTextLine {}
 unsafe impl Sync for TimedTextLine {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedTextRegion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedTextRegion, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedTextRegion {
@@ -6042,7 +6042,7 @@ impl windows_core::RuntimeName for TimedTextRegion {
 unsafe impl Send for TimedTextRegion {}
 unsafe impl Sync for TimedTextRegion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedTextRuby(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedTextRuby, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedTextRuby {
@@ -6104,7 +6104,7 @@ impl windows_core::RuntimeName for TimedTextRuby {
 unsafe impl Send for TimedTextRuby {}
 unsafe impl Sync for TimedTextRuby {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedTextSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedTextSource, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedTextSource {
@@ -6226,7 +6226,7 @@ impl windows_core::RuntimeName for TimedTextSource {
 unsafe impl Send for TimedTextSource {}
 unsafe impl Sync for TimedTextSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedTextSourceResolveResultEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedTextSourceResolveResultEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedTextSourceResolveResultEventArgs {
@@ -6259,7 +6259,7 @@ impl windows_core::RuntimeName for TimedTextSourceResolveResultEventArgs {
 unsafe impl Send for TimedTextSourceResolveResultEventArgs {}
 unsafe impl Sync for TimedTextSourceResolveResultEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedTextStyle(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedTextStyle, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedTextStyle {
@@ -6502,7 +6502,7 @@ impl windows_core::RuntimeName for TimedTextStyle {
 unsafe impl Send for TimedTextStyle {}
 unsafe impl Sync for TimedTextStyle {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedTextSubformat(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedTextSubformat, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedTextSubformat {
@@ -6563,7 +6563,7 @@ impl windows_core::RuntimeName for TimedTextSubformat {
 unsafe impl Send for TimedTextSubformat {}
 unsafe impl Sync for TimedTextSubformat {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoStabilizationEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoStabilizationEffect, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VideoStabilizationEffect, super::IMediaExtension);
@@ -6628,7 +6628,7 @@ unsafe impl Send for VideoStabilizationEffect {}
 unsafe impl Sync for VideoStabilizationEffect {}
 #[cfg(feature = "Media_Effects")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoStabilizationEffectDefinition(windows_core::IUnknown);
 #[cfg(feature = "Media_Effects")]
 windows_core::imp::interface_hierarchy!(VideoStabilizationEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
@@ -6678,7 +6678,7 @@ unsafe impl Send for VideoStabilizationEffectDefinition {}
 #[cfg(feature = "Media_Effects")]
 unsafe impl Sync for VideoStabilizationEffectDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoStabilizationEffectEnabledChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoStabilizationEffectEnabledChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl VideoStabilizationEffectEnabledChangedEventArgs {
@@ -6703,7 +6703,7 @@ impl windows_core::RuntimeName for VideoStabilizationEffectEnabledChangedEventAr
 unsafe impl Send for VideoStabilizationEffectEnabledChangedEventArgs {}
 unsafe impl Sync for VideoStabilizationEffectEnabledChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoStreamDescriptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoStreamDescriptor, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VideoStreamDescriptor, IMediaStreamDescriptor, IMediaStreamDescriptor2);
@@ -6792,7 +6792,7 @@ impl windows_core::RuntimeName for VideoStreamDescriptor {
 unsafe impl Send for VideoStreamDescriptor {}
 unsafe impl Sync for VideoStreamDescriptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoTrack(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoTrack, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VideoTrack, IMediaTrack);
@@ -6887,7 +6887,7 @@ impl windows_core::RuntimeName for VideoTrack {
 unsafe impl Send for VideoTrack {}
 unsafe impl Sync for VideoTrack {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoTrackOpenFailedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoTrackOpenFailedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl VideoTrackOpenFailedEventArgs {
@@ -6912,7 +6912,7 @@ impl windows_core::RuntimeName for VideoTrackOpenFailedEventArgs {
 unsafe impl Send for VideoTrackOpenFailedEventArgs {}
 unsafe impl Sync for VideoTrackOpenFailedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoTrackSupportInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoTrackSupportInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl VideoTrackSupportInfo {

--- a/crates/libs/windows/src/Windows/Media/Devices/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/Core/mod.rs
@@ -282,7 +282,7 @@ pub struct IVariablePhotoSequenceController_Vtbl {
     DesiredFrameControllers: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CameraIntrinsics(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CameraIntrinsics, windows_core::IUnknown, windows_core::IInspectable);
 impl CameraIntrinsics {
@@ -414,7 +414,7 @@ impl windows_core::RuntimeName for CameraIntrinsics {
 unsafe impl Send for CameraIntrinsics {}
 unsafe impl Sync for CameraIntrinsics {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DepthCorrelatedCoordinateMapper(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DepthCorrelatedCoordinateMapper, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DepthCorrelatedCoordinateMapper, super::super::super::Foundation::IClosable);
@@ -477,7 +477,7 @@ impl windows_core::RuntimeName for DepthCorrelatedCoordinateMapper {
 unsafe impl Send for DepthCorrelatedCoordinateMapper {}
 unsafe impl Sync for DepthCorrelatedCoordinateMapper {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameControlCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameControlCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameControlCapabilities {
@@ -535,7 +535,7 @@ impl windows_core::RuntimeName for FrameControlCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameControlCapabilities";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameController, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameController {
@@ -609,7 +609,7 @@ impl windows_core::RuntimeName for FrameController {
 unsafe impl Send for FrameController {}
 unsafe impl Sync for FrameController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameExposureCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameExposureCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameExposureCapabilities {
@@ -653,7 +653,7 @@ impl windows_core::RuntimeName for FrameExposureCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameExposureCapabilities";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameExposureCompensationCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameExposureCompensationCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameExposureCompensationCapabilities {
@@ -697,7 +697,7 @@ impl windows_core::RuntimeName for FrameExposureCompensationCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameExposureCompensationCapabilities";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameExposureCompensationControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameExposureCompensationControl, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameExposureCompensationControl {
@@ -727,7 +727,7 @@ impl windows_core::RuntimeName for FrameExposureCompensationControl {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameExposureCompensationControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameExposureControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameExposureControl, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameExposureControl {
@@ -768,7 +768,7 @@ impl windows_core::RuntimeName for FrameExposureControl {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameExposureControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameFlashCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameFlashCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameFlashCapabilities {
@@ -805,7 +805,7 @@ impl windows_core::RuntimeName for FrameFlashCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameFlashCapabilities";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameFlashControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameFlashControl, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameFlashControl {
@@ -865,7 +865,7 @@ impl windows_core::RuntimeName for FrameFlashControl {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameFlashControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameFocusCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameFocusCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameFocusCapabilities {
@@ -909,7 +909,7 @@ impl windows_core::RuntimeName for FrameFocusCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameFocusCapabilities";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameFocusControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameFocusControl, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameFocusControl {
@@ -939,7 +939,7 @@ impl windows_core::RuntimeName for FrameFocusControl {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameFocusControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameIsoSpeedCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameIsoSpeedCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameIsoSpeedCapabilities {
@@ -983,7 +983,7 @@ impl windows_core::RuntimeName for FrameIsoSpeedCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameIsoSpeedCapabilities";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FrameIsoSpeedControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FrameIsoSpeedControl, windows_core::IUnknown, windows_core::IInspectable);
 impl FrameIsoSpeedControl {
@@ -1024,7 +1024,7 @@ impl windows_core::RuntimeName for FrameIsoSpeedControl {
     const NAME: &'static str = "Windows.Media.Devices.Core.FrameIsoSpeedControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VariablePhotoSequenceController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VariablePhotoSequenceController, windows_core::IUnknown, windows_core::IInspectable);
 impl VariablePhotoSequenceController {

--- a/crates/libs/windows/src/Windows/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/mod.rs
@@ -1025,7 +1025,7 @@ pub struct IZoomSettings_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdvancedPhotoCaptureSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdvancedPhotoCaptureSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl AdvancedPhotoCaptureSettings {
@@ -1061,7 +1061,7 @@ impl windows_core::RuntimeName for AdvancedPhotoCaptureSettings {
 unsafe impl Send for AdvancedPhotoCaptureSettings {}
 unsafe impl Sync for AdvancedPhotoCaptureSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdvancedPhotoControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdvancedPhotoControl, windows_core::IUnknown, windows_core::IInspectable);
 impl AdvancedPhotoControl {
@@ -1108,7 +1108,7 @@ impl windows_core::RuntimeName for AdvancedPhotoControl {
 unsafe impl Send for AdvancedPhotoControl {}
 unsafe impl Sync for AdvancedPhotoControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioDeviceController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioDeviceController, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioDeviceController, IMediaDeviceController);
@@ -1174,7 +1174,7 @@ impl windows_core::RuntimeName for AudioDeviceController {
     const NAME: &'static str = "Windows.Media.Devices.AudioDeviceController";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioDeviceModule(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioDeviceModule, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioDeviceModule {
@@ -1236,7 +1236,7 @@ impl windows_core::RuntimeName for AudioDeviceModule {
     const NAME: &'static str = "Windows.Media.Devices.AudioDeviceModule";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioDeviceModuleNotificationEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioDeviceModuleNotificationEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioDeviceModuleNotificationEventArgs {
@@ -1269,7 +1269,7 @@ impl windows_core::RuntimeName for AudioDeviceModuleNotificationEventArgs {
 unsafe impl Send for AudioDeviceModuleNotificationEventArgs {}
 unsafe impl Sync for AudioDeviceModuleNotificationEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioDeviceModulesManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioDeviceModulesManager, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioDeviceModulesManager {
@@ -1328,7 +1328,7 @@ impl windows_core::RuntimeName for AudioDeviceModulesManager {
 unsafe impl Send for AudioDeviceModulesManager {}
 unsafe impl Sync for AudioDeviceModulesManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CallControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CallControl, windows_core::IUnknown, windows_core::IInspectable);
 impl CallControl {
@@ -1476,7 +1476,7 @@ impl windows_core::RuntimeName for CallControl {
 unsafe impl Send for CallControl {}
 unsafe impl Sync for CallControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CameraOcclusionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CameraOcclusionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl CameraOcclusionInfo {
@@ -1522,7 +1522,7 @@ impl windows_core::RuntimeName for CameraOcclusionInfo {
 unsafe impl Send for CameraOcclusionInfo {}
 unsafe impl Sync for CameraOcclusionInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CameraOcclusionState(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CameraOcclusionState, windows_core::IUnknown, windows_core::IInspectable);
 impl CameraOcclusionState {
@@ -1554,7 +1554,7 @@ impl windows_core::RuntimeName for CameraOcclusionState {
 unsafe impl Send for CameraOcclusionState {}
 unsafe impl Sync for CameraOcclusionState {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CameraOcclusionStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CameraOcclusionStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CameraOcclusionStateChangedEventArgs {
@@ -1579,7 +1579,7 @@ impl windows_core::RuntimeName for CameraOcclusionStateChangedEventArgs {
 unsafe impl Send for CameraOcclusionStateChangedEventArgs {}
 unsafe impl Sync for CameraOcclusionStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DefaultAudioCaptureDeviceChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DefaultAudioCaptureDeviceChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DefaultAudioCaptureDeviceChangedEventArgs, IDefaultAudioDeviceChangedEventArgs);
@@ -1612,7 +1612,7 @@ impl windows_core::RuntimeName for DefaultAudioCaptureDeviceChangedEventArgs {
 unsafe impl Send for DefaultAudioCaptureDeviceChangedEventArgs {}
 unsafe impl Sync for DefaultAudioCaptureDeviceChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DefaultAudioRenderDeviceChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DefaultAudioRenderDeviceChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DefaultAudioRenderDeviceChangedEventArgs, IDefaultAudioDeviceChangedEventArgs);
@@ -1645,7 +1645,7 @@ impl windows_core::RuntimeName for DefaultAudioRenderDeviceChangedEventArgs {
 unsafe impl Send for DefaultAudioRenderDeviceChangedEventArgs {}
 unsafe impl Sync for DefaultAudioRenderDeviceChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DialRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DialRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DialRequestedEventArgs {
@@ -1674,7 +1674,7 @@ impl windows_core::RuntimeName for DialRequestedEventArgs {
 unsafe impl Send for DialRequestedEventArgs {}
 unsafe impl Sync for DialRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DigitalWindowBounds(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DigitalWindowBounds, windows_core::IUnknown, windows_core::IInspectable);
 impl DigitalWindowBounds {
@@ -1732,7 +1732,7 @@ impl windows_core::RuntimeName for DigitalWindowBounds {
 unsafe impl Send for DigitalWindowBounds {}
 unsafe impl Sync for DigitalWindowBounds {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DigitalWindowCapability(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DigitalWindowCapability, windows_core::IUnknown, windows_core::IInspectable);
 impl DigitalWindowCapability {
@@ -1792,7 +1792,7 @@ impl windows_core::RuntimeName for DigitalWindowCapability {
 unsafe impl Send for DigitalWindowCapability {}
 unsafe impl Sync for DigitalWindowCapability {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DigitalWindowControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DigitalWindowControl, windows_core::IUnknown, windows_core::IInspectable);
 impl DigitalWindowControl {
@@ -1864,7 +1864,7 @@ impl windows_core::RuntimeName for DigitalWindowControl {
 unsafe impl Send for DigitalWindowControl {}
 unsafe impl Sync for DigitalWindowControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExposureCompensationControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ExposureCompensationControl, windows_core::IUnknown, windows_core::IInspectable);
 impl ExposureCompensationControl {
@@ -1922,7 +1922,7 @@ impl windows_core::RuntimeName for ExposureCompensationControl {
     const NAME: &'static str = "Windows.Media.Devices.ExposureCompensationControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExposureControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ExposureControl, windows_core::IUnknown, windows_core::IInspectable);
 impl ExposureControl {
@@ -1994,7 +1994,7 @@ impl windows_core::RuntimeName for ExposureControl {
     const NAME: &'static str = "Windows.Media.Devices.ExposureControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExposurePriorityVideoControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ExposurePriorityVideoControl, windows_core::IUnknown, windows_core::IInspectable);
 impl ExposurePriorityVideoControl {
@@ -2030,7 +2030,7 @@ impl windows_core::RuntimeName for ExposurePriorityVideoControl {
 unsafe impl Send for ExposurePriorityVideoControl {}
 unsafe impl Sync for ExposurePriorityVideoControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FlashControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FlashControl, windows_core::IUnknown, windows_core::IInspectable);
 impl FlashControl {
@@ -2129,7 +2129,7 @@ impl windows_core::RuntimeName for FlashControl {
     const NAME: &'static str = "Windows.Media.Devices.FlashControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FocusControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FocusControl, windows_core::IUnknown, windows_core::IInspectable);
 impl FocusControl {
@@ -2296,7 +2296,7 @@ impl windows_core::RuntimeName for FocusControl {
     const NAME: &'static str = "Windows.Media.Devices.FocusControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FocusSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FocusSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl FocusSettings {
@@ -2393,7 +2393,7 @@ impl windows_core::RuntimeName for FocusSettings {
 unsafe impl Send for FocusSettings {}
 unsafe impl Sync for FocusSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HdrVideoControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HdrVideoControl, windows_core::IUnknown, windows_core::IInspectable);
 impl HdrVideoControl {
@@ -2437,7 +2437,7 @@ impl windows_core::RuntimeName for HdrVideoControl {
 unsafe impl Send for HdrVideoControl {}
 unsafe impl Sync for HdrVideoControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InfraredTorchControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InfraredTorchControl, windows_core::IUnknown, windows_core::IInspectable);
 impl InfraredTorchControl {
@@ -2513,7 +2513,7 @@ impl windows_core::RuntimeName for InfraredTorchControl {
 unsafe impl Send for InfraredTorchControl {}
 unsafe impl Sync for InfraredTorchControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsoSpeedControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsoSpeedControl, windows_core::IUnknown, windows_core::IInspectable);
 impl IsoSpeedControl {
@@ -2609,7 +2609,7 @@ impl windows_core::RuntimeName for IsoSpeedControl {
     const NAME: &'static str = "Windows.Media.Devices.IsoSpeedControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeypadPressedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeypadPressedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl KeypadPressedEventArgs {
@@ -2634,7 +2634,7 @@ impl windows_core::RuntimeName for KeypadPressedEventArgs {
 unsafe impl Send for KeypadPressedEventArgs {}
 unsafe impl Sync for KeypadPressedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LowLagPhotoControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LowLagPhotoControl, windows_core::IUnknown, windows_core::IInspectable);
 impl LowLagPhotoControl {
@@ -2711,7 +2711,7 @@ impl windows_core::RuntimeName for LowLagPhotoControl {
     const NAME: &'static str = "Windows.Media.Devices.LowLagPhotoControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LowLagPhotoSequenceControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LowLagPhotoSequenceControl, windows_core::IUnknown, windows_core::IInspectable);
 impl LowLagPhotoSequenceControl {
@@ -2896,7 +2896,7 @@ impl windows_core::RuntimeName for MediaDevice {
     const NAME: &'static str = "Windows.Media.Devices.MediaDevice";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaDeviceControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaDeviceControl, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaDeviceControl {
@@ -2947,7 +2947,7 @@ impl windows_core::RuntimeName for MediaDeviceControl {
     const NAME: &'static str = "Windows.Media.Devices.MediaDeviceControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaDeviceControlCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaDeviceControlCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaDeviceControlCapabilities {
@@ -3005,7 +3005,7 @@ impl windows_core::RuntimeName for MediaDeviceControlCapabilities {
     const NAME: &'static str = "Windows.Media.Devices.MediaDeviceControlCapabilities";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ModuleCommandResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ModuleCommandResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ModuleCommandResult {
@@ -3036,7 +3036,7 @@ impl windows_core::RuntimeName for ModuleCommandResult {
     const NAME: &'static str = "Windows.Media.Devices.ModuleCommandResult";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OpticalImageStabilizationControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OpticalImageStabilizationControl, windows_core::IUnknown, windows_core::IInspectable);
 impl OpticalImageStabilizationControl {
@@ -3080,7 +3080,7 @@ impl windows_core::RuntimeName for OpticalImageStabilizationControl {
 unsafe impl Send for OpticalImageStabilizationControl {}
 unsafe impl Sync for OpticalImageStabilizationControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PanelBasedOptimizationControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PanelBasedOptimizationControl, windows_core::IUnknown, windows_core::IInspectable);
 impl PanelBasedOptimizationControl {
@@ -3118,7 +3118,7 @@ impl windows_core::RuntimeName for PanelBasedOptimizationControl {
 unsafe impl Send for PanelBasedOptimizationControl {}
 unsafe impl Sync for PanelBasedOptimizationControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoConfirmationControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoConfirmationControl, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoConfirmationControl {
@@ -3165,7 +3165,7 @@ impl windows_core::RuntimeName for PhotoConfirmationControl {
     const NAME: &'static str = "Windows.Media.Devices.PhotoConfirmationControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RedialRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RedialRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RedialRequestedEventArgs {
@@ -3187,7 +3187,7 @@ impl windows_core::RuntimeName for RedialRequestedEventArgs {
 unsafe impl Send for RedialRequestedEventArgs {}
 unsafe impl Sync for RedialRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RegionOfInterest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RegionOfInterest, windows_core::IUnknown, windows_core::IInspectable);
 impl RegionOfInterest {
@@ -3289,7 +3289,7 @@ impl windows_core::RuntimeName for RegionOfInterest {
 unsafe impl Send for RegionOfInterest {}
 unsafe impl Sync for RegionOfInterest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RegionsOfInterestControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RegionsOfInterestControl, windows_core::IUnknown, windows_core::IInspectable);
 impl RegionsOfInterestControl {
@@ -3362,7 +3362,7 @@ impl windows_core::RuntimeName for RegionsOfInterestControl {
     const NAME: &'static str = "Windows.Media.Devices.RegionsOfInterestControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneModeControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneModeControl, windows_core::IUnknown, windows_core::IInspectable);
 impl SceneModeControl {
@@ -3400,7 +3400,7 @@ impl windows_core::RuntimeName for SceneModeControl {
     const NAME: &'static str = "Windows.Media.Devices.SceneModeControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TorchControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TorchControl, windows_core::IUnknown, windows_core::IInspectable);
 impl TorchControl {
@@ -3452,7 +3452,7 @@ impl windows_core::RuntimeName for TorchControl {
     const NAME: &'static str = "Windows.Media.Devices.TorchControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoDeviceController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoDeviceController, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VideoDeviceController, IMediaDeviceController);
@@ -3839,7 +3839,7 @@ impl windows_core::RuntimeName for VideoDeviceController {
     const NAME: &'static str = "Windows.Media.Devices.VideoDeviceController";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoDeviceControllerGetDevicePropertyResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoDeviceControllerGetDevicePropertyResult, windows_core::IUnknown, windows_core::IInspectable);
 impl VideoDeviceControllerGetDevicePropertyResult {
@@ -3871,7 +3871,7 @@ impl windows_core::RuntimeName for VideoDeviceControllerGetDevicePropertyResult 
 unsafe impl Send for VideoDeviceControllerGetDevicePropertyResult {}
 unsafe impl Sync for VideoDeviceControllerGetDevicePropertyResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoTemporalDenoisingControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoTemporalDenoisingControl, windows_core::IUnknown, windows_core::IInspectable);
 impl VideoTemporalDenoisingControl {
@@ -3915,7 +3915,7 @@ impl windows_core::RuntimeName for VideoTemporalDenoisingControl {
 unsafe impl Send for VideoTemporalDenoisingControl {}
 unsafe impl Sync for VideoTemporalDenoisingControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WhiteBalanceControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WhiteBalanceControl, windows_core::IUnknown, windows_core::IInspectable);
 impl WhiteBalanceControl {
@@ -3987,7 +3987,7 @@ impl windows_core::RuntimeName for WhiteBalanceControl {
     const NAME: &'static str = "Windows.Media.Devices.WhiteBalanceControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ZoomControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ZoomControl, windows_core::IUnknown, windows_core::IInspectable);
 impl ZoomControl {
@@ -4064,7 +4064,7 @@ impl windows_core::RuntimeName for ZoomControl {
     const NAME: &'static str = "Windows.Media.Devices.ZoomControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ZoomSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ZoomSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl ZoomSettings {

--- a/crates/libs/windows/src/Windows/Media/DialProtocol/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/DialProtocol/mod.rs
@@ -153,7 +153,7 @@ pub struct IDialReceiverAppStatics_Vtbl {
     pub Current: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DialApp(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DialApp, windows_core::IUnknown, windows_core::IInspectable);
 impl DialApp {
@@ -199,7 +199,7 @@ impl windows_core::RuntimeName for DialApp {
 unsafe impl Send for DialApp {}
 unsafe impl Sync for DialApp {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DialAppStateDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DialAppStateDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl DialAppStateDetails {
@@ -231,7 +231,7 @@ impl windows_core::RuntimeName for DialAppStateDetails {
 unsafe impl Send for DialAppStateDetails {}
 unsafe impl Sync for DialAppStateDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DialDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DialDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl DialDevice {
@@ -305,7 +305,7 @@ impl windows_core::RuntimeName for DialDevice {
 unsafe impl Send for DialDevice {}
 unsafe impl Sync for DialDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DialDevicePicker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DialDevicePicker, windows_core::IUnknown, windows_core::IInspectable);
 impl DialDevicePicker {
@@ -422,7 +422,7 @@ impl windows_core::RuntimeName for DialDevicePicker {
 unsafe impl Send for DialDevicePicker {}
 unsafe impl Sync for DialDevicePicker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DialDevicePickerFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DialDevicePickerFilter, windows_core::IUnknown, windows_core::IInspectable);
 impl DialDevicePickerFilter {
@@ -448,7 +448,7 @@ impl windows_core::RuntimeName for DialDevicePickerFilter {
 unsafe impl Send for DialDevicePickerFilter {}
 unsafe impl Sync for DialDevicePickerFilter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DialDeviceSelectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DialDeviceSelectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DialDeviceSelectedEventArgs {
@@ -473,7 +473,7 @@ impl windows_core::RuntimeName for DialDeviceSelectedEventArgs {
 unsafe impl Send for DialDeviceSelectedEventArgs {}
 unsafe impl Sync for DialDeviceSelectedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DialDisconnectButtonClickedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DialDisconnectButtonClickedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DialDisconnectButtonClickedEventArgs {
@@ -498,7 +498,7 @@ impl windows_core::RuntimeName for DialDisconnectButtonClickedEventArgs {
 unsafe impl Send for DialDisconnectButtonClickedEventArgs {}
 unsafe impl Sync for DialDisconnectButtonClickedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DialReceiverApp(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DialReceiverApp, windows_core::IUnknown, windows_core::IInspectable);
 impl DialReceiverApp {

--- a/crates/libs/windows/src/Windows/Media/Editing/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Editing/mod.rs
@@ -271,7 +271,7 @@ pub struct IMediaOverlayLayerFactory_Vtbl {
     CreateWithCompositorDefinition: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundAudioTrack(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundAudioTrack, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundAudioTrack {
@@ -402,7 +402,7 @@ impl windows_core::RuntimeName for BackgroundAudioTrack {
 unsafe impl Send for BackgroundAudioTrack {}
 unsafe impl Sync for BackgroundAudioTrack {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmbeddedAudioTrack(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmbeddedAudioTrack, windows_core::IUnknown, windows_core::IInspectable);
 impl EmbeddedAudioTrack {
@@ -428,7 +428,7 @@ impl windows_core::RuntimeName for EmbeddedAudioTrack {
 unsafe impl Send for EmbeddedAudioTrack {}
 unsafe impl Sync for EmbeddedAudioTrack {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaClip(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaClip, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaClip {
@@ -612,7 +612,7 @@ impl windows_core::RuntimeName for MediaClip {
 unsafe impl Send for MediaClip {}
 unsafe impl Sync for MediaClip {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaComposition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaComposition, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaComposition {
@@ -797,7 +797,7 @@ impl windows_core::RuntimeName for MediaComposition {
 unsafe impl Send for MediaComposition {}
 unsafe impl Sync for MediaComposition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaOverlay(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaOverlay, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaOverlay {
@@ -896,7 +896,7 @@ impl windows_core::RuntimeName for MediaOverlay {
 unsafe impl Send for MediaOverlay {}
 unsafe impl Sync for MediaOverlay {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaOverlayLayer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaOverlayLayer, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaOverlayLayer {

--- a/crates/libs/windows/src/Windows/Media/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Effects/mod.rs
@@ -604,7 +604,7 @@ pub struct IVideoTransformSphericalProjection_Vtbl {
     SetViewOrientation: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioCaptureEffectsManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioCaptureEffectsManager, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioCaptureEffectsManager {
@@ -644,7 +644,7 @@ impl windows_core::RuntimeName for AudioCaptureEffectsManager {
 unsafe impl Send for AudioCaptureEffectsManager {}
 unsafe impl Sync for AudioCaptureEffectsManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioEffect, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioEffect {
@@ -669,7 +669,7 @@ impl windows_core::RuntimeName for AudioEffect {
 unsafe impl Send for AudioEffect {}
 unsafe impl Sync for AudioEffect {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioEffectDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioEffectDefinition, IAudioEffectDefinition);
@@ -763,7 +763,7 @@ impl windows_core::RuntimeName for AudioEffectsManager {
     const NAME: &'static str = "Windows.Media.Effects.AudioEffectsManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioRenderEffectsManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioRenderEffectsManager, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioRenderEffectsManager {
@@ -824,7 +824,7 @@ impl windows_core::RuntimeName for AudioRenderEffectsManager {
 unsafe impl Send for AudioRenderEffectsManager {}
 unsafe impl Sync for AudioRenderEffectsManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositeVideoFrameContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositeVideoFrameContext, windows_core::IUnknown, windows_core::IInspectable);
 impl CompositeVideoFrameContext {
@@ -875,7 +875,7 @@ impl windows_core::RuntimeName for CompositeVideoFrameContext {
 unsafe impl Send for CompositeVideoFrameContext {}
 unsafe impl Sync for CompositeVideoFrameContext {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessAudioFrameContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessAudioFrameContext, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessAudioFrameContext {
@@ -907,7 +907,7 @@ impl windows_core::RuntimeName for ProcessAudioFrameContext {
 unsafe impl Send for ProcessAudioFrameContext {}
 unsafe impl Sync for ProcessAudioFrameContext {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessVideoFrameContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessVideoFrameContext, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessVideoFrameContext {
@@ -939,7 +939,7 @@ impl windows_core::RuntimeName for ProcessVideoFrameContext {
 unsafe impl Send for ProcessVideoFrameContext {}
 unsafe impl Sync for ProcessVideoFrameContext {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SlowMotionEffectDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SlowMotionEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SlowMotionEffectDefinition, IVideoEffectDefinition);
@@ -991,7 +991,7 @@ impl windows_core::RuntimeName for SlowMotionEffectDefinition {
 unsafe impl Send for SlowMotionEffectDefinition {}
 unsafe impl Sync for SlowMotionEffectDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoCompositorDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoCompositorDefinition, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VideoCompositorDefinition, IVideoCompositorDefinition);
@@ -1046,7 +1046,7 @@ impl windows_core::RuntimeName for VideoCompositorDefinition {
 unsafe impl Send for VideoCompositorDefinition {}
 unsafe impl Sync for VideoCompositorDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoEffectDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VideoEffectDefinition, IVideoEffectDefinition);
@@ -1101,7 +1101,7 @@ impl windows_core::RuntimeName for VideoEffectDefinition {
 unsafe impl Send for VideoEffectDefinition {}
 unsafe impl Sync for VideoEffectDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoTransformEffectDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoTransformEffectDefinition, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VideoTransformEffectDefinition, IVideoEffectDefinition);
@@ -1223,7 +1223,7 @@ impl windows_core::RuntimeName for VideoTransformEffectDefinition {
 unsafe impl Send for VideoTransformEffectDefinition {}
 unsafe impl Sync for VideoTransformEffectDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoTransformSphericalProjection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoTransformSphericalProjection, windows_core::IUnknown, windows_core::IInspectable);
 impl VideoTransformSphericalProjection {

--- a/crates/libs/windows/src/Windows/Media/FaceAnalysis/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/FaceAnalysis/mod.rs
@@ -107,7 +107,7 @@ pub struct IFaceTrackerStatics_Vtbl {
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DetectedFace(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DetectedFace, windows_core::IUnknown, windows_core::IInspectable);
 impl DetectedFace {
@@ -133,7 +133,7 @@ impl windows_core::RuntimeName for DetectedFace {
 unsafe impl Send for DetectedFace {}
 unsafe impl Sync for DetectedFace {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FaceDetector(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FaceDetector, windows_core::IUnknown, windows_core::IInspectable);
 impl FaceDetector {
@@ -230,7 +230,7 @@ impl windows_core::RuntimeName for FaceDetector {
 unsafe impl Send for FaceDetector {}
 unsafe impl Sync for FaceDetector {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FaceTracker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FaceTracker, windows_core::IUnknown, windows_core::IInspectable);
 impl FaceTracker {

--- a/crates/libs/windows/src/Windows/Media/Import/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Import/mod.rs
@@ -318,7 +318,7 @@ pub struct IPhotoImportVideoSegment_Vtbl {
     Sidecars: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportDeleteImportedItemsFromSourceResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportDeleteImportedItemsFromSourceResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportDeleteImportedItemsFromSourceResult {
@@ -428,7 +428,7 @@ impl windows_core::RuntimeName for PhotoImportDeleteImportedItemsFromSourceResul
 unsafe impl Send for PhotoImportDeleteImportedItemsFromSourceResult {}
 unsafe impl Sync for PhotoImportDeleteImportedItemsFromSourceResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportFindItemsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportFindItemsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportFindItemsResult {
@@ -673,7 +673,7 @@ impl windows_core::RuntimeName for PhotoImportFindItemsResult {
 unsafe impl Send for PhotoImportFindItemsResult {}
 unsafe impl Sync for PhotoImportFindItemsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportImportItemsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportImportItemsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportImportItemsResult {
@@ -790,7 +790,7 @@ impl windows_core::RuntimeName for PhotoImportImportItemsResult {
 unsafe impl Send for PhotoImportImportItemsResult {}
 unsafe impl Sync for PhotoImportImportItemsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportItem, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportItem {
@@ -908,7 +908,7 @@ impl windows_core::RuntimeName for PhotoImportItem {
 unsafe impl Send for PhotoImportItem {}
 unsafe impl Sync for PhotoImportItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportItemImportedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportItemImportedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportItemImportedEventArgs {
@@ -964,7 +964,7 @@ impl windows_core::RuntimeName for PhotoImportManager {
     const NAME: &'static str = "Windows.Media.Import.PhotoImportManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportOperation {
@@ -1017,7 +1017,7 @@ impl windows_core::RuntimeName for PhotoImportOperation {
 unsafe impl Send for PhotoImportOperation {}
 unsafe impl Sync for PhotoImportOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportSelectionChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportSelectionChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportSelectionChangedEventArgs {
@@ -1042,7 +1042,7 @@ impl windows_core::RuntimeName for PhotoImportSelectionChangedEventArgs {
 unsafe impl Send for PhotoImportSelectionChangedEventArgs {}
 unsafe impl Sync for PhotoImportSelectionChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PhotoImportSession, super::super::Foundation::IClosable);
@@ -1157,7 +1157,7 @@ impl windows_core::RuntimeName for PhotoImportSession {
 unsafe impl Send for PhotoImportSession {}
 unsafe impl Sync for PhotoImportSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportSidecar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportSidecar, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportSidecar {
@@ -1196,7 +1196,7 @@ impl windows_core::RuntimeName for PhotoImportSidecar {
 unsafe impl Send for PhotoImportSidecar {}
 unsafe impl Sync for PhotoImportSidecar {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportSource, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportSource {
@@ -1356,7 +1356,7 @@ impl windows_core::RuntimeName for PhotoImportSource {
 unsafe impl Send for PhotoImportSource {}
 unsafe impl Sync for PhotoImportSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportStorageMedium(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportStorageMedium, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportStorageMedium {
@@ -1427,7 +1427,7 @@ impl windows_core::RuntimeName for PhotoImportStorageMedium {
 unsafe impl Send for PhotoImportStorageMedium {}
 unsafe impl Sync for PhotoImportStorageMedium {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhotoImportVideoSegment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhotoImportVideoSegment, windows_core::IUnknown, windows_core::IInspectable);
 impl PhotoImportVideoSegment {

--- a/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
@@ -611,7 +611,7 @@ pub struct IVp9ProfileIdsStatics_Vtbl {
     pub Profile2ChromaSubsampling420BitDepth12: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioEncodingProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioEncodingProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioEncodingProperties, IMediaEncodingProperties);
@@ -864,7 +864,7 @@ impl windows_core::RuntimeName for Av1ProfileIds {
     const NAME: &'static str = "Windows.Media.MediaProperties.Av1ProfileIds";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContainerEncodingProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContainerEncodingProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContainerEncodingProperties, IMediaEncodingProperties);
@@ -1137,7 +1137,7 @@ impl windows_core::RuntimeName for HevcProfileIds {
     const NAME: &'static str = "Windows.Media.MediaProperties.HevcProfileIds";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageEncodingProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageEncodingProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ImageEncodingProperties, IMediaEncodingProperties);
@@ -1269,7 +1269,7 @@ impl windows_core::RuntimeName for ImageEncodingProperties {
 unsafe impl Send for ImageEncodingProperties {}
 unsafe impl Sync for ImageEncodingProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaEncodingProfile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaEncodingProfile, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaEncodingProfile {
@@ -1856,7 +1856,7 @@ impl windows_core::RuntimeName for MediaEncodingSubtypes {
 }
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPropertySet(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(MediaPropertySet, windows_core::IUnknown, windows_core::IInspectable);
@@ -1967,7 +1967,7 @@ unsafe impl Send for MediaPropertySet {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for MediaPropertySet {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaRatio(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaRatio, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaRatio {
@@ -2048,7 +2048,7 @@ impl windows_core::RuntimeName for Mpeg2ProfileIds {
     const NAME: &'static str = "Windows.Media.MediaProperties.Mpeg2ProfileIds";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedMetadataEncodingProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedMetadataEncodingProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TimedMetadataEncodingProperties, IMediaEncodingProperties);
@@ -2144,7 +2144,7 @@ impl windows_core::RuntimeName for TimedMetadataEncodingProperties {
 unsafe impl Send for TimedMetadataEncodingProperties {}
 unsafe impl Sync for TimedMetadataEncodingProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoEncodingProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoEncodingProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VideoEncodingProperties, IMediaEncodingProperties);

--- a/crates/libs/windows/src/Windows/Media/Miracast/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Miracast/mod.rs
@@ -286,7 +286,7 @@ pub struct IMiracastTransmitter_Vtbl {
     pub LastConnectionTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiver(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiver, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiver {
@@ -413,7 +413,7 @@ impl windows_core::RuntimeName for MiracastReceiver {
 unsafe impl Send for MiracastReceiver {}
 unsafe impl Sync for MiracastReceiver {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverApplySettingsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverApplySettingsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverApplySettingsResult {
@@ -445,7 +445,7 @@ impl windows_core::RuntimeName for MiracastReceiverApplySettingsResult {
 unsafe impl Send for MiracastReceiverApplySettingsResult {}
 unsafe impl Sync for MiracastReceiverApplySettingsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverConnection, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MiracastReceiverConnection, super::super::Foundation::IClosable);
@@ -526,7 +526,7 @@ impl windows_core::RuntimeName for MiracastReceiverConnection {
 unsafe impl Send for MiracastReceiverConnection {}
 unsafe impl Sync for MiracastReceiverConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverConnectionCreatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverConnectionCreatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverConnectionCreatedEventArgs {
@@ -565,7 +565,7 @@ impl windows_core::RuntimeName for MiracastReceiverConnectionCreatedEventArgs {
 unsafe impl Send for MiracastReceiverConnectionCreatedEventArgs {}
 unsafe impl Sync for MiracastReceiverConnectionCreatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverCursorImageChannel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverCursorImageChannel, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverCursorImageChannel {
@@ -642,7 +642,7 @@ impl windows_core::RuntimeName for MiracastReceiverCursorImageChannel {
 unsafe impl Send for MiracastReceiverCursorImageChannel {}
 unsafe impl Sync for MiracastReceiverCursorImageChannel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverCursorImageChannelSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverCursorImageChannelSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverCursorImageChannelSettings {
@@ -684,7 +684,7 @@ impl windows_core::RuntimeName for MiracastReceiverCursorImageChannelSettings {
 unsafe impl Send for MiracastReceiverCursorImageChannelSettings {}
 unsafe impl Sync for MiracastReceiverCursorImageChannelSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverDisconnectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverDisconnectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverDisconnectedEventArgs {
@@ -709,7 +709,7 @@ impl windows_core::RuntimeName for MiracastReceiverDisconnectedEventArgs {
 unsafe impl Send for MiracastReceiverDisconnectedEventArgs {}
 unsafe impl Sync for MiracastReceiverDisconnectedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverGameControllerDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverGameControllerDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverGameControllerDevice {
@@ -777,7 +777,7 @@ impl windows_core::RuntimeName for MiracastReceiverGameControllerDevice {
 unsafe impl Send for MiracastReceiverGameControllerDevice {}
 unsafe impl Sync for MiracastReceiverGameControllerDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverInputDevices(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverInputDevices, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverInputDevices {
@@ -809,7 +809,7 @@ impl windows_core::RuntimeName for MiracastReceiverInputDevices {
 unsafe impl Send for MiracastReceiverInputDevices {}
 unsafe impl Sync for MiracastReceiverInputDevices {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverKeyboardDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverKeyboardDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverKeyboardDevice {
@@ -866,7 +866,7 @@ impl windows_core::RuntimeName for MiracastReceiverKeyboardDevice {
 unsafe impl Send for MiracastReceiverKeyboardDevice {}
 unsafe impl Sync for MiracastReceiverKeyboardDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverMediaSourceCreatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverMediaSourceCreatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverMediaSourceCreatedEventArgs {
@@ -913,7 +913,7 @@ impl windows_core::RuntimeName for MiracastReceiverMediaSourceCreatedEventArgs {
 unsafe impl Send for MiracastReceiverMediaSourceCreatedEventArgs {}
 unsafe impl Sync for MiracastReceiverMediaSourceCreatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MiracastReceiverSession, super::super::Foundation::IClosable);
@@ -1014,7 +1014,7 @@ impl windows_core::RuntimeName for MiracastReceiverSession {
 unsafe impl Send for MiracastReceiverSession {}
 unsafe impl Sync for MiracastReceiverSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverSessionStartResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverSessionStartResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverSessionStartResult {
@@ -1046,7 +1046,7 @@ impl windows_core::RuntimeName for MiracastReceiverSessionStartResult {
 unsafe impl Send for MiracastReceiverSessionStartResult {}
 unsafe impl Sync for MiracastReceiverSessionStartResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverSettings {
@@ -1119,7 +1119,7 @@ impl windows_core::RuntimeName for MiracastReceiverSettings {
 unsafe impl Send for MiracastReceiverSettings {}
 unsafe impl Sync for MiracastReceiverSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverStatus(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverStatus, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverStatus {
@@ -1173,7 +1173,7 @@ impl windows_core::RuntimeName for MiracastReceiverStatus {
 unsafe impl Send for MiracastReceiverStatus {}
 unsafe impl Sync for MiracastReceiverStatus {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverStreamControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverStreamControl, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverStreamControl {
@@ -1233,7 +1233,7 @@ impl windows_core::RuntimeName for MiracastReceiverStreamControl {
 unsafe impl Send for MiracastReceiverStreamControl {}
 unsafe impl Sync for MiracastReceiverStreamControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastReceiverVideoStreamSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastReceiverVideoStreamSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastReceiverVideoStreamSettings {
@@ -1275,7 +1275,7 @@ impl windows_core::RuntimeName for MiracastReceiverVideoStreamSettings {
 unsafe impl Send for MiracastReceiverVideoStreamSettings {}
 unsafe impl Sync for MiracastReceiverVideoStreamSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MiracastTransmitter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MiracastTransmitter, windows_core::IUnknown, windows_core::IInspectable);
 impl MiracastTransmitter {

--- a/crates/libs/windows/src/Windows/Media/Ocr/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Ocr/mod.rs
@@ -74,7 +74,7 @@ pub struct IOcrWord_Vtbl {
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OcrEngine(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OcrEngine, windows_core::IUnknown, windows_core::IInspectable);
 impl OcrEngine {
@@ -155,7 +155,7 @@ impl windows_core::RuntimeName for OcrEngine {
 unsafe impl Send for OcrEngine {}
 unsafe impl Sync for OcrEngine {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OcrLine(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OcrLine, windows_core::IUnknown, windows_core::IInspectable);
 impl OcrLine {
@@ -188,7 +188,7 @@ impl windows_core::RuntimeName for OcrLine {
 unsafe impl Send for OcrLine {}
 unsafe impl Sync for OcrLine {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OcrResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OcrResult, windows_core::IUnknown, windows_core::IInspectable);
 impl OcrResult {
@@ -228,7 +228,7 @@ impl windows_core::RuntimeName for OcrResult {
 unsafe impl Send for OcrResult {}
 unsafe impl Sync for OcrResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OcrWord(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OcrWord, windows_core::IUnknown, windows_core::IInspectable);
 impl OcrWord {

--- a/crates/libs/windows/src/Windows/Media/PlayTo/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/PlayTo/mod.rs
@@ -398,7 +398,7 @@ pub struct IVolumeChangeRequestedEventArgs_Vtbl {
     pub Volume: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CurrentTimeChangeRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CurrentTimeChangeRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CurrentTimeChangeRequestedEventArgs {
@@ -421,7 +421,7 @@ impl windows_core::RuntimeName for CurrentTimeChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.CurrentTimeChangeRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MuteChangeRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MuteChangeRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MuteChangeRequestedEventArgs {
@@ -445,7 +445,7 @@ impl windows_core::RuntimeName for MuteChangeRequestedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToConnection(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PlayToConnection, windows_core::IUnknown, windows_core::IInspectable);
@@ -527,7 +527,7 @@ unsafe impl Send for PlayToConnection {}
 unsafe impl Sync for PlayToConnection {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToConnectionErrorEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PlayToConnectionErrorEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -569,7 +569,7 @@ unsafe impl Send for PlayToConnectionErrorEventArgs {}
 unsafe impl Sync for PlayToConnectionErrorEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToConnectionStateChangedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PlayToConnectionStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -611,7 +611,7 @@ unsafe impl Send for PlayToConnectionStateChangedEventArgs {}
 unsafe impl Sync for PlayToConnectionStateChangedEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToConnectionTransferredEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PlayToConnectionTransferredEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -653,7 +653,7 @@ unsafe impl Send for PlayToConnectionTransferredEventArgs {}
 unsafe impl Sync for PlayToConnectionTransferredEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToManager(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PlayToManager, windows_core::IUnknown, windows_core::IInspectable);
@@ -740,7 +740,7 @@ unsafe impl Send for PlayToManager {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for PlayToManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToReceiver(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayToReceiver, windows_core::IUnknown, windows_core::IInspectable);
 impl PlayToReceiver {
@@ -1004,7 +1004,7 @@ impl windows_core::RuntimeName for PlayToReceiver {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToSource(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PlayToSource, windows_core::IUnknown, windows_core::IInspectable);
@@ -1075,7 +1075,7 @@ unsafe impl Send for PlayToSource {}
 unsafe impl Sync for PlayToSource {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToSourceDeferral(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PlayToSourceDeferral, windows_core::IUnknown, windows_core::IInspectable);
@@ -1106,7 +1106,7 @@ unsafe impl Send for PlayToSourceDeferral {}
 unsafe impl Sync for PlayToSourceDeferral {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToSourceRequest(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PlayToSourceRequest, windows_core::IUnknown, windows_core::IInspectable);
@@ -1161,7 +1161,7 @@ unsafe impl Send for PlayToSourceRequest {}
 unsafe impl Sync for PlayToSourceRequest {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToSourceRequestedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PlayToSourceRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1195,7 +1195,7 @@ unsafe impl Send for PlayToSourceRequestedEventArgs {}
 unsafe impl Sync for PlayToSourceRequestedEventArgs {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayToSourceSelectedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(PlayToSourceSelectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1260,7 +1260,7 @@ unsafe impl Send for PlayToSourceSelectedEventArgs {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for PlayToSourceSelectedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlaybackRateChangeRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlaybackRateChangeRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PlaybackRateChangeRequestedEventArgs {
@@ -1283,7 +1283,7 @@ impl windows_core::RuntimeName for PlaybackRateChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.PlaybackRateChangeRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SourceChangeRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SourceChangeRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SourceChangeRequestedEventArgs {
@@ -1372,7 +1372,7 @@ impl windows_core::RuntimeName for SourceChangeRequestedEventArgs {
     const NAME: &'static str = "Windows.Media.PlayTo.SourceChangeRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VolumeChangeRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VolumeChangeRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl VolumeChangeRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/Media/Playback/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Playback/mod.rs
@@ -1267,7 +1267,7 @@ impl windows_core::RuntimeName for BackgroundMediaPlayer {
     const NAME: &'static str = "Windows.Media.Playback.BackgroundMediaPlayer";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CurrentMediaPlaybackItemChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CurrentMediaPlaybackItemChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CurrentMediaPlaybackItemChangedEventArgs {
@@ -1306,7 +1306,7 @@ impl windows_core::RuntimeName for CurrentMediaPlaybackItemChangedEventArgs {
 unsafe impl Send for CurrentMediaPlaybackItemChangedEventArgs {}
 unsafe impl Sync for CurrentMediaPlaybackItemChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaBreak(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaBreak, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaBreak {
@@ -1381,7 +1381,7 @@ impl windows_core::RuntimeName for MediaBreak {
 unsafe impl Send for MediaBreak {}
 unsafe impl Sync for MediaBreak {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaBreakEndedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaBreakEndedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaBreakEndedEventArgs {
@@ -1406,7 +1406,7 @@ impl windows_core::RuntimeName for MediaBreakEndedEventArgs {
 unsafe impl Send for MediaBreakEndedEventArgs {}
 unsafe impl Sync for MediaBreakEndedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaBreakManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaBreakManager, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaBreakManager {
@@ -1505,7 +1505,7 @@ impl windows_core::RuntimeName for MediaBreakManager {
 unsafe impl Send for MediaBreakManager {}
 unsafe impl Sync for MediaBreakManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaBreakSchedule(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaBreakSchedule, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaBreakSchedule {
@@ -1594,7 +1594,7 @@ impl windows_core::RuntimeName for MediaBreakSchedule {
 unsafe impl Send for MediaBreakSchedule {}
 unsafe impl Sync for MediaBreakSchedule {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaBreakSeekedOverEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaBreakSeekedOverEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaBreakSeekedOverEventArgs {
@@ -1634,7 +1634,7 @@ impl windows_core::RuntimeName for MediaBreakSeekedOverEventArgs {
 unsafe impl Send for MediaBreakSeekedOverEventArgs {}
 unsafe impl Sync for MediaBreakSeekedOverEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaBreakSkippedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaBreakSkippedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaBreakSkippedEventArgs {
@@ -1659,7 +1659,7 @@ impl windows_core::RuntimeName for MediaBreakSkippedEventArgs {
 unsafe impl Send for MediaBreakSkippedEventArgs {}
 unsafe impl Sync for MediaBreakSkippedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaBreakStartedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaBreakStartedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaBreakStartedEventArgs {
@@ -1684,7 +1684,7 @@ impl windows_core::RuntimeName for MediaBreakStartedEventArgs {
 unsafe impl Send for MediaBreakStartedEventArgs {}
 unsafe impl Sync for MediaBreakStartedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaItemDisplayProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaItemDisplayProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaItemDisplayProperties {
@@ -1748,7 +1748,7 @@ unsafe impl Send for MediaItemDisplayProperties {}
 unsafe impl Sync for MediaItemDisplayProperties {}
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackAudioTrackList(windows_core::IUnknown);
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 windows_core::imp::interface_hierarchy!(MediaPlaybackAudioTrackList, windows_core::IUnknown, windows_core::IInspectable);
@@ -1863,7 +1863,7 @@ unsafe impl Send for MediaPlaybackAudioTrackList {}
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 unsafe impl Sync for MediaPlaybackAudioTrackList {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManager, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManager {
@@ -2109,7 +2109,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManager {
 unsafe impl Send for MediaPlaybackCommandManager {}
 unsafe impl Sync for MediaPlaybackCommandManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {
@@ -2152,7 +2152,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerAutoRepeatModeRece
 unsafe impl Send for MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {}
 unsafe impl Sync for MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerCommandBehavior(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerCommandBehavior, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerCommandBehavior {
@@ -2209,7 +2209,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerCommandBehavior {
 unsafe impl Send for MediaPlaybackCommandManagerCommandBehavior {}
 unsafe impl Sync for MediaPlaybackCommandManagerCommandBehavior {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerFastForwardReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerFastForwardReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerFastForwardReceivedEventArgs {
@@ -2245,7 +2245,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerFastForwardReceive
 unsafe impl Send for MediaPlaybackCommandManagerFastForwardReceivedEventArgs {}
 unsafe impl Sync for MediaPlaybackCommandManagerFastForwardReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerNextReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerNextReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerNextReceivedEventArgs {
@@ -2281,7 +2281,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerNextReceivedEventA
 unsafe impl Send for MediaPlaybackCommandManagerNextReceivedEventArgs {}
 unsafe impl Sync for MediaPlaybackCommandManagerNextReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerPauseReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerPauseReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerPauseReceivedEventArgs {
@@ -2317,7 +2317,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerPauseReceivedEvent
 unsafe impl Send for MediaPlaybackCommandManagerPauseReceivedEventArgs {}
 unsafe impl Sync for MediaPlaybackCommandManagerPauseReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerPlayReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerPlayReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerPlayReceivedEventArgs {
@@ -2353,7 +2353,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerPlayReceivedEventA
 unsafe impl Send for MediaPlaybackCommandManagerPlayReceivedEventArgs {}
 unsafe impl Sync for MediaPlaybackCommandManagerPlayReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerPositionReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerPositionReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerPositionReceivedEventArgs {
@@ -2396,7 +2396,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerPositionReceivedEv
 unsafe impl Send for MediaPlaybackCommandManagerPositionReceivedEventArgs {}
 unsafe impl Sync for MediaPlaybackCommandManagerPositionReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerPreviousReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerPreviousReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerPreviousReceivedEventArgs {
@@ -2432,7 +2432,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerPreviousReceivedEv
 unsafe impl Send for MediaPlaybackCommandManagerPreviousReceivedEventArgs {}
 unsafe impl Sync for MediaPlaybackCommandManagerPreviousReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerRateReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerRateReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerRateReceivedEventArgs {
@@ -2475,7 +2475,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerRateReceivedEventA
 unsafe impl Send for MediaPlaybackCommandManagerRateReceivedEventArgs {}
 unsafe impl Sync for MediaPlaybackCommandManagerRateReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerRewindReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerRewindReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerRewindReceivedEventArgs {
@@ -2511,7 +2511,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerRewindReceivedEven
 unsafe impl Send for MediaPlaybackCommandManagerRewindReceivedEventArgs {}
 unsafe impl Sync for MediaPlaybackCommandManagerRewindReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackCommandManagerShuffleReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackCommandManagerShuffleReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackCommandManagerShuffleReceivedEventArgs {
@@ -2554,7 +2554,7 @@ impl windows_core::RuntimeName for MediaPlaybackCommandManagerShuffleReceivedEve
 unsafe impl Send for MediaPlaybackCommandManagerShuffleReceivedEventArgs {}
 unsafe impl Sync for MediaPlaybackCommandManagerShuffleReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackItem, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaPlaybackItem, IMediaPlaybackSource);
@@ -2780,7 +2780,7 @@ impl windows_core::RuntimeName for MediaPlaybackItem {
 unsafe impl Send for MediaPlaybackItem {}
 unsafe impl Sync for MediaPlaybackItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackItemError(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackItemError, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackItemError {
@@ -2812,7 +2812,7 @@ impl windows_core::RuntimeName for MediaPlaybackItemError {
 unsafe impl Send for MediaPlaybackItemError {}
 unsafe impl Sync for MediaPlaybackItemError {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackItemFailedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackItemFailedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackItemFailedEventArgs {
@@ -2844,7 +2844,7 @@ impl windows_core::RuntimeName for MediaPlaybackItemFailedEventArgs {
 unsafe impl Send for MediaPlaybackItemFailedEventArgs {}
 unsafe impl Sync for MediaPlaybackItemFailedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackItemOpenedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackItemOpenedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackItemOpenedEventArgs {
@@ -2869,7 +2869,7 @@ impl windows_core::RuntimeName for MediaPlaybackItemOpenedEventArgs {
 unsafe impl Send for MediaPlaybackItemOpenedEventArgs {}
 unsafe impl Sync for MediaPlaybackItemOpenedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackList(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackList, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaPlaybackList, IMediaPlaybackSource);
@@ -3060,7 +3060,7 @@ impl windows_core::RuntimeName for MediaPlaybackList {
 unsafe impl Send for MediaPlaybackList {}
 unsafe impl Sync for MediaPlaybackList {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackSession, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackSession {
@@ -3459,7 +3459,7 @@ impl windows_core::RuntimeName for MediaPlaybackSession {
 unsafe impl Send for MediaPlaybackSession {}
 unsafe impl Sync for MediaPlaybackSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackSessionBufferingStartedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackSessionBufferingStartedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackSessionBufferingStartedEventArgs {
@@ -3484,7 +3484,7 @@ impl windows_core::RuntimeName for MediaPlaybackSessionBufferingStartedEventArgs
 unsafe impl Send for MediaPlaybackSessionBufferingStartedEventArgs {}
 unsafe impl Sync for MediaPlaybackSessionBufferingStartedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackSessionOutputDegradationPolicyState(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackSessionOutputDegradationPolicyState, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackSessionOutputDegradationPolicyState {
@@ -3509,7 +3509,7 @@ impl windows_core::RuntimeName for MediaPlaybackSessionOutputDegradationPolicySt
 unsafe impl Send for MediaPlaybackSessionOutputDegradationPolicyState {}
 unsafe impl Sync for MediaPlaybackSessionOutputDegradationPolicyState {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackSphericalVideoProjection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlaybackSphericalVideoProjection, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlaybackSphericalVideoProjection {
@@ -3587,7 +3587,7 @@ unsafe impl Send for MediaPlaybackSphericalVideoProjection {}
 unsafe impl Sync for MediaPlaybackSphericalVideoProjection {}
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackTimedMetadataTrackList(windows_core::IUnknown);
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 windows_core::imp::interface_hierarchy!(MediaPlaybackTimedMetadataTrackList, windows_core::IUnknown, windows_core::IInspectable);
@@ -3700,7 +3700,7 @@ unsafe impl Send for MediaPlaybackTimedMetadataTrackList {}
 unsafe impl Sync for MediaPlaybackTimedMetadataTrackList {}
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlaybackVideoTrackList(windows_core::IUnknown);
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 windows_core::imp::interface_hierarchy!(MediaPlaybackVideoTrackList, windows_core::IUnknown, windows_core::IInspectable);
@@ -3815,7 +3815,7 @@ unsafe impl Send for MediaPlaybackVideoTrackList {}
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 unsafe impl Sync for MediaPlaybackVideoTrackList {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlayer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlayer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaPlayer, super::super::Foundation::IClosable);
@@ -4490,7 +4490,7 @@ impl windows_core::RuntimeName for MediaPlayer {
 unsafe impl Send for MediaPlayer {}
 unsafe impl Sync for MediaPlayer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlayerDataReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlayerDataReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlayerDataReceivedEventArgs {
@@ -4516,7 +4516,7 @@ impl windows_core::RuntimeName for MediaPlayerDataReceivedEventArgs {
 unsafe impl Send for MediaPlayerDataReceivedEventArgs {}
 unsafe impl Sync for MediaPlayerDataReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlayerFailedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlayerFailedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlayerFailedEventArgs {
@@ -4555,7 +4555,7 @@ impl windows_core::RuntimeName for MediaPlayerFailedEventArgs {
 unsafe impl Send for MediaPlayerFailedEventArgs {}
 unsafe impl Sync for MediaPlayerFailedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlayerRateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlayerRateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPlayerRateChangedEventArgs {
@@ -4580,7 +4580,7 @@ impl windows_core::RuntimeName for MediaPlayerRateChangedEventArgs {
 unsafe impl Send for MediaPlayerRateChangedEventArgs {}
 unsafe impl Sync for MediaPlayerRateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaPlayerSurface(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPlayerSurface, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaPlayerSurface, super::super::Foundation::IClosable);
@@ -4626,7 +4626,7 @@ impl windows_core::RuntimeName for MediaPlayerSurface {
 unsafe impl Send for MediaPlayerSurface {}
 unsafe impl Sync for MediaPlayerSurface {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlaybackMediaMarker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlaybackMediaMarker, windows_core::IUnknown, windows_core::IInspectable);
 impl PlaybackMediaMarker {
@@ -4682,7 +4682,7 @@ impl windows_core::RuntimeName for PlaybackMediaMarker {
 unsafe impl Send for PlaybackMediaMarker {}
 unsafe impl Sync for PlaybackMediaMarker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlaybackMediaMarkerReachedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlaybackMediaMarkerReachedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PlaybackMediaMarkerReachedEventArgs {
@@ -4707,7 +4707,7 @@ impl windows_core::RuntimeName for PlaybackMediaMarkerReachedEventArgs {
 unsafe impl Send for PlaybackMediaMarkerReachedEventArgs {}
 unsafe impl Sync for PlaybackMediaMarkerReachedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlaybackMediaMarkerSequence(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlaybackMediaMarkerSequence, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -4769,7 +4769,7 @@ impl IntoIterator for &PlaybackMediaMarkerSequence {
 unsafe impl Send for PlaybackMediaMarkerSequence {}
 unsafe impl Sync for PlaybackMediaMarkerSequence {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TimedMetadataPresentationModeChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimedMetadataPresentationModeChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TimedMetadataPresentationModeChangedEventArgs {

--- a/crates/libs/windows/src/Windows/Media/Playlists/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Playlists/mod.rs
@@ -32,7 +32,7 @@ pub struct IPlaylistStatics_Vtbl {
     LoadAsync: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Playlist(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Playlist, windows_core::IUnknown, windows_core::IInspectable);
 impl Playlist {

--- a/crates/libs/windows/src/Windows/Media/Protection/PlayReady/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/PlayReady/mod.rs
@@ -2014,7 +2014,7 @@ pub struct IPlayReadyStatics5_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NDClient(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(NDClient, windows_core::IUnknown, windows_core::IInspectable);
@@ -2174,7 +2174,7 @@ impl windows_core::RuntimeName for NDClient {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NDCustomData(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(NDCustomData, windows_core::IUnknown, windows_core::IInspectable);
@@ -2227,7 +2227,7 @@ impl windows_core::RuntimeName for NDCustomData {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NDDownloadEngineNotifier(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(NDDownloadEngineNotifier, windows_core::IUnknown, windows_core::IInspectable);
@@ -2291,7 +2291,7 @@ impl windows_core::RuntimeName for NDDownloadEngineNotifier {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NDLicenseFetchDescriptor(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(NDLicenseFetchDescriptor, windows_core::IUnknown, windows_core::IInspectable);
@@ -2363,7 +2363,7 @@ impl windows_core::RuntimeName for NDLicenseFetchDescriptor {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NDStorageFileHelper(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(NDStorageFileHelper, windows_core::IUnknown, windows_core::IInspectable);
@@ -2405,7 +2405,7 @@ impl windows_core::RuntimeName for NDStorageFileHelper {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NDStreamParserNotifier(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(NDStreamParserNotifier, windows_core::IUnknown, windows_core::IInspectable);
@@ -2469,7 +2469,7 @@ impl windows_core::RuntimeName for NDStreamParserNotifier {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NDTCPMessenger(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(NDTCPMessenger, windows_core::IUnknown, windows_core::IInspectable);
@@ -2537,7 +2537,7 @@ impl windows_core::RuntimeName for NDTCPMessenger {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.NDTCPMessenger";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyContentHeader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyContentHeader, windows_core::IUnknown, windows_core::IInspectable);
 impl PlayReadyContentHeader {
@@ -2703,7 +2703,7 @@ impl windows_core::RuntimeName for PlayReadyContentResolver {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyContentResolver";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyDomain(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyDomain, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PlayReadyDomain, IPlayReadyDomain);
@@ -2756,7 +2756,7 @@ impl windows_core::RuntimeName for PlayReadyDomain {
 }
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyDomainIterable(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(PlayReadyDomainIterable, windows_core::IUnknown, windows_core::IInspectable);
@@ -2816,7 +2816,7 @@ impl IntoIterator for &PlayReadyDomainIterable {
 }
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyDomainIterator(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(PlayReadyDomainIterator, windows_core::IUnknown, windows_core::IInspectable);
@@ -2871,7 +2871,7 @@ impl windows_core::RuntimeName for PlayReadyDomainIterator {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyDomainIterator";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyDomainJoinServiceRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyDomainJoinServiceRequest, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PlayReadyDomainJoinServiceRequest, super::IMediaProtectionServiceRequest, IPlayReadyServiceRequest);
@@ -3002,7 +3002,7 @@ impl windows_core::RuntimeName for PlayReadyDomainJoinServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyDomainJoinServiceRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyDomainLeaveServiceRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyDomainLeaveServiceRequest, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PlayReadyDomainLeaveServiceRequest, super::IMediaProtectionServiceRequest, IPlayReadyServiceRequest);
@@ -3122,7 +3122,7 @@ impl windows_core::RuntimeName for PlayReadyDomainLeaveServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyDomainLeaveServiceRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyITADataGenerator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyITADataGenerator, windows_core::IUnknown, windows_core::IInspectable);
 impl PlayReadyITADataGenerator {
@@ -3156,7 +3156,7 @@ impl windows_core::RuntimeName for PlayReadyITADataGenerator {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyITADataGenerator";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyIndividualizationServiceRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyIndividualizationServiceRequest, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PlayReadyIndividualizationServiceRequest, super::IMediaProtectionServiceRequest, IPlayReadyServiceRequest);
@@ -3254,7 +3254,7 @@ impl windows_core::RuntimeName for PlayReadyIndividualizationServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyIndividualizationServiceRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyLicense(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyLicense, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PlayReadyLicense, IPlayReadyLicense);
@@ -3348,7 +3348,7 @@ impl windows_core::RuntimeName for PlayReadyLicense {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyLicense";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyLicenseAcquisitionServiceRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyLicenseAcquisitionServiceRequest, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PlayReadyLicenseAcquisitionServiceRequest, super::IMediaProtectionServiceRequest, IPlayReadyLicenseAcquisitionServiceRequest, IPlayReadyServiceRequest);
@@ -3490,7 +3490,7 @@ impl windows_core::RuntimeName for PlayReadyLicenseAcquisitionServiceRequest {
 }
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyLicenseIterable(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(PlayReadyLicenseIterable, windows_core::IUnknown, windows_core::IInspectable);
@@ -3560,7 +3560,7 @@ impl IntoIterator for &PlayReadyLicenseIterable {
 }
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyLicenseIterator(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(PlayReadyLicenseIterator, windows_core::IUnknown, windows_core::IInspectable);
@@ -3635,7 +3635,7 @@ impl windows_core::RuntimeName for PlayReadyLicenseManagement {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyLicenseManagement";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyLicenseSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyLicenseSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PlayReadyLicenseSession, IPlayReadyLicenseSession, IPlayReadyLicenseSession2);
@@ -3692,7 +3692,7 @@ impl windows_core::RuntimeName for PlayReadyLicenseSession {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyLicenseSession";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyMeteringReportServiceRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyMeteringReportServiceRequest, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PlayReadyMeteringReportServiceRequest, super::IMediaProtectionServiceRequest, IPlayReadyServiceRequest);
@@ -3801,7 +3801,7 @@ impl windows_core::RuntimeName for PlayReadyMeteringReportServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadyMeteringReportServiceRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadyRevocationServiceRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadyRevocationServiceRequest, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PlayReadyRevocationServiceRequest, super::IMediaProtectionServiceRequest, IPlayReadyServiceRequest);
@@ -3900,7 +3900,7 @@ impl windows_core::RuntimeName for PlayReadyRevocationServiceRequest {
 }
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadySecureStopIterable(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(PlayReadySecureStopIterable, windows_core::IUnknown, windows_core::IInspectable);
@@ -3960,7 +3960,7 @@ impl IntoIterator for &PlayReadySecureStopIterable {
 }
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadySecureStopIterator(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(PlayReadySecureStopIterator, windows_core::IUnknown, windows_core::IInspectable);
@@ -4015,7 +4015,7 @@ impl windows_core::RuntimeName for PlayReadySecureStopIterator {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadySecureStopIterator";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadySecureStopServiceRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadySecureStopServiceRequest, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PlayReadySecureStopServiceRequest, super::IMediaProtectionServiceRequest, IPlayReadySecureStopServiceRequest, IPlayReadyServiceRequest);
@@ -4158,7 +4158,7 @@ impl windows_core::RuntimeName for PlayReadySecureStopServiceRequest {
     const NAME: &'static str = "Windows.Media.Protection.PlayReady.PlayReadySecureStopServiceRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlayReadySoapMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlayReadySoapMessage, windows_core::IUnknown, windows_core::IInspectable);
 impl PlayReadySoapMessage {

--- a/crates/libs/windows/src/Windows/Media/Protection/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/mod.rs
@@ -173,7 +173,7 @@ pub struct IServiceRequestedEventArgs2_Vtbl {
     MediaPlaybackItem: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ComponentLoadFailedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ComponentLoadFailedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ComponentLoadFailedEventArgs {
@@ -225,7 +225,7 @@ impl windows_core::RuntimeName for ComponentRenewal {
     const NAME: &'static str = "Windows.Media.Protection.ComponentRenewal";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HdcpSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HdcpSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HdcpSession, super::super::Foundation::IClosable);
@@ -290,7 +290,7 @@ impl windows_core::RuntimeName for HdcpSession {
 unsafe impl Send for HdcpSession {}
 unsafe impl Sync for HdcpSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaProtectionManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaProtectionManager, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaProtectionManager {
@@ -365,7 +365,7 @@ impl windows_core::RuntimeName for MediaProtectionManager {
 unsafe impl Send for MediaProtectionManager {}
 unsafe impl Sync for MediaProtectionManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaProtectionPMPServer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaProtectionPMPServer, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaProtectionPMPServer {
@@ -406,7 +406,7 @@ impl windows_core::RuntimeName for MediaProtectionPMPServer {
 unsafe impl Send for MediaProtectionPMPServer {}
 unsafe impl Sync for MediaProtectionPMPServer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaProtectionServiceCompletion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaProtectionServiceCompletion, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaProtectionServiceCompletion {
@@ -428,7 +428,7 @@ impl windows_core::RuntimeName for MediaProtectionServiceCompletion {
 unsafe impl Send for MediaProtectionServiceCompletion {}
 unsafe impl Sync for MediaProtectionServiceCompletion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtectionCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtectionCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl ProtectionCapabilities {
@@ -460,7 +460,7 @@ impl windows_core::RuntimeName for ProtectionCapabilities {
 unsafe impl Send for ProtectionCapabilities {}
 unsafe impl Sync for ProtectionCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RevocationAndRenewalInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RevocationAndRenewalInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl RevocationAndRenewalInformation {
@@ -486,7 +486,7 @@ impl windows_core::RuntimeName for RevocationAndRenewalInformation {
 unsafe impl Send for RevocationAndRenewalInformation {}
 unsafe impl Sync for RevocationAndRenewalInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RevocationAndRenewalItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RevocationAndRenewalItem, windows_core::IUnknown, windows_core::IInspectable);
 impl RevocationAndRenewalItem {
@@ -539,7 +539,7 @@ impl windows_core::RuntimeName for RevocationAndRenewalItem {
 unsafe impl Send for RevocationAndRenewalItem {}
 unsafe impl Sync for RevocationAndRenewalItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ServiceRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ServiceRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ServiceRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/Media/SpeechRecognition/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/SpeechRecognition/mod.rs
@@ -416,7 +416,7 @@ pub struct IVoiceCommandSet_Vtbl {
     SetPhraseListAsync: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechContinuousRecognitionCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechContinuousRecognitionCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechContinuousRecognitionCompletedEventArgs {
@@ -441,7 +441,7 @@ impl windows_core::RuntimeName for SpeechContinuousRecognitionCompletedEventArgs
 unsafe impl Send for SpeechContinuousRecognitionCompletedEventArgs {}
 unsafe impl Sync for SpeechContinuousRecognitionCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechContinuousRecognitionResultGeneratedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechContinuousRecognitionResultGeneratedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechContinuousRecognitionResultGeneratedEventArgs {
@@ -466,7 +466,7 @@ impl windows_core::RuntimeName for SpeechContinuousRecognitionResultGeneratedEve
 unsafe impl Send for SpeechContinuousRecognitionResultGeneratedEventArgs {}
 unsafe impl Sync for SpeechContinuousRecognitionResultGeneratedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechContinuousRecognitionSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechContinuousRecognitionSession, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechContinuousRecognitionSession {
@@ -562,7 +562,7 @@ impl windows_core::RuntimeName for SpeechContinuousRecognitionSession {
 unsafe impl Send for SpeechContinuousRecognitionSession {}
 unsafe impl Sync for SpeechContinuousRecognitionSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognitionCompilationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognitionCompilationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechRecognitionCompilationResult {
@@ -587,7 +587,7 @@ impl windows_core::RuntimeName for SpeechRecognitionCompilationResult {
 unsafe impl Send for SpeechRecognitionCompilationResult {}
 unsafe impl Sync for SpeechRecognitionCompilationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognitionGrammarFileConstraint(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognitionGrammarFileConstraint, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpeechRecognitionGrammarFileConstraint, ISpeechRecognitionConstraint);
@@ -679,7 +679,7 @@ impl windows_core::RuntimeName for SpeechRecognitionGrammarFileConstraint {
 unsafe impl Send for SpeechRecognitionGrammarFileConstraint {}
 unsafe impl Sync for SpeechRecognitionGrammarFileConstraint {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognitionHypothesis(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognitionHypothesis, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechRecognitionHypothesis {
@@ -704,7 +704,7 @@ impl windows_core::RuntimeName for SpeechRecognitionHypothesis {
 unsafe impl Send for SpeechRecognitionHypothesis {}
 unsafe impl Sync for SpeechRecognitionHypothesis {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognitionHypothesisGeneratedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognitionHypothesisGeneratedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechRecognitionHypothesisGeneratedEventArgs {
@@ -729,7 +729,7 @@ impl windows_core::RuntimeName for SpeechRecognitionHypothesisGeneratedEventArgs
 unsafe impl Send for SpeechRecognitionHypothesisGeneratedEventArgs {}
 unsafe impl Sync for SpeechRecognitionHypothesisGeneratedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognitionListConstraint(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognitionListConstraint, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpeechRecognitionListConstraint, ISpeechRecognitionConstraint);
@@ -821,7 +821,7 @@ impl windows_core::RuntimeName for SpeechRecognitionListConstraint {
 unsafe impl Send for SpeechRecognitionListConstraint {}
 unsafe impl Sync for SpeechRecognitionListConstraint {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognitionQualityDegradingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognitionQualityDegradingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechRecognitionQualityDegradingEventArgs {
@@ -846,7 +846,7 @@ impl windows_core::RuntimeName for SpeechRecognitionQualityDegradingEventArgs {
 unsafe impl Send for SpeechRecognitionQualityDegradingEventArgs {}
 unsafe impl Sync for SpeechRecognitionQualityDegradingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognitionResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognitionResult, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechRecognitionResult {
@@ -936,7 +936,7 @@ impl windows_core::RuntimeName for SpeechRecognitionResult {
 unsafe impl Send for SpeechRecognitionResult {}
 unsafe impl Sync for SpeechRecognitionResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognitionSemanticInterpretation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognitionSemanticInterpretation, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechRecognitionSemanticInterpretation {
@@ -962,7 +962,7 @@ impl windows_core::RuntimeName for SpeechRecognitionSemanticInterpretation {
 unsafe impl Send for SpeechRecognitionSemanticInterpretation {}
 unsafe impl Sync for SpeechRecognitionSemanticInterpretation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognitionTopicConstraint(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognitionTopicConstraint, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpeechRecognitionTopicConstraint, ISpeechRecognitionConstraint);
@@ -1052,7 +1052,7 @@ impl windows_core::RuntimeName for SpeechRecognitionTopicConstraint {
 unsafe impl Send for SpeechRecognitionTopicConstraint {}
 unsafe impl Sync for SpeechRecognitionTopicConstraint {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognitionVoiceCommandDefinitionConstraint(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognitionVoiceCommandDefinitionConstraint, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpeechRecognitionVoiceCommandDefinitionConstraint, ISpeechRecognitionConstraint);
@@ -1111,7 +1111,7 @@ impl windows_core::RuntimeName for SpeechRecognitionVoiceCommandDefinitionConstr
 unsafe impl Send for SpeechRecognitionVoiceCommandDefinitionConstraint {}
 unsafe impl Sync for SpeechRecognitionVoiceCommandDefinitionConstraint {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognizer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognizer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpeechRecognizer, super::super::Foundation::IClosable);
@@ -1311,7 +1311,7 @@ impl windows_core::RuntimeName for SpeechRecognizer {
 unsafe impl Send for SpeechRecognizer {}
 unsafe impl Sync for SpeechRecognizer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognizerStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognizerStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechRecognizerStateChangedEventArgs {
@@ -1336,7 +1336,7 @@ impl windows_core::RuntimeName for SpeechRecognizerStateChangedEventArgs {
 unsafe impl Send for SpeechRecognizerStateChangedEventArgs {}
 unsafe impl Sync for SpeechRecognizerStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognizerTimeouts(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognizerTimeouts, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechRecognizerTimeouts {
@@ -1387,7 +1387,7 @@ impl windows_core::RuntimeName for SpeechRecognizerTimeouts {
 unsafe impl Send for SpeechRecognizerTimeouts {}
 unsafe impl Sync for SpeechRecognizerTimeouts {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechRecognizerUIOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechRecognizerUIOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechRecognizerUIOptions {
@@ -1477,7 +1477,7 @@ impl windows_core::RuntimeName for VoiceCommandManager {
     const NAME: &'static str = "Windows.Media.SpeechRecognition.VoiceCommandManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceCommandSet(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceCommandSet, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceCommandSet {

--- a/crates/libs/windows/src/Windows/Media/SpeechSynthesis/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/SpeechSynthesis/mod.rs
@@ -105,7 +105,7 @@ pub struct IVoiceInformation_Vtbl {
     pub Gender: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VoiceGender) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechSynthesisStream(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechSynthesisStream, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(all(feature = "Media_Core", feature = "Storage_Streams"))]
@@ -249,7 +249,7 @@ impl windows_core::RuntimeName for SpeechSynthesisStream {
 unsafe impl Send for SpeechSynthesisStream {}
 unsafe impl Sync for SpeechSynthesisStream {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechSynthesizer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechSynthesizer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpeechSynthesizer, super::super::Foundation::IClosable);
@@ -346,7 +346,7 @@ impl windows_core::RuntimeName for SpeechSynthesizer {
 unsafe impl Send for SpeechSynthesizer {}
 unsafe impl Sync for SpeechSynthesizer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeechSynthesizerOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeechSynthesizerOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeechSynthesizerOptions {
@@ -441,7 +441,7 @@ impl windows_core::RuntimeName for SpeechSynthesizerOptions {
 unsafe impl Send for SpeechSynthesizerOptions {}
 unsafe impl Sync for SpeechSynthesizerOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VoiceInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VoiceInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl VoiceInformation {

--- a/crates/libs/windows/src/Windows/Media/Streaming/Adaptive/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Streaming/Adaptive/mod.rs
@@ -377,7 +377,7 @@ pub struct IAdaptiveMediaSourceStatics_Vtbl {
     CreateFromStreamWithDownloaderAsync: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSource, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Media_Core")]
@@ -678,7 +678,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSource {
 unsafe impl Send for AdaptiveMediaSource {}
 unsafe impl Sync for AdaptiveMediaSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceAdvancedSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceAdvancedSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceAdvancedSettings {
@@ -735,7 +735,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceAdvancedSettings {
 unsafe impl Send for AdaptiveMediaSourceAdvancedSettings {}
 unsafe impl Sync for AdaptiveMediaSourceAdvancedSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceCorrelatedTimes(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceCorrelatedTimes, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceCorrelatedTimes {
@@ -774,7 +774,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceCorrelatedTimes {
 unsafe impl Send for AdaptiveMediaSourceCorrelatedTimes {}
 unsafe impl Sync for AdaptiveMediaSourceCorrelatedTimes {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceCreationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceCreationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceCreationResult {
@@ -821,7 +821,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceCreationResult {
 unsafe impl Send for AdaptiveMediaSourceCreationResult {}
 unsafe impl Sync for AdaptiveMediaSourceCreationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceDiagnosticAvailableEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceDiagnosticAvailableEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceDiagnosticAvailableEventArgs {
@@ -923,7 +923,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceDiagnosticAvailableEventAr
 unsafe impl Send for AdaptiveMediaSourceDiagnosticAvailableEventArgs {}
 unsafe impl Sync for AdaptiveMediaSourceDiagnosticAvailableEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceDiagnostics(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceDiagnostics, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceDiagnostics {
@@ -955,7 +955,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceDiagnostics {
 unsafe impl Send for AdaptiveMediaSourceDiagnostics {}
 unsafe impl Sync for AdaptiveMediaSourceDiagnostics {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceDownloadBitrateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceDownloadBitrateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceDownloadBitrateChangedEventArgs {
@@ -994,7 +994,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceDownloadBitrateChangedEven
 unsafe impl Send for AdaptiveMediaSourceDownloadBitrateChangedEventArgs {}
 unsafe impl Sync for AdaptiveMediaSourceDownloadBitrateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceDownloadCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceDownloadCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceDownloadCompletedEventArgs {
@@ -1083,7 +1083,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceDownloadCompletedEventArgs
 unsafe impl Send for AdaptiveMediaSourceDownloadCompletedEventArgs {}
 unsafe impl Sync for AdaptiveMediaSourceDownloadCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceDownloadFailedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceDownloadFailedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceDownloadFailedEventArgs {
@@ -1179,7 +1179,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceDownloadFailedEventArgs {
 unsafe impl Send for AdaptiveMediaSourceDownloadFailedEventArgs {}
 unsafe impl Sync for AdaptiveMediaSourceDownloadFailedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceDownloadRequestedDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceDownloadRequestedDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceDownloadRequestedDeferral {
@@ -1201,7 +1201,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceDownloadRequestedDeferral 
 unsafe impl Send for AdaptiveMediaSourceDownloadRequestedDeferral {}
 unsafe impl Sync for AdaptiveMediaSourceDownloadRequestedDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceDownloadRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceDownloadRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceDownloadRequestedEventArgs {
@@ -1289,7 +1289,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceDownloadRequestedEventArgs
 unsafe impl Send for AdaptiveMediaSourceDownloadRequestedEventArgs {}
 unsafe impl Sync for AdaptiveMediaSourceDownloadRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceDownloadResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceDownloadResult, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceDownloadResult {
@@ -1403,7 +1403,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceDownloadResult {
 unsafe impl Send for AdaptiveMediaSourceDownloadResult {}
 unsafe impl Sync for AdaptiveMediaSourceDownloadResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourceDownloadStatistics(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourceDownloadStatistics, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourceDownloadStatistics {
@@ -1449,7 +1449,7 @@ impl windows_core::RuntimeName for AdaptiveMediaSourceDownloadStatistics {
 unsafe impl Send for AdaptiveMediaSourceDownloadStatistics {}
 unsafe impl Sync for AdaptiveMediaSourceDownloadStatistics {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveMediaSourcePlaybackBitrateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveMediaSourcePlaybackBitrateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AdaptiveMediaSourcePlaybackBitrateChangedEventArgs {

--- a/crates/libs/windows/src/Windows/Media/Transcoding/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Transcoding/mod.rs
@@ -59,7 +59,7 @@ pub struct IPrepareTranscodeResult_Vtbl {
     pub TranscodeAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaTranscoder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaTranscoder, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaTranscoder {
@@ -206,7 +206,7 @@ impl windows_core::RuntimeName for MediaTranscoder {
 unsafe impl Send for MediaTranscoder {}
 unsafe impl Sync for MediaTranscoder {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PrepareTranscodeResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrepareTranscodeResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PrepareTranscodeResult {

--- a/crates/libs/windows/src/Windows/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/mod.rs
@@ -876,7 +876,7 @@ pub struct IVideoFrameStatics_Vtbl {
     CreateWithDirect3D11Surface: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioBuffer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioBuffer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioBuffer, super::Foundation::IClosable, super::Foundation::IMemoryBuffer);
@@ -924,7 +924,7 @@ impl windows_core::RuntimeName for AudioBuffer {
 unsafe impl Send for AudioBuffer {}
 unsafe impl Sync for AudioBuffer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioFrame, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AudioFrame, super::Foundation::IClosable, IMediaFrame);
@@ -1040,7 +1040,7 @@ impl windows_core::RuntimeName for AudioFrame {
 unsafe impl Send for AudioFrame {}
 unsafe impl Sync for AudioFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AutoRepeatModeChangeRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AutoRepeatModeChangeRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AutoRepeatModeChangeRequestedEventArgs {
@@ -1065,7 +1065,7 @@ impl windows_core::RuntimeName for AutoRepeatModeChangeRequestedEventArgs {
 unsafe impl Send for AutoRepeatModeChangeRequestedEventArgs {}
 unsafe impl Sync for AutoRepeatModeChangeRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageDisplayProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageDisplayProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl ImageDisplayProperties {
@@ -1342,7 +1342,7 @@ impl windows_core::RuntimeName for MediaControl {
     const NAME: &'static str = "Windows.Media.MediaControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaExtensionManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaExtensionManager, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaExtensionManager {
@@ -1465,7 +1465,7 @@ impl windows_core::RuntimeName for MediaMarkerTypes {
     const NAME: &'static str = "Windows.Media.MediaMarkerTypes";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaProcessingTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaProcessingTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaProcessingTriggerDetails {
@@ -1491,7 +1491,7 @@ impl windows_core::RuntimeName for MediaProcessingTriggerDetails {
 unsafe impl Send for MediaProcessingTriggerDetails {}
 unsafe impl Sync for MediaProcessingTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaTimelineController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaTimelineController, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaTimelineController {
@@ -1638,7 +1638,7 @@ impl windows_core::RuntimeName for MediaTimelineController {
 unsafe impl Send for MediaTimelineController {}
 unsafe impl Sync for MediaTimelineController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaTimelineControllerFailedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaTimelineControllerFailedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaTimelineControllerFailedEventArgs {
@@ -1663,7 +1663,7 @@ impl windows_core::RuntimeName for MediaTimelineControllerFailedEventArgs {
 unsafe impl Send for MediaTimelineControllerFailedEventArgs {}
 unsafe impl Sync for MediaTimelineControllerFailedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MusicDisplayProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MusicDisplayProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl MusicDisplayProperties {
@@ -1755,7 +1755,7 @@ impl windows_core::RuntimeName for MusicDisplayProperties {
 unsafe impl Send for MusicDisplayProperties {}
 unsafe impl Sync for MusicDisplayProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlaybackPositionChangeRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlaybackPositionChangeRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PlaybackPositionChangeRequestedEventArgs {
@@ -1780,7 +1780,7 @@ impl windows_core::RuntimeName for PlaybackPositionChangeRequestedEventArgs {
 unsafe impl Send for PlaybackPositionChangeRequestedEventArgs {}
 unsafe impl Sync for PlaybackPositionChangeRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlaybackRateChangeRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlaybackRateChangeRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PlaybackRateChangeRequestedEventArgs {
@@ -1805,7 +1805,7 @@ impl windows_core::RuntimeName for PlaybackRateChangeRequestedEventArgs {
 unsafe impl Send for PlaybackRateChangeRequestedEventArgs {}
 unsafe impl Sync for PlaybackRateChangeRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShuffleEnabledChangeRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShuffleEnabledChangeRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ShuffleEnabledChangeRequestedEventArgs {
@@ -1830,7 +1830,7 @@ impl windows_core::RuntimeName for ShuffleEnabledChangeRequestedEventArgs {
 unsafe impl Send for ShuffleEnabledChangeRequestedEventArgs {}
 unsafe impl Sync for ShuffleEnabledChangeRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemMediaTransportControls(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemMediaTransportControls, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemMediaTransportControls {
@@ -2129,7 +2129,7 @@ impl windows_core::RuntimeName for SystemMediaTransportControls {
 unsafe impl Send for SystemMediaTransportControls {}
 unsafe impl Sync for SystemMediaTransportControls {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemMediaTransportControlsButtonPressedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemMediaTransportControlsButtonPressedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemMediaTransportControlsButtonPressedEventArgs {
@@ -2154,7 +2154,7 @@ impl windows_core::RuntimeName for SystemMediaTransportControlsButtonPressedEven
 unsafe impl Send for SystemMediaTransportControlsButtonPressedEventArgs {}
 unsafe impl Sync for SystemMediaTransportControlsButtonPressedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemMediaTransportControlsDisplayUpdater(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemMediaTransportControlsDisplayUpdater, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemMediaTransportControlsDisplayUpdater {
@@ -2250,7 +2250,7 @@ impl windows_core::RuntimeName for SystemMediaTransportControlsDisplayUpdater {
 unsafe impl Send for SystemMediaTransportControlsDisplayUpdater {}
 unsafe impl Sync for SystemMediaTransportControlsDisplayUpdater {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemMediaTransportControlsPropertyChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemMediaTransportControlsPropertyChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemMediaTransportControlsPropertyChangedEventArgs {
@@ -2275,7 +2275,7 @@ impl windows_core::RuntimeName for SystemMediaTransportControlsPropertyChangedEv
 unsafe impl Send for SystemMediaTransportControlsPropertyChangedEventArgs {}
 unsafe impl Sync for SystemMediaTransportControlsPropertyChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemMediaTransportControlsTimelineProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemMediaTransportControlsTimelineProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemMediaTransportControlsTimelineProperties {
@@ -2355,7 +2355,7 @@ impl windows_core::RuntimeName for SystemMediaTransportControlsTimelinePropertie
 unsafe impl Send for SystemMediaTransportControlsTimelineProperties {}
 unsafe impl Sync for SystemMediaTransportControlsTimelineProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoDisplayProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoDisplayProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl VideoDisplayProperties {
@@ -2420,7 +2420,7 @@ impl windows_core::RuntimeName for VideoEffects {
     const NAME: &'static str = "Windows.Media.VideoEffects";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoFrame, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VideoFrame, super::Foundation::IClosable, IMediaFrame);

--- a/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/mod.rs
@@ -779,7 +779,7 @@ pub struct IUploadOperation4_Vtbl {
     pub RemoveRequestHeader: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundDownloader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundDownloader, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BackgroundDownloader, IBackgroundTransferBase);
@@ -1063,7 +1063,7 @@ impl windows_core::RuntimeName for BackgroundDownloader {
 unsafe impl Send for BackgroundDownloader {}
 unsafe impl Sync for BackgroundDownloader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTransferCompletionGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTransferCompletionGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundTransferCompletionGroup {
@@ -1107,7 +1107,7 @@ impl windows_core::RuntimeName for BackgroundTransferCompletionGroup {
 unsafe impl Send for BackgroundTransferCompletionGroup {}
 unsafe impl Sync for BackgroundTransferCompletionGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTransferCompletionGroupTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTransferCompletionGroupTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundTransferCompletionGroupTriggerDetails {
@@ -1141,7 +1141,7 @@ impl windows_core::RuntimeName for BackgroundTransferCompletionGroupTriggerDetai
 unsafe impl Send for BackgroundTransferCompletionGroupTriggerDetails {}
 unsafe impl Sync for BackgroundTransferCompletionGroupTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTransferContentPart(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTransferContentPart, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundTransferContentPart {
@@ -1217,7 +1217,7 @@ impl windows_core::RuntimeName for BackgroundTransferError {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.BackgroundTransferError";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTransferGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTransferGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundTransferGroup {
@@ -1264,7 +1264,7 @@ impl windows_core::RuntimeName for BackgroundTransferGroup {
 unsafe impl Send for BackgroundTransferGroup {}
 unsafe impl Sync for BackgroundTransferGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundTransferRangesDownloadedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundTransferRangesDownloadedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BackgroundTransferRangesDownloadedEventArgs {
@@ -1304,7 +1304,7 @@ impl windows_core::RuntimeName for BackgroundTransferRangesDownloadedEventArgs {
 unsafe impl Send for BackgroundTransferRangesDownloadedEventArgs {}
 unsafe impl Sync for BackgroundTransferRangesDownloadedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundUploader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackgroundUploader, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BackgroundUploader, IBackgroundTransferBase);
@@ -1651,7 +1651,7 @@ impl windows_core::RuntimeName for ContentPrefetcher {
     const NAME: &'static str = "Windows.Networking.BackgroundTransfer.ContentPrefetcher";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DownloadOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DownloadOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DownloadOperation, IBackgroundTransferOperation, IBackgroundTransferOperationPriority);
@@ -1856,7 +1856,7 @@ impl windows_core::RuntimeName for DownloadOperation {
 unsafe impl Send for DownloadOperation {}
 unsafe impl Sync for DownloadOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResponseInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ResponseInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl ResponseInformation {
@@ -1904,7 +1904,7 @@ unsafe impl Send for ResponseInformation {}
 unsafe impl Sync for ResponseInformation {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UnconstrainedTransferRequestResult(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(UnconstrainedTransferRequestResult, windows_core::IUnknown, windows_core::IInspectable);
@@ -1937,7 +1937,7 @@ unsafe impl Send for UnconstrainedTransferRequestResult {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for UnconstrainedTransferRequestResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UploadOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UploadOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UploadOperation, IBackgroundTransferOperation, IBackgroundTransferOperationPriority);

--- a/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
@@ -498,7 +498,7 @@ pub struct IWwanConnectionProfileDetails2_Vtbl {
     PurposeGuids: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AttributedNetworkUsage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AttributedNetworkUsage, windows_core::IUnknown, windows_core::IInspectable);
 impl AttributedNetworkUsage {
@@ -552,7 +552,7 @@ impl windows_core::RuntimeName for AttributedNetworkUsage {
 unsafe impl Send for AttributedNetworkUsage {}
 unsafe impl Sync for AttributedNetworkUsage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CellularApnContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CellularApnContext, windows_core::IUnknown, windows_core::IInspectable);
 impl CellularApnContext {
@@ -654,7 +654,7 @@ impl windows_core::RuntimeName for CellularApnContext {
 unsafe impl Send for CellularApnContext {}
 unsafe impl Sync for CellularApnContext {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConnectionCost(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConnectionCost, windows_core::IUnknown, windows_core::IInspectable);
 impl ConnectionCost {
@@ -707,7 +707,7 @@ impl windows_core::RuntimeName for ConnectionCost {
 unsafe impl Send for ConnectionCost {}
 unsafe impl Sync for ConnectionCost {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConnectionProfile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConnectionProfile, windows_core::IUnknown, windows_core::IInspectable);
 impl ConnectionProfile {
@@ -893,7 +893,7 @@ impl windows_core::RuntimeName for ConnectionProfile {
 unsafe impl Send for ConnectionProfile {}
 unsafe impl Sync for ConnectionProfile {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConnectionProfileFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConnectionProfileFilter, windows_core::IUnknown, windows_core::IInspectable);
 impl ConnectionProfileFilter {
@@ -1040,7 +1040,7 @@ impl windows_core::RuntimeName for ConnectionProfileFilter {
 unsafe impl Send for ConnectionProfileFilter {}
 unsafe impl Sync for ConnectionProfileFilter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConnectionSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConnectionSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ConnectionSession, super::super::Foundation::IClosable);
@@ -1070,7 +1070,7 @@ impl windows_core::RuntimeName for ConnectionSession {
 unsafe impl Send for ConnectionSession {}
 unsafe impl Sync for ConnectionSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConnectivityInterval(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConnectivityInterval, windows_core::IUnknown, windows_core::IInspectable);
 impl ConnectivityInterval {
@@ -1134,7 +1134,7 @@ impl windows_core::RuntimeName for ConnectivityManager {
     const NAME: &'static str = "Windows.Networking.Connectivity.ConnectivityManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataPlanStatus(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataPlanStatus, windows_core::IUnknown, windows_core::IInspectable);
 impl DataPlanStatus {
@@ -1194,7 +1194,7 @@ impl windows_core::RuntimeName for DataPlanStatus {
 unsafe impl Send for DataPlanStatus {}
 unsafe impl Sync for DataPlanStatus {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataPlanUsage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataPlanUsage, windows_core::IUnknown, windows_core::IInspectable);
 impl DataPlanUsage {
@@ -1227,7 +1227,7 @@ unsafe impl Send for DataPlanUsage {}
 unsafe impl Sync for DataPlanUsage {}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataUsage(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(DataUsage, windows_core::IUnknown, windows_core::IInspectable);
@@ -1268,7 +1268,7 @@ unsafe impl Send for DataUsage {}
 #[cfg(feature = "deprecated")]
 unsafe impl Sync for DataUsage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IPInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IPInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl IPInformation {
@@ -1300,7 +1300,7 @@ impl windows_core::RuntimeName for IPInformation {
 unsafe impl Send for IPInformation {}
 unsafe impl Sync for IPInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LanIdentifier(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LanIdentifier, windows_core::IUnknown, windows_core::IInspectable);
 impl LanIdentifier {
@@ -1339,7 +1339,7 @@ impl windows_core::RuntimeName for LanIdentifier {
 unsafe impl Send for LanIdentifier {}
 unsafe impl Sync for LanIdentifier {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LanIdentifierData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LanIdentifierData, windows_core::IUnknown, windows_core::IInspectable);
 impl LanIdentifierData {
@@ -1372,7 +1372,7 @@ impl windows_core::RuntimeName for LanIdentifierData {
 unsafe impl Send for LanIdentifierData {}
 unsafe impl Sync for LanIdentifierData {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkAdapter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkAdapter, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkAdapter {
@@ -1516,7 +1516,7 @@ impl windows_core::RuntimeName for NetworkInformation {
     const NAME: &'static str = "Windows.Networking.Connectivity.NetworkInformation";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkItem, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkItem {
@@ -1548,7 +1548,7 @@ impl windows_core::RuntimeName for NetworkItem {
 unsafe impl Send for NetworkItem {}
 unsafe impl Sync for NetworkItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkSecuritySettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkSecuritySettings, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkSecuritySettings {
@@ -1580,7 +1580,7 @@ impl windows_core::RuntimeName for NetworkSecuritySettings {
 unsafe impl Send for NetworkSecuritySettings {}
 unsafe impl Sync for NetworkSecuritySettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkStateChangeEventDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkStateChangeEventDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkStateChangeEventDetails {
@@ -1654,7 +1654,7 @@ impl windows_core::RuntimeName for NetworkStateChangeEventDetails {
 unsafe impl Send for NetworkStateChangeEventDetails {}
 unsafe impl Sync for NetworkStateChangeEventDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkUsage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkUsage, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkUsage {
@@ -1693,7 +1693,7 @@ impl windows_core::RuntimeName for NetworkUsage {
 unsafe impl Send for NetworkUsage {}
 unsafe impl Sync for NetworkUsage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProviderNetworkUsage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProviderNetworkUsage, windows_core::IUnknown, windows_core::IInspectable);
 impl ProviderNetworkUsage {
@@ -1732,7 +1732,7 @@ impl windows_core::RuntimeName for ProviderNetworkUsage {
 unsafe impl Send for ProviderNetworkUsage {}
 unsafe impl Sync for ProviderNetworkUsage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProxyConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProxyConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl ProxyConfiguration {
@@ -1765,7 +1765,7 @@ impl windows_core::RuntimeName for ProxyConfiguration {
 unsafe impl Send for ProxyConfiguration {}
 unsafe impl Sync for ProxyConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RoutePolicy(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RoutePolicy, windows_core::IUnknown, windows_core::IInspectable);
 impl RoutePolicy {
@@ -1819,7 +1819,7 @@ impl windows_core::RuntimeName for RoutePolicy {
 unsafe impl Send for RoutePolicy {}
 unsafe impl Sync for RoutePolicy {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WlanConnectionProfileDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WlanConnectionProfileDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl WlanConnectionProfileDetails {
@@ -1844,7 +1844,7 @@ impl windows_core::RuntimeName for WlanConnectionProfileDetails {
 unsafe impl Send for WlanConnectionProfileDetails {}
 unsafe impl Sync for WlanConnectionProfileDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WwanConnectionProfileDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WwanConnectionProfileDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl WwanConnectionProfileDetails {

--- a/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
@@ -1535,7 +1535,7 @@ pub struct IUssdSessionStatics_Vtbl {
     pub CreateFromNetworkInterfaceId: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESim(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESim, windows_core::IUnknown, windows_core::IInspectable);
 impl ESim {
@@ -1673,7 +1673,7 @@ impl windows_core::RuntimeName for ESim {
 unsafe impl Send for ESim {}
 unsafe impl Sync for ESim {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimAddedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimAddedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimAddedEventArgs {
@@ -1698,7 +1698,7 @@ impl windows_core::RuntimeName for ESimAddedEventArgs {
 unsafe impl Send for ESimAddedEventArgs {}
 unsafe impl Sync for ESimAddedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimDiscoverEvent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimDiscoverEvent, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimDiscoverEvent {
@@ -1730,7 +1730,7 @@ impl windows_core::RuntimeName for ESimDiscoverEvent {
 unsafe impl Send for ESimDiscoverEvent {}
 unsafe impl Sync for ESimDiscoverEvent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimDiscoverResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimDiscoverResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimDiscoverResult {
@@ -1777,7 +1777,7 @@ impl windows_core::RuntimeName for ESimDiscoverResult {
 unsafe impl Send for ESimDiscoverResult {}
 unsafe impl Sync for ESimDiscoverResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimDownloadProfileMetadataResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimDownloadProfileMetadataResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimDownloadProfileMetadataResult {
@@ -1844,7 +1844,7 @@ impl windows_core::RuntimeName for ESimManager {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ESimManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimOperationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimOperationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimOperationResult {
@@ -1869,7 +1869,7 @@ impl windows_core::RuntimeName for ESimOperationResult {
 unsafe impl Send for ESimOperationResult {}
 unsafe impl Sync for ESimOperationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimPolicy(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimPolicy, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimPolicy {
@@ -1894,7 +1894,7 @@ impl windows_core::RuntimeName for ESimPolicy {
 unsafe impl Send for ESimPolicy {}
 unsafe impl Sync for ESimPolicy {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimProfile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimProfile, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimProfile {
@@ -1990,7 +1990,7 @@ impl windows_core::RuntimeName for ESimProfile {
 unsafe impl Send for ESimProfile {}
 unsafe impl Sync for ESimProfile {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimProfileMetadata(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimProfileMetadata, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimProfileMetadata {
@@ -2100,7 +2100,7 @@ impl windows_core::RuntimeName for ESimProfileMetadata {
 unsafe impl Send for ESimProfileMetadata {}
 unsafe impl Sync for ESimProfileMetadata {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimProfilePolicy(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimProfilePolicy, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimProfilePolicy {
@@ -2139,7 +2139,7 @@ impl windows_core::RuntimeName for ESimProfilePolicy {
 unsafe impl Send for ESimProfilePolicy {}
 unsafe impl Sync for ESimProfilePolicy {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimRemovedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimRemovedEventArgs {
@@ -2164,7 +2164,7 @@ impl windows_core::RuntimeName for ESimRemovedEventArgs {
 unsafe impl Send for ESimRemovedEventArgs {}
 unsafe impl Sync for ESimRemovedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimServiceInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimServiceInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimServiceInfo {
@@ -2196,7 +2196,7 @@ impl windows_core::RuntimeName for ESimServiceInfo {
 unsafe impl Send for ESimServiceInfo {}
 unsafe impl Sync for ESimServiceInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimUpdatedEventArgs {
@@ -2221,7 +2221,7 @@ impl windows_core::RuntimeName for ESimUpdatedEventArgs {
 unsafe impl Send for ESimUpdatedEventArgs {}
 unsafe impl Sync for ESimUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ESimWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ESimWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl ESimWatcher {
@@ -2341,7 +2341,7 @@ impl windows_core::RuntimeName for FdnAccessManager {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.FdnAccessManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HotspotAuthenticationContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HotspotAuthenticationContext, windows_core::IUnknown, windows_core::IInspectable);
 impl HotspotAuthenticationContext {
@@ -2428,7 +2428,7 @@ impl windows_core::RuntimeName for HotspotAuthenticationContext {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.HotspotAuthenticationContext";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HotspotAuthenticationEventDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HotspotAuthenticationEventDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl HotspotAuthenticationEventDetails {
@@ -2451,7 +2451,7 @@ impl windows_core::RuntimeName for HotspotAuthenticationEventDetails {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.HotspotAuthenticationEventDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HotspotCredentialsAuthenticationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HotspotCredentialsAuthenticationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl HotspotCredentialsAuthenticationResult {
@@ -2645,7 +2645,7 @@ impl windows_core::RuntimeName for KnownUSimFilePaths {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.KnownUSimFilePaths";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandAccount(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandAccount, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandAccount {
@@ -2729,7 +2729,7 @@ impl windows_core::RuntimeName for MobileBroadbandAccount {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandAccount";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandAccountEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandAccountEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandAccountEventArgs {
@@ -2752,7 +2752,7 @@ impl windows_core::RuntimeName for MobileBroadbandAccountEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandAccountEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandAccountUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandAccountUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandAccountUpdatedEventArgs {
@@ -2789,7 +2789,7 @@ impl windows_core::RuntimeName for MobileBroadbandAccountUpdatedEventArgs {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandAccountUpdatedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandAccountWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandAccountWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandAccountWatcher {
@@ -2897,7 +2897,7 @@ impl windows_core::RuntimeName for MobileBroadbandAccountWatcher {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandAccountWatcher";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandAntennaSar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandAntennaSar, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandAntennaSar {
@@ -2940,7 +2940,7 @@ impl windows_core::RuntimeName for MobileBroadbandAntennaSar {
 unsafe impl Send for MobileBroadbandAntennaSar {}
 unsafe impl Sync for MobileBroadbandAntennaSar {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandCellCdma(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandCellCdma, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandCellCdma {
@@ -3014,7 +3014,7 @@ impl windows_core::RuntimeName for MobileBroadbandCellCdma {
 unsafe impl Send for MobileBroadbandCellCdma {}
 unsafe impl Sync for MobileBroadbandCellCdma {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandCellGsm(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandCellGsm, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandCellGsm {
@@ -3081,7 +3081,7 @@ impl windows_core::RuntimeName for MobileBroadbandCellGsm {
 unsafe impl Send for MobileBroadbandCellGsm {}
 unsafe impl Sync for MobileBroadbandCellGsm {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandCellLte(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandCellLte, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandCellLte {
@@ -3155,7 +3155,7 @@ impl windows_core::RuntimeName for MobileBroadbandCellLte {
 unsafe impl Send for MobileBroadbandCellLte {}
 unsafe impl Sync for MobileBroadbandCellLte {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandCellNR(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandCellNR, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandCellNR {
@@ -3236,7 +3236,7 @@ impl windows_core::RuntimeName for MobileBroadbandCellNR {
 unsafe impl Send for MobileBroadbandCellNR {}
 unsafe impl Sync for MobileBroadbandCellNR {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandCellTdscdma(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandCellTdscdma, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandCellTdscdma {
@@ -3310,7 +3310,7 @@ impl windows_core::RuntimeName for MobileBroadbandCellTdscdma {
 unsafe impl Send for MobileBroadbandCellTdscdma {}
 unsafe impl Sync for MobileBroadbandCellTdscdma {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandCellUmts(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandCellUmts, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandCellUmts {
@@ -3384,7 +3384,7 @@ impl windows_core::RuntimeName for MobileBroadbandCellUmts {
 unsafe impl Send for MobileBroadbandCellUmts {}
 unsafe impl Sync for MobileBroadbandCellUmts {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandCellsInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandCellsInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandCellsInfo {
@@ -3498,7 +3498,7 @@ impl windows_core::RuntimeName for MobileBroadbandCellsInfo {
 unsafe impl Send for MobileBroadbandCellsInfo {}
 unsafe impl Sync for MobileBroadbandCellsInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandCurrentSlotIndexChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandCurrentSlotIndexChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandCurrentSlotIndexChangedEventArgs {
@@ -3523,7 +3523,7 @@ impl windows_core::RuntimeName for MobileBroadbandCurrentSlotIndexChangedEventAr
 unsafe impl Send for MobileBroadbandCurrentSlotIndexChangedEventArgs {}
 unsafe impl Sync for MobileBroadbandCurrentSlotIndexChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandDeviceInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandDeviceInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandDeviceInformation {
@@ -3688,7 +3688,7 @@ impl windows_core::RuntimeName for MobileBroadbandDeviceInformation {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandDeviceInformation";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandDeviceService(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandDeviceService, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandDeviceService {
@@ -3735,7 +3735,7 @@ impl windows_core::RuntimeName for MobileBroadbandDeviceService {
 unsafe impl Send for MobileBroadbandDeviceService {}
 unsafe impl Sync for MobileBroadbandDeviceService {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandDeviceServiceCommandResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandDeviceServiceCommandResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandDeviceServiceCommandResult {
@@ -3768,7 +3768,7 @@ impl windows_core::RuntimeName for MobileBroadbandDeviceServiceCommandResult {
 unsafe impl Send for MobileBroadbandDeviceServiceCommandResult {}
 unsafe impl Sync for MobileBroadbandDeviceServiceCommandResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandDeviceServiceCommandSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandDeviceServiceCommandSession, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandDeviceServiceCommandSession {
@@ -3812,7 +3812,7 @@ impl windows_core::RuntimeName for MobileBroadbandDeviceServiceCommandSession {
 unsafe impl Send for MobileBroadbandDeviceServiceCommandSession {}
 unsafe impl Sync for MobileBroadbandDeviceServiceCommandSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandDeviceServiceDataReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandDeviceServiceDataReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandDeviceServiceDataReceivedEventArgs {
@@ -3838,7 +3838,7 @@ impl windows_core::RuntimeName for MobileBroadbandDeviceServiceDataReceivedEvent
 unsafe impl Send for MobileBroadbandDeviceServiceDataReceivedEventArgs {}
 unsafe impl Sync for MobileBroadbandDeviceServiceDataReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandDeviceServiceDataSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandDeviceServiceDataSession, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandDeviceServiceDataSession {
@@ -3885,7 +3885,7 @@ impl windows_core::RuntimeName for MobileBroadbandDeviceServiceDataSession {
 unsafe impl Send for MobileBroadbandDeviceServiceDataSession {}
 unsafe impl Sync for MobileBroadbandDeviceServiceDataSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandDeviceServiceInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandDeviceServiceInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandDeviceServiceInformation {
@@ -3924,7 +3924,7 @@ impl windows_core::RuntimeName for MobileBroadbandDeviceServiceInformation {
 unsafe impl Send for MobileBroadbandDeviceServiceInformation {}
 unsafe impl Sync for MobileBroadbandDeviceServiceInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandDeviceServiceTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandDeviceServiceTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandDeviceServiceTriggerDetails {
@@ -3971,7 +3971,7 @@ impl windows_core::RuntimeName for MobileBroadbandDeviceServiceTriggerDetails {
 unsafe impl Send for MobileBroadbandDeviceServiceTriggerDetails {}
 unsafe impl Sync for MobileBroadbandDeviceServiceTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandModem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandModem, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandModem {
@@ -4153,7 +4153,7 @@ impl windows_core::RuntimeName for MobileBroadbandModem {
 unsafe impl Send for MobileBroadbandModem {}
 unsafe impl Sync for MobileBroadbandModem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandModemConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandModemConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandModemConfiguration {
@@ -4197,7 +4197,7 @@ impl windows_core::RuntimeName for MobileBroadbandModemConfiguration {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandModemConfiguration";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandModemIsolation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandModemIsolation, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandModemIsolation {
@@ -4255,7 +4255,7 @@ impl windows_core::RuntimeName for MobileBroadbandModemIsolation {
 unsafe impl Send for MobileBroadbandModemIsolation {}
 unsafe impl Sync for MobileBroadbandModemIsolation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandNetwork(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandNetwork, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandNetwork {
@@ -4361,7 +4361,7 @@ impl windows_core::RuntimeName for MobileBroadbandNetwork {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.MobileBroadbandNetwork";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandNetworkRegistrationStateChange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandNetworkRegistrationStateChange, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandNetworkRegistrationStateChange {
@@ -4393,7 +4393,7 @@ impl windows_core::RuntimeName for MobileBroadbandNetworkRegistrationStateChange
 unsafe impl Send for MobileBroadbandNetworkRegistrationStateChange {}
 unsafe impl Sync for MobileBroadbandNetworkRegistrationStateChange {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandNetworkRegistrationStateChangeTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandNetworkRegistrationStateChangeTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandNetworkRegistrationStateChangeTriggerDetails {
@@ -4419,7 +4419,7 @@ impl windows_core::RuntimeName for MobileBroadbandNetworkRegistrationStateChange
 unsafe impl Send for MobileBroadbandNetworkRegistrationStateChangeTriggerDetails {}
 unsafe impl Sync for MobileBroadbandNetworkRegistrationStateChangeTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandPco(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandPco, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandPco {
@@ -4459,7 +4459,7 @@ impl windows_core::RuntimeName for MobileBroadbandPco {
 unsafe impl Send for MobileBroadbandPco {}
 unsafe impl Sync for MobileBroadbandPco {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandPcoDataChangeTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandPcoDataChangeTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandPcoDataChangeTriggerDetails {
@@ -4484,7 +4484,7 @@ impl windows_core::RuntimeName for MobileBroadbandPcoDataChangeTriggerDetails {
 unsafe impl Send for MobileBroadbandPcoDataChangeTriggerDetails {}
 unsafe impl Sync for MobileBroadbandPcoDataChangeTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandPin(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandPin, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandPin {
@@ -4586,7 +4586,7 @@ impl windows_core::RuntimeName for MobileBroadbandPin {
 unsafe impl Send for MobileBroadbandPin {}
 unsafe impl Sync for MobileBroadbandPin {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandPinLockStateChange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandPinLockStateChange, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandPinLockStateChange {
@@ -4625,7 +4625,7 @@ impl windows_core::RuntimeName for MobileBroadbandPinLockStateChange {
 unsafe impl Send for MobileBroadbandPinLockStateChange {}
 unsafe impl Sync for MobileBroadbandPinLockStateChange {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandPinLockStateChangeTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandPinLockStateChangeTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandPinLockStateChangeTriggerDetails {
@@ -4651,7 +4651,7 @@ impl windows_core::RuntimeName for MobileBroadbandPinLockStateChangeTriggerDetai
 unsafe impl Send for MobileBroadbandPinLockStateChangeTriggerDetails {}
 unsafe impl Sync for MobileBroadbandPinLockStateChangeTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandPinManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandPinManager, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandPinManager {
@@ -4684,7 +4684,7 @@ impl windows_core::RuntimeName for MobileBroadbandPinManager {
 unsafe impl Send for MobileBroadbandPinManager {}
 unsafe impl Sync for MobileBroadbandPinManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandPinOperationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandPinOperationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandPinOperationResult {
@@ -4716,7 +4716,7 @@ impl windows_core::RuntimeName for MobileBroadbandPinOperationResult {
 unsafe impl Send for MobileBroadbandPinOperationResult {}
 unsafe impl Sync for MobileBroadbandPinOperationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandRadioStateChange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandRadioStateChange, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandRadioStateChange {
@@ -4748,7 +4748,7 @@ impl windows_core::RuntimeName for MobileBroadbandRadioStateChange {
 unsafe impl Send for MobileBroadbandRadioStateChange {}
 unsafe impl Sync for MobileBroadbandRadioStateChange {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandRadioStateChangeTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandRadioStateChangeTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandRadioStateChangeTriggerDetails {
@@ -4774,7 +4774,7 @@ impl windows_core::RuntimeName for MobileBroadbandRadioStateChangeTriggerDetails
 unsafe impl Send for MobileBroadbandRadioStateChangeTriggerDetails {}
 unsafe impl Sync for MobileBroadbandRadioStateChangeTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandSarManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandSarManager, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandSarManager {
@@ -4896,7 +4896,7 @@ impl windows_core::RuntimeName for MobileBroadbandSarManager {
 unsafe impl Send for MobileBroadbandSarManager {}
 unsafe impl Sync for MobileBroadbandSarManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandSlotInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandSlotInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandSlotInfo {
@@ -4935,7 +4935,7 @@ impl windows_core::RuntimeName for MobileBroadbandSlotInfo {
 unsafe impl Send for MobileBroadbandSlotInfo {}
 unsafe impl Sync for MobileBroadbandSlotInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandSlotInfoChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandSlotInfoChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandSlotInfoChangedEventArgs {
@@ -4960,7 +4960,7 @@ impl windows_core::RuntimeName for MobileBroadbandSlotInfoChangedEventArgs {
 unsafe impl Send for MobileBroadbandSlotInfoChangedEventArgs {}
 unsafe impl Sync for MobileBroadbandSlotInfoChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandSlotManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandSlotManager, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandSlotManager {
@@ -5035,7 +5035,7 @@ impl windows_core::RuntimeName for MobileBroadbandSlotManager {
 unsafe impl Send for MobileBroadbandSlotManager {}
 unsafe impl Sync for MobileBroadbandSlotManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandTransmissionStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandTransmissionStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandTransmissionStateChangedEventArgs {
@@ -5060,7 +5060,7 @@ impl windows_core::RuntimeName for MobileBroadbandTransmissionStateChangedEventA
 unsafe impl Send for MobileBroadbandTransmissionStateChangedEventArgs {}
 unsafe impl Sync for MobileBroadbandTransmissionStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandUicc(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandUicc, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandUicc {
@@ -5092,7 +5092,7 @@ impl windows_core::RuntimeName for MobileBroadbandUicc {
 unsafe impl Send for MobileBroadbandUicc {}
 unsafe impl Sync for MobileBroadbandUicc {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandUiccApp(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandUiccApp, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandUiccApp {
@@ -5147,7 +5147,7 @@ impl windows_core::RuntimeName for MobileBroadbandUiccApp {
 unsafe impl Send for MobileBroadbandUiccApp {}
 unsafe impl Sync for MobileBroadbandUiccApp {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandUiccAppReadRecordResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandUiccAppReadRecordResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandUiccAppReadRecordResult {
@@ -5180,7 +5180,7 @@ impl windows_core::RuntimeName for MobileBroadbandUiccAppReadRecordResult {
 unsafe impl Send for MobileBroadbandUiccAppReadRecordResult {}
 unsafe impl Sync for MobileBroadbandUiccAppReadRecordResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandUiccAppRecordDetailsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandUiccAppRecordDetailsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandUiccAppRecordDetailsResult {
@@ -5240,7 +5240,7 @@ impl windows_core::RuntimeName for MobileBroadbandUiccAppRecordDetailsResult {
 unsafe impl Send for MobileBroadbandUiccAppRecordDetailsResult {}
 unsafe impl Sync for MobileBroadbandUiccAppRecordDetailsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MobileBroadbandUiccAppsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MobileBroadbandUiccAppsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MobileBroadbandUiccAppsResult {
@@ -5273,7 +5273,7 @@ impl windows_core::RuntimeName for MobileBroadbandUiccAppsResult {
 unsafe impl Send for MobileBroadbandUiccAppsResult {}
 unsafe impl Sync for MobileBroadbandUiccAppsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkOperatorDataUsageTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkOperatorDataUsageTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkOperatorDataUsageTriggerDetails {
@@ -5298,7 +5298,7 @@ impl windows_core::RuntimeName for NetworkOperatorDataUsageTriggerDetails {
 unsafe impl Send for NetworkOperatorDataUsageTriggerDetails {}
 unsafe impl Sync for NetworkOperatorDataUsageTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkOperatorNotificationEventDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkOperatorNotificationEventDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkOperatorNotificationEventDetails {
@@ -5363,7 +5363,7 @@ impl windows_core::RuntimeName for NetworkOperatorNotificationEventDetails {
 unsafe impl Send for NetworkOperatorNotificationEventDetails {}
 unsafe impl Sync for NetworkOperatorNotificationEventDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkOperatorTetheringAccessPointConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkOperatorTetheringAccessPointConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkOperatorTetheringAccessPointConfiguration {
@@ -5435,7 +5435,7 @@ impl windows_core::RuntimeName for NetworkOperatorTetheringAccessPointConfigurat
 unsafe impl Send for NetworkOperatorTetheringAccessPointConfiguration {}
 unsafe impl Sync for NetworkOperatorTetheringAccessPointConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkOperatorTetheringClient(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkOperatorTetheringClient, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkOperatorTetheringClient {
@@ -5468,7 +5468,7 @@ impl windows_core::RuntimeName for NetworkOperatorTetheringClient {
 unsafe impl Send for NetworkOperatorTetheringClient {}
 unsafe impl Sync for NetworkOperatorTetheringClient {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkOperatorTetheringManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkOperatorTetheringManager, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkOperatorTetheringManager {
@@ -5631,7 +5631,7 @@ impl windows_core::RuntimeName for NetworkOperatorTetheringManager {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.NetworkOperatorTetheringManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NetworkOperatorTetheringOperationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NetworkOperatorTetheringOperationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl NetworkOperatorTetheringOperationResult {
@@ -5661,7 +5661,7 @@ impl windows_core::RuntimeName for NetworkOperatorTetheringOperationResult {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.NetworkOperatorTetheringOperationResult";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProvisionFromXmlDocumentResults(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProvisionFromXmlDocumentResults, windows_core::IUnknown, windows_core::IInspectable);
 impl ProvisionFromXmlDocumentResults {
@@ -5691,7 +5691,7 @@ impl windows_core::RuntimeName for ProvisionFromXmlDocumentResults {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ProvisionFromXmlDocumentResults";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProvisionedProfile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProvisionedProfile, windows_core::IUnknown, windows_core::IInspectable);
 impl ProvisionedProfile {
@@ -5716,7 +5716,7 @@ impl windows_core::RuntimeName for ProvisionedProfile {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ProvisionedProfile";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProvisioningAgent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProvisioningAgent, windows_core::IUnknown, windows_core::IInspectable);
 impl ProvisioningAgent {
@@ -5764,7 +5764,7 @@ impl windows_core::RuntimeName for ProvisioningAgent {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.ProvisioningAgent";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TetheringEntitlementCheckTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TetheringEntitlementCheckTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl TetheringEntitlementCheckTriggerDetails {
@@ -5797,7 +5797,7 @@ impl windows_core::RuntimeName for TetheringEntitlementCheckTriggerDetails {
 unsafe impl Send for TetheringEntitlementCheckTriggerDetails {}
 unsafe impl Sync for TetheringEntitlementCheckTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UssdMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UssdMessage, windows_core::IUnknown, windows_core::IInspectable);
 impl UssdMessage {
@@ -5859,7 +5859,7 @@ impl windows_core::RuntimeName for UssdMessage {
 unsafe impl Send for UssdMessage {}
 unsafe impl Sync for UssdMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UssdReply(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UssdReply, windows_core::IUnknown, windows_core::IInspectable);
 impl UssdReply {
@@ -5889,7 +5889,7 @@ impl windows_core::RuntimeName for UssdReply {
     const NAME: &'static str = "Windows.Networking.NetworkOperators.UssdReply";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UssdSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UssdSession, windows_core::IUnknown, windows_core::IInspectable);
 impl UssdSession {

--- a/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
@@ -186,7 +186,7 @@ pub struct ITriggeredConnectionStateChangedEventArgs_Vtbl {
     Socket: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ConnectionRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConnectionRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ConnectionRequestedEventArgs {
@@ -355,7 +355,7 @@ impl windows_core::RuntimeName for PeerFinder {
     const NAME: &'static str = "Windows.Networking.Proximity.PeerFinder";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PeerInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PeerInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl PeerInformation {
@@ -409,7 +409,7 @@ impl windows_core::RuntimeName for PeerInformation {
 unsafe impl Send for PeerInformation {}
 unsafe impl Sync for PeerInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PeerWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PeerWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl PeerWatcher {
@@ -512,7 +512,7 @@ impl windows_core::RuntimeName for PeerWatcher {
 unsafe impl Send for PeerWatcher {}
 unsafe impl Sync for PeerWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProximityDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProximityDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl ProximityDevice {
@@ -681,7 +681,7 @@ impl windows_core::RuntimeName for ProximityDevice {
 unsafe impl Send for ProximityDevice {}
 unsafe impl Sync for ProximityDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProximityMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProximityMessage, windows_core::IUnknown, windows_core::IInspectable);
 impl ProximityMessage {
@@ -728,7 +728,7 @@ impl windows_core::RuntimeName for ProximityMessage {
 unsafe impl Send for ProximityMessage {}
 unsafe impl Sync for ProximityMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TriggeredConnectionStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TriggeredConnectionStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TriggeredConnectionStateChangedEventArgs {

--- a/crates/libs/windows/src/Windows/Networking/PushNotifications/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/PushNotifications/mod.rs
@@ -151,7 +151,7 @@ pub struct IRawNotification3_Vtbl {
     ContentBytes: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PushNotificationChannel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PushNotificationChannel, windows_core::IUnknown, windows_core::IInspectable);
 impl PushNotificationChannel {
@@ -273,7 +273,7 @@ impl windows_core::RuntimeName for PushNotificationChannelManager {
     const NAME: &'static str = "Windows.Networking.PushNotifications.PushNotificationChannelManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PushNotificationChannelManagerForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PushNotificationChannelManagerForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl PushNotificationChannelManagerForUser {
@@ -342,7 +342,7 @@ impl windows_core::RuntimeName for PushNotificationChannelManagerForUser {
 unsafe impl Send for PushNotificationChannelManagerForUser {}
 unsafe impl Sync for PushNotificationChannelManagerForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PushNotificationChannelsRevokedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PushNotificationChannelsRevokedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PushNotificationChannelsRevokedEventArgs {}
@@ -359,7 +359,7 @@ impl windows_core::RuntimeName for PushNotificationChannelsRevokedEventArgs {
 unsafe impl Send for PushNotificationChannelsRevokedEventArgs {}
 unsafe impl Sync for PushNotificationChannelsRevokedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PushNotificationReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PushNotificationReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PushNotificationReceivedEventArgs {
@@ -426,7 +426,7 @@ impl windows_core::RuntimeName for PushNotificationReceivedEventArgs {
 unsafe impl Send for PushNotificationReceivedEventArgs {}
 unsafe impl Sync for PushNotificationReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RawNotification(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RawNotification, windows_core::IUnknown, windows_core::IInspectable);
 impl RawNotification {

--- a/crates/libs/windows/src/Windows/Networking/ServiceDiscovery/Dnssd/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/ServiceDiscovery/Dnssd/mod.rs
@@ -74,7 +74,7 @@ pub struct IDnssdServiceWatcher_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DnssdRegistrationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DnssdRegistrationResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DnssdRegistrationResult, super::super::super::Foundation::IStringable);
@@ -128,7 +128,7 @@ impl windows_core::RuntimeName for DnssdRegistrationResult {
 unsafe impl Send for DnssdRegistrationResult {}
 unsafe impl Sync for DnssdRegistrationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DnssdServiceInstance(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DnssdServiceInstance, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DnssdServiceInstance, super::super::super::Foundation::IStringable);
@@ -281,7 +281,7 @@ unsafe impl Send for DnssdServiceInstance {}
 unsafe impl Sync for DnssdServiceInstance {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DnssdServiceInstanceCollection(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(DnssdServiceInstanceCollection, windows_core::IUnknown, windows_core::IInspectable);
@@ -367,7 +367,7 @@ unsafe impl Send for DnssdServiceInstanceCollection {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for DnssdServiceInstanceCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DnssdServiceWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DnssdServiceWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl DnssdServiceWatcher {

--- a/crates/libs/windows/src/Windows/Networking/Sockets/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Sockets/mod.rs
@@ -1196,7 +1196,7 @@ pub struct IWebSocketServerCustomValidationRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ControlChannelTrigger(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ControlChannelTrigger, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ControlChannelTrigger, super::super::Foundation::IClosable);
@@ -1313,7 +1313,7 @@ impl windows_core::RuntimeName for ControlChannelTrigger {
 unsafe impl Send for ControlChannelTrigger {}
 unsafe impl Sync for ControlChannelTrigger {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DatagramSocket(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DatagramSocket, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DatagramSocket, super::super::Foundation::IClosable);
@@ -1514,7 +1514,7 @@ impl windows_core::RuntimeName for DatagramSocket {
 unsafe impl Send for DatagramSocket {}
 unsafe impl Sync for DatagramSocket {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DatagramSocketControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DatagramSocketControl, windows_core::IUnknown, windows_core::IInspectable);
 impl DatagramSocketControl {
@@ -1587,7 +1587,7 @@ impl windows_core::RuntimeName for DatagramSocketControl {
 unsafe impl Send for DatagramSocketControl {}
 unsafe impl Sync for DatagramSocketControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DatagramSocketInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DatagramSocketInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl DatagramSocketInformation {
@@ -1633,7 +1633,7 @@ impl windows_core::RuntimeName for DatagramSocketInformation {
 unsafe impl Send for DatagramSocketInformation {}
 unsafe impl Sync for DatagramSocketInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DatagramSocketMessageReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DatagramSocketMessageReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DatagramSocketMessageReceivedEventArgs {
@@ -1688,7 +1688,7 @@ impl windows_core::RuntimeName for DatagramSocketMessageReceivedEventArgs {
 unsafe impl Send for DatagramSocketMessageReceivedEventArgs {}
 unsafe impl Sync for DatagramSocketMessageReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MessageWebSocket(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MessageWebSocket, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MessageWebSocket, super::super::Foundation::IClosable, IWebSocket);
@@ -1822,7 +1822,7 @@ impl windows_core::RuntimeName for MessageWebSocket {
 unsafe impl Send for MessageWebSocket {}
 unsafe impl Sync for MessageWebSocket {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MessageWebSocketControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MessageWebSocketControl, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MessageWebSocketControl, IWebSocketControl, IWebSocketControl2);
@@ -1967,7 +1967,7 @@ impl windows_core::RuntimeName for MessageWebSocketControl {
 unsafe impl Send for MessageWebSocketControl {}
 unsafe impl Sync for MessageWebSocketControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MessageWebSocketInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MessageWebSocketInformation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MessageWebSocketInformation, IWebSocketInformation, IWebSocketInformation2);
@@ -2038,7 +2038,7 @@ impl windows_core::RuntimeName for MessageWebSocketInformation {
 unsafe impl Send for MessageWebSocketInformation {}
 unsafe impl Sync for MessageWebSocketInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MessageWebSocketMessageReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MessageWebSocketMessageReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MessageWebSocketMessageReceivedEventArgs {
@@ -2086,7 +2086,7 @@ impl windows_core::RuntimeName for MessageWebSocketMessageReceivedEventArgs {
 unsafe impl Send for MessageWebSocketMessageReceivedEventArgs {}
 unsafe impl Sync for MessageWebSocketMessageReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ServerMessageWebSocket(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ServerMessageWebSocket, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ServerMessageWebSocket, super::super::Foundation::IClosable);
@@ -2163,7 +2163,7 @@ impl windows_core::RuntimeName for ServerMessageWebSocket {
 unsafe impl Send for ServerMessageWebSocket {}
 unsafe impl Sync for ServerMessageWebSocket {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ServerMessageWebSocketControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ServerMessageWebSocketControl, windows_core::IUnknown, windows_core::IInspectable);
 impl ServerMessageWebSocketControl {
@@ -2192,7 +2192,7 @@ impl windows_core::RuntimeName for ServerMessageWebSocketControl {
 unsafe impl Send for ServerMessageWebSocketControl {}
 unsafe impl Sync for ServerMessageWebSocketControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ServerMessageWebSocketInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ServerMessageWebSocketInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl ServerMessageWebSocketInformation {
@@ -2231,7 +2231,7 @@ impl windows_core::RuntimeName for ServerMessageWebSocketInformation {
 unsafe impl Send for ServerMessageWebSocketInformation {}
 unsafe impl Sync for ServerMessageWebSocketInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ServerStreamWebSocket(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ServerStreamWebSocket, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ServerStreamWebSocket, super::super::Foundation::IClosable);
@@ -2295,7 +2295,7 @@ impl windows_core::RuntimeName for ServerStreamWebSocket {
 unsafe impl Send for ServerStreamWebSocket {}
 unsafe impl Sync for ServerStreamWebSocket {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ServerStreamWebSocketInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ServerStreamWebSocketInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl ServerStreamWebSocketInformation {
@@ -2334,7 +2334,7 @@ impl windows_core::RuntimeName for ServerStreamWebSocketInformation {
 unsafe impl Send for ServerStreamWebSocketInformation {}
 unsafe impl Sync for ServerStreamWebSocketInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SocketActivityContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SocketActivityContext, windows_core::IUnknown, windows_core::IInspectable);
 impl SocketActivityContext {
@@ -2375,7 +2375,7 @@ impl windows_core::RuntimeName for SocketActivityContext {
 unsafe impl Send for SocketActivityContext {}
 unsafe impl Sync for SocketActivityContext {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SocketActivityInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SocketActivityInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl SocketActivityInformation {
@@ -2454,7 +2454,7 @@ impl windows_core::RuntimeName for SocketActivityInformation {
 unsafe impl Send for SocketActivityInformation {}
 unsafe impl Sync for SocketActivityInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SocketActivityTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SocketActivityTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl SocketActivityTriggerDetails {
@@ -2503,7 +2503,7 @@ impl windows_core::RuntimeName for SocketError {
     const NAME: &'static str = "Windows.Networking.Sockets.SocketError";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamSocket(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StreamSocket, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StreamSocket, super::super::Foundation::IClosable);
@@ -2683,7 +2683,7 @@ impl windows_core::RuntimeName for StreamSocket {
 unsafe impl Send for StreamSocket {}
 unsafe impl Sync for StreamSocket {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamSocketControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StreamSocketControl, windows_core::IUnknown, windows_core::IInspectable);
 impl StreamSocketControl {
@@ -2802,7 +2802,7 @@ impl windows_core::RuntimeName for StreamSocketControl {
 unsafe impl Send for StreamSocketControl {}
 unsafe impl Sync for StreamSocketControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamSocketInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StreamSocketInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl StreamSocketInformation {
@@ -2922,7 +2922,7 @@ impl windows_core::RuntimeName for StreamSocketInformation {
 unsafe impl Send for StreamSocketInformation {}
 unsafe impl Sync for StreamSocketInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamSocketListener(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StreamSocketListener, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StreamSocketListener, super::super::Foundation::IClosable);
@@ -3041,7 +3041,7 @@ impl windows_core::RuntimeName for StreamSocketListener {
 unsafe impl Send for StreamSocketListener {}
 unsafe impl Sync for StreamSocketListener {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamSocketListenerConnectionReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StreamSocketListenerConnectionReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl StreamSocketListenerConnectionReceivedEventArgs {
@@ -3066,7 +3066,7 @@ impl windows_core::RuntimeName for StreamSocketListenerConnectionReceivedEventAr
 unsafe impl Send for StreamSocketListenerConnectionReceivedEventArgs {}
 unsafe impl Sync for StreamSocketListenerConnectionReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamSocketListenerControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StreamSocketListenerControl, windows_core::IUnknown, windows_core::IInspectable);
 impl StreamSocketListenerControl {
@@ -3139,7 +3139,7 @@ impl windows_core::RuntimeName for StreamSocketListenerControl {
 unsafe impl Send for StreamSocketListenerControl {}
 unsafe impl Sync for StreamSocketListenerControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamSocketListenerInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StreamSocketListenerInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl StreamSocketListenerInformation {
@@ -3164,7 +3164,7 @@ impl windows_core::RuntimeName for StreamSocketListenerInformation {
 unsafe impl Send for StreamSocketListenerInformation {}
 unsafe impl Sync for StreamSocketListenerInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamWebSocket(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StreamWebSocket, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StreamWebSocket, super::super::Foundation::IClosable, IWebSocket);
@@ -3270,7 +3270,7 @@ impl windows_core::RuntimeName for StreamWebSocket {
 unsafe impl Send for StreamWebSocket {}
 unsafe impl Sync for StreamWebSocket {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamWebSocketControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StreamWebSocketControl, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StreamWebSocketControl, IWebSocketControl, IWebSocketControl2);
@@ -3393,7 +3393,7 @@ impl windows_core::RuntimeName for StreamWebSocketControl {
 unsafe impl Send for StreamWebSocketControl {}
 unsafe impl Sync for StreamWebSocketControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamWebSocketInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StreamWebSocketInformation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StreamWebSocketInformation, IWebSocketInformation, IWebSocketInformation2);
@@ -3464,7 +3464,7 @@ impl windows_core::RuntimeName for StreamWebSocketInformation {
 unsafe impl Send for StreamWebSocketInformation {}
 unsafe impl Sync for StreamWebSocketInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebSocketClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebSocketClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebSocketClosedEventArgs {
@@ -3515,7 +3515,7 @@ impl windows_core::RuntimeName for WebSocketError {
 }
 #[cfg(feature = "ApplicationModel_Background")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebSocketKeepAlive(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Background")]
 windows_core::imp::interface_hierarchy!(WebSocketKeepAlive, windows_core::IUnknown, windows_core::IInspectable);
@@ -3557,7 +3557,7 @@ unsafe impl Send for WebSocketKeepAlive {}
 #[cfg(feature = "ApplicationModel_Background")]
 unsafe impl Sync for WebSocketKeepAlive {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebSocketServerCustomValidationRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebSocketServerCustomValidationRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebSocketServerCustomValidationRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
@@ -1207,7 +1207,7 @@ pub struct IVpnTrafficFilterFactory_Vtbl {
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnAppId(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnAppId, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnAppId {
@@ -1258,7 +1258,7 @@ impl windows_core::RuntimeName for VpnAppId {
 unsafe impl Send for VpnAppId {}
 unsafe impl Sync for VpnAppId {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnChannel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnChannel, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnChannel {
@@ -1598,7 +1598,7 @@ impl windows_core::RuntimeName for VpnChannel {
 unsafe impl Send for VpnChannel {}
 unsafe impl Sync for VpnChannel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnChannelActivityEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnChannelActivityEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnChannelActivityEventArgs {
@@ -1623,7 +1623,7 @@ impl windows_core::RuntimeName for VpnChannelActivityEventArgs {
 unsafe impl Send for VpnChannelActivityEventArgs {}
 unsafe impl Sync for VpnChannelActivityEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnChannelActivityStateChangedArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnChannelActivityStateChangedArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnChannelActivityStateChangedArgs {
@@ -1648,7 +1648,7 @@ impl windows_core::RuntimeName for VpnChannelActivityStateChangedArgs {
 unsafe impl Send for VpnChannelActivityStateChangedArgs {}
 unsafe impl Sync for VpnChannelActivityStateChangedArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnChannelConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnChannelConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnChannelConfiguration {
@@ -1696,7 +1696,7 @@ impl windows_core::RuntimeName for VpnChannelConfiguration {
 unsafe impl Send for VpnChannelConfiguration {}
 unsafe impl Sync for VpnChannelConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnCredential(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnCredential, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnCredential, IVpnCredential);
@@ -1746,7 +1746,7 @@ impl windows_core::RuntimeName for VpnCredential {
 unsafe impl Send for VpnCredential {}
 unsafe impl Sync for VpnCredential {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnCustomCheckBox(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnCustomCheckBox, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnCustomCheckBox, IVpnCustomPrompt);
@@ -1823,7 +1823,7 @@ impl windows_core::RuntimeName for VpnCustomCheckBox {
 unsafe impl Send for VpnCustomCheckBox {}
 unsafe impl Sync for VpnCustomCheckBox {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnCustomComboBox(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnCustomComboBox, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnCustomComboBox, IVpnCustomPrompt);
@@ -1905,7 +1905,7 @@ impl windows_core::RuntimeName for VpnCustomComboBox {
 unsafe impl Send for VpnCustomComboBox {}
 unsafe impl Sync for VpnCustomComboBox {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnCustomEditBox(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnCustomEditBox, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnCustomEditBox, IVpnCustomPrompt);
@@ -1993,7 +1993,7 @@ impl windows_core::RuntimeName for VpnCustomEditBox {
 unsafe impl Send for VpnCustomEditBox {}
 unsafe impl Sync for VpnCustomEditBox {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnCustomErrorBox(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnCustomErrorBox, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnCustomErrorBox, IVpnCustomPrompt);
@@ -2052,7 +2052,7 @@ impl windows_core::RuntimeName for VpnCustomErrorBox {
 unsafe impl Send for VpnCustomErrorBox {}
 unsafe impl Sync for VpnCustomErrorBox {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnCustomPromptBooleanInput(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnCustomPromptBooleanInput, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnCustomPromptBooleanInput, IVpnCustomPromptElement);
@@ -2129,7 +2129,7 @@ impl windows_core::RuntimeName for VpnCustomPromptBooleanInput {
 unsafe impl Send for VpnCustomPromptBooleanInput {}
 unsafe impl Sync for VpnCustomPromptBooleanInput {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnCustomPromptOptionSelector(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnCustomPromptOptionSelector, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnCustomPromptOptionSelector, IVpnCustomPromptElement);
@@ -2203,7 +2203,7 @@ impl windows_core::RuntimeName for VpnCustomPromptOptionSelector {
 unsafe impl Send for VpnCustomPromptOptionSelector {}
 unsafe impl Sync for VpnCustomPromptOptionSelector {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnCustomPromptText(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnCustomPromptText, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnCustomPromptText, IVpnCustomPromptElement);
@@ -2273,7 +2273,7 @@ impl windows_core::RuntimeName for VpnCustomPromptText {
 unsafe impl Send for VpnCustomPromptText {}
 unsafe impl Sync for VpnCustomPromptText {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnCustomPromptTextInput(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnCustomPromptTextInput, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnCustomPromptTextInput, IVpnCustomPromptElement);
@@ -2361,7 +2361,7 @@ impl windows_core::RuntimeName for VpnCustomPromptTextInput {
 unsafe impl Send for VpnCustomPromptTextInput {}
 unsafe impl Sync for VpnCustomPromptTextInput {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnCustomTextBox(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnCustomTextBox, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnCustomTextBox, IVpnCustomPrompt);
@@ -2431,7 +2431,7 @@ impl windows_core::RuntimeName for VpnCustomTextBox {
 unsafe impl Send for VpnCustomTextBox {}
 unsafe impl Sync for VpnCustomTextBox {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnDomainNameAssignment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnDomainNameAssignment, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnDomainNameAssignment {
@@ -2478,7 +2478,7 @@ impl windows_core::RuntimeName for VpnDomainNameAssignment {
 unsafe impl Send for VpnDomainNameAssignment {}
 unsafe impl Sync for VpnDomainNameAssignment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnDomainNameInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnDomainNameInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnDomainNameInfo {
@@ -2561,7 +2561,7 @@ impl windows_core::RuntimeName for VpnDomainNameInfo {
 unsafe impl Send for VpnDomainNameInfo {}
 unsafe impl Sync for VpnDomainNameInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnForegroundActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnForegroundActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "ApplicationModel_Activation")]
@@ -2635,7 +2635,7 @@ impl windows_core::RuntimeName for VpnForegroundActivatedEventArgs {
 unsafe impl Send for VpnForegroundActivatedEventArgs {}
 unsafe impl Sync for VpnForegroundActivatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnForegroundActivationOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnForegroundActivationOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnForegroundActivationOperation {
@@ -2661,7 +2661,7 @@ impl windows_core::RuntimeName for VpnForegroundActivationOperation {
 unsafe impl Send for VpnForegroundActivationOperation {}
 unsafe impl Sync for VpnForegroundActivationOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnInterfaceId(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnInterfaceId, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnInterfaceId {
@@ -2694,7 +2694,7 @@ impl windows_core::RuntimeName for VpnInterfaceId {
 unsafe impl Send for VpnInterfaceId {}
 unsafe impl Sync for VpnInterfaceId {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnManagementAgent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnManagementAgent, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnManagementAgent {
@@ -2803,7 +2803,7 @@ impl windows_core::RuntimeName for VpnManagementAgent {
 unsafe impl Send for VpnManagementAgent {}
 unsafe impl Sync for VpnManagementAgent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnNamespaceAssignment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnNamespaceAssignment, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnNamespaceAssignment {
@@ -2858,7 +2858,7 @@ impl windows_core::RuntimeName for VpnNamespaceAssignment {
 unsafe impl Send for VpnNamespaceAssignment {}
 unsafe impl Sync for VpnNamespaceAssignment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnNamespaceInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnNamespaceInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnNamespaceInfo {
@@ -2935,7 +2935,7 @@ impl windows_core::RuntimeName for VpnNamespaceInfo {
 unsafe impl Send for VpnNamespaceInfo {}
 unsafe impl Sync for VpnNamespaceInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnNativeProfile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnNativeProfile, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnNativeProfile, IVpnProfile);
@@ -3107,7 +3107,7 @@ impl windows_core::RuntimeName for VpnNativeProfile {
 unsafe impl Send for VpnNativeProfile {}
 unsafe impl Sync for VpnNativeProfile {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnPacketBuffer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnPacketBuffer, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnPacketBuffer {
@@ -3190,7 +3190,7 @@ impl windows_core::RuntimeName for VpnPacketBuffer {
 unsafe impl Send for VpnPacketBuffer {}
 unsafe impl Sync for VpnPacketBuffer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnPacketBufferList(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnPacketBufferList, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -3284,7 +3284,7 @@ impl IntoIterator for &VpnPacketBufferList {
 unsafe impl Send for VpnPacketBufferList {}
 unsafe impl Sync for VpnPacketBufferList {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnPickedCredential(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnPickedCredential, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnPickedCredential {
@@ -3325,7 +3325,7 @@ impl windows_core::RuntimeName for VpnPickedCredential {
 unsafe impl Send for VpnPickedCredential {}
 unsafe impl Sync for VpnPickedCredential {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnPlugInProfile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnPlugInProfile, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VpnPlugInProfile, IVpnProfile);
@@ -3464,7 +3464,7 @@ impl windows_core::RuntimeName for VpnPlugInProfile {
 unsafe impl Send for VpnPlugInProfile {}
 unsafe impl Sync for VpnPlugInProfile {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnRoute(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnRoute, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnRoute {
@@ -3521,7 +3521,7 @@ impl windows_core::RuntimeName for VpnRoute {
 unsafe impl Send for VpnRoute {}
 unsafe impl Sync for VpnRoute {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnRouteAssignment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnRouteAssignment, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnRouteAssignment {
@@ -3621,7 +3621,7 @@ impl windows_core::RuntimeName for VpnRouteAssignment {
 unsafe impl Send for VpnRouteAssignment {}
 unsafe impl Sync for VpnRouteAssignment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnSystemHealth(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnSystemHealth, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnSystemHealth {
@@ -3647,7 +3647,7 @@ impl windows_core::RuntimeName for VpnSystemHealth {
 unsafe impl Send for VpnSystemHealth {}
 unsafe impl Sync for VpnSystemHealth {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnTrafficFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnTrafficFilter, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnTrafficFilter {
@@ -3755,7 +3755,7 @@ impl windows_core::RuntimeName for VpnTrafficFilter {
 unsafe impl Send for VpnTrafficFilter {}
 unsafe impl Sync for VpnTrafficFilter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VpnTrafficFilterAssignment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VpnTrafficFilterAssignment, windows_core::IUnknown, windows_core::IInspectable);
 impl VpnTrafficFilterAssignment {

--- a/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
@@ -226,7 +226,7 @@ pub struct IXboxLiveQualityOfServicePrivatePayloadResult_Vtbl {
     Value: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XboxLiveDeviceAddress(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XboxLiveDeviceAddress, windows_core::IUnknown, windows_core::IInspectable);
 impl XboxLiveDeviceAddress {
@@ -347,7 +347,7 @@ impl windows_core::RuntimeName for XboxLiveDeviceAddress {
 unsafe impl Send for XboxLiveDeviceAddress {}
 unsafe impl Sync for XboxLiveDeviceAddress {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XboxLiveEndpointPair(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XboxLiveEndpointPair, windows_core::IUnknown, windows_core::IInspectable);
 impl XboxLiveEndpointPair {
@@ -464,7 +464,7 @@ impl windows_core::RuntimeName for XboxLiveEndpointPair {
 unsafe impl Send for XboxLiveEndpointPair {}
 unsafe impl Sync for XboxLiveEndpointPair {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XboxLiveEndpointPairCreationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XboxLiveEndpointPairCreationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl XboxLiveEndpointPairCreationResult {
@@ -510,7 +510,7 @@ impl windows_core::RuntimeName for XboxLiveEndpointPairCreationResult {
 unsafe impl Send for XboxLiveEndpointPairCreationResult {}
 unsafe impl Sync for XboxLiveEndpointPairCreationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XboxLiveEndpointPairStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XboxLiveEndpointPairStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl XboxLiveEndpointPairStateChangedEventArgs {
@@ -542,7 +542,7 @@ impl windows_core::RuntimeName for XboxLiveEndpointPairStateChangedEventArgs {
 unsafe impl Send for XboxLiveEndpointPairStateChangedEventArgs {}
 unsafe impl Sync for XboxLiveEndpointPairStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XboxLiveEndpointPairTemplate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XboxLiveEndpointPairTemplate, windows_core::IUnknown, windows_core::IInspectable);
 impl XboxLiveEndpointPairTemplate {
@@ -682,7 +682,7 @@ impl windows_core::RuntimeName for XboxLiveEndpointPairTemplate {
 unsafe impl Send for XboxLiveEndpointPairTemplate {}
 unsafe impl Sync for XboxLiveEndpointPairTemplate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XboxLiveInboundEndpointPairCreatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XboxLiveInboundEndpointPairCreatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl XboxLiveInboundEndpointPairCreatedEventArgs {
@@ -707,7 +707,7 @@ impl windows_core::RuntimeName for XboxLiveInboundEndpointPairCreatedEventArgs {
 unsafe impl Send for XboxLiveInboundEndpointPairCreatedEventArgs {}
 unsafe impl Sync for XboxLiveInboundEndpointPairCreatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XboxLiveQualityOfServiceMeasurement(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XboxLiveQualityOfServiceMeasurement, windows_core::IUnknown, windows_core::IInspectable);
 impl XboxLiveQualityOfServiceMeasurement {
@@ -908,7 +908,7 @@ impl windows_core::RuntimeName for XboxLiveQualityOfServiceMeasurement {
 unsafe impl Send for XboxLiveQualityOfServiceMeasurement {}
 unsafe impl Sync for XboxLiveQualityOfServiceMeasurement {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XboxLiveQualityOfServiceMetricResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XboxLiveQualityOfServiceMetricResult, windows_core::IUnknown, windows_core::IInspectable);
 impl XboxLiveQualityOfServiceMetricResult {
@@ -954,7 +954,7 @@ impl windows_core::RuntimeName for XboxLiveQualityOfServiceMetricResult {
 unsafe impl Send for XboxLiveQualityOfServiceMetricResult {}
 unsafe impl Sync for XboxLiveQualityOfServiceMetricResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct XboxLiveQualityOfServicePrivatePayloadResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(XboxLiveQualityOfServicePrivatePayloadResult, windows_core::IUnknown, windows_core::IInspectable);
 impl XboxLiveQualityOfServicePrivatePayloadResult {

--- a/crates/libs/windows/src/Windows/Networking/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/mod.rs
@@ -77,7 +77,7 @@ pub struct IHostNameStatics_Vtbl {
     pub Compare: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, core::mem::MaybeUninit<windows_core::HSTRING>, *mut i32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EndpointPair(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EndpointPair, windows_core::IUnknown, windows_core::IInspectable);
 impl EndpointPair {
@@ -160,7 +160,7 @@ impl windows_core::RuntimeName for EndpointPair {
 unsafe impl Send for EndpointPair {}
 unsafe impl Sync for EndpointPair {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HostName(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HostName, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HostName, super::Foundation::IStringable);

--- a/crates/libs/windows/src/Windows/Perception/People/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/People/mod.rs
@@ -106,7 +106,7 @@ pub struct IHeadPose_Vtbl {
     UpDirection: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EyesPose(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EyesPose, windows_core::IUnknown, windows_core::IInspectable);
 impl EyesPose {
@@ -164,7 +164,7 @@ impl windows_core::RuntimeName for EyesPose {
 unsafe impl Send for EyesPose {}
 unsafe impl Sync for EyesPose {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HandMeshObserver(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HandMeshObserver, windows_core::IUnknown, windows_core::IInspectable);
 impl HandMeshObserver {
@@ -239,7 +239,7 @@ impl windows_core::RuntimeName for HandMeshObserver {
 unsafe impl Send for HandMeshObserver {}
 unsafe impl Sync for HandMeshObserver {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HandMeshVertexState(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HandMeshVertexState, windows_core::IUnknown, windows_core::IInspectable);
 impl HandMeshVertexState {
@@ -277,7 +277,7 @@ impl windows_core::RuntimeName for HandMeshVertexState {
 unsafe impl Send for HandMeshVertexState {}
 unsafe impl Sync for HandMeshVertexState {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HandPose(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HandPose, windows_core::IUnknown, windows_core::IInspectable);
 impl HandPose {
@@ -330,7 +330,7 @@ impl windows_core::RuntimeName for HandPose {
 unsafe impl Send for HandPose {}
 unsafe impl Sync for HandPose {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HeadPose(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HeadPose, windows_core::IUnknown, windows_core::IInspectable);
 impl HeadPose {

--- a/crates/libs/windows/src/Windows/Perception/Spatial/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/Preview/mod.rs
@@ -48,7 +48,7 @@ pub struct ISpatialGraphInteropPreviewStatics2_Vtbl {
     TryCreateFrameOfReferenceWithPositionAndOrientation: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialGraphInteropFrameOfReferencePreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialGraphInteropFrameOfReferencePreview, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialGraphInteropFrameOfReferencePreview {

--- a/crates/libs/windows/src/Windows/Perception/Spatial/Surfaces/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/Surfaces/mod.rs
@@ -141,7 +141,7 @@ pub struct ISpatialSurfaceObserverStatics2_Vtbl {
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialSurfaceInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialSurfaceInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialSurfaceInfo {
@@ -201,7 +201,7 @@ impl windows_core::RuntimeName for SpatialSurfaceInfo {
 unsafe impl Send for SpatialSurfaceInfo {}
 unsafe impl Sync for SpatialSurfaceInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialSurfaceMesh(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialSurfaceMesh, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialSurfaceMesh {
@@ -262,7 +262,7 @@ impl windows_core::RuntimeName for SpatialSurfaceMesh {
 unsafe impl Send for SpatialSurfaceMesh {}
 unsafe impl Sync for SpatialSurfaceMesh {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialSurfaceMeshBuffer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialSurfaceMeshBuffer, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialSurfaceMeshBuffer {
@@ -310,7 +310,7 @@ impl windows_core::RuntimeName for SpatialSurfaceMeshBuffer {
 unsafe impl Send for SpatialSurfaceMeshBuffer {}
 unsafe impl Sync for SpatialSurfaceMeshBuffer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialSurfaceMeshOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialSurfaceMeshOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialSurfaceMeshOptions {
@@ -411,7 +411,7 @@ impl windows_core::RuntimeName for SpatialSurfaceMeshOptions {
 unsafe impl Send for SpatialSurfaceMeshOptions {}
 unsafe impl Sync for SpatialSurfaceMeshOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialSurfaceObserver(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialSurfaceObserver, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialSurfaceObserver {

--- a/crates/libs/windows/src/Windows/Perception/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/mod.rs
@@ -446,7 +446,7 @@ pub struct ISpatialStationaryFrameOfReference_Vtbl {
     pub CoordinateSystem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialAnchor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialAnchor, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialAnchor {
@@ -533,7 +533,7 @@ impl windows_core::RuntimeName for SpatialAnchor {
 unsafe impl Send for SpatialAnchor {}
 unsafe impl Sync for SpatialAnchor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialAnchorExportSufficiency(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialAnchorExportSufficiency, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialAnchorExportSufficiency {
@@ -572,7 +572,7 @@ impl windows_core::RuntimeName for SpatialAnchorExportSufficiency {
 unsafe impl Send for SpatialAnchorExportSufficiency {}
 unsafe impl Sync for SpatialAnchorExportSufficiency {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialAnchorExporter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialAnchorExporter, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialAnchorExporter {
@@ -646,7 +646,7 @@ impl windows_core::RuntimeName for SpatialAnchorManager {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialAnchorManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialAnchorRawCoordinateSystemAdjustedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialAnchorRawCoordinateSystemAdjustedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialAnchorRawCoordinateSystemAdjustedEventArgs {
@@ -672,7 +672,7 @@ impl windows_core::RuntimeName for SpatialAnchorRawCoordinateSystemAdjustedEvent
 unsafe impl Send for SpatialAnchorRawCoordinateSystemAdjustedEventArgs {}
 unsafe impl Sync for SpatialAnchorRawCoordinateSystemAdjustedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialAnchorStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialAnchorStore, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialAnchorStore {
@@ -759,7 +759,7 @@ impl windows_core::RuntimeName for SpatialAnchorTransferManager {
     const NAME: &'static str = "Windows.Perception.Spatial.SpatialAnchorTransferManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialBoundingVolume(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialBoundingVolume, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialBoundingVolume {
@@ -822,7 +822,7 @@ impl windows_core::RuntimeName for SpatialBoundingVolume {
 unsafe impl Send for SpatialBoundingVolume {}
 unsafe impl Sync for SpatialBoundingVolume {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialCoordinateSystem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialCoordinateSystem, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialCoordinateSystem {
@@ -851,7 +851,7 @@ impl windows_core::RuntimeName for SpatialCoordinateSystem {
 unsafe impl Send for SpatialCoordinateSystem {}
 unsafe impl Sync for SpatialCoordinateSystem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialEntity(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialEntity, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialEntity {
@@ -916,7 +916,7 @@ impl windows_core::RuntimeName for SpatialEntity {
 unsafe impl Send for SpatialEntity {}
 unsafe impl Sync for SpatialEntity {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialEntityAddedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialEntityAddedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialEntityAddedEventArgs {
@@ -941,7 +941,7 @@ impl windows_core::RuntimeName for SpatialEntityAddedEventArgs {
 unsafe impl Send for SpatialEntityAddedEventArgs {}
 unsafe impl Sync for SpatialEntityAddedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialEntityRemovedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialEntityRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialEntityRemovedEventArgs {
@@ -966,7 +966,7 @@ impl windows_core::RuntimeName for SpatialEntityRemovedEventArgs {
 unsafe impl Send for SpatialEntityRemovedEventArgs {}
 unsafe impl Sync for SpatialEntityRemovedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialEntityStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialEntityStore, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialEntityStore {
@@ -1032,7 +1032,7 @@ impl windows_core::RuntimeName for SpatialEntityStore {
 unsafe impl Send for SpatialEntityStore {}
 unsafe impl Sync for SpatialEntityStore {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialEntityUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialEntityUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialEntityUpdatedEventArgs {
@@ -1057,7 +1057,7 @@ impl windows_core::RuntimeName for SpatialEntityUpdatedEventArgs {
 unsafe impl Send for SpatialEntityUpdatedEventArgs {}
 unsafe impl Sync for SpatialEntityUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialEntityWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialEntityWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialEntityWatcher {
@@ -1146,7 +1146,7 @@ impl windows_core::RuntimeName for SpatialEntityWatcher {
 unsafe impl Send for SpatialEntityWatcher {}
 unsafe impl Sync for SpatialEntityWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialLocation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialLocation, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialLocation {
@@ -1228,7 +1228,7 @@ impl windows_core::RuntimeName for SpatialLocation {
 unsafe impl Send for SpatialLocation {}
 unsafe impl Sync for SpatialLocation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialLocator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialLocator, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialLocator {
@@ -1365,7 +1365,7 @@ impl windows_core::RuntimeName for SpatialLocator {
 unsafe impl Send for SpatialLocator {}
 unsafe impl Sync for SpatialLocator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialLocatorAttachedFrameOfReference(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialLocatorAttachedFrameOfReference, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialLocatorAttachedFrameOfReference {
@@ -1433,7 +1433,7 @@ impl windows_core::RuntimeName for SpatialLocatorAttachedFrameOfReference {
 unsafe impl Send for SpatialLocatorAttachedFrameOfReference {}
 unsafe impl Sync for SpatialLocatorAttachedFrameOfReference {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialLocatorPositionalTrackingDeactivatingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialLocatorPositionalTrackingDeactivatingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialLocatorPositionalTrackingDeactivatingEventArgs {
@@ -1462,7 +1462,7 @@ impl windows_core::RuntimeName for SpatialLocatorPositionalTrackingDeactivatingE
 unsafe impl Send for SpatialLocatorPositionalTrackingDeactivatingEventArgs {}
 unsafe impl Sync for SpatialLocatorPositionalTrackingDeactivatingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialStageFrameOfReference(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialStageFrameOfReference, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialStageFrameOfReference {
@@ -1551,7 +1551,7 @@ impl windows_core::RuntimeName for SpatialStageFrameOfReference {
 unsafe impl Send for SpatialStageFrameOfReference {}
 unsafe impl Sync for SpatialStageFrameOfReference {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialStationaryFrameOfReference(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialStationaryFrameOfReference, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialStationaryFrameOfReference {

--- a/crates/libs/windows/src/Windows/Perception/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/mod.rs
@@ -42,7 +42,7 @@ pub struct IPerceptionTimestampHelperStatics2_Vtbl {
     pub FromSystemRelativeTargetTime: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::TimeSpan, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PerceptionTimestamp(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PerceptionTimestamp, windows_core::IUnknown, windows_core::IInspectable);
 impl PerceptionTimestamp {

--- a/crates/libs/windows/src/Windows/Phone/Devices/Notification/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Devices/Notification/mod.rs
@@ -18,7 +18,7 @@ pub struct IVibrationDeviceStatics_Vtbl {
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VibrationDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VibrationDevice, windows_core::IUnknown, windows_core::IInspectable);
 impl VibrationDevice {

--- a/crates/libs/windows/src/Windows/Phone/Devices/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Devices/Power/mod.rs
@@ -20,7 +20,7 @@ pub struct IBatteryStatics_Vtbl {
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Battery(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Battery, windows_core::IUnknown, windows_core::IInspectable);
 impl Battery {

--- a/crates/libs/windows/src/Windows/Phone/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Management/Deployment/mod.rs
@@ -103,7 +103,7 @@ pub struct IPackageInstallResult2_Vtbl {
     pub ErrorText: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Enterprise(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Enterprise, windows_core::IUnknown, windows_core::IInspectable);
 impl Enterprise {
@@ -208,7 +208,7 @@ impl windows_core::RuntimeName for EnterpriseEnrollmentManager {
     const NAME: &'static str = "Windows.Phone.Management.Deployment.EnterpriseEnrollmentManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EnterpriseEnrollmentResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EnterpriseEnrollmentResult, windows_core::IUnknown, windows_core::IInspectable);
 impl EnterpriseEnrollmentResult {
@@ -319,7 +319,7 @@ impl windows_core::RuntimeName for InstallationManager {
     const NAME: &'static str = "Windows.Phone.Management.Deployment.InstallationManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PackageInstallResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PackageInstallResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PackageInstallResult {

--- a/crates/libs/windows/src/Windows/Phone/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Media/Devices/mod.rs
@@ -21,7 +21,7 @@ pub struct IAudioRoutingManagerStatics_Vtbl {
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AudioRoutingManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AudioRoutingManager, windows_core::IUnknown, windows_core::IInspectable);
 impl AudioRoutingManager {

--- a/crates/libs/windows/src/Windows/Phone/Notification/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Notification/Management/mod.rs
@@ -756,7 +756,7 @@ impl windows_core::RuntimeName for AccessoryManager {
     const NAME: &'static str = "Windows.Phone.Notification.Management.AccessoryManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AlarmNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AlarmNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AlarmNotificationTriggerDetails, IAccessoryNotificationTriggerDetails);
@@ -847,7 +847,7 @@ impl windows_core::RuntimeName for AlarmNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.AlarmNotificationTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppNotificationInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppNotificationInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AppNotificationInfo {
@@ -877,7 +877,7 @@ impl windows_core::RuntimeName for AppNotificationInfo {
     const NAME: &'static str = "Windows.Phone.Notification.Management.AppNotificationInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BinaryId(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BinaryId, windows_core::IUnknown, windows_core::IInspectable);
 impl BinaryId {
@@ -907,7 +907,7 @@ impl windows_core::RuntimeName for BinaryId {
     const NAME: &'static str = "Windows.Phone.Notification.Management.BinaryId";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CalendarChangedNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CalendarChangedNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CalendarChangedNotificationTriggerDetails, IAccessoryNotificationTriggerDetails);
@@ -977,7 +977,7 @@ impl windows_core::RuntimeName for CalendarChangedNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.CalendarChangedNotificationTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CortanaTileNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CortanaTileNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CortanaTileNotificationTriggerDetails, IAccessoryNotificationTriggerDetails);
@@ -1103,7 +1103,7 @@ impl windows_core::RuntimeName for CortanaTileNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.CortanaTileNotificationTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailAccountInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailAccountInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailAccountInfo {
@@ -1133,7 +1133,7 @@ impl windows_core::RuntimeName for EmailAccountInfo {
     const NAME: &'static str = "Windows.Phone.Notification.Management.EmailAccountInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailFolderInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailFolderInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailFolderInfo {
@@ -1163,7 +1163,7 @@ impl windows_core::RuntimeName for EmailFolderInfo {
     const NAME: &'static str = "Windows.Phone.Notification.Management.EmailFolderInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(EmailNotificationTriggerDetails, IAccessoryNotificationTriggerDetails);
@@ -1269,7 +1269,7 @@ impl windows_core::RuntimeName for EmailNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.EmailNotificationTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EmailReadNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailReadNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(EmailReadNotificationTriggerDetails, IAccessoryNotificationTriggerDetails);
@@ -1353,7 +1353,7 @@ impl windows_core::RuntimeName for EmailReadNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.EmailReadNotificationTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaControlsTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaControlsTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MediaControlsTriggerDetails, IAccessoryNotificationTriggerDetails);
@@ -1423,7 +1423,7 @@ impl windows_core::RuntimeName for MediaControlsTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.MediaControlsTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MediaMetadata(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaMetadata, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaMetadata {
@@ -1489,7 +1489,7 @@ impl windows_core::RuntimeName for MediaMetadata {
     const NAME: &'static str = "Windows.Phone.Notification.Management.MediaMetadata";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneCallDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneCallDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneCallDetails {
@@ -1590,7 +1590,7 @@ impl windows_core::RuntimeName for PhoneCallDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.PhoneCallDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneLineDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneLineDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl PhoneLineDetails {
@@ -1655,7 +1655,7 @@ impl windows_core::RuntimeName for PhoneLineDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.PhoneLineDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PhoneNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PhoneNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PhoneNotificationTriggerDetails, IAccessoryNotificationTriggerDetails);
@@ -1732,7 +1732,7 @@ impl windows_core::RuntimeName for PhoneNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.PhoneNotificationTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ReminderNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ReminderNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ReminderNotificationTriggerDetails, IAccessoryNotificationTriggerDetails);
@@ -1845,7 +1845,7 @@ impl windows_core::RuntimeName for ReminderNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.ReminderNotificationTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpeedDialEntry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpeedDialEntry, windows_core::IUnknown, windows_core::IInspectable);
 impl SpeedDialEntry {
@@ -1882,7 +1882,7 @@ impl windows_core::RuntimeName for SpeedDialEntry {
     const NAME: &'static str = "Windows.Phone.Notification.Management.SpeedDialEntry";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TextResponse(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TextResponse, windows_core::IUnknown, windows_core::IInspectable);
 impl TextResponse {
@@ -1912,7 +1912,7 @@ impl windows_core::RuntimeName for TextResponse {
     const NAME: &'static str = "Windows.Phone.Notification.Management.TextResponse";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ToastNotificationTriggerDetails, IAccessoryNotificationTriggerDetails);
@@ -2010,7 +2010,7 @@ impl windows_core::RuntimeName for ToastNotificationTriggerDetails {
     const NAME: &'static str = "Windows.Phone.Notification.Management.ToastNotificationTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VolumeInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VolumeInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl VolumeInfo {

--- a/crates/libs/windows/src/Windows/Phone/PersonalInformation/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/PersonalInformation/mod.rs
@@ -379,7 +379,7 @@ pub struct IStoredContactFactory_Vtbl {
     pub CreateStoredContactFromInformation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactAddress(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactAddress, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactAddress {
@@ -459,7 +459,7 @@ impl windows_core::RuntimeName for ContactAddress {
 unsafe impl Send for ContactAddress {}
 unsafe impl Sync for ContactAddress {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactChangeRecord(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactChangeRecord, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactChangeRecord {
@@ -505,7 +505,7 @@ impl windows_core::RuntimeName for ContactChangeRecord {
 unsafe impl Send for ContactChangeRecord {}
 unsafe impl Sync for ContactChangeRecord {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactInformation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContactInformation, IContactInformation);
@@ -652,7 +652,7 @@ impl windows_core::RuntimeName for ContactInformation {
 unsafe impl Send for ContactInformation {}
 unsafe impl Sync for ContactInformation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactQueryOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactQueryOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactQueryOptions {
@@ -696,7 +696,7 @@ impl windows_core::RuntimeName for ContactQueryOptions {
 unsafe impl Send for ContactQueryOptions {}
 unsafe impl Sync for ContactQueryOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactQueryResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactQueryResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactQueryResult {
@@ -744,7 +744,7 @@ impl windows_core::RuntimeName for ContactQueryResult {
 unsafe impl Send for ContactQueryResult {}
 unsafe impl Sync for ContactQueryResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContactStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactStore, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactStore {
@@ -1086,7 +1086,7 @@ impl windows_core::RuntimeName for KnownContactProperties {
     const NAME: &'static str = "Windows.Phone.PersonalInformation.KnownContactProperties";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoredContact(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoredContact, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StoredContact, IContactInformation, IContactInformation2);

--- a/crates/libs/windows/src/Windows/Phone/StartScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/StartScreen/mod.rs
@@ -76,7 +76,7 @@ pub struct IToastNotificationManagerStatics3_Vtbl {
     CreateToastNotifierForSecondaryTile: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DualSimTile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DualSimTile, windows_core::IUnknown, windows_core::IInspectable);
 impl DualSimTile {

--- a/crates/libs/windows/src/Windows/Phone/System/UserProfile/GameServices/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/System/UserProfile/GameServices/Core/mod.rs
@@ -111,7 +111,7 @@ impl windows_core::RuntimeName for GameService {
     const NAME: &'static str = "Windows.Phone.System.UserProfile.GameServices.Core.GameService";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GameServicePropertyCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GameServicePropertyCollection, windows_core::IUnknown, windows_core::IInspectable);
 impl GameServicePropertyCollection {

--- a/crates/libs/windows/src/Windows/Phone/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/UI/Input/mod.rs
@@ -41,7 +41,7 @@ pub struct IHardwareButtonsStatics2_Vtbl {
     pub RemoveCameraReleased: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackPressedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackPressedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BackPressedEventArgs {
@@ -70,7 +70,7 @@ impl windows_core::RuntimeName for BackPressedEventArgs {
 unsafe impl Send for BackPressedEventArgs {}
 unsafe impl Sync for BackPressedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CameraEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CameraEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CameraEventArgs {}

--- a/crates/libs/windows/src/Windows/Security/Authentication/Identity/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Identity/Core/mod.rs
@@ -89,7 +89,7 @@ pub struct IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo_Vtbl {
     pub ServiceResponse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MicrosoftAccountMultiFactorServiceResponse) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MicrosoftAccountMultiFactorAuthenticationManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MicrosoftAccountMultiFactorAuthenticationManager, windows_core::IUnknown, windows_core::IInspectable);
 impl MicrosoftAccountMultiFactorAuthenticationManager {
@@ -202,7 +202,7 @@ impl windows_core::RuntimeName for MicrosoftAccountMultiFactorAuthenticationMana
 unsafe impl Send for MicrosoftAccountMultiFactorAuthenticationManager {}
 unsafe impl Sync for MicrosoftAccountMultiFactorAuthenticationManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MicrosoftAccountMultiFactorGetSessionsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MicrosoftAccountMultiFactorGetSessionsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MicrosoftAccountMultiFactorGetSessionsResult {
@@ -235,7 +235,7 @@ impl windows_core::RuntimeName for MicrosoftAccountMultiFactorGetSessionsResult 
 unsafe impl Send for MicrosoftAccountMultiFactorGetSessionsResult {}
 unsafe impl Sync for MicrosoftAccountMultiFactorGetSessionsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MicrosoftAccountMultiFactorOneTimeCodedInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MicrosoftAccountMultiFactorOneTimeCodedInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl MicrosoftAccountMultiFactorOneTimeCodedInfo {
@@ -281,7 +281,7 @@ impl windows_core::RuntimeName for MicrosoftAccountMultiFactorOneTimeCodedInfo {
 unsafe impl Send for MicrosoftAccountMultiFactorOneTimeCodedInfo {}
 unsafe impl Sync for MicrosoftAccountMultiFactorOneTimeCodedInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MicrosoftAccountMultiFactorSessionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MicrosoftAccountMultiFactorSessionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl MicrosoftAccountMultiFactorSessionInfo {
@@ -348,7 +348,7 @@ impl windows_core::RuntimeName for MicrosoftAccountMultiFactorSessionInfo {
 unsafe impl Send for MicrosoftAccountMultiFactorSessionInfo {}
 unsafe impl Sync for MicrosoftAccountMultiFactorSessionInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo {

--- a/crates/libs/windows/src/Windows/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Identity/mod.rs
@@ -35,7 +35,7 @@ pub struct IEnterpriseKeyCredentialRegistrationManagerStatics_Vtbl {
     pub Current: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EnterpriseKeyCredentialRegistrationInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EnterpriseKeyCredentialRegistrationInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl EnterpriseKeyCredentialRegistrationInfo {
@@ -88,7 +88,7 @@ impl windows_core::RuntimeName for EnterpriseKeyCredentialRegistrationInfo {
 unsafe impl Send for EnterpriseKeyCredentialRegistrationInfo {}
 unsafe impl Sync for EnterpriseKeyCredentialRegistrationInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EnterpriseKeyCredentialRegistrationManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EnterpriseKeyCredentialRegistrationManager, windows_core::IUnknown, windows_core::IInspectable);
 impl EnterpriseKeyCredentialRegistrationManager {

--- a/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
@@ -116,7 +116,7 @@ pub struct IUserIdentity_Vtbl {
     pub IsConfirmedPC: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OnlineIdAuthenticator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OnlineIdAuthenticator, windows_core::IUnknown, windows_core::IInspectable);
 impl OnlineIdAuthenticator {
@@ -194,7 +194,7 @@ impl windows_core::RuntimeName for OnlineIdAuthenticator {
 unsafe impl Send for OnlineIdAuthenticator {}
 unsafe impl Sync for OnlineIdAuthenticator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OnlineIdServiceTicket(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OnlineIdServiceTicket, windows_core::IUnknown, windows_core::IInspectable);
 impl OnlineIdServiceTicket {
@@ -233,7 +233,7 @@ impl windows_core::RuntimeName for OnlineIdServiceTicket {
 unsafe impl Send for OnlineIdServiceTicket {}
 unsafe impl Sync for OnlineIdServiceTicket {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OnlineIdServiceTicketRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OnlineIdServiceTicketRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl OnlineIdServiceTicketRequest {
@@ -309,7 +309,7 @@ impl windows_core::RuntimeName for OnlineIdSystemAuthenticator {
     const NAME: &'static str = "Windows.Security.Authentication.OnlineId.OnlineIdSystemAuthenticator";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OnlineIdSystemAuthenticatorForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OnlineIdSystemAuthenticatorForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl OnlineIdSystemAuthenticatorForUser {
@@ -356,7 +356,7 @@ impl windows_core::RuntimeName for OnlineIdSystemAuthenticatorForUser {
 unsafe impl Send for OnlineIdSystemAuthenticatorForUser {}
 unsafe impl Sync for OnlineIdSystemAuthenticatorForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OnlineIdSystemIdentity(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OnlineIdSystemIdentity, windows_core::IUnknown, windows_core::IInspectable);
 impl OnlineIdSystemIdentity {
@@ -388,7 +388,7 @@ impl windows_core::RuntimeName for OnlineIdSystemIdentity {
 unsafe impl Send for OnlineIdSystemIdentity {}
 unsafe impl Sync for OnlineIdSystemIdentity {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OnlineIdSystemTicketResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OnlineIdSystemTicketResult, windows_core::IUnknown, windows_core::IInspectable);
 impl OnlineIdSystemTicketResult {
@@ -427,7 +427,7 @@ impl windows_core::RuntimeName for OnlineIdSystemTicketResult {
 unsafe impl Send for OnlineIdSystemTicketResult {}
 unsafe impl Sync for OnlineIdSystemTicketResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SignOutUserOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SignOutUserOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SignOutUserOperation, super::super::super::Foundation::IAsyncAction, super::super::super::Foundation::IAsyncInfo);
@@ -522,7 +522,7 @@ impl std::future::Future for SignOutUserOperation {
 unsafe impl Send for SignOutUserOperation {}
 unsafe impl Sync for SignOutUserOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserAuthenticationOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserAuthenticationOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UserAuthenticationOperation, super::super::super::Foundation::IAsyncInfo, super::super::super::Foundation::IAsyncOperation::<UserIdentity>);
@@ -620,7 +620,7 @@ impl std::future::Future for UserAuthenticationOperation {
 unsafe impl Send for UserAuthenticationOperation {}
 unsafe impl Sync for UserAuthenticationOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserIdentity(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserIdentity, windows_core::IUnknown, windows_core::IInspectable);
 impl UserIdentity {

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Core/mod.rs
@@ -269,7 +269,7 @@ pub struct IWebTokenResponseFactory_Vtbl {
     CreateWithTokenAccountAndError: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FindAllAccountsResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FindAllAccountsResult, windows_core::IUnknown, windows_core::IInspectable);
 impl FindAllAccountsResult {
@@ -309,7 +309,7 @@ impl windows_core::RuntimeName for FindAllAccountsResult {
 unsafe impl Send for FindAllAccountsResult {}
 unsafe impl Sync for FindAllAccountsResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebAccountEventArgs {
@@ -335,7 +335,7 @@ impl windows_core::RuntimeName for WebAccountEventArgs {
 unsafe impl Send for WebAccountEventArgs {}
 unsafe impl Sync for WebAccountEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountMonitor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountMonitor, windows_core::IUnknown, windows_core::IInspectable);
 impl WebAccountMonitor {
@@ -563,7 +563,7 @@ impl windows_core::RuntimeName for WebAuthenticationCoreManager {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Core.WebAuthenticationCoreManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebProviderError(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebProviderError, windows_core::IUnknown, windows_core::IInspectable);
 impl WebProviderError {
@@ -614,7 +614,7 @@ impl windows_core::RuntimeName for WebProviderError {
 unsafe impl Send for WebProviderError {}
 unsafe impl Sync for WebProviderError {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebTokenRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebTokenRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl WebTokenRequest {
@@ -733,7 +733,7 @@ impl windows_core::RuntimeName for WebTokenRequest {
 unsafe impl Send for WebTokenRequest {}
 unsafe impl Sync for WebTokenRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebTokenRequestResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebTokenRequestResult, windows_core::IUnknown, windows_core::IInspectable);
 impl WebTokenRequestResult {
@@ -780,7 +780,7 @@ impl windows_core::RuntimeName for WebTokenRequestResult {
 unsafe impl Send for WebTokenRequestResult {}
 unsafe impl Sync for WebTokenRequestResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebTokenResponse(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebTokenResponse, windows_core::IUnknown, windows_core::IInspectable);
 impl WebTokenResponse {

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
@@ -552,7 +552,7 @@ pub struct IWebProviderTokenResponseFactory_Vtbl {
     Create: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountClientView(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountClientView, windows_core::IUnknown, windows_core::IInspectable);
 impl WebAccountClientView {
@@ -887,7 +887,7 @@ impl windows_core::RuntimeName for WebAccountManager {
     const NAME: &'static str = "Windows.Security.Authentication.Web.Provider.WebAccountManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProviderAddAccountOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProviderAddAccountOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAccountProviderAddAccountOperation, IWebAccountProviderOperation);
@@ -917,7 +917,7 @@ impl windows_core::RuntimeName for WebAccountProviderAddAccountOperation {
 unsafe impl Send for WebAccountProviderAddAccountOperation {}
 unsafe impl Sync for WebAccountProviderAddAccountOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProviderDeleteAccountOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProviderDeleteAccountOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAccountProviderDeleteAccountOperation, IWebAccountProviderBaseReportOperation, IWebAccountProviderOperation);
@@ -963,7 +963,7 @@ impl windows_core::RuntimeName for WebAccountProviderDeleteAccountOperation {
 unsafe impl Send for WebAccountProviderDeleteAccountOperation {}
 unsafe impl Sync for WebAccountProviderDeleteAccountOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProviderGetTokenSilentOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProviderGetTokenSilentOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAccountProviderGetTokenSilentOperation, IWebAccountProviderBaseReportOperation, IWebAccountProviderOperation, IWebAccountProviderSilentReportOperation, IWebAccountProviderTokenOperation);
@@ -1039,7 +1039,7 @@ impl windows_core::RuntimeName for WebAccountProviderGetTokenSilentOperation {
 unsafe impl Send for WebAccountProviderGetTokenSilentOperation {}
 unsafe impl Sync for WebAccountProviderGetTokenSilentOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProviderManageAccountOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProviderManageAccountOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAccountProviderManageAccountOperation, IWebAccountProviderOperation);
@@ -1077,7 +1077,7 @@ impl windows_core::RuntimeName for WebAccountProviderManageAccountOperation {
 unsafe impl Send for WebAccountProviderManageAccountOperation {}
 unsafe impl Sync for WebAccountProviderManageAccountOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProviderRequestTokenOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProviderRequestTokenOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAccountProviderRequestTokenOperation, IWebAccountProviderBaseReportOperation, IWebAccountProviderOperation, IWebAccountProviderTokenOperation, IWebAccountProviderUIReportOperation);
@@ -1145,7 +1145,7 @@ impl windows_core::RuntimeName for WebAccountProviderRequestTokenOperation {
 unsafe impl Send for WebAccountProviderRequestTokenOperation {}
 unsafe impl Sync for WebAccountProviderRequestTokenOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProviderRetrieveCookiesOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProviderRetrieveCookiesOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAccountProviderRetrieveCookiesOperation, IWebAccountProviderBaseReportOperation, IWebAccountProviderOperation);
@@ -1219,7 +1219,7 @@ impl windows_core::RuntimeName for WebAccountProviderRetrieveCookiesOperation {
 unsafe impl Send for WebAccountProviderRetrieveCookiesOperation {}
 unsafe impl Sync for WebAccountProviderRetrieveCookiesOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProviderSignOutAccountOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProviderSignOutAccountOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAccountProviderSignOutAccountOperation, IWebAccountProviderBaseReportOperation, IWebAccountProviderOperation);
@@ -1279,7 +1279,7 @@ impl windows_core::RuntimeName for WebAccountProviderSignOutAccountOperation {
 unsafe impl Send for WebAccountProviderSignOutAccountOperation {}
 unsafe impl Sync for WebAccountProviderSignOutAccountOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProviderTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProviderTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAccountProviderTriggerDetails, IWebAccountProviderTokenObjects, IWebAccountProviderTokenObjects2);
@@ -1313,7 +1313,7 @@ impl windows_core::RuntimeName for WebAccountProviderTriggerDetails {
 unsafe impl Send for WebAccountProviderTriggerDetails {}
 unsafe impl Sync for WebAccountProviderTriggerDetails {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebProviderTokenRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebProviderTokenRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl WebProviderTokenRequest {
@@ -1404,7 +1404,7 @@ impl windows_core::RuntimeName for WebProviderTokenRequest {
 unsafe impl Send for WebProviderTokenRequest {}
 unsafe impl Sync for WebProviderTokenRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebProviderTokenResponse(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebProviderTokenResponse, windows_core::IUnknown, windows_core::IInspectable);
 impl WebProviderTokenResponse {

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
@@ -122,7 +122,7 @@ impl windows_core::RuntimeName for WebAuthenticationBroker {
     const NAME: &'static str = "Windows.Security.Authentication.Web.WebAuthenticationBroker";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAuthenticationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAuthenticationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl WebAuthenticationResult {

--- a/crates/libs/windows/src/Windows/Security/Authorization/AppCapabilityAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authorization/AppCapabilityAccess/mod.rs
@@ -55,7 +55,7 @@ pub struct IAppCapabilityStatics_Vtbl {
     CreateWithProcessIdForUser: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCapability(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCapability, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCapability {
@@ -169,7 +169,7 @@ impl windows_core::RuntimeName for AppCapability {
 unsafe impl Send for AppCapability {}
 unsafe impl Sync for AppCapability {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppCapabilityAccessChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCapabilityAccessChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCapabilityAccessChangedEventArgs {}

--- a/crates/libs/windows/src/Windows/Security/Credentials/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/UI/mod.rs
@@ -104,7 +104,7 @@ impl windows_core::RuntimeName for CredentialPicker {
     const NAME: &'static str = "Windows.Security.Credentials.UI.CredentialPicker";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CredentialPickerOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CredentialPickerOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl CredentialPickerOptions {
@@ -242,7 +242,7 @@ impl windows_core::RuntimeName for CredentialPickerOptions {
     const NAME: &'static str = "Windows.Security.Credentials.UI.CredentialPickerOptions";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CredentialPickerResults(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CredentialPickerResults, windows_core::IUnknown, windows_core::IInspectable);
 impl CredentialPickerResults {

--- a/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
@@ -250,7 +250,7 @@ pub struct IWebAccountProviderFactory_Vtbl {
     pub CreateWebAccountProvider: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, core::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeyCredential(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeyCredential, windows_core::IUnknown, windows_core::IInspectable);
 impl KeyCredential {
@@ -309,7 +309,7 @@ impl windows_core::RuntimeName for KeyCredential {
 unsafe impl Send for KeyCredential {}
 unsafe impl Sync for KeyCredential {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeyCredentialAttestationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeyCredentialAttestationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl KeyCredentialAttestationResult {
@@ -391,7 +391,7 @@ impl windows_core::RuntimeName for KeyCredentialManager {
     const NAME: &'static str = "Windows.Security.Credentials.KeyCredentialManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeyCredentialOperationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeyCredentialOperationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl KeyCredentialOperationResult {
@@ -424,7 +424,7 @@ impl windows_core::RuntimeName for KeyCredentialOperationResult {
 unsafe impl Send for KeyCredentialOperationResult {}
 unsafe impl Sync for KeyCredentialOperationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeyCredentialRetrievalResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeyCredentialRetrievalResult, windows_core::IUnknown, windows_core::IInspectable);
 impl KeyCredentialRetrievalResult {
@@ -456,7 +456,7 @@ impl windows_core::RuntimeName for KeyCredentialRetrievalResult {
 unsafe impl Send for KeyCredentialRetrievalResult {}
 unsafe impl Sync for KeyCredentialRetrievalResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PasswordCredential(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PasswordCredential, windows_core::IUnknown, windows_core::IInspectable);
 impl PasswordCredential {
@@ -538,7 +538,7 @@ unsafe impl Send for PasswordCredential {}
 unsafe impl Sync for PasswordCredential {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PasswordCredentialPropertyStore(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(PasswordCredentialPropertyStore, windows_core::IUnknown, windows_core::IInspectable);
@@ -665,7 +665,7 @@ unsafe impl Send for PasswordCredentialPropertyStore {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for PasswordCredentialPropertyStore {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PasswordVault(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PasswordVault, windows_core::IUnknown, windows_core::IInspectable);
 impl PasswordVault {
@@ -735,7 +735,7 @@ impl windows_core::RuntimeName for PasswordVault {
 unsafe impl Send for PasswordVault {}
 unsafe impl Sync for PasswordVault {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccount(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccount, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebAccount, IWebAccount);
@@ -826,7 +826,7 @@ impl windows_core::RuntimeName for WebAccount {
 unsafe impl Send for WebAccount {}
 unsafe impl Sync for WebAccount {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl WebAccountProvider {

--- a/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
@@ -662,7 +662,7 @@ pub struct IUserCertificateStore_Vtbl {
     pub Name: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Certificate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Certificate, windows_core::IUnknown, windows_core::IInspectable);
 impl Certificate {
@@ -871,7 +871,7 @@ impl windows_core::RuntimeName for Certificate {
 unsafe impl Send for Certificate {}
 unsafe impl Sync for Certificate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CertificateChain(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CertificateChain, windows_core::IUnknown, windows_core::IInspectable);
 impl CertificateChain {
@@ -977,7 +977,7 @@ impl windows_core::RuntimeName for CertificateEnrollmentManager {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CertificateEnrollmentManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CertificateExtension(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CertificateExtension, windows_core::IUnknown, windows_core::IInspectable);
 impl CertificateExtension {
@@ -1039,7 +1039,7 @@ impl windows_core::RuntimeName for CertificateExtension {
 unsafe impl Send for CertificateExtension {}
 unsafe impl Sync for CertificateExtension {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CertificateKeyUsages(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CertificateKeyUsages, windows_core::IUnknown, windows_core::IInspectable);
 impl CertificateKeyUsages {
@@ -1152,7 +1152,7 @@ impl windows_core::RuntimeName for CertificateKeyUsages {
 unsafe impl Send for CertificateKeyUsages {}
 unsafe impl Sync for CertificateKeyUsages {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CertificateQuery(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CertificateQuery, windows_core::IUnknown, windows_core::IInspectable);
 impl CertificateQuery {
@@ -1262,7 +1262,7 @@ impl windows_core::RuntimeName for CertificateQuery {
 unsafe impl Send for CertificateQuery {}
 unsafe impl Sync for CertificateQuery {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CertificateRequestProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CertificateRequestProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl CertificateRequestProperties {
@@ -1503,7 +1503,7 @@ impl windows_core::RuntimeName for CertificateRequestProperties {
 unsafe impl Send for CertificateRequestProperties {}
 unsafe impl Sync for CertificateRequestProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CertificateStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CertificateStore, windows_core::IUnknown, windows_core::IInspectable);
 impl CertificateStore {
@@ -1599,7 +1599,7 @@ impl windows_core::RuntimeName for CertificateStores {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.CertificateStores";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChainBuildingParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChainBuildingParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl ChainBuildingParameters {
@@ -1695,7 +1695,7 @@ impl windows_core::RuntimeName for ChainBuildingParameters {
 unsafe impl Send for ChainBuildingParameters {}
 unsafe impl Sync for ChainBuildingParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ChainValidationParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ChainValidationParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl ChainValidationParameters {
@@ -1747,7 +1747,7 @@ impl windows_core::RuntimeName for ChainValidationParameters {
 unsafe impl Send for ChainValidationParameters {}
 unsafe impl Sync for ChainValidationParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CmsAttachedSignature(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CmsAttachedSignature, windows_core::IUnknown, windows_core::IInspectable);
 impl CmsAttachedSignature {
@@ -1827,7 +1827,7 @@ impl windows_core::RuntimeName for CmsAttachedSignature {
 unsafe impl Send for CmsAttachedSignature {}
 unsafe impl Sync for CmsAttachedSignature {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CmsDetachedSignature(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CmsDetachedSignature, windows_core::IUnknown, windows_core::IInspectable);
 impl CmsDetachedSignature {
@@ -1904,7 +1904,7 @@ impl windows_core::RuntimeName for CmsDetachedSignature {
 unsafe impl Send for CmsDetachedSignature {}
 unsafe impl Sync for CmsDetachedSignature {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CmsSignerInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CmsSignerInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl CmsSignerInfo {
@@ -1961,7 +1961,7 @@ impl windows_core::RuntimeName for CmsSignerInfo {
 unsafe impl Send for CmsSignerInfo {}
 unsafe impl Sync for CmsSignerInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CmsTimestampInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CmsTimestampInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl CmsTimestampInfo {
@@ -2151,7 +2151,7 @@ impl windows_core::RuntimeName for KeyStorageProviderNames {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.KeyStorageProviderNames";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PfxImportParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PfxImportParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl PfxImportParameters {
@@ -2282,7 +2282,7 @@ impl windows_core::RuntimeName for StandardCertificateStoreNames {
     const NAME: &'static str = "Windows.Security.Cryptography.Certificates.StandardCertificateStoreNames";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SubjectAlternativeNameInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SubjectAlternativeNameInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl SubjectAlternativeNameInfo {
@@ -2410,7 +2410,7 @@ impl windows_core::RuntimeName for SubjectAlternativeNameInfo {
 unsafe impl Send for SubjectAlternativeNameInfo {}
 unsafe impl Sync for SubjectAlternativeNameInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserCertificateEnrollmentManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserCertificateEnrollmentManager, windows_core::IUnknown, windows_core::IInspectable);
 impl UserCertificateEnrollmentManager {
@@ -2469,7 +2469,7 @@ impl windows_core::RuntimeName for UserCertificateEnrollmentManager {
 unsafe impl Send for UserCertificateEnrollmentManager {}
 unsafe impl Sync for UserCertificateEnrollmentManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserCertificateStore(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserCertificateStore, windows_core::IUnknown, windows_core::IInspectable);
 impl UserCertificateStore {

--- a/crates/libs/windows/src/Windows/Security/Cryptography/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/Core/mod.rs
@@ -667,7 +667,7 @@ impl windows_core::RuntimeName for AsymmetricAlgorithmNames {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.AsymmetricAlgorithmNames";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AsymmetricKeyAlgorithmProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AsymmetricKeyAlgorithmProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl AsymmetricKeyAlgorithmProvider {
@@ -926,7 +926,7 @@ impl windows_core::RuntimeName for CryptographicEngine {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.CryptographicEngine";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CryptographicHash(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CryptographicHash, windows_core::IUnknown, windows_core::IInspectable);
 impl CryptographicHash {
@@ -960,7 +960,7 @@ impl windows_core::RuntimeName for CryptographicHash {
 unsafe impl Send for CryptographicHash {}
 unsafe impl Sync for CryptographicHash {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CryptographicKey(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CryptographicKey, windows_core::IUnknown, windows_core::IInspectable);
 impl CryptographicKey {
@@ -1305,7 +1305,7 @@ impl windows_core::RuntimeName for EccCurveNames {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.EccCurveNames";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EncryptedAndAuthenticatedData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EncryptedAndAuthenticatedData, windows_core::IUnknown, windows_core::IInspectable);
 impl EncryptedAndAuthenticatedData {
@@ -1380,7 +1380,7 @@ impl windows_core::RuntimeName for HashAlgorithmNames {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.HashAlgorithmNames";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HashAlgorithmProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HashAlgorithmProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl HashAlgorithmProvider {
@@ -1577,7 +1577,7 @@ impl windows_core::RuntimeName for KeyDerivationAlgorithmNames {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.KeyDerivationAlgorithmNames";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeyDerivationAlgorithmProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeyDerivationAlgorithmProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl KeyDerivationAlgorithmProvider {
@@ -1624,7 +1624,7 @@ impl windows_core::RuntimeName for KeyDerivationAlgorithmProvider {
 unsafe impl Send for KeyDerivationAlgorithmProvider {}
 unsafe impl Sync for KeyDerivationAlgorithmProvider {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeyDerivationParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeyDerivationParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl KeyDerivationParameters {
@@ -1774,7 +1774,7 @@ impl windows_core::RuntimeName for MacAlgorithmNames {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.MacAlgorithmNames";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MacAlgorithmProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MacAlgorithmProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl MacAlgorithmProvider {
@@ -1995,7 +1995,7 @@ impl windows_core::RuntimeName for SymmetricAlgorithmNames {
     const NAME: &'static str = "Windows.Security.Cryptography.Core.SymmetricAlgorithmNames";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SymmetricKeyAlgorithmProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SymmetricKeyAlgorithmProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl SymmetricKeyAlgorithmProvider {

--- a/crates/libs/windows/src/Windows/Security/Cryptography/DataProtection/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/DataProtection/mod.rs
@@ -32,7 +32,7 @@ pub struct IDataProtectionProviderFactory_Vtbl {
     pub CreateOverloadExplicit: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataProtectionProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataProtectionProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl DataProtectionProvider {

--- a/crates/libs/windows/src/Windows/Security/DataProtection/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/DataProtection/mod.rs
@@ -70,7 +70,7 @@ pub struct IUserDataStorageItemProtectionInfo_Vtbl {
     pub Availability: unsafe extern "system" fn(*mut core::ffi::c_void, *mut UserDataAvailability) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataAvailabilityStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataAvailabilityStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataAvailabilityStateChangedEventArgs {
@@ -95,7 +95,7 @@ impl windows_core::RuntimeName for UserDataAvailabilityStateChangedEventArgs {
 unsafe impl Send for UserDataAvailabilityStateChangedEventArgs {}
 unsafe impl Sync for UserDataAvailabilityStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataBufferUnprotectResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataBufferUnprotectResult, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataBufferUnprotectResult {
@@ -128,7 +128,7 @@ impl windows_core::RuntimeName for UserDataBufferUnprotectResult {
 unsafe impl Send for UserDataBufferUnprotectResult {}
 unsafe impl Sync for UserDataBufferUnprotectResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataProtectionManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataProtectionManager, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataProtectionManager {
@@ -232,7 +232,7 @@ impl windows_core::RuntimeName for UserDataProtectionManager {
 unsafe impl Send for UserDataProtectionManager {}
 unsafe impl Sync for UserDataProtectionManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataStorageItemProtectionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataStorageItemProtectionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataStorageItemProtectionInfo {

--- a/crates/libs/windows/src/Windows/Security/EnterpriseData/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/EnterpriseData/mod.rs
@@ -420,7 +420,7 @@ pub struct IThreadNetworkContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BufferProtectUnprotectResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BufferProtectUnprotectResult, windows_core::IUnknown, windows_core::IInspectable);
 impl BufferProtectUnprotectResult {
@@ -453,7 +453,7 @@ impl windows_core::RuntimeName for BufferProtectUnprotectResult {
 unsafe impl Send for BufferProtectUnprotectResult {}
 unsafe impl Sync for BufferProtectUnprotectResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataProtectionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataProtectionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl DataProtectionInfo {
@@ -558,7 +558,7 @@ impl windows_core::RuntimeName for DataProtectionManager {
     const NAME: &'static str = "Windows.Security.EnterpriseData.DataProtectionManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileProtectionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileProtectionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl FileProtectionInfo {
@@ -800,7 +800,7 @@ impl windows_core::RuntimeName for FileRevocationManager {
     const NAME: &'static str = "Windows.Security.EnterpriseData.FileRevocationManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileUnprotectOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileUnprotectOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl FileUnprotectOptions {
@@ -840,7 +840,7 @@ impl windows_core::RuntimeName for FileUnprotectOptions {
 unsafe impl Send for FileUnprotectOptions {}
 unsafe impl Sync for FileUnprotectOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtectedAccessResumedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtectedAccessResumedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ProtectedAccessResumedEventArgs {
@@ -866,7 +866,7 @@ impl windows_core::RuntimeName for ProtectedAccessResumedEventArgs {
 unsafe impl Send for ProtectedAccessResumedEventArgs {}
 unsafe impl Sync for ProtectedAccessResumedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtectedAccessSuspendingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtectedAccessSuspendingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ProtectedAccessSuspendingEventArgs {
@@ -906,7 +906,7 @@ impl windows_core::RuntimeName for ProtectedAccessSuspendingEventArgs {
 unsafe impl Send for ProtectedAccessSuspendingEventArgs {}
 unsafe impl Sync for ProtectedAccessSuspendingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtectedContainerExportResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtectedContainerExportResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ProtectedContainerExportResult {
@@ -939,7 +939,7 @@ impl windows_core::RuntimeName for ProtectedContainerExportResult {
 unsafe impl Send for ProtectedContainerExportResult {}
 unsafe impl Sync for ProtectedContainerExportResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtectedContainerImportResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtectedContainerImportResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ProtectedContainerImportResult {
@@ -972,7 +972,7 @@ impl windows_core::RuntimeName for ProtectedContainerImportResult {
 unsafe impl Send for ProtectedContainerImportResult {}
 unsafe impl Sync for ProtectedContainerImportResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtectedContentRevokedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtectedContentRevokedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ProtectedContentRevokedEventArgs {
@@ -998,7 +998,7 @@ impl windows_core::RuntimeName for ProtectedContentRevokedEventArgs {
 unsafe impl Send for ProtectedContentRevokedEventArgs {}
 unsafe impl Sync for ProtectedContentRevokedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtectedFileCreateResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtectedFileCreateResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ProtectedFileCreateResult {
@@ -1039,7 +1039,7 @@ impl windows_core::RuntimeName for ProtectedFileCreateResult {
 unsafe impl Send for ProtectedFileCreateResult {}
 unsafe impl Sync for ProtectedFileCreateResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtectionPolicyAuditInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtectionPolicyAuditInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl ProtectionPolicyAuditInfo {
@@ -1118,7 +1118,7 @@ impl windows_core::RuntimeName for ProtectionPolicyAuditInfo {
 unsafe impl Send for ProtectionPolicyAuditInfo {}
 unsafe impl Sync for ProtectionPolicyAuditInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtectionPolicyManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtectionPolicyManager, windows_core::IUnknown, windows_core::IInspectable);
 impl ProtectionPolicyManager {
@@ -1462,7 +1462,7 @@ impl windows_core::RuntimeName for ProtectionPolicyManager {
 unsafe impl Send for ProtectionPolicyManager {}
 unsafe impl Sync for ProtectionPolicyManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ThreadNetworkContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ThreadNetworkContext, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ThreadNetworkContext, super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/Security/ExchangeActiveSyncProvisioning/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/ExchangeActiveSyncProvisioning/mod.rs
@@ -75,7 +75,7 @@ pub struct IEasComplianceResults2_Vtbl {
     pub EncryptionProviderType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut EasEncryptionProviderType) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EasClientDeviceInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EasClientDeviceInformation, windows_core::IUnknown, windows_core::IInspectable);
 impl EasClientDeviceInformation {
@@ -154,7 +154,7 @@ impl windows_core::RuntimeName for EasClientDeviceInformation {
     const NAME: &'static str = "Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EasClientSecurityPolicy(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EasClientSecurityPolicy, windows_core::IUnknown, windows_core::IInspectable);
 impl EasClientSecurityPolicy {
@@ -279,7 +279,7 @@ impl windows_core::RuntimeName for EasClientSecurityPolicy {
     const NAME: &'static str = "Windows.Security.ExchangeActiveSyncProvisioning.EasClientSecurityPolicy";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EasComplianceResults(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EasComplianceResults, windows_core::IUnknown, windows_core::IInspectable);
 impl EasComplianceResults {

--- a/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
@@ -361,7 +361,7 @@ pub struct IIsolatedWindowsHostMessengerStatics2_Vtbl {
     pub UnregisterHostMessageReceiver: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironment, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironment {
@@ -562,7 +562,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironment {
 unsafe impl Send for IsolatedWindowsEnvironment {}
 unsafe impl Sync for IsolatedWindowsEnvironment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentCreateResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentCreateResult, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentCreateResult {
@@ -605,7 +605,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentCreateResult {
 unsafe impl Send for IsolatedWindowsEnvironmentCreateResult {}
 unsafe impl Sync for IsolatedWindowsEnvironmentCreateResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentFile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentFile, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentFile {
@@ -679,7 +679,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentHost {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentHost";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentLaunchFileResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentLaunchFileResult, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentLaunchFileResult {
@@ -718,7 +718,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentLaunchFileResult {
 unsafe impl Send for IsolatedWindowsEnvironmentLaunchFileResult {}
 unsafe impl Sync for IsolatedWindowsEnvironmentLaunchFileResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentOptions {
@@ -905,7 +905,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentOwnerRegistration {
     const NAME: &'static str = "Windows.Security.Isolation.IsolatedWindowsEnvironmentOwnerRegistration";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentOwnerRegistrationData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentOwnerRegistrationData, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentOwnerRegistrationData {
@@ -962,7 +962,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentOwnerRegistrationDa
 unsafe impl Send for IsolatedWindowsEnvironmentOwnerRegistrationData {}
 unsafe impl Sync for IsolatedWindowsEnvironmentOwnerRegistrationData {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentOwnerRegistrationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentOwnerRegistrationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentOwnerRegistrationResult {
@@ -994,7 +994,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentOwnerRegistrationRe
 unsafe impl Send for IsolatedWindowsEnvironmentOwnerRegistrationResult {}
 unsafe impl Sync for IsolatedWindowsEnvironmentOwnerRegistrationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentPostMessageResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentPostMessageResult, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentPostMessageResult {
@@ -1026,7 +1026,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentPostMessageResult {
 unsafe impl Send for IsolatedWindowsEnvironmentPostMessageResult {}
 unsafe impl Sync for IsolatedWindowsEnvironmentPostMessageResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentProcess(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentProcess, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentProcess {
@@ -1073,7 +1073,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentProcess {
 unsafe impl Send for IsolatedWindowsEnvironmentProcess {}
 unsafe impl Sync for IsolatedWindowsEnvironmentProcess {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentShareFileRequestOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentShareFileRequestOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentShareFileRequestOptions {
@@ -1109,7 +1109,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentShareFileRequestOpt
 unsafe impl Send for IsolatedWindowsEnvironmentShareFileRequestOptions {}
 unsafe impl Sync for IsolatedWindowsEnvironmentShareFileRequestOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentShareFileResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentShareFileResult, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentShareFileResult {
@@ -1148,7 +1148,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentShareFileResult {
 unsafe impl Send for IsolatedWindowsEnvironmentShareFileResult {}
 unsafe impl Sync for IsolatedWindowsEnvironmentShareFileResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentShareFolderRequestOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentShareFolderRequestOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentShareFolderRequestOptions {
@@ -1184,7 +1184,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentShareFolderRequestO
 unsafe impl Send for IsolatedWindowsEnvironmentShareFolderRequestOptions {}
 unsafe impl Sync for IsolatedWindowsEnvironmentShareFolderRequestOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentShareFolderResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentShareFolderResult, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentShareFolderResult {
@@ -1216,7 +1216,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentShareFolderResult {
 unsafe impl Send for IsolatedWindowsEnvironmentShareFolderResult {}
 unsafe impl Sync for IsolatedWindowsEnvironmentShareFolderResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentStartProcessResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentStartProcessResult, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentStartProcessResult {
@@ -1255,7 +1255,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentStartProcessResult 
 unsafe impl Send for IsolatedWindowsEnvironmentStartProcessResult {}
 unsafe impl Sync for IsolatedWindowsEnvironmentStartProcessResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentTelemetryParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentTelemetryParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentTelemetryParameters {
@@ -1291,7 +1291,7 @@ impl windows_core::RuntimeName for IsolatedWindowsEnvironmentTelemetryParameters
 unsafe impl Send for IsolatedWindowsEnvironmentTelemetryParameters {}
 unsafe impl Sync for IsolatedWindowsEnvironmentTelemetryParameters {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IsolatedWindowsEnvironmentUserInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IsolatedWindowsEnvironmentUserInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl IsolatedWindowsEnvironmentUserInfo {

--- a/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
@@ -280,7 +280,7 @@ pub struct IGuidanceUpdatedEventArgs_Vtbl {
     LaneInfo: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceAudioNotificationRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceAudioNotificationRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceAudioNotificationRequestedEventArgs {
@@ -320,7 +320,7 @@ impl windows_core::RuntimeName for GuidanceAudioNotificationRequestedEventArgs {
 unsafe impl Send for GuidanceAudioNotificationRequestedEventArgs {}
 unsafe impl Sync for GuidanceAudioNotificationRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceLaneInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceLaneInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceLaneInfo {
@@ -352,7 +352,7 @@ impl windows_core::RuntimeName for GuidanceLaneInfo {
 unsafe impl Send for GuidanceLaneInfo {}
 unsafe impl Sync for GuidanceLaneInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceManeuver(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceManeuver, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceManeuver {
@@ -455,7 +455,7 @@ impl windows_core::RuntimeName for GuidanceManeuver {
 unsafe impl Send for GuidanceManeuver {}
 unsafe impl Sync for GuidanceManeuver {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceMapMatchedCoordinate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceMapMatchedCoordinate, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceMapMatchedCoordinate {
@@ -509,7 +509,7 @@ impl windows_core::RuntimeName for GuidanceMapMatchedCoordinate {
 unsafe impl Send for GuidanceMapMatchedCoordinate {}
 unsafe impl Sync for GuidanceMapMatchedCoordinate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceNavigator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceNavigator, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceNavigator {
@@ -748,7 +748,7 @@ impl windows_core::RuntimeName for GuidanceNavigator {
 unsafe impl Send for GuidanceNavigator {}
 unsafe impl Sync for GuidanceNavigator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceReroutedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceReroutedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceReroutedEventArgs {
@@ -773,7 +773,7 @@ impl windows_core::RuntimeName for GuidanceReroutedEventArgs {
 unsafe impl Send for GuidanceReroutedEventArgs {}
 unsafe impl Sync for GuidanceReroutedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceRoadSegment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceRoadSegment, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceRoadSegment {
@@ -862,7 +862,7 @@ impl windows_core::RuntimeName for GuidanceRoadSegment {
 unsafe impl Send for GuidanceRoadSegment {}
 unsafe impl Sync for GuidanceRoadSegment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceRoadSignpost(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceRoadSignpost, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceRoadSignpost {
@@ -918,7 +918,7 @@ impl windows_core::RuntimeName for GuidanceRoadSignpost {
 unsafe impl Send for GuidanceRoadSignpost {}
 unsafe impl Sync for GuidanceRoadSignpost {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceRoute(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceRoute, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceRoute {
@@ -1012,7 +1012,7 @@ impl windows_core::RuntimeName for GuidanceRoute {
 unsafe impl Send for GuidanceRoute {}
 unsafe impl Sync for GuidanceRoute {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceTelemetryCollector(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceTelemetryCollector, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceTelemetryCollector {
@@ -1078,7 +1078,7 @@ impl windows_core::RuntimeName for GuidanceTelemetryCollector {
 unsafe impl Send for GuidanceTelemetryCollector {}
 unsafe impl Sync for GuidanceTelemetryCollector {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GuidanceUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GuidanceUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl GuidanceUpdatedEventArgs {

--- a/crates/libs/windows/src/Windows/Services/Maps/LocalSearch/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/LocalSearch/mod.rs
@@ -165,7 +165,7 @@ impl windows_core::RuntimeName for LocalCategories {
     const NAME: &'static str = "Windows.Services.Maps.LocalSearch.LocalCategories";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LocalLocation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LocalLocation, windows_core::IUnknown, windows_core::IInspectable);
 impl LocalLocation {
@@ -276,7 +276,7 @@ impl windows_core::RuntimeName for LocalLocationFinder {
     const NAME: &'static str = "Windows.Services.Maps.LocalSearch.LocalLocationFinder";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LocalLocationFinderResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LocalLocationFinderResult, windows_core::IUnknown, windows_core::IInspectable);
 impl LocalLocationFinderResult {
@@ -309,7 +309,7 @@ impl windows_core::RuntimeName for LocalLocationFinderResult {
 unsafe impl Send for LocalLocationFinderResult {}
 unsafe impl Sync for LocalLocationFinderResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LocalLocationHoursOfOperationItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LocalLocationHoursOfOperationItem, windows_core::IUnknown, windows_core::IInspectable);
 impl LocalLocationHoursOfOperationItem {
@@ -349,7 +349,7 @@ impl windows_core::RuntimeName for LocalLocationHoursOfOperationItem {
 unsafe impl Send for LocalLocationHoursOfOperationItem {}
 unsafe impl Sync for LocalLocationHoursOfOperationItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LocalLocationRatingInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LocalLocationRatingInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl LocalLocationRatingInfo {

--- a/crates/libs/windows/src/Windows/Services/Maps/OfflineMaps/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/OfflineMaps/mod.rs
@@ -56,7 +56,7 @@ pub struct IOfflineMapPackageStatics_Vtbl {
     FindPackagesInGeocircleAsync: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OfflineMapPackage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OfflineMapPackage, windows_core::IUnknown, windows_core::IInspectable);
 impl OfflineMapPackage {
@@ -158,7 +158,7 @@ impl windows_core::RuntimeName for OfflineMapPackage {
 unsafe impl Send for OfflineMapPackage {}
 unsafe impl Sync for OfflineMapPackage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OfflineMapPackageQueryResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OfflineMapPackageQueryResult, windows_core::IUnknown, windows_core::IInspectable);
 impl OfflineMapPackageQueryResult {
@@ -191,7 +191,7 @@ impl windows_core::RuntimeName for OfflineMapPackageQueryResult {
 unsafe impl Send for OfflineMapPackageQueryResult {}
 unsafe impl Sync for OfflineMapPackageQueryResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OfflineMapPackageStartDownloadResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OfflineMapPackageStartDownloadResult, windows_core::IUnknown, windows_core::IInspectable);
 impl OfflineMapPackageStartDownloadResult {

--- a/crates/libs/windows/src/Windows/Services/Maps/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/mod.rs
@@ -493,7 +493,7 @@ pub struct IPlaceInfoStatics2_Vtbl {
     pub CreateFromAddressWithName: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EnhancedWaypoint(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EnhancedWaypoint, windows_core::IUnknown, windows_core::IInspectable);
 impl EnhancedWaypoint {
@@ -541,7 +541,7 @@ impl windows_core::RuntimeName for EnhancedWaypoint {
 unsafe impl Send for EnhancedWaypoint {}
 unsafe impl Sync for EnhancedWaypoint {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ManeuverWarning(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ManeuverWarning, windows_core::IUnknown, windows_core::IInspectable);
 impl ManeuverWarning {
@@ -573,7 +573,7 @@ impl windows_core::RuntimeName for ManeuverWarning {
 unsafe impl Send for ManeuverWarning {}
 unsafe impl Sync for ManeuverWarning {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MapAddress(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MapAddress, windows_core::IUnknown, windows_core::IInspectable);
 impl MapAddress {
@@ -703,7 +703,7 @@ impl windows_core::RuntimeName for MapAddress {
 unsafe impl Send for MapAddress {}
 unsafe impl Sync for MapAddress {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MapLocation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MapLocation, windows_core::IUnknown, windows_core::IInspectable);
 impl MapLocation {
@@ -806,7 +806,7 @@ impl windows_core::RuntimeName for MapLocationFinder {
     const NAME: &'static str = "Windows.Services.Maps.MapLocationFinder";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MapLocationFinderResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MapLocationFinderResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MapLocationFinderResult {
@@ -856,7 +856,7 @@ impl windows_core::RuntimeName for MapManager {
     const NAME: &'static str = "Windows.Services.Maps.MapManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MapRoute(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MapRoute, windows_core::IUnknown, windows_core::IInspectable);
 impl MapRoute {
@@ -954,7 +954,7 @@ impl windows_core::RuntimeName for MapRoute {
 unsafe impl Send for MapRoute {}
 unsafe impl Sync for MapRoute {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MapRouteDrivingOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MapRouteDrivingOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl MapRouteDrivingOptions {
@@ -1199,7 +1199,7 @@ impl windows_core::RuntimeName for MapRouteFinder {
     const NAME: &'static str = "Windows.Services.Maps.MapRouteFinder";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MapRouteFinderResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MapRouteFinderResult, windows_core::IUnknown, windows_core::IInspectable);
 impl MapRouteFinderResult {
@@ -1239,7 +1239,7 @@ impl windows_core::RuntimeName for MapRouteFinderResult {
 unsafe impl Send for MapRouteFinderResult {}
 unsafe impl Sync for MapRouteFinderResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MapRouteLeg(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MapRouteLeg, windows_core::IUnknown, windows_core::IInspectable);
 impl MapRouteLeg {
@@ -1309,7 +1309,7 @@ impl windows_core::RuntimeName for MapRouteLeg {
 unsafe impl Send for MapRouteLeg {}
 unsafe impl Sync for MapRouteLeg {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MapRouteManeuver(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MapRouteManeuver, windows_core::IUnknown, windows_core::IInspectable);
 impl MapRouteManeuver {
@@ -1455,7 +1455,7 @@ impl windows_core::RuntimeName for MapService {
     const NAME: &'static str = "Windows.Services.Maps.MapService";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlaceInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlaceInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl PlaceInfo {
@@ -1586,7 +1586,7 @@ impl windows_core::RuntimeName for PlaceInfo {
 unsafe impl Send for PlaceInfo {}
 unsafe impl Sync for PlaceInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlaceInfoCreateOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlaceInfoCreateOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl PlaceInfoCreateOptions {

--- a/crates/libs/windows/src/Windows/Services/Store/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Store/mod.rs
@@ -661,7 +661,7 @@ pub struct IStoreVideo_Vtbl {
     pub PreviewImage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreAcquireLicenseResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreAcquireLicenseResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreAcquireLicenseResult {
@@ -693,7 +693,7 @@ impl windows_core::RuntimeName for StoreAcquireLicenseResult {
 unsafe impl Send for StoreAcquireLicenseResult {}
 unsafe impl Sync for StoreAcquireLicenseResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreAppLicense(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreAppLicense, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreAppLicense {
@@ -782,7 +782,7 @@ impl windows_core::RuntimeName for StoreAppLicense {
 unsafe impl Send for StoreAppLicense {}
 unsafe impl Sync for StoreAppLicense {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreAvailability(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreAvailability, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreAvailability {
@@ -845,7 +845,7 @@ impl windows_core::RuntimeName for StoreAvailability {
 unsafe impl Send for StoreAvailability {}
 unsafe impl Sync for StoreAvailability {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreCanAcquireLicenseResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreCanAcquireLicenseResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreCanAcquireLicenseResult {
@@ -884,7 +884,7 @@ impl windows_core::RuntimeName for StoreCanAcquireLicenseResult {
 unsafe impl Send for StoreCanAcquireLicenseResult {}
 unsafe impl Sync for StoreCanAcquireLicenseResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreCollectionData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreCollectionData, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreCollectionData {
@@ -958,7 +958,7 @@ impl windows_core::RuntimeName for StoreCollectionData {
 unsafe impl Send for StoreCollectionData {}
 unsafe impl Sync for StoreCollectionData {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreConsumableResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreConsumableResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreConsumableResult {
@@ -1004,7 +1004,7 @@ impl windows_core::RuntimeName for StoreConsumableResult {
 unsafe impl Send for StoreConsumableResult {}
 unsafe impl Sync for StoreConsumableResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreContext, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreContext {
@@ -1429,7 +1429,7 @@ impl windows_core::RuntimeName for StoreContext {
 unsafe impl Send for StoreContext {}
 unsafe impl Sync for StoreContext {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreImage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreImage, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreImage {
@@ -1482,7 +1482,7 @@ impl windows_core::RuntimeName for StoreImage {
 unsafe impl Send for StoreImage {}
 unsafe impl Sync for StoreImage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreLicense(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreLicense, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreLicense {
@@ -1535,7 +1535,7 @@ impl windows_core::RuntimeName for StoreLicense {
 unsafe impl Send for StoreLicense {}
 unsafe impl Sync for StoreLicense {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorePackageInstallOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorePackageInstallOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl StorePackageInstallOptions {
@@ -1571,7 +1571,7 @@ impl windows_core::RuntimeName for StorePackageInstallOptions {
 unsafe impl Send for StorePackageInstallOptions {}
 unsafe impl Sync for StorePackageInstallOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorePackageLicense(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorePackageLicense, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StorePackageLicense, super::super::Foundation::IClosable);
@@ -1627,7 +1627,7 @@ impl windows_core::RuntimeName for StorePackageLicense {
 unsafe impl Send for StorePackageLicense {}
 unsafe impl Sync for StorePackageLicense {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorePackageUpdate(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorePackageUpdate, windows_core::IUnknown, windows_core::IInspectable);
 impl StorePackageUpdate {
@@ -1660,7 +1660,7 @@ impl windows_core::RuntimeName for StorePackageUpdate {
 unsafe impl Send for StorePackageUpdate {}
 unsafe impl Sync for StorePackageUpdate {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorePackageUpdateResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorePackageUpdateResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StorePackageUpdateResult {
@@ -1701,7 +1701,7 @@ impl windows_core::RuntimeName for StorePackageUpdateResult {
 unsafe impl Send for StorePackageUpdateResult {}
 unsafe impl Sync for StorePackageUpdateResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorePrice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorePrice, windows_core::IUnknown, windows_core::IInspectable);
 impl StorePrice {
@@ -1782,7 +1782,7 @@ impl windows_core::RuntimeName for StorePrice {
 unsafe impl Send for StorePrice {}
 unsafe impl Sync for StorePrice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreProduct(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreProduct, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreProduct {
@@ -1933,7 +1933,7 @@ impl windows_core::RuntimeName for StoreProduct {
 unsafe impl Send for StoreProduct {}
 unsafe impl Sync for StoreProduct {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreProductOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreProductOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreProductOptions {
@@ -1966,7 +1966,7 @@ impl windows_core::RuntimeName for StoreProductOptions {
 unsafe impl Send for StoreProductOptions {}
 unsafe impl Sync for StoreProductOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreProductPagedQueryResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreProductPagedQueryResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreProductPagedQueryResult {
@@ -2013,7 +2013,7 @@ impl windows_core::RuntimeName for StoreProductPagedQueryResult {
 unsafe impl Send for StoreProductPagedQueryResult {}
 unsafe impl Sync for StoreProductPagedQueryResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreProductQueryResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreProductQueryResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreProductQueryResult {
@@ -2046,7 +2046,7 @@ impl windows_core::RuntimeName for StoreProductQueryResult {
 unsafe impl Send for StoreProductQueryResult {}
 unsafe impl Sync for StoreProductQueryResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreProductResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreProductResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreProductResult {
@@ -2078,7 +2078,7 @@ impl windows_core::RuntimeName for StoreProductResult {
 unsafe impl Send for StoreProductResult {}
 unsafe impl Sync for StoreProductResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorePurchaseProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorePurchaseProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl StorePurchaseProperties {
@@ -2136,7 +2136,7 @@ impl windows_core::RuntimeName for StorePurchaseProperties {
 unsafe impl Send for StorePurchaseProperties {}
 unsafe impl Sync for StorePurchaseProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorePurchaseResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorePurchaseResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StorePurchaseResult {
@@ -2168,7 +2168,7 @@ impl windows_core::RuntimeName for StorePurchaseResult {
 unsafe impl Send for StorePurchaseResult {}
 unsafe impl Sync for StorePurchaseResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreQueueItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreQueueItem, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreQueueItem {
@@ -2263,7 +2263,7 @@ impl windows_core::RuntimeName for StoreQueueItem {
 unsafe impl Send for StoreQueueItem {}
 unsafe impl Sync for StoreQueueItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreQueueItemCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreQueueItemCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreQueueItemCompletedEventArgs {
@@ -2288,7 +2288,7 @@ impl windows_core::RuntimeName for StoreQueueItemCompletedEventArgs {
 unsafe impl Send for StoreQueueItemCompletedEventArgs {}
 unsafe impl Sync for StoreQueueItemCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreQueueItemStatus(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreQueueItemStatus, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreQueueItemStatus {
@@ -2334,7 +2334,7 @@ impl windows_core::RuntimeName for StoreQueueItemStatus {
 unsafe impl Send for StoreQueueItemStatus {}
 unsafe impl Sync for StoreQueueItemStatus {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreRateAndReviewResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreRateAndReviewResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreRateAndReviewResult {
@@ -2400,7 +2400,7 @@ impl windows_core::RuntimeName for StoreRequestHelper {
     const NAME: &'static str = "Windows.Services.Store.StoreRequestHelper";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreSendRequestResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreSendRequestResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreSendRequestResult {
@@ -2440,7 +2440,7 @@ impl windows_core::RuntimeName for StoreSendRequestResult {
 unsafe impl Send for StoreSendRequestResult {}
 unsafe impl Sync for StoreSendRequestResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreSku(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreSku, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreSku {
@@ -2598,7 +2598,7 @@ impl windows_core::RuntimeName for StoreSku {
 unsafe impl Send for StoreSku {}
 unsafe impl Sync for StoreSku {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreSubscriptionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreSubscriptionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreSubscriptionInfo {
@@ -2651,7 +2651,7 @@ impl windows_core::RuntimeName for StoreSubscriptionInfo {
 unsafe impl Send for StoreSubscriptionInfo {}
 unsafe impl Sync for StoreSubscriptionInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreUninstallStorePackageResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreUninstallStorePackageResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreUninstallStorePackageResult {
@@ -2683,7 +2683,7 @@ impl windows_core::RuntimeName for StoreUninstallStorePackageResult {
 unsafe impl Send for StoreUninstallStorePackageResult {}
 unsafe impl Sync for StoreUninstallStorePackageResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StoreVideo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StoreVideo, windows_core::IUnknown, windows_core::IInspectable);
 impl StoreVideo {

--- a/crates/libs/windows/src/Windows/Services/TargetedContent/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/TargetedContent/mod.rs
@@ -228,7 +228,7 @@ pub struct ITargetedContentValue_Vtbl {
     Actions: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentAction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentAction, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentAction {
@@ -253,7 +253,7 @@ impl windows_core::RuntimeName for TargetedContentAction {
 unsafe impl Send for TargetedContentAction {}
 unsafe impl Sync for TargetedContentAction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentAvailabilityChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentAvailabilityChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentAvailabilityChangedEventArgs {
@@ -278,7 +278,7 @@ impl windows_core::RuntimeName for TargetedContentAvailabilityChangedEventArgs {
 unsafe impl Send for TargetedContentAvailabilityChangedEventArgs {}
 unsafe impl Sync for TargetedContentAvailabilityChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentChangedEventArgs {
@@ -310,7 +310,7 @@ impl windows_core::RuntimeName for TargetedContentChangedEventArgs {
 unsafe impl Send for TargetedContentChangedEventArgs {}
 unsafe impl Sync for TargetedContentChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentCollection, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentCollection {
@@ -374,7 +374,7 @@ impl windows_core::RuntimeName for TargetedContentCollection {
 unsafe impl Send for TargetedContentCollection {}
 unsafe impl Sync for TargetedContentCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentContainer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentContainer, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentContainer {
@@ -439,7 +439,7 @@ unsafe impl Send for TargetedContentContainer {}
 unsafe impl Sync for TargetedContentContainer {}
 #[cfg(feature = "Storage_Streams")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentFile(windows_core::IUnknown);
 #[cfg(feature = "Storage_Streams")]
 windows_core::imp::interface_hierarchy!(TargetedContentFile, windows_core::IUnknown, windows_core::IInspectable);
@@ -474,7 +474,7 @@ unsafe impl Send for TargetedContentFile {}
 #[cfg(feature = "Storage_Streams")]
 unsafe impl Sync for TargetedContentFile {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentImage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentImage, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Storage_Streams")]
@@ -516,7 +516,7 @@ impl windows_core::RuntimeName for TargetedContentImage {
 unsafe impl Send for TargetedContentImage {}
 unsafe impl Sync for TargetedContentImage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentItem, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentItem {
@@ -572,7 +572,7 @@ impl windows_core::RuntimeName for TargetedContentItem {
 unsafe impl Send for TargetedContentItem {}
 unsafe impl Sync for TargetedContentItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentItemState(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentItemState, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentItemState {
@@ -604,7 +604,7 @@ impl windows_core::RuntimeName for TargetedContentItemState {
 unsafe impl Send for TargetedContentItemState {}
 unsafe impl Sync for TargetedContentItemState {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentObject(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentObject, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentObject {
@@ -650,7 +650,7 @@ impl windows_core::RuntimeName for TargetedContentObject {
 unsafe impl Send for TargetedContentObject {}
 unsafe impl Sync for TargetedContentObject {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentStateChangedEventArgs {
@@ -675,7 +675,7 @@ impl windows_core::RuntimeName for TargetedContentStateChangedEventArgs {
 unsafe impl Send for TargetedContentStateChangedEventArgs {}
 unsafe impl Sync for TargetedContentStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentSubscription(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentSubscription, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentSubscription {
@@ -766,7 +766,7 @@ impl windows_core::RuntimeName for TargetedContentSubscription {
 unsafe impl Send for TargetedContentSubscription {}
 unsafe impl Sync for TargetedContentSubscription {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentSubscriptionOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentSubscriptionOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentSubscriptionOptions {
@@ -822,7 +822,7 @@ impl windows_core::RuntimeName for TargetedContentSubscriptionOptions {
 unsafe impl Send for TargetedContentSubscriptionOptions {}
 unsafe impl Sync for TargetedContentSubscriptionOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetedContentValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetedContentValue, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetedContentValue {

--- a/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
@@ -207,7 +207,7 @@ pub struct IStorageItemMostRecentlyUsedList2_Vtbl {
 }
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AccessListEntryView(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(AccessListEntryView, windows_core::IUnknown, windows_core::IInspectable);
@@ -289,7 +289,7 @@ impl IntoIterator for &AccessListEntryView {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ItemRemovedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ItemRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ItemRemovedEventArgs {
@@ -360,7 +360,7 @@ impl windows_core::RuntimeName for StorageApplicationPermissions {
     const NAME: &'static str = "Windows.Storage.AccessCache.StorageApplicationPermissions";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageItemAccessList(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageItemAccessList, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StorageItemAccessList, IStorageItemAccessList);
@@ -493,7 +493,7 @@ impl windows_core::RuntimeName for StorageItemAccessList {
     const NAME: &'static str = "Windows.Storage.AccessCache.StorageItemAccessList";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageItemMostRecentlyUsedList(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageItemMostRecentlyUsedList, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StorageItemMostRecentlyUsedList, IStorageItemAccessList);

--- a/crates/libs/windows/src/Windows/Storage/BulkAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/BulkAccess/mod.rs
@@ -179,7 +179,7 @@ pub struct IStorageItemInformation_Vtbl {
     pub RemovePropertiesUpdated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileInformation, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Storage_Streams")]
@@ -568,7 +568,7 @@ impl windows_core::RuntimeName for FileInformation {
     const NAME: &'static str = "Windows.Storage.BulkAccess.FileInformation";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileInformationFactory(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileInformationFactory, windows_core::IUnknown, windows_core::IInspectable);
 impl FileInformationFactory {
@@ -700,7 +700,7 @@ impl windows_core::RuntimeName for FileInformationFactory {
 unsafe impl Send for FileInformationFactory {}
 unsafe impl Sync for FileInformationFactory {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FolderInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FolderInformation, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Storage_Search")]

--- a/crates/libs/windows/src/Windows/Storage/Compression/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Compression/mod.rs
@@ -52,7 +52,7 @@ pub struct IDecompressorFactory_Vtbl {
     CreateDecompressor: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Compressor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Compressor, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Storage_Streams")]
@@ -135,7 +135,7 @@ impl windows_core::RuntimeName for Compressor {
 unsafe impl Send for Compressor {}
 unsafe impl Sync for Compressor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Decompressor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Decompressor, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Storage_Streams")]

--- a/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
@@ -249,7 +249,7 @@ pub struct IVideoProperties_Vtbl {
     pub Orientation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VideoOrientation) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BasicProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BasicProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BasicProperties, IStorageItemExtraProperties);
@@ -316,7 +316,7 @@ impl windows_core::RuntimeName for BasicProperties {
     const NAME: &'static str = "Windows.Storage.FileProperties.BasicProperties";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DocumentProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DocumentProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DocumentProperties, IStorageItemExtraProperties);
@@ -443,7 +443,7 @@ impl windows_core::RuntimeName for GeotagHelper {
     const NAME: &'static str = "Windows.Storage.FileProperties.GeotagHelper";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImageProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImageProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ImageProperties, IStorageItemExtraProperties);
@@ -595,7 +595,7 @@ impl windows_core::RuntimeName for ImageProperties {
     const NAME: &'static str = "Windows.Storage.FileProperties.ImageProperties";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MusicProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MusicProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(MusicProperties, IStorageItemExtraProperties);
@@ -794,7 +794,7 @@ impl windows_core::RuntimeName for MusicProperties {
     const NAME: &'static str = "Windows.Storage.FileProperties.MusicProperties";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageItemContentProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageItemContentProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StorageItemContentProperties, IStorageItemExtraProperties);
@@ -869,7 +869,7 @@ impl windows_core::RuntimeName for StorageItemContentProperties {
 }
 #[cfg(feature = "Storage_Streams")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageItemThumbnail(windows_core::IUnknown);
 #[cfg(feature = "Storage_Streams")]
 windows_core::imp::interface_hierarchy!(StorageItemThumbnail, windows_core::IUnknown, windows_core::IInspectable);
@@ -1028,7 +1028,7 @@ impl windows_core::RuntimeName for StorageItemThumbnail {
     const NAME: &'static str = "Windows.Storage.FileProperties.StorageItemThumbnail";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VideoProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VideoProperties, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VideoProperties, IStorageItemExtraProperties);

--- a/crates/libs/windows/src/Windows/Storage/Pickers/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Pickers/Provider/mod.rs
@@ -123,7 +123,7 @@ pub struct ITargetFileRequestedEventArgs_Vtbl {
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileOpenPickerUI(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileOpenPickerUI, windows_core::IUnknown, windows_core::IInspectable);
 impl FileOpenPickerUI {
@@ -234,7 +234,7 @@ impl windows_core::RuntimeName for FileOpenPickerUI {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileRemovedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(FileRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -263,7 +263,7 @@ impl windows_core::RuntimeName for FileRemovedEventArgs {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.FileRemovedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileSavePickerUI(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileSavePickerUI, windows_core::IUnknown, windows_core::IInspectable);
 impl FileSavePickerUI {
@@ -347,7 +347,7 @@ impl windows_core::RuntimeName for FileSavePickerUI {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.FileSavePickerUI";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PickerClosingDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PickerClosingDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl PickerClosingDeferral {
@@ -367,7 +367,7 @@ impl windows_core::RuntimeName for PickerClosingDeferral {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.PickerClosingDeferral";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PickerClosingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PickerClosingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PickerClosingEventArgs {
@@ -397,7 +397,7 @@ impl windows_core::RuntimeName for PickerClosingEventArgs {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.PickerClosingEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PickerClosingOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PickerClosingOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl PickerClosingOperation {
@@ -427,7 +427,7 @@ impl windows_core::RuntimeName for PickerClosingOperation {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.PickerClosingOperation";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetFileRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetFileRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetFileRequest {
@@ -464,7 +464,7 @@ impl windows_core::RuntimeName for TargetFileRequest {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.TargetFileRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetFileRequestDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetFileRequestDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetFileRequestDeferral {
@@ -484,7 +484,7 @@ impl windows_core::RuntimeName for TargetFileRequestDeferral {
     const NAME: &'static str = "Windows.Storage.Pickers.Provider.TargetFileRequestDeferral";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TargetFileRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TargetFileRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TargetFileRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/Storage/Pickers/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Pickers/mod.rs
@@ -228,7 +228,7 @@ pub struct IFolderPickerStatics_Vtbl {
 }
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileExtensionVector(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(FileExtensionVector, windows_core::IUnknown, windows_core::IInspectable);
@@ -354,7 +354,7 @@ unsafe impl Send for FileExtensionVector {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for FileExtensionVector {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileOpenPicker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileOpenPicker, windows_core::IUnknown, windows_core::IInspectable);
 impl FileOpenPicker {
@@ -507,7 +507,7 @@ unsafe impl Send for FileOpenPicker {}
 unsafe impl Sync for FileOpenPicker {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FilePickerFileTypesOrderedMap(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(FilePickerFileTypesOrderedMap, windows_core::IUnknown, windows_core::IInspectable);
@@ -612,7 +612,7 @@ unsafe impl Send for FilePickerFileTypesOrderedMap {}
 unsafe impl Sync for FilePickerFileTypesOrderedMap {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FilePickerSelectedFilesArray(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(FilePickerSelectedFilesArray, windows_core::IUnknown, windows_core::IInspectable);
@@ -698,7 +698,7 @@ unsafe impl Send for FilePickerSelectedFilesArray {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for FilePickerSelectedFilesArray {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileSavePicker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileSavePicker, windows_core::IUnknown, windows_core::IInspectable);
 impl FileSavePicker {
@@ -854,7 +854,7 @@ impl windows_core::RuntimeName for FileSavePicker {
 unsafe impl Send for FileSavePicker {}
 unsafe impl Sync for FileSavePicker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FolderPicker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FolderPicker, windows_core::IUnknown, windows_core::IInspectable);
 impl FolderPicker {

--- a/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
@@ -649,7 +649,7 @@ impl windows_core::RuntimeName for CachedFileUpdater {
     const NAME: &'static str = "Windows.Storage.Provider.CachedFileUpdater";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CachedFileUpdaterUI(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CachedFileUpdaterUI, windows_core::IUnknown, windows_core::IInspectable);
 impl CachedFileUpdaterUI {
@@ -732,7 +732,7 @@ impl windows_core::RuntimeName for CachedFileUpdaterUI {
     const NAME: &'static str = "Windows.Storage.Provider.CachedFileUpdaterUI";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileUpdateRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileUpdateRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl FileUpdateRequest {
@@ -798,7 +798,7 @@ impl windows_core::RuntimeName for FileUpdateRequest {
     const NAME: &'static str = "Windows.Storage.Provider.FileUpdateRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileUpdateRequestDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileUpdateRequestDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl FileUpdateRequestDeferral {
@@ -818,7 +818,7 @@ impl windows_core::RuntimeName for FileUpdateRequestDeferral {
     const NAME: &'static str = "Windows.Storage.Provider.FileUpdateRequestDeferral";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileUpdateRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileUpdateRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl FileUpdateRequestedEventArgs {
@@ -841,7 +841,7 @@ impl windows_core::RuntimeName for FileUpdateRequestedEventArgs {
     const NAME: &'static str = "Windows.Storage.Provider.FileUpdateRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderFileTypeInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderFileTypeInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderFileTypeInfo {
@@ -884,7 +884,7 @@ impl windows_core::RuntimeName for StorageProviderFileTypeInfo {
 unsafe impl Send for StorageProviderFileTypeInfo {}
 unsafe impl Sync for StorageProviderFileTypeInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderGetContentInfoForPathResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderGetContentInfoForPathResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderGetContentInfoForPathResult {
@@ -942,7 +942,7 @@ impl windows_core::RuntimeName for StorageProviderGetContentInfoForPathResult {
 unsafe impl Send for StorageProviderGetContentInfoForPathResult {}
 unsafe impl Sync for StorageProviderGetContentInfoForPathResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderGetPathForContentUriResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderGetPathForContentUriResult, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderGetPathForContentUriResult {
@@ -1011,7 +1011,7 @@ impl windows_core::RuntimeName for StorageProviderItemProperties {
     const NAME: &'static str = "Windows.Storage.Provider.StorageProviderItemProperties";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderItemProperty(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderItemProperty, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderItemProperty {
@@ -1069,7 +1069,7 @@ impl windows_core::RuntimeName for StorageProviderItemProperty {
 unsafe impl Send for StorageProviderItemProperty {}
 unsafe impl Sync for StorageProviderItemProperty {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderItemPropertyDefinition(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderItemPropertyDefinition, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderItemPropertyDefinition {
@@ -1116,7 +1116,7 @@ impl windows_core::RuntimeName for StorageProviderItemPropertyDefinition {
 unsafe impl Send for StorageProviderItemPropertyDefinition {}
 unsafe impl Sync for StorageProviderItemPropertyDefinition {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderKnownFolderEntry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderKnownFolderEntry, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderKnownFolderEntry {
@@ -1163,7 +1163,7 @@ impl windows_core::RuntimeName for StorageProviderKnownFolderEntry {
 unsafe impl Send for StorageProviderKnownFolderEntry {}
 unsafe impl Sync for StorageProviderKnownFolderEntry {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderKnownFolderSyncInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderKnownFolderSyncInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderKnownFolderSyncInfo {
@@ -1221,7 +1221,7 @@ impl windows_core::RuntimeName for StorageProviderKnownFolderSyncInfo {
 unsafe impl Send for StorageProviderKnownFolderSyncInfo {}
 unsafe impl Sync for StorageProviderKnownFolderSyncInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderKnownFolderSyncRequestArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderKnownFolderSyncRequestArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderKnownFolderSyncRequestArgs {
@@ -1254,7 +1254,7 @@ impl windows_core::RuntimeName for StorageProviderKnownFolderSyncRequestArgs {
 unsafe impl Send for StorageProviderKnownFolderSyncRequestArgs {}
 unsafe impl Sync for StorageProviderKnownFolderSyncRequestArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderMoreInfoUI(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderMoreInfoUI, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderMoreInfoUI {
@@ -1304,7 +1304,7 @@ impl windows_core::RuntimeName for StorageProviderMoreInfoUI {
 unsafe impl Send for StorageProviderMoreInfoUI {}
 unsafe impl Sync for StorageProviderMoreInfoUI {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderQuotaUI(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderQuotaUI, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderQuotaUI {
@@ -1378,7 +1378,7 @@ impl windows_core::RuntimeName for StorageProviderQuotaUI {
 unsafe impl Send for StorageProviderQuotaUI {}
 unsafe impl Sync for StorageProviderQuotaUI {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderStatusUI(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderStatusUI, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderStatusUI {
@@ -1511,7 +1511,7 @@ impl windows_core::RuntimeName for StorageProviderStatusUI {
 unsafe impl Send for StorageProviderStatusUI {}
 unsafe impl Sync for StorageProviderStatusUI {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProviderSyncRootInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProviderSyncRootInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProviderSyncRootInfo {

--- a/crates/libs/windows/src/Windows/Storage/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Search/mod.rs
@@ -587,7 +587,7 @@ pub struct IValueAndLanguage_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContentIndexer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContentIndexer, windows_core::IUnknown, windows_core::IInspectable);
 impl ContentIndexer {
@@ -720,7 +720,7 @@ impl windows_core::RuntimeName for ContentIndexer {
 unsafe impl Send for ContentIndexer {}
 unsafe impl Sync for ContentIndexer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContentIndexerQuery(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContentIndexerQuery, windows_core::IUnknown, windows_core::IInspectable);
 impl ContentIndexerQuery {
@@ -784,7 +784,7 @@ impl windows_core::RuntimeName for ContentIndexerQuery {
 unsafe impl Send for ContentIndexerQuery {}
 unsafe impl Sync for ContentIndexerQuery {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IndexableContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IndexableContent, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(IndexableContent, IIndexableContent);
@@ -856,7 +856,7 @@ impl windows_core::RuntimeName for IndexableContent {
 unsafe impl Send for IndexableContent {}
 unsafe impl Sync for IndexableContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct QueryOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(QueryOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl QueryOptions {
@@ -1020,7 +1020,7 @@ unsafe impl Send for QueryOptions {}
 unsafe impl Sync for QueryOptions {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SortEntryVector(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(SortEntryVector, windows_core::IUnknown, windows_core::IInspectable);
@@ -1154,7 +1154,7 @@ impl IntoIterator for &SortEntryVector {
     }
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageFileQueryResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageFileQueryResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StorageFileQueryResult, IStorageQueryResultBase);
@@ -1264,7 +1264,7 @@ impl windows_core::RuntimeName for StorageFileQueryResult {
     const NAME: &'static str = "Windows.Storage.Search.StorageFileQueryResult";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageFolderQueryResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageFolderQueryResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StorageFolderQueryResult, IStorageQueryResultBase);
@@ -1363,7 +1363,7 @@ impl windows_core::RuntimeName for StorageFolderQueryResult {
     const NAME: &'static str = "Windows.Storage.Search.StorageFolderQueryResult";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageItemQueryResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageItemQueryResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StorageItemQueryResult, IStorageQueryResultBase);
@@ -1462,7 +1462,7 @@ impl windows_core::RuntimeName for StorageItemQueryResult {
     const NAME: &'static str = "Windows.Storage.Search.StorageItemQueryResult";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageLibraryChangeTrackerTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageLibraryChangeTrackerTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageLibraryChangeTrackerTriggerDetails {
@@ -1492,7 +1492,7 @@ impl windows_core::RuntimeName for StorageLibraryChangeTrackerTriggerDetails {
     const NAME: &'static str = "Windows.Storage.Search.StorageLibraryChangeTrackerTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageLibraryContentChangedTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageLibraryContentChangedTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageLibraryContentChangedTriggerDetails {
@@ -1522,7 +1522,7 @@ impl windows_core::RuntimeName for StorageLibraryContentChangedTriggerDetails {
     const NAME: &'static str = "Windows.Storage.Search.StorageLibraryContentChangedTriggerDetails";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ValueAndLanguage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ValueAndLanguage, windows_core::IUnknown, windows_core::IInspectable);
 impl ValueAndLanguage {

--- a/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
@@ -953,7 +953,7 @@ pub struct IRandomAccessStreamWithContentType_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Buffer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Buffer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Buffer, IBuffer);
@@ -1024,7 +1024,7 @@ impl windows_core::RuntimeName for Buffer {
 unsafe impl Send for Buffer {}
 unsafe impl Sync for Buffer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataReader, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DataReader, super::super::Foundation::IClosable, IDataReader);
@@ -1245,7 +1245,7 @@ impl windows_core::RuntimeName for DataReader {
 unsafe impl Send for DataReader {}
 unsafe impl Sync for DataReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataReaderLoadOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataReaderLoadOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DataReaderLoadOperation, super::super::Foundation::IAsyncInfo, super::super::Foundation::IAsyncOperation::<u32>);
@@ -1343,7 +1343,7 @@ impl std::future::Future for DataReaderLoadOperation {
 unsafe impl Send for DataReaderLoadOperation {}
 unsafe impl Sync for DataReaderLoadOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataWriter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataWriter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DataWriter, super::super::Foundation::IClosable, IDataWriter);
@@ -1528,7 +1528,7 @@ impl windows_core::RuntimeName for DataWriter {
 unsafe impl Send for DataWriter {}
 unsafe impl Sync for DataWriter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DataWriterStoreOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DataWriterStoreOperation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DataWriterStoreOperation, super::super::Foundation::IAsyncInfo, super::super::Foundation::IAsyncOperation::<u32>);
@@ -1626,7 +1626,7 @@ impl std::future::Future for DataWriterStoreOperation {
 unsafe impl Send for DataWriterStoreOperation {}
 unsafe impl Sync for DataWriterStoreOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileInputStream(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileInputStream, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FileInputStream, super::super::Foundation::IClosable, IInputStream);
@@ -1659,7 +1659,7 @@ impl windows_core::RuntimeName for FileInputStream {
 unsafe impl Send for FileInputStream {}
 unsafe impl Sync for FileInputStream {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileOutputStream(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileOutputStream, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FileOutputStream, super::super::Foundation::IClosable, IOutputStream);
@@ -1699,7 +1699,7 @@ impl windows_core::RuntimeName for FileOutputStream {
 unsafe impl Send for FileOutputStream {}
 unsafe impl Sync for FileOutputStream {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FileRandomAccessStream(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FileRandomAccessStream, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FileRandomAccessStream, super::super::Foundation::IClosable, IInputStream, IOutputStream, IRandomAccessStream);
@@ -1875,7 +1875,7 @@ impl windows_core::RuntimeName for FileRandomAccessStream {
 unsafe impl Send for FileRandomAccessStream {}
 unsafe impl Sync for FileRandomAccessStream {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InMemoryRandomAccessStream(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InMemoryRandomAccessStream, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InMemoryRandomAccessStream, super::super::Foundation::IClosable, IInputStream, IOutputStream, IRandomAccessStream);
@@ -1989,7 +1989,7 @@ impl windows_core::RuntimeName for InMemoryRandomAccessStream {
 unsafe impl Send for InMemoryRandomAccessStream {}
 unsafe impl Sync for InMemoryRandomAccessStream {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InputStreamOverStream(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InputStreamOverStream, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InputStreamOverStream, super::super::Foundation::IClosable, IInputStream);
@@ -2022,7 +2022,7 @@ impl windows_core::RuntimeName for InputStreamOverStream {
 unsafe impl Send for InputStreamOverStream {}
 unsafe impl Sync for InputStreamOverStream {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OutputStreamOverStream(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OutputStreamOverStream, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(OutputStreamOverStream, super::super::Foundation::IClosable, IOutputStream);
@@ -2103,7 +2103,7 @@ impl windows_core::RuntimeName for RandomAccessStream {
     const NAME: &'static str = "Windows.Storage.Streams.RandomAccessStream";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RandomAccessStreamOverStream(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RandomAccessStreamOverStream, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RandomAccessStreamOverStream, super::super::Foundation::IClosable, IInputStream, IOutputStream, IRandomAccessStream);
@@ -2210,7 +2210,7 @@ impl windows_core::RuntimeName for RandomAccessStreamOverStream {
 unsafe impl Send for RandomAccessStreamOverStream {}
 unsafe impl Sync for RandomAccessStreamOverStream {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RandomAccessStreamReference(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RandomAccessStreamReference, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RandomAccessStreamReference, IRandomAccessStreamReference);

--- a/crates/libs/windows/src/Windows/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/mod.rs
@@ -1809,7 +1809,7 @@ pub struct IUserDataPathsStatics_Vtbl {
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppDataPaths(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppDataPaths, windows_core::IUnknown, windows_core::IInspectable);
 impl AppDataPaths {
@@ -1911,7 +1911,7 @@ impl windows_core::RuntimeName for AppDataPaths {
 unsafe impl Send for AppDataPaths {}
 unsafe impl Sync for AppDataPaths {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ApplicationData, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ApplicationData, super::Foundation::IClosable);
@@ -2080,7 +2080,7 @@ unsafe impl Send for ApplicationData {}
 unsafe impl Sync for ApplicationData {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationDataCompositeValue(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(ApplicationDataCompositeValue, windows_core::IUnknown, windows_core::IInspectable);
@@ -2207,7 +2207,7 @@ unsafe impl Send for ApplicationDataCompositeValue {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for ApplicationDataCompositeValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationDataContainer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ApplicationDataContainer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ApplicationDataContainer, super::Foundation::IClosable);
@@ -2272,7 +2272,7 @@ unsafe impl Send for ApplicationDataContainer {}
 unsafe impl Sync for ApplicationDataContainer {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationDataContainerSettings(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(ApplicationDataContainerSettings, windows_core::IUnknown, windows_core::IInspectable);
@@ -2939,7 +2939,7 @@ impl windows_core::RuntimeName for PathIO {
     const NAME: &'static str = "Windows.Storage.PathIO";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SetVersionDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SetVersionDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl SetVersionDeferral {
@@ -2961,7 +2961,7 @@ impl windows_core::RuntimeName for SetVersionDeferral {
 unsafe impl Send for SetVersionDeferral {}
 unsafe impl Sync for SetVersionDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SetVersionRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SetVersionRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl SetVersionRequest {
@@ -3000,7 +3000,7 @@ impl windows_core::RuntimeName for SetVersionRequest {
 unsafe impl Send for SetVersionRequest {}
 unsafe impl Sync for SetVersionRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageFile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageFile, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Storage_Streams")]
@@ -3418,7 +3418,7 @@ impl windows_core::RuntimeName for StorageFile {
     const NAME: &'static str = "Windows.Storage.StorageFile";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageFolder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageFolder, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Storage_Search")]
@@ -3869,7 +3869,7 @@ impl windows_core::RuntimeName for StorageFolder {
     const NAME: &'static str = "Windows.Storage.StorageFolder";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageLibrary(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageLibrary, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageLibrary {
@@ -3971,7 +3971,7 @@ impl windows_core::RuntimeName for StorageLibrary {
     const NAME: &'static str = "Windows.Storage.StorageLibrary";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageLibraryChange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageLibraryChange, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageLibraryChange {
@@ -4024,7 +4024,7 @@ impl windows_core::RuntimeName for StorageLibraryChange {
 unsafe impl Send for StorageLibraryChange {}
 unsafe impl Sync for StorageLibraryChange {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageLibraryChangeReader(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageLibraryChangeReader, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageLibraryChangeReader {
@@ -4064,7 +4064,7 @@ impl windows_core::RuntimeName for StorageLibraryChangeReader {
 unsafe impl Send for StorageLibraryChangeReader {}
 unsafe impl Sync for StorageLibraryChangeReader {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageLibraryChangeTracker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageLibraryChangeTracker, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageLibraryChangeTracker {
@@ -4108,7 +4108,7 @@ impl windows_core::RuntimeName for StorageLibraryChangeTracker {
 unsafe impl Send for StorageLibraryChangeTracker {}
 unsafe impl Sync for StorageLibraryChangeTracker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageLibraryChangeTrackerOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageLibraryChangeTrackerOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageLibraryChangeTrackerOptions {
@@ -4144,7 +4144,7 @@ impl windows_core::RuntimeName for StorageLibraryChangeTrackerOptions {
 unsafe impl Send for StorageLibraryChangeTrackerOptions {}
 unsafe impl Sync for StorageLibraryChangeTrackerOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageLibraryLastChangeId(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageLibraryLastChangeId, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageLibraryLastChangeId {
@@ -4173,7 +4173,7 @@ impl windows_core::RuntimeName for StorageLibraryLastChangeId {
 unsafe impl Send for StorageLibraryLastChangeId {}
 unsafe impl Sync for StorageLibraryLastChangeId {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl StorageProvider {
@@ -4210,7 +4210,7 @@ impl windows_core::RuntimeName for StorageProvider {
     const NAME: &'static str = "Windows.Storage.StorageProvider";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StorageStreamTransaction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StorageStreamTransaction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StorageStreamTransaction, super::Foundation::IClosable);
@@ -4247,7 +4247,7 @@ impl windows_core::RuntimeName for StorageStreamTransaction {
 }
 #[cfg(feature = "Storage_Streams")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StreamedFileDataRequest(windows_core::IUnknown);
 #[cfg(feature = "Storage_Streams")]
 windows_core::imp::interface_hierarchy!(StreamedFileDataRequest, windows_core::IUnknown, windows_core::IInspectable);
@@ -4297,7 +4297,7 @@ impl windows_core::RuntimeName for StreamedFileDataRequest {
     const NAME: &'static str = "Windows.Storage.StreamedFileDataRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemAudioProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemAudioProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemAudioProperties {
@@ -4322,7 +4322,7 @@ impl windows_core::RuntimeName for SystemAudioProperties {
 unsafe impl Send for SystemAudioProperties {}
 unsafe impl Sync for SystemAudioProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemDataPaths(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemDataPaths, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemDataPaths {
@@ -4463,7 +4463,7 @@ impl windows_core::RuntimeName for SystemDataPaths {
 unsafe impl Send for SystemDataPaths {}
 unsafe impl Sync for SystemDataPaths {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemGPSProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemGPSProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemGPSProperties {
@@ -4495,7 +4495,7 @@ impl windows_core::RuntimeName for SystemGPSProperties {
 unsafe impl Send for SystemGPSProperties {}
 unsafe impl Sync for SystemGPSProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemImageProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemImageProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemImageProperties {
@@ -4527,7 +4527,7 @@ impl windows_core::RuntimeName for SystemImageProperties {
 unsafe impl Send for SystemImageProperties {}
 unsafe impl Sync for SystemImageProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemMediaProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemMediaProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemMediaProperties {
@@ -4587,7 +4587,7 @@ impl windows_core::RuntimeName for SystemMediaProperties {
 unsafe impl Send for SystemMediaProperties {}
 unsafe impl Sync for SystemMediaProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemMusicProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemMusicProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemMusicProperties {
@@ -4661,7 +4661,7 @@ impl windows_core::RuntimeName for SystemMusicProperties {
 unsafe impl Send for SystemMusicProperties {}
 unsafe impl Sync for SystemMusicProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemPhotoProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemPhotoProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemPhotoProperties {
@@ -4803,7 +4803,7 @@ impl windows_core::RuntimeName for SystemProperties {
     const NAME: &'static str = "Windows.Storage.SystemProperties";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemVideoProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemVideoProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemVideoProperties {
@@ -4856,7 +4856,7 @@ impl windows_core::RuntimeName for SystemVideoProperties {
 unsafe impl Send for SystemVideoProperties {}
 unsafe impl Sync for SystemVideoProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDataPaths(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDataPaths, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDataPaths {

--- a/crates/libs/windows/src/Windows/System/Diagnostics/DevicePortal/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/DevicePortal/mod.rs
@@ -90,7 +90,7 @@ pub struct IDevicePortalWebSocketConnectionRequestReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DevicePortalConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DevicePortalConnection, windows_core::IUnknown, windows_core::IInspectable);
 impl DevicePortalConnection {
@@ -206,7 +206,7 @@ impl windows_core::RuntimeName for DevicePortalConnection {
 unsafe impl Send for DevicePortalConnection {}
 unsafe impl Sync for DevicePortalConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DevicePortalConnectionClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DevicePortalConnectionClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DevicePortalConnectionClosedEventArgs {
@@ -231,7 +231,7 @@ impl windows_core::RuntimeName for DevicePortalConnectionClosedEventArgs {
 unsafe impl Send for DevicePortalConnectionClosedEventArgs {}
 unsafe impl Sync for DevicePortalConnectionClosedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DevicePortalConnectionRequestReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DevicePortalConnectionRequestReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DevicePortalConnectionRequestReceivedEventArgs {

--- a/crates/libs/windows/src/Windows/System/Diagnostics/Telemetry/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/Telemetry/mod.rs
@@ -56,7 +56,7 @@ impl windows_core::RuntimeName for PlatformTelemetryClient {
     const NAME: &'static str = "Windows.System.Diagnostics.Telemetry.PlatformTelemetryClient";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlatformTelemetryRegistrationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlatformTelemetryRegistrationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl PlatformTelemetryRegistrationResult {
@@ -81,7 +81,7 @@ impl windows_core::RuntimeName for PlatformTelemetryRegistrationResult {
 unsafe impl Send for PlatformTelemetryRegistrationResult {}
 unsafe impl Sync for PlatformTelemetryRegistrationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlatformTelemetryRegistrationSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlatformTelemetryRegistrationSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl PlatformTelemetryRegistrationSettings {

--- a/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
@@ -113,7 +113,7 @@ impl windows_core::RuntimeName for PlatformDiagnosticActions {
     const NAME: &'static str = "Windows.System.Diagnostics.TraceReporting.PlatformDiagnosticActions";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlatformDiagnosticTraceInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlatformDiagnosticTraceInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl PlatformDiagnosticTraceInfo {
@@ -173,7 +173,7 @@ impl windows_core::RuntimeName for PlatformDiagnosticTraceInfo {
 unsafe impl Send for PlatformDiagnosticTraceInfo {}
 unsafe impl Sync for PlatformDiagnosticTraceInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PlatformDiagnosticTraceRuntimeInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlatformDiagnosticTraceRuntimeInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl PlatformDiagnosticTraceRuntimeInfo {

--- a/crates/libs/windows/src/Windows/System/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/mod.rs
@@ -240,7 +240,7 @@ pub struct ISystemMemoryUsageReport_Vtbl {
     pub CommittedSizeInBytes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DiagnosticActionResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DiagnosticActionResult, windows_core::IUnknown, windows_core::IInspectable);
 impl DiagnosticActionResult {
@@ -273,7 +273,7 @@ impl windows_core::RuntimeName for DiagnosticActionResult {
 unsafe impl Send for DiagnosticActionResult {}
 unsafe impl Sync for DiagnosticActionResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DiagnosticInvoker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DiagnosticInvoker, windows_core::IUnknown, windows_core::IInspectable);
 impl DiagnosticInvoker {
@@ -335,7 +335,7 @@ impl windows_core::RuntimeName for DiagnosticInvoker {
 unsafe impl Send for DiagnosticInvoker {}
 unsafe impl Sync for DiagnosticInvoker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessCpuUsage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessCpuUsage, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessCpuUsage {
@@ -360,7 +360,7 @@ impl windows_core::RuntimeName for ProcessCpuUsage {
 unsafe impl Send for ProcessCpuUsage {}
 unsafe impl Sync for ProcessCpuUsage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessCpuUsageReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessCpuUsageReport, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessCpuUsageReport {
@@ -392,7 +392,7 @@ impl windows_core::RuntimeName for ProcessCpuUsageReport {
 unsafe impl Send for ProcessCpuUsageReport {}
 unsafe impl Sync for ProcessCpuUsageReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessDiagnosticInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessDiagnosticInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessDiagnosticInfo {
@@ -503,7 +503,7 @@ impl windows_core::RuntimeName for ProcessDiagnosticInfo {
 unsafe impl Send for ProcessDiagnosticInfo {}
 unsafe impl Sync for ProcessDiagnosticInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessDiskUsage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessDiskUsage, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessDiskUsage {
@@ -528,7 +528,7 @@ impl windows_core::RuntimeName for ProcessDiskUsage {
 unsafe impl Send for ProcessDiskUsage {}
 unsafe impl Sync for ProcessDiskUsage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessDiskUsageReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessDiskUsageReport, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessDiskUsageReport {
@@ -588,7 +588,7 @@ impl windows_core::RuntimeName for ProcessDiskUsageReport {
 unsafe impl Send for ProcessDiskUsageReport {}
 unsafe impl Sync for ProcessDiskUsageReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessMemoryUsage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessMemoryUsage, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessMemoryUsage {
@@ -613,7 +613,7 @@ impl windows_core::RuntimeName for ProcessMemoryUsage {
 unsafe impl Send for ProcessMemoryUsage {}
 unsafe impl Sync for ProcessMemoryUsage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessMemoryUsageReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessMemoryUsageReport, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessMemoryUsageReport {
@@ -715,7 +715,7 @@ impl windows_core::RuntimeName for ProcessMemoryUsageReport {
 unsafe impl Send for ProcessMemoryUsageReport {}
 unsafe impl Sync for ProcessMemoryUsageReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemCpuUsage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemCpuUsage, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemCpuUsage {
@@ -740,7 +740,7 @@ impl windows_core::RuntimeName for SystemCpuUsage {
 unsafe impl Send for SystemCpuUsage {}
 unsafe impl Sync for SystemCpuUsage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemCpuUsageReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemCpuUsageReport, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemCpuUsageReport {
@@ -779,7 +779,7 @@ impl windows_core::RuntimeName for SystemCpuUsageReport {
 unsafe impl Send for SystemCpuUsageReport {}
 unsafe impl Sync for SystemCpuUsageReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemDiagnosticInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemDiagnosticInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemDiagnosticInfo {
@@ -839,7 +839,7 @@ impl windows_core::RuntimeName for SystemDiagnosticInfo {
 unsafe impl Send for SystemDiagnosticInfo {}
 unsafe impl Sync for SystemDiagnosticInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemMemoryUsage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemMemoryUsage, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemMemoryUsage {
@@ -864,7 +864,7 @@ impl windows_core::RuntimeName for SystemMemoryUsage {
 unsafe impl Send for SystemMemoryUsage {}
 unsafe impl Sync for SystemMemoryUsage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemMemoryUsageReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemMemoryUsageReport, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemMemoryUsageReport {

--- a/crates/libs/windows/src/Windows/System/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Display/mod.rs
@@ -9,7 +9,7 @@ pub struct IDisplayRequest_Vtbl {
     pub RequestRelease: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayRequest {

--- a/crates/libs/windows/src/Windows/System/Implementation/FileExplorer/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Implementation/FileExplorer/mod.rs
@@ -115,7 +115,7 @@ pub struct ISysStorageProviderHttpRequestProvider_Vtbl {
     SendRequestAsync: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SysStorageProviderEventReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SysStorageProviderEventReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SysStorageProviderEventReceivedEventArgs {

--- a/crates/libs/windows/src/Windows/System/Inventory/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Inventory/mod.rs
@@ -23,7 +23,7 @@ pub struct IInstalledDesktopAppStatics_Vtbl {
     GetInventoryAsync: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InstalledDesktopApp(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InstalledDesktopApp, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InstalledDesktopApp, super::super::Foundation::IStringable);

--- a/crates/libs/windows/src/Windows/System/Profile/SystemManufacturers/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Profile/SystemManufacturers/mod.rs
@@ -53,7 +53,7 @@ pub struct ISystemSupportInfoStatics2_Vtbl {
     pub LocalDeviceInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OemSupportInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OemSupportInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl OemSupportInfo {
@@ -109,7 +109,7 @@ impl windows_core::RuntimeName for SmbiosInformation {
     const NAME: &'static str = "Windows.System.Profile.SystemManufacturers.SmbiosInformation";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemSupportDeviceInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemSupportDeviceInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemSupportDeviceInfo {

--- a/crates/libs/windows/src/Windows/System/Profile/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Profile/mod.rs
@@ -275,7 +275,7 @@ impl windows_core::RuntimeName for AnalyticsInfo {
     const NAME: &'static str = "Windows.System.Profile.AnalyticsInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AnalyticsVersionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AnalyticsVersionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AnalyticsVersionInfo {
@@ -373,7 +373,7 @@ impl windows_core::RuntimeName for HardwareIdentification {
     const NAME: &'static str = "Windows.System.Profile.HardwareIdentification";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HardwareToken(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HardwareToken, windows_core::IUnknown, windows_core::IInspectable);
 impl HardwareToken {
@@ -700,7 +700,7 @@ impl windows_core::RuntimeName for SystemIdentification {
     const NAME: &'static str = "Windows.System.Profile.SystemIdentification";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemIdentificationInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemIdentificationInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemIdentificationInfo {
@@ -762,7 +762,7 @@ impl windows_core::RuntimeName for SystemSetupInfo {
     const NAME: &'static str = "Windows.System.Profile.SystemSetupInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UnsupportedAppRequirement(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UnsupportedAppRequirement, windows_core::IUnknown, windows_core::IInspectable);
 impl UnsupportedAppRequirement {

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
@@ -21,7 +21,7 @@ pub struct IRemoteTextConnectionFactory_Vtbl {
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteTextConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteTextConnection, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RemoteTextConnection, super::super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/Provider/mod.rs
@@ -85,7 +85,7 @@ pub struct IRemoteDesktopRegistrarStatics_Vtbl {
     pub IsSwitchToLocalSessionEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PerformLocalActionRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PerformLocalActionRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PerformLocalActionRequestedEventArgs {
@@ -110,7 +110,7 @@ impl windows_core::RuntimeName for PerformLocalActionRequestedEventArgs {
 unsafe impl Send for PerformLocalActionRequestedEventArgs {}
 unsafe impl Sync for PerformLocalActionRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteDesktopConnectionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteDesktopConnectionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteDesktopConnectionInfo {
@@ -151,7 +151,7 @@ impl windows_core::RuntimeName for RemoteDesktopConnectionInfo {
 unsafe impl Send for RemoteDesktopConnectionInfo {}
 unsafe impl Sync for RemoteDesktopConnectionInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteDesktopConnectionRemoteInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteDesktopConnectionRemoteInfo, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RemoteDesktopConnectionRemoteInfo, super::super::super::Foundation::IClosable);
@@ -226,7 +226,7 @@ impl windows_core::RuntimeName for RemoteDesktopConnectionRemoteInfo {
 unsafe impl Send for RemoteDesktopConnectionRemoteInfo {}
 unsafe impl Sync for RemoteDesktopConnectionRemoteInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteDesktopInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteDesktopInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteDesktopInfo {

--- a/crates/libs/windows/src/Windows/System/RemoteSystems/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteSystems/mod.rs
@@ -781,7 +781,7 @@ impl windows_core::RuntimeName for KnownRemoteSystemCapabilities {
     const NAME: &'static str = "Windows.System.RemoteSystems.KnownRemoteSystemCapabilities";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystem, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystem {
@@ -957,7 +957,7 @@ impl windows_core::RuntimeName for RemoteSystem {
 unsafe impl Send for RemoteSystem {}
 unsafe impl Sync for RemoteSystem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemAddedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemAddedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemAddedEventArgs {
@@ -982,7 +982,7 @@ impl windows_core::RuntimeName for RemoteSystemAddedEventArgs {
 unsafe impl Send for RemoteSystemAddedEventArgs {}
 unsafe impl Sync for RemoteSystemAddedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemApp(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemApp, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemApp {
@@ -1050,7 +1050,7 @@ impl windows_core::RuntimeName for RemoteSystemApp {
 unsafe impl Send for RemoteSystemApp {}
 unsafe impl Sync for RemoteSystemApp {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemAppRegistration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemAppRegistration, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemAppRegistration {
@@ -1110,7 +1110,7 @@ impl windows_core::RuntimeName for RemoteSystemAppRegistration {
 unsafe impl Send for RemoteSystemAppRegistration {}
 unsafe impl Sync for RemoteSystemAppRegistration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemAuthorizationKindFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemAuthorizationKindFilter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RemoteSystemAuthorizationKindFilter, IRemoteSystemFilter);
@@ -1147,7 +1147,7 @@ impl windows_core::RuntimeName for RemoteSystemAuthorizationKindFilter {
 unsafe impl Send for RemoteSystemAuthorizationKindFilter {}
 unsafe impl Sync for RemoteSystemAuthorizationKindFilter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemConnectionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemConnectionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemConnectionInfo {
@@ -1187,7 +1187,7 @@ impl windows_core::RuntimeName for RemoteSystemConnectionInfo {
 unsafe impl Send for RemoteSystemConnectionInfo {}
 unsafe impl Sync for RemoteSystemConnectionInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemConnectionRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemConnectionRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemConnectionRequest {
@@ -1274,7 +1274,7 @@ impl windows_core::RuntimeName for RemoteSystemConnectionRequest {
 unsafe impl Send for RemoteSystemConnectionRequest {}
 unsafe impl Sync for RemoteSystemConnectionRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemDiscoveryTypeFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemDiscoveryTypeFilter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RemoteSystemDiscoveryTypeFilter, IRemoteSystemFilter);
@@ -1311,7 +1311,7 @@ impl windows_core::RuntimeName for RemoteSystemDiscoveryTypeFilter {
 unsafe impl Send for RemoteSystemDiscoveryTypeFilter {}
 unsafe impl Sync for RemoteSystemDiscoveryTypeFilter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemEnumerationCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemEnumerationCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemEnumerationCompletedEventArgs {}
@@ -1328,7 +1328,7 @@ impl windows_core::RuntimeName for RemoteSystemEnumerationCompletedEventArgs {
 unsafe impl Send for RemoteSystemEnumerationCompletedEventArgs {}
 unsafe impl Sync for RemoteSystemEnumerationCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemKindFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemKindFilter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RemoteSystemKindFilter, IRemoteSystemFilter);
@@ -1434,7 +1434,7 @@ impl windows_core::RuntimeName for RemoteSystemKinds {
     const NAME: &'static str = "Windows.System.RemoteSystems.RemoteSystemKinds";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemRemovedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemRemovedEventArgs {
@@ -1459,7 +1459,7 @@ impl windows_core::RuntimeName for RemoteSystemRemovedEventArgs {
 unsafe impl Send for RemoteSystemRemovedEventArgs {}
 unsafe impl Sync for RemoteSystemRemovedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSession, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RemoteSystemSession, super::super::Foundation::IClosable);
@@ -1545,7 +1545,7 @@ impl windows_core::RuntimeName for RemoteSystemSession {
 unsafe impl Send for RemoteSystemSession {}
 unsafe impl Sync for RemoteSystemSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionAddedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionAddedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionAddedEventArgs {
@@ -1570,7 +1570,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionAddedEventArgs {
 unsafe impl Send for RemoteSystemSessionAddedEventArgs {}
 unsafe impl Sync for RemoteSystemSessionAddedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionController, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionController {
@@ -1639,7 +1639,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionController {
 unsafe impl Send for RemoteSystemSessionController {}
 unsafe impl Sync for RemoteSystemSessionController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionCreationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionCreationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionCreationResult {
@@ -1671,7 +1671,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionCreationResult {
 unsafe impl Send for RemoteSystemSessionCreationResult {}
 unsafe impl Sync for RemoteSystemSessionCreationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionDisconnectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionDisconnectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionDisconnectedEventArgs {
@@ -1696,7 +1696,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionDisconnectedEventArgs {
 unsafe impl Send for RemoteSystemSessionDisconnectedEventArgs {}
 unsafe impl Sync for RemoteSystemSessionDisconnectedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionInfo {
@@ -1735,7 +1735,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionInfo {
 unsafe impl Send for RemoteSystemSessionInfo {}
 unsafe impl Sync for RemoteSystemSessionInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionInvitation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionInvitation, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionInvitation {
@@ -1767,7 +1767,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionInvitation {
 unsafe impl Send for RemoteSystemSessionInvitation {}
 unsafe impl Sync for RemoteSystemSessionInvitation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionInvitationListener(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionInvitationListener, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionInvitationListener {
@@ -1806,7 +1806,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionInvitationListener {
 unsafe impl Send for RemoteSystemSessionInvitationListener {}
 unsafe impl Sync for RemoteSystemSessionInvitationListener {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionInvitationReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionInvitationReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionInvitationReceivedEventArgs {
@@ -1831,7 +1831,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionInvitationReceivedEventArg
 unsafe impl Send for RemoteSystemSessionInvitationReceivedEventArgs {}
 unsafe impl Sync for RemoteSystemSessionInvitationReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionJoinRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionJoinRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionJoinRequest {
@@ -1860,7 +1860,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionJoinRequest {
 unsafe impl Send for RemoteSystemSessionJoinRequest {}
 unsafe impl Sync for RemoteSystemSessionJoinRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionJoinRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionJoinRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionJoinRequestedEventArgs {
@@ -1892,7 +1892,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionJoinRequestedEventArgs {
 unsafe impl Send for RemoteSystemSessionJoinRequestedEventArgs {}
 unsafe impl Sync for RemoteSystemSessionJoinRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionJoinResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionJoinResult, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionJoinResult {
@@ -1924,7 +1924,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionJoinResult {
 unsafe impl Send for RemoteSystemSessionJoinResult {}
 unsafe impl Sync for RemoteSystemSessionJoinResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionMessageChannel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionMessageChannel, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionMessageChannel {
@@ -2021,7 +2021,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionMessageChannel {
 unsafe impl Send for RemoteSystemSessionMessageChannel {}
 unsafe impl Sync for RemoteSystemSessionMessageChannel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionOptions {
@@ -2057,7 +2057,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionOptions {
 unsafe impl Send for RemoteSystemSessionOptions {}
 unsafe impl Sync for RemoteSystemSessionOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionParticipant(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionParticipant, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionParticipant {
@@ -2090,7 +2090,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionParticipant {
 unsafe impl Send for RemoteSystemSessionParticipant {}
 unsafe impl Sync for RemoteSystemSessionParticipant {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionParticipantAddedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionParticipantAddedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionParticipantAddedEventArgs {
@@ -2115,7 +2115,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionParticipantAddedEventArgs 
 unsafe impl Send for RemoteSystemSessionParticipantAddedEventArgs {}
 unsafe impl Sync for RemoteSystemSessionParticipantAddedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionParticipantRemovedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionParticipantRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionParticipantRemovedEventArgs {
@@ -2140,7 +2140,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionParticipantRemovedEventArg
 unsafe impl Send for RemoteSystemSessionParticipantRemovedEventArgs {}
 unsafe impl Sync for RemoteSystemSessionParticipantRemovedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionParticipantWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionParticipantWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionParticipantWatcher {
@@ -2215,7 +2215,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionParticipantWatcher {
 unsafe impl Send for RemoteSystemSessionParticipantWatcher {}
 unsafe impl Sync for RemoteSystemSessionParticipantWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionRemovedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionRemovedEventArgs {
@@ -2240,7 +2240,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionRemovedEventArgs {
 unsafe impl Send for RemoteSystemSessionRemovedEventArgs {}
 unsafe impl Sync for RemoteSystemSessionRemovedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionUpdatedEventArgs {
@@ -2265,7 +2265,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionUpdatedEventArgs {
 unsafe impl Send for RemoteSystemSessionUpdatedEventArgs {}
 unsafe impl Sync for RemoteSystemSessionUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionValueSetReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionValueSetReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionValueSetReceivedEventArgs {
@@ -2298,7 +2298,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionValueSetReceivedEventArgs 
 unsafe impl Send for RemoteSystemSessionValueSetReceivedEventArgs {}
 unsafe impl Sync for RemoteSystemSessionValueSetReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemSessionWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemSessionWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemSessionWatcher {
@@ -2373,7 +2373,7 @@ impl windows_core::RuntimeName for RemoteSystemSessionWatcher {
 unsafe impl Send for RemoteSystemSessionWatcher {}
 unsafe impl Sync for RemoteSystemSessionWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemStatusTypeFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemStatusTypeFilter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RemoteSystemStatusTypeFilter, IRemoteSystemFilter);
@@ -2410,7 +2410,7 @@ impl windows_core::RuntimeName for RemoteSystemStatusTypeFilter {
 unsafe impl Send for RemoteSystemStatusTypeFilter {}
 unsafe impl Sync for RemoteSystemStatusTypeFilter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemUpdatedEventArgs {
@@ -2435,7 +2435,7 @@ impl windows_core::RuntimeName for RemoteSystemUpdatedEventArgs {
 unsafe impl Send for RemoteSystemUpdatedEventArgs {}
 unsafe impl Sync for RemoteSystemUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemWatcher {
@@ -2538,7 +2538,7 @@ impl windows_core::RuntimeName for RemoteSystemWatcher {
 unsafe impl Send for RemoteSystemWatcher {}
 unsafe impl Sync for RemoteSystemWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemWatcherErrorOccurredEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemWatcherErrorOccurredEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemWatcherErrorOccurredEventArgs {
@@ -2563,7 +2563,7 @@ impl windows_core::RuntimeName for RemoteSystemWatcherErrorOccurredEventArgs {
 unsafe impl Send for RemoteSystemWatcherErrorOccurredEventArgs {}
 unsafe impl Sync for RemoteSystemWatcherErrorOccurredEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteSystemWebAccountFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemWebAccountFilter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RemoteSystemWebAccountFilter, IRemoteSystemFilter);

--- a/crates/libs/windows/src/Windows/System/Threading/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/Core/mod.rs
@@ -41,7 +41,7 @@ pub struct ISignalNotifierStatics_Vtbl {
     pub AttachToSemaphoreWithTimeout: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, super::super::super::Foundation::TimeSpan, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PreallocatedWorkItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PreallocatedWorkItem, windows_core::IUnknown, windows_core::IInspectable);
 impl PreallocatedWorkItem {
@@ -98,7 +98,7 @@ impl windows_core::RuntimeName for PreallocatedWorkItem {
 unsafe impl Send for PreallocatedWorkItem {}
 unsafe impl Sync for PreallocatedWorkItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SignalNotifier(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SignalNotifier, windows_core::IUnknown, windows_core::IInspectable);
 impl SignalNotifier {

--- a/crates/libs/windows/src/Windows/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/mod.rs
@@ -73,7 +73,7 @@ impl windows_core::RuntimeName for ThreadPool {
     const NAME: &'static str = "Windows.System.Threading.ThreadPool";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ThreadPoolTimer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ThreadPoolTimer, windows_core::IUnknown, windows_core::IInspectable);
 impl ThreadPoolTimer {

--- a/crates/libs/windows/src/Windows/System/Update/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Update/mod.rs
@@ -64,7 +64,7 @@ pub struct ISystemUpdateManagerStatics_Vtbl {
     pub StartCancelUpdates: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemUpdateItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemUpdateItem, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemUpdateItem {
@@ -138,7 +138,7 @@ impl windows_core::RuntimeName for SystemUpdateItem {
 unsafe impl Send for SystemUpdateItem {}
 unsafe impl Sync for SystemUpdateItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemUpdateLastErrorInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemUpdateLastErrorInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemUpdateLastErrorInfo {

--- a/crates/libs/windows/src/Windows/System/UserProfile/mod.rs
+++ b/crates/libs/windows/src/Windows/System/UserProfile/mod.rs
@@ -325,7 +325,7 @@ impl windows_core::RuntimeName for AdvertisingManager {
     const NAME: &'static str = "Windows.System.UserProfile.AdvertisingManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdvertisingManagerForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdvertisingManagerForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl AdvertisingManagerForUser {
@@ -357,7 +357,7 @@ impl windows_core::RuntimeName for AdvertisingManagerForUser {
 unsafe impl Send for AdvertisingManagerForUser {}
 unsafe impl Sync for AdvertisingManagerForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AssignedAccessSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AssignedAccessSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl AssignedAccessSettings {
@@ -416,7 +416,7 @@ impl windows_core::RuntimeName for AssignedAccessSettings {
 unsafe impl Send for AssignedAccessSettings {}
 unsafe impl Sync for AssignedAccessSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DiagnosticsSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DiagnosticsSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl DiagnosticsSettings {
@@ -468,7 +468,7 @@ impl windows_core::RuntimeName for DiagnosticsSettings {
 unsafe impl Send for DiagnosticsSettings {}
 unsafe impl Sync for DiagnosticsSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FirstSignInSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FirstSignInSettings, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -639,7 +639,7 @@ impl windows_core::RuntimeName for GlobalizationPreferences {
     const NAME: &'static str = "Windows.System.UserProfile.GlobalizationPreferences";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GlobalizationPreferencesForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GlobalizationPreferencesForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl GlobalizationPreferencesForUser {
@@ -911,7 +911,7 @@ impl windows_core::RuntimeName for UserInformation {
     const NAME: &'static str = "Windows.System.UserProfile.UserInformation";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserProfilePersonalizationSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserProfilePersonalizationSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl UserProfilePersonalizationSettings {

--- a/crates/libs/windows/src/Windows/System/mod.rs
+++ b/crates/libs/windows/src/Windows/System/mod.rs
@@ -1117,7 +1117,7 @@ pub struct IUserWatcher_Vtbl {
     pub RemoveStopped: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppActivationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppActivationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl AppActivationResult {
@@ -1149,7 +1149,7 @@ impl windows_core::RuntimeName for AppActivationResult {
 unsafe impl Send for AppActivationResult {}
 unsafe impl Sync for AppActivationResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppDiagnosticInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppDiagnosticInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AppDiagnosticInfo {
@@ -1247,7 +1247,7 @@ impl windows_core::RuntimeName for AppDiagnosticInfo {
 unsafe impl Send for AppDiagnosticInfo {}
 unsafe impl Sync for AppDiagnosticInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppDiagnosticInfoWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppDiagnosticInfoWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl AppDiagnosticInfoWatcher {
@@ -1336,7 +1336,7 @@ impl windows_core::RuntimeName for AppDiagnosticInfoWatcher {
 unsafe impl Send for AppDiagnosticInfoWatcher {}
 unsafe impl Sync for AppDiagnosticInfoWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppDiagnosticInfoWatcherEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppDiagnosticInfoWatcherEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppDiagnosticInfoWatcherEventArgs {
@@ -1361,7 +1361,7 @@ impl windows_core::RuntimeName for AppDiagnosticInfoWatcherEventArgs {
 unsafe impl Send for AppDiagnosticInfoWatcherEventArgs {}
 unsafe impl Sync for AppDiagnosticInfoWatcherEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppExecutionStateChangeResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppExecutionStateChangeResult, windows_core::IUnknown, windows_core::IInspectable);
 impl AppExecutionStateChangeResult {
@@ -1386,7 +1386,7 @@ impl windows_core::RuntimeName for AppExecutionStateChangeResult {
 unsafe impl Send for AppExecutionStateChangeResult {}
 unsafe impl Sync for AppExecutionStateChangeResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppMemoryReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppMemoryReport, windows_core::IUnknown, windows_core::IInspectable);
 impl AppMemoryReport {
@@ -1439,7 +1439,7 @@ impl windows_core::RuntimeName for AppMemoryReport {
 unsafe impl Send for AppMemoryReport {}
 unsafe impl Sync for AppMemoryReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppMemoryUsageLimitChangingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppMemoryUsageLimitChangingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppMemoryUsageLimitChangingEventArgs {
@@ -1471,7 +1471,7 @@ impl windows_core::RuntimeName for AppMemoryUsageLimitChangingEventArgs {
 unsafe impl Send for AppMemoryUsageLimitChangingEventArgs {}
 unsafe impl Sync for AppMemoryUsageLimitChangingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppResourceGroupBackgroundTaskReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppResourceGroupBackgroundTaskReport, windows_core::IUnknown, windows_core::IInspectable);
 impl AppResourceGroupBackgroundTaskReport {
@@ -1517,7 +1517,7 @@ impl windows_core::RuntimeName for AppResourceGroupBackgroundTaskReport {
 unsafe impl Send for AppResourceGroupBackgroundTaskReport {}
 unsafe impl Sync for AppResourceGroupBackgroundTaskReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppResourceGroupInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppResourceGroupInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl AppResourceGroupInfo {
@@ -1600,7 +1600,7 @@ impl windows_core::RuntimeName for AppResourceGroupInfo {
 unsafe impl Send for AppResourceGroupInfo {}
 unsafe impl Sync for AppResourceGroupInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppResourceGroupInfoWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppResourceGroupInfoWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl AppResourceGroupInfoWatcher {
@@ -1703,7 +1703,7 @@ impl windows_core::RuntimeName for AppResourceGroupInfoWatcher {
 unsafe impl Send for AppResourceGroupInfoWatcher {}
 unsafe impl Sync for AppResourceGroupInfoWatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppResourceGroupInfoWatcherEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppResourceGroupInfoWatcherEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppResourceGroupInfoWatcherEventArgs {
@@ -1736,7 +1736,7 @@ impl windows_core::RuntimeName for AppResourceGroupInfoWatcherEventArgs {
 unsafe impl Send for AppResourceGroupInfoWatcherEventArgs {}
 unsafe impl Sync for AppResourceGroupInfoWatcherEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppResourceGroupInfoWatcherExecutionStateChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppResourceGroupInfoWatcherExecutionStateChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppResourceGroupInfoWatcherExecutionStateChangedEventArgs {
@@ -1769,7 +1769,7 @@ impl windows_core::RuntimeName for AppResourceGroupInfoWatcherExecutionStateChan
 unsafe impl Send for AppResourceGroupInfoWatcherExecutionStateChangedEventArgs {}
 unsafe impl Sync for AppResourceGroupInfoWatcherExecutionStateChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppResourceGroupMemoryReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppResourceGroupMemoryReport, windows_core::IUnknown, windows_core::IInspectable);
 impl AppResourceGroupMemoryReport {
@@ -1815,7 +1815,7 @@ impl windows_core::RuntimeName for AppResourceGroupMemoryReport {
 unsafe impl Send for AppResourceGroupMemoryReport {}
 unsafe impl Sync for AppResourceGroupMemoryReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppResourceGroupStateReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppResourceGroupStateReport, windows_core::IUnknown, windows_core::IInspectable);
 impl AppResourceGroupStateReport {
@@ -1847,7 +1847,7 @@ impl windows_core::RuntimeName for AppResourceGroupStateReport {
 unsafe impl Send for AppResourceGroupStateReport {}
 unsafe impl Sync for AppResourceGroupStateReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppUriHandlerHost(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppUriHandlerHost, windows_core::IUnknown, windows_core::IInspectable);
 impl AppUriHandlerHost {
@@ -1905,7 +1905,7 @@ impl windows_core::RuntimeName for AppUriHandlerHost {
 unsafe impl Send for AppUriHandlerHost {}
 unsafe impl Sync for AppUriHandlerHost {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppUriHandlerRegistration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppUriHandlerRegistration, windows_core::IUnknown, windows_core::IInspectable);
 impl AppUriHandlerRegistration {
@@ -1979,7 +1979,7 @@ impl windows_core::RuntimeName for AppUriHandlerRegistration {
 unsafe impl Send for AppUriHandlerRegistration {}
 unsafe impl Sync for AppUriHandlerRegistration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppUriHandlerRegistrationManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppUriHandlerRegistrationManager, windows_core::IUnknown, windows_core::IInspectable);
 impl AppUriHandlerRegistrationManager {
@@ -2072,7 +2072,7 @@ impl windows_core::RuntimeName for DateTimeSettings {
     const NAME: &'static str = "Windows.System.DateTimeSettings";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DispatcherQueue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DispatcherQueue, windows_core::IUnknown, windows_core::IInspectable);
 impl DispatcherQueue {
@@ -2163,7 +2163,7 @@ impl windows_core::RuntimeName for DispatcherQueue {
 unsafe impl Send for DispatcherQueue {}
 unsafe impl Sync for DispatcherQueue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DispatcherQueueController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DispatcherQueueController, windows_core::IUnknown, windows_core::IInspectable);
 impl DispatcherQueueController {
@@ -2206,7 +2206,7 @@ impl windows_core::RuntimeName for DispatcherQueueController {
 unsafe impl Send for DispatcherQueueController {}
 unsafe impl Sync for DispatcherQueueController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DispatcherQueueShutdownStartingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DispatcherQueueShutdownStartingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DispatcherQueueShutdownStartingEventArgs {
@@ -2231,7 +2231,7 @@ impl windows_core::RuntimeName for DispatcherQueueShutdownStartingEventArgs {
 unsafe impl Send for DispatcherQueueShutdownStartingEventArgs {}
 unsafe impl Sync for DispatcherQueueShutdownStartingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DispatcherQueueTimer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DispatcherQueueTimer, windows_core::IUnknown, windows_core::IInspectable);
 impl DispatcherQueueTimer {
@@ -2300,7 +2300,7 @@ impl windows_core::RuntimeName for DispatcherQueueTimer {
 unsafe impl Send for DispatcherQueueTimer {}
 unsafe impl Sync for DispatcherQueueTimer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FolderLauncherOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FolderLauncherOptions, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FolderLauncherOptions, ILauncherViewOptions);
@@ -2423,7 +2423,7 @@ impl windows_core::RuntimeName for KnownUserProperties {
     const NAME: &'static str = "Windows.System.KnownUserProperties";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LaunchUriResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LaunchUriResult, windows_core::IUnknown, windows_core::IInspectable);
 impl LaunchUriResult {
@@ -2761,7 +2761,7 @@ impl windows_core::RuntimeName for Launcher {
     const NAME: &'static str = "Windows.System.Launcher";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LauncherOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LauncherOptions, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LauncherOptions, ILauncherViewOptions);
@@ -2925,7 +2925,7 @@ impl windows_core::RuntimeName for LauncherOptions {
 unsafe impl Send for LauncherOptions {}
 unsafe impl Sync for LauncherOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LauncherUIOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LauncherUIOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl LauncherUIOptions {
@@ -3114,7 +3114,7 @@ impl windows_core::RuntimeName for ProcessLauncher {
     const NAME: &'static str = "Windows.System.ProcessLauncher";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessLauncherOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessLauncherOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessLauncherOptions {
@@ -3198,7 +3198,7 @@ impl windows_core::RuntimeName for ProcessLauncherOptions {
 unsafe impl Send for ProcessLauncherOptions {}
 unsafe impl Sync for ProcessLauncherOptions {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessLauncherResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessLauncherResult, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessLauncherResult {
@@ -3223,7 +3223,7 @@ impl windows_core::RuntimeName for ProcessLauncherResult {
 unsafe impl Send for ProcessLauncherResult {}
 unsafe impl Sync for ProcessLauncherResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProcessMemoryReport(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProcessMemoryReport, windows_core::IUnknown, windows_core::IInspectable);
 impl ProcessMemoryReport {
@@ -3255,7 +3255,7 @@ impl windows_core::RuntimeName for ProcessMemoryReport {
 unsafe impl Send for ProcessMemoryReport {}
 unsafe impl Sync for ProcessMemoryReport {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ProtocolForResultsOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ProtocolForResultsOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl ProtocolForResultsOperation {
@@ -3328,7 +3328,7 @@ impl windows_core::RuntimeName for RemoteLauncher {
     const NAME: &'static str = "Windows.System.RemoteLauncher";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteLauncherOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteLauncherOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteLauncherOptions {
@@ -3453,7 +3453,7 @@ impl windows_core::RuntimeName for TimeZoneSettings {
     const NAME: &'static str = "Windows.System.TimeZoneSettings";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct User(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(User, windows_core::IUnknown, windows_core::IInspectable);
 impl User {
@@ -3574,7 +3574,7 @@ impl windows_core::RuntimeName for User {
 unsafe impl Send for User {}
 unsafe impl Sync for User {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserAuthenticationStatusChangeDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserAuthenticationStatusChangeDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl UserAuthenticationStatusChangeDeferral {
@@ -3596,7 +3596,7 @@ impl windows_core::RuntimeName for UserAuthenticationStatusChangeDeferral {
 unsafe impl Send for UserAuthenticationStatusChangeDeferral {}
 unsafe impl Sync for UserAuthenticationStatusChangeDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserAuthenticationStatusChangingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserAuthenticationStatusChangingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserAuthenticationStatusChangingEventArgs {
@@ -3642,7 +3642,7 @@ impl windows_core::RuntimeName for UserAuthenticationStatusChangingEventArgs {
 unsafe impl Send for UserAuthenticationStatusChangingEventArgs {}
 unsafe impl Sync for UserAuthenticationStatusChangingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserChangedEventArgs {
@@ -3704,7 +3704,7 @@ impl windows_core::RuntimeName for UserDeviceAssociation {
     const NAME: &'static str = "Windows.System.UserDeviceAssociation";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserDeviceAssociationChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserDeviceAssociationChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserDeviceAssociationChangedEventArgs {
@@ -3743,7 +3743,7 @@ impl windows_core::RuntimeName for UserDeviceAssociationChangedEventArgs {
 unsafe impl Send for UserDeviceAssociationChangedEventArgs {}
 unsafe impl Sync for UserDeviceAssociationChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserPicker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserPicker, windows_core::IUnknown, windows_core::IInspectable);
 impl UserPicker {
@@ -3811,7 +3811,7 @@ impl windows_core::RuntimeName for UserPicker {
 unsafe impl Send for UserPicker {}
 unsafe impl Sync for UserPicker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserWatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserWatcher, windows_core::IUnknown, windows_core::IInspectable);
 impl UserWatcher {

--- a/crates/libs/windows/src/Windows/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Accessibility/mod.rs
@@ -20,7 +20,7 @@ pub struct IScreenReaderService_Vtbl {
     pub RemoveScreenReaderPositionChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ScreenReaderPositionChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ScreenReaderPositionChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ScreenReaderPositionChangedEventArgs {
@@ -52,7 +52,7 @@ impl windows_core::RuntimeName for ScreenReaderPositionChangedEventArgs {
 unsafe impl Send for ScreenReaderPositionChangedEventArgs {}
 unsafe impl Sync for ScreenReaderPositionChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ScreenReaderService(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ScreenReaderService, windows_core::IUnknown, windows_core::IInspectable);
 impl ScreenReaderService {

--- a/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
@@ -278,7 +278,7 @@ pub struct IWebAccountProviderCommandFactory_Vtbl {
     CreateWebAccountProviderCommand: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AccountsSettingsPane(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AccountsSettingsPane, windows_core::IUnknown, windows_core::IInspectable);
 impl AccountsSettingsPane {
@@ -364,7 +364,7 @@ impl windows_core::RuntimeName for AccountsSettingsPane {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.AccountsSettingsPane";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AccountsSettingsPaneCommandsRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AccountsSettingsPaneCommandsRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AccountsSettingsPaneCommandsRequestedEventArgs {
@@ -438,7 +438,7 @@ impl windows_core::RuntimeName for AccountsSettingsPaneCommandsRequestedEventArg
     const NAME: &'static str = "Windows.UI.ApplicationSettings.AccountsSettingsPaneCommandsRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AccountsSettingsPaneEventDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AccountsSettingsPaneEventDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl AccountsSettingsPaneEventDeferral {
@@ -458,7 +458,7 @@ impl windows_core::RuntimeName for AccountsSettingsPaneEventDeferral {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.AccountsSettingsPaneEventDeferral";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CredentialCommand(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CredentialCommand, windows_core::IUnknown, windows_core::IInspectable);
 impl CredentialCommand {
@@ -516,7 +516,7 @@ impl windows_core::RuntimeName for CredentialCommand {
 }
 #[cfg(feature = "UI_Popups")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SettingsCommand(windows_core::IUnknown);
 #[cfg(feature = "UI_Popups")]
 windows_core::imp::interface_hierarchy!(SettingsCommand, windows_core::IUnknown, windows_core::IInspectable);
@@ -613,7 +613,7 @@ impl windows_core::RuntimeName for SettingsCommand {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SettingsPane(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SettingsPane, windows_core::IUnknown, windows_core::IInspectable);
@@ -675,7 +675,7 @@ impl windows_core::RuntimeName for SettingsPane {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SettingsPaneCommandsRequest(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SettingsPaneCommandsRequest, windows_core::IUnknown, windows_core::IInspectable);
@@ -705,7 +705,7 @@ impl windows_core::RuntimeName for SettingsPaneCommandsRequest {
 }
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SettingsPaneCommandsRequestedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "deprecated")]
 windows_core::imp::interface_hierarchy!(SettingsPaneCommandsRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -734,7 +734,7 @@ impl windows_core::RuntimeName for SettingsPaneCommandsRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.SettingsPaneCommandsRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountCommand(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountCommand, windows_core::IUnknown, windows_core::IInspectable);
 impl WebAccountCommand {
@@ -788,7 +788,7 @@ impl windows_core::RuntimeName for WebAccountCommand {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.WebAccountCommand";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountInvokedArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountInvokedArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebAccountInvokedArgs {
@@ -811,7 +811,7 @@ impl windows_core::RuntimeName for WebAccountInvokedArgs {
     const NAME: &'static str = "Windows.UI.ApplicationSettings.WebAccountInvokedArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebAccountProviderCommand(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebAccountProviderCommand, windows_core::IUnknown, windows_core::IInspectable);
 impl WebAccountProviderCommand {

--- a/crates/libs/windows/src/Windows/UI/Composition/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Core/mod.rs
@@ -12,7 +12,7 @@ pub struct ICompositorController_Vtbl {
     pub RemoveCommitNeeded: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositorController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositorController, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositorController, super::super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/UI/Composition/Desktop/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Desktop/mod.rs
@@ -8,7 +8,7 @@ pub struct IDesktopWindowTarget_Vtbl {
     pub IsTopmost: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DesktopWindowTarget(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DesktopWindowTarget, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DesktopWindowTarget, super::IAnimationObject, super::super::super::Foundation::IClosable, super::CompositionTarget, super::CompositionObject);

--- a/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
@@ -29,7 +29,7 @@ pub struct ICompositionDebugSettingsStatics_Vtbl {
     pub TryGetSettings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionDebugHeatMaps(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionDebugHeatMaps, windows_core::IUnknown, windows_core::IInspectable);
 impl CompositionDebugHeatMaps {
@@ -75,7 +75,7 @@ impl windows_core::RuntimeName for CompositionDebugHeatMaps {
 unsafe impl Send for CompositionDebugHeatMaps {}
 unsafe impl Sync for CompositionDebugHeatMaps {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionDebugSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionDebugSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl CompositionDebugSettings {

--- a/crates/libs/windows/src/Windows/UI/Composition/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Effects/mod.rs
@@ -33,7 +33,7 @@ pub struct ISceneLightingEffect2_Vtbl {
     pub SetReflectanceModel: unsafe extern "system" fn(*mut core::ffi::c_void, SceneLightingEffectReflectanceModel) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneLightingEffect(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneLightingEffect, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Graphics_Effects")]

--- a/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
@@ -649,7 +649,7 @@ pub struct IVisualInteractionSourceStatics2_Vtbl {
     pub CreateFromIVisualElement: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionConditionalValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionConditionalValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionConditionalValue, super::IAnimationObject, super::super::super::Foundation::IClosable, super::CompositionObject);
@@ -816,7 +816,7 @@ impl windows_core::RuntimeName for CompositionConditionalValue {
 unsafe impl Send for CompositionConditionalValue {}
 unsafe impl Sync for CompositionConditionalValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionInteractionSourceCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionInteractionSourceCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -991,7 +991,7 @@ impl IntoIterator for &CompositionInteractionSourceCollection {
 unsafe impl Send for CompositionInteractionSourceCollection {}
 unsafe impl Sync for CompositionInteractionSourceCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionSourceConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionSourceConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InteractionSourceConfiguration, super::IAnimationObject, super::super::super::Foundation::IClosable, super::CompositionObject);
@@ -1149,7 +1149,7 @@ impl windows_core::RuntimeName for InteractionSourceConfiguration {
 unsafe impl Send for InteractionSourceConfiguration {}
 unsafe impl Sync for InteractionSourceConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTracker(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTracker, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InteractionTracker, super::IAnimationObject, super::super::super::Foundation::IClosable, super::CompositionObject);
@@ -1612,7 +1612,7 @@ impl windows_core::RuntimeName for InteractionTracker {
 unsafe impl Send for InteractionTracker {}
 unsafe impl Sync for InteractionTracker {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerCustomAnimationStateEnteredArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerCustomAnimationStateEnteredArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InteractionTrackerCustomAnimationStateEnteredArgs {
@@ -1644,7 +1644,7 @@ impl windows_core::RuntimeName for InteractionTrackerCustomAnimationStateEntered
 unsafe impl Send for InteractionTrackerCustomAnimationStateEnteredArgs {}
 unsafe impl Sync for InteractionTrackerCustomAnimationStateEnteredArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerIdleStateEnteredArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerIdleStateEnteredArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InteractionTrackerIdleStateEnteredArgs {
@@ -1676,7 +1676,7 @@ impl windows_core::RuntimeName for InteractionTrackerIdleStateEnteredArgs {
 unsafe impl Send for InteractionTrackerIdleStateEnteredArgs {}
 unsafe impl Sync for InteractionTrackerIdleStateEnteredArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerInertiaModifier(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerInertiaModifier, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InteractionTrackerInertiaModifier, super::IAnimationObject, super::super::super::Foundation::IClosable, super::CompositionObject);
@@ -1801,7 +1801,7 @@ impl windows_core::RuntimeName for InteractionTrackerInertiaModifier {
 unsafe impl Send for InteractionTrackerInertiaModifier {}
 unsafe impl Sync for InteractionTrackerInertiaModifier {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerInertiaMotion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerInertiaMotion, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InteractionTrackerInertiaMotion, super::IAnimationObject, super::super::super::Foundation::IClosable, InteractionTrackerInertiaModifier, super::CompositionObject);
@@ -1968,7 +1968,7 @@ impl windows_core::RuntimeName for InteractionTrackerInertiaMotion {
 unsafe impl Send for InteractionTrackerInertiaMotion {}
 unsafe impl Sync for InteractionTrackerInertiaMotion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerInertiaNaturalMotion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerInertiaNaturalMotion, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InteractionTrackerInertiaNaturalMotion, super::IAnimationObject, super::super::super::Foundation::IClosable, InteractionTrackerInertiaModifier, super::CompositionObject);
@@ -2135,7 +2135,7 @@ impl windows_core::RuntimeName for InteractionTrackerInertiaNaturalMotion {
 unsafe impl Send for InteractionTrackerInertiaNaturalMotion {}
 unsafe impl Sync for InteractionTrackerInertiaNaturalMotion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerInertiaRestingValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerInertiaRestingValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InteractionTrackerInertiaRestingValue, super::IAnimationObject, super::super::super::Foundation::IClosable, InteractionTrackerInertiaModifier, super::CompositionObject);
@@ -2302,7 +2302,7 @@ impl windows_core::RuntimeName for InteractionTrackerInertiaRestingValue {
 unsafe impl Send for InteractionTrackerInertiaRestingValue {}
 unsafe impl Sync for InteractionTrackerInertiaRestingValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerInertiaStateEnteredArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerInertiaStateEnteredArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InteractionTrackerInertiaStateEnteredArgs {
@@ -2386,7 +2386,7 @@ impl windows_core::RuntimeName for InteractionTrackerInertiaStateEnteredArgs {
 unsafe impl Send for InteractionTrackerInertiaStateEnteredArgs {}
 unsafe impl Sync for InteractionTrackerInertiaStateEnteredArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerInteractingStateEnteredArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerInteractingStateEnteredArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InteractionTrackerInteractingStateEnteredArgs {
@@ -2418,7 +2418,7 @@ impl windows_core::RuntimeName for InteractionTrackerInteractingStateEnteredArgs
 unsafe impl Send for InteractionTrackerInteractingStateEnteredArgs {}
 unsafe impl Sync for InteractionTrackerInteractingStateEnteredArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerRequestIgnoredArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerRequestIgnoredArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InteractionTrackerRequestIgnoredArgs {
@@ -2443,7 +2443,7 @@ impl windows_core::RuntimeName for InteractionTrackerRequestIgnoredArgs {
 unsafe impl Send for InteractionTrackerRequestIgnoredArgs {}
 unsafe impl Sync for InteractionTrackerRequestIgnoredArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerValuesChangedArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerValuesChangedArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InteractionTrackerValuesChangedArgs {
@@ -2483,7 +2483,7 @@ impl windows_core::RuntimeName for InteractionTrackerValuesChangedArgs {
 unsafe impl Send for InteractionTrackerValuesChangedArgs {}
 unsafe impl Sync for InteractionTrackerValuesChangedArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerVector2InertiaModifier(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerVector2InertiaModifier, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InteractionTrackerVector2InertiaModifier, super::IAnimationObject, super::super::super::Foundation::IClosable, super::CompositionObject);
@@ -2608,7 +2608,7 @@ impl windows_core::RuntimeName for InteractionTrackerVector2InertiaModifier {
 unsafe impl Send for InteractionTrackerVector2InertiaModifier {}
 unsafe impl Sync for InteractionTrackerVector2InertiaModifier {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InteractionTrackerVector2InertiaNaturalMotion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InteractionTrackerVector2InertiaNaturalMotion, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InteractionTrackerVector2InertiaNaturalMotion, super::IAnimationObject, super::super::super::Foundation::IClosable, InteractionTrackerVector2InertiaModifier, super::CompositionObject);
@@ -2775,7 +2775,7 @@ impl windows_core::RuntimeName for InteractionTrackerVector2InertiaNaturalMotion
 unsafe impl Send for InteractionTrackerVector2InertiaNaturalMotion {}
 unsafe impl Sync for InteractionTrackerVector2InertiaNaturalMotion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VisualInteractionSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VisualInteractionSource, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VisualInteractionSource, super::IAnimationObject, super::super::super::Foundation::IClosable, ICompositionInteractionSource, super::CompositionObject);

--- a/crates/libs/windows/src/Windows/UI/Composition/Scenes/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Scenes/mod.rs
@@ -373,7 +373,7 @@ pub struct ISceneVisualStatics_Vtbl {
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneBoundingBox(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneBoundingBox, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneBoundingBox, super::IAnimationObject, super::super::super::Foundation::IClosable, SceneObject, super::CompositionObject);
@@ -538,7 +538,7 @@ impl windows_core::RuntimeName for SceneBoundingBox {
 unsafe impl Send for SceneBoundingBox {}
 unsafe impl Sync for SceneBoundingBox {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneComponent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneComponent, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneComponent, super::IAnimationObject, super::super::super::Foundation::IClosable, SceneObject, super::CompositionObject);
@@ -671,7 +671,7 @@ unsafe impl Send for SceneComponent {}
 unsafe impl Sync for SceneComponent {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneComponentCollection(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(SceneComponentCollection, windows_core::IUnknown, windows_core::IInspectable);
@@ -915,7 +915,7 @@ unsafe impl Send for SceneComponentCollection {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for SceneComponentCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneMaterial(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneMaterial, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneMaterial, super::IAnimationObject, super::super::super::Foundation::IClosable, SceneObject, super::CompositionObject);
@@ -1040,7 +1040,7 @@ impl windows_core::RuntimeName for SceneMaterial {
 unsafe impl Send for SceneMaterial {}
 unsafe impl Sync for SceneMaterial {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneMaterialInput(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneMaterialInput, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneMaterialInput, super::IAnimationObject, super::super::super::Foundation::IClosable, SceneObject, super::CompositionObject);
@@ -1165,7 +1165,7 @@ impl windows_core::RuntimeName for SceneMaterialInput {
 unsafe impl Send for SceneMaterialInput {}
 unsafe impl Sync for SceneMaterialInput {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneMesh(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneMesh, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneMesh, super::IAnimationObject, super::super::super::Foundation::IClosable, SceneObject, super::CompositionObject);
@@ -1332,7 +1332,7 @@ impl windows_core::RuntimeName for SceneMesh {
 unsafe impl Send for SceneMesh {}
 unsafe impl Sync for SceneMesh {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneMeshMaterialAttributeMap(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneMeshMaterialAttributeMap, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -1532,7 +1532,7 @@ impl IntoIterator for &SceneMeshMaterialAttributeMap {
 unsafe impl Send for SceneMeshMaterialAttributeMap {}
 unsafe impl Sync for SceneMeshMaterialAttributeMap {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneMeshRendererComponent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneMeshRendererComponent, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneMeshRendererComponent, super::IAnimationObject, super::super::super::Foundation::IClosable, SceneRendererComponent, SceneComponent, SceneObject, super::CompositionObject);
@@ -1713,7 +1713,7 @@ impl windows_core::RuntimeName for SceneMeshRendererComponent {
 unsafe impl Send for SceneMeshRendererComponent {}
 unsafe impl Sync for SceneMeshRendererComponent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneMetallicRoughnessMaterial(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneMetallicRoughnessMaterial, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneMetallicRoughnessMaterial, super::IAnimationObject, super::super::super::Foundation::IClosable, ScenePbrMaterial, SceneMaterial, SceneObject, super::CompositionObject);
@@ -2025,7 +2025,7 @@ impl windows_core::RuntimeName for SceneMetallicRoughnessMaterial {
 unsafe impl Send for SceneMetallicRoughnessMaterial {}
 unsafe impl Sync for SceneMetallicRoughnessMaterial {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneModelTransform(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneModelTransform, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneModelTransform, super::IAnimationObject, super::super::super::Foundation::IClosable, super::CompositionTransform, super::CompositionObject);
@@ -2224,7 +2224,7 @@ impl windows_core::RuntimeName for SceneModelTransform {
 unsafe impl Send for SceneModelTransform {}
 unsafe impl Sync for SceneModelTransform {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneNode, super::IAnimationObject, super::super::super::Foundation::IClosable, SceneObject, super::CompositionObject);
@@ -2401,7 +2401,7 @@ unsafe impl Send for SceneNode {}
 unsafe impl Sync for SceneNode {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneNodeCollection(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(SceneNodeCollection, windows_core::IUnknown, windows_core::IInspectable);
@@ -2645,7 +2645,7 @@ unsafe impl Send for SceneNodeCollection {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for SceneNodeCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneObject(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneObject, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneObject, super::IAnimationObject, super::super::super::Foundation::IClosable, super::CompositionObject);
@@ -2770,7 +2770,7 @@ impl windows_core::RuntimeName for SceneObject {
 unsafe impl Send for SceneObject {}
 unsafe impl Sync for SceneObject {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ScenePbrMaterial(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ScenePbrMaterial, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ScenePbrMaterial, super::IAnimationObject, super::super::super::Foundation::IClosable, SceneMaterial, SceneObject, super::CompositionObject);
@@ -3005,7 +3005,7 @@ impl windows_core::RuntimeName for ScenePbrMaterial {
 unsafe impl Send for ScenePbrMaterial {}
 unsafe impl Sync for ScenePbrMaterial {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneRendererComponent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneRendererComponent, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneRendererComponent, super::IAnimationObject, super::super::super::Foundation::IClosable, SceneComponent, SceneObject, super::CompositionObject);
@@ -3137,7 +3137,7 @@ impl windows_core::RuntimeName for SceneRendererComponent {
 unsafe impl Send for SceneRendererComponent {}
 unsafe impl Sync for SceneRendererComponent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneSurfaceMaterialInput(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneSurfaceMaterialInput, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneSurfaceMaterialInput, super::IAnimationObject, super::super::super::Foundation::IClosable, SceneMaterialInput, SceneObject, super::CompositionObject);
@@ -3323,7 +3323,7 @@ impl windows_core::RuntimeName for SceneSurfaceMaterialInput {
 unsafe impl Send for SceneSurfaceMaterialInput {}
 unsafe impl Sync for SceneSurfaceMaterialInput {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SceneVisual(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SceneVisual, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SceneVisual, super::IAnimationObject, super::super::super::Foundation::IClosable, super::ContainerVisual, super::Visual, super::CompositionObject);

--- a/crates/libs/windows/src/Windows/UI/Composition/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/mod.rs
@@ -2866,7 +2866,7 @@ pub struct IVisualUnorderedCollection_Vtbl {
     pub RemoveAll: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AmbientLight(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AmbientLight, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AmbientLight, IAnimationObject, super::super::Foundation::IClosable, CompositionLight, CompositionObject);
@@ -3038,7 +3038,7 @@ impl windows_core::RuntimeName for AmbientLight {
 unsafe impl Send for AmbientLight {}
 unsafe impl Sync for AmbientLight {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AnimationController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AnimationController, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AnimationController, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -3221,7 +3221,7 @@ impl windows_core::RuntimeName for AnimationController {
 unsafe impl Send for AnimationController {}
 unsafe impl Sync for AnimationController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AnimationPropertyInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AnimationPropertyInfo, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AnimationPropertyInfo, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -3371,7 +3371,7 @@ impl windows_core::RuntimeName for AnimationPropertyInfo {
 unsafe impl Send for AnimationPropertyInfo {}
 unsafe impl Sync for AnimationPropertyInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BackEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionEasingFunction, CompositionObject);
@@ -3510,7 +3510,7 @@ impl windows_core::RuntimeName for BackEasingFunction {
 unsafe impl Send for BackEasingFunction {}
 unsafe impl Sync for BackEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BooleanKeyFrameAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BooleanKeyFrameAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BooleanKeyFrameAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, KeyFrameAnimation, CompositionAnimation, CompositionObject);
@@ -3817,7 +3817,7 @@ impl windows_core::RuntimeName for BooleanKeyFrameAnimation {
 unsafe impl Send for BooleanKeyFrameAnimation {}
 unsafe impl Sync for BooleanKeyFrameAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BounceEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BounceEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BounceEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionEasingFunction, CompositionObject);
@@ -3963,7 +3963,7 @@ impl windows_core::RuntimeName for BounceEasingFunction {
 unsafe impl Send for BounceEasingFunction {}
 unsafe impl Sync for BounceEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BounceScalarNaturalMotionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BounceScalarNaturalMotionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BounceScalarNaturalMotionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, ScalarNaturalMotionAnimation, NaturalMotionAnimation, CompositionAnimation, CompositionObject);
@@ -4265,7 +4265,7 @@ impl windows_core::RuntimeName for BounceScalarNaturalMotionAnimation {
 unsafe impl Send for BounceScalarNaturalMotionAnimation {}
 unsafe impl Sync for BounceScalarNaturalMotionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BounceVector2NaturalMotionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BounceVector2NaturalMotionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BounceVector2NaturalMotionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, Vector2NaturalMotionAnimation, NaturalMotionAnimation, CompositionAnimation, CompositionObject);
@@ -4573,7 +4573,7 @@ impl windows_core::RuntimeName for BounceVector2NaturalMotionAnimation {
 unsafe impl Send for BounceVector2NaturalMotionAnimation {}
 unsafe impl Sync for BounceVector2NaturalMotionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BounceVector3NaturalMotionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BounceVector3NaturalMotionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(BounceVector3NaturalMotionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, Vector3NaturalMotionAnimation, NaturalMotionAnimation, CompositionAnimation, CompositionObject);
@@ -4881,7 +4881,7 @@ impl windows_core::RuntimeName for BounceVector3NaturalMotionAnimation {
 unsafe impl Send for BounceVector3NaturalMotionAnimation {}
 unsafe impl Sync for BounceVector3NaturalMotionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CircleEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CircleEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CircleEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionEasingFunction, CompositionObject);
@@ -5013,7 +5013,7 @@ impl windows_core::RuntimeName for CircleEasingFunction {
 unsafe impl Send for CircleEasingFunction {}
 unsafe impl Sync for CircleEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ColorKeyFrameAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ColorKeyFrameAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ColorKeyFrameAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, KeyFrameAnimation, CompositionAnimation, CompositionObject);
@@ -5338,7 +5338,7 @@ impl windows_core::RuntimeName for ColorKeyFrameAnimation {
 unsafe impl Send for ColorKeyFrameAnimation {}
 unsafe impl Sync for ColorKeyFrameAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, CompositionObject);
@@ -5546,7 +5546,7 @@ impl windows_core::RuntimeName for CompositionAnimation {
 unsafe impl Send for CompositionAnimation {}
 unsafe impl Sync for CompositionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionAnimationGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionAnimationGroup, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -5721,7 +5721,7 @@ impl IntoIterator for &CompositionAnimationGroup {
 unsafe impl Send for CompositionAnimationGroup {}
 unsafe impl Sync for CompositionAnimationGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionBackdropBrush(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionBackdropBrush, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionBackdropBrush, IAnimationObject, super::super::Foundation::IClosable, CompositionBrush, CompositionObject);
@@ -5846,7 +5846,7 @@ impl windows_core::RuntimeName for CompositionBackdropBrush {
 unsafe impl Send for CompositionBackdropBrush {}
 unsafe impl Sync for CompositionBackdropBrush {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionBatchCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionBatchCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionBatchCompletedEventArgs, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -5971,7 +5971,7 @@ impl windows_core::RuntimeName for CompositionBatchCompletedEventArgs {
 unsafe impl Send for CompositionBatchCompletedEventArgs {}
 unsafe impl Sync for CompositionBatchCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionBrush(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionBrush, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionBrush, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -6096,7 +6096,7 @@ impl windows_core::RuntimeName for CompositionBrush {
 unsafe impl Send for CompositionBrush {}
 unsafe impl Sync for CompositionBrush {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionCapabilities(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionCapabilities, windows_core::IUnknown, windows_core::IInspectable);
 impl CompositionCapabilities {
@@ -6153,7 +6153,7 @@ impl windows_core::RuntimeName for CompositionCapabilities {
 unsafe impl Send for CompositionCapabilities {}
 unsafe impl Sync for CompositionCapabilities {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionClip(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionClip, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionClip, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -6365,7 +6365,7 @@ impl windows_core::RuntimeName for CompositionClip {
 unsafe impl Send for CompositionClip {}
 unsafe impl Sync for CompositionClip {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionColorBrush(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionColorBrush, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionColorBrush, IAnimationObject, super::super::Foundation::IClosable, CompositionBrush, CompositionObject);
@@ -6501,7 +6501,7 @@ impl windows_core::RuntimeName for CompositionColorBrush {
 unsafe impl Send for CompositionColorBrush {}
 unsafe impl Sync for CompositionColorBrush {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionColorGradientStop(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionColorGradientStop, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionColorGradientStop, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -6648,7 +6648,7 @@ impl windows_core::RuntimeName for CompositionColorGradientStop {
 unsafe impl Send for CompositionColorGradientStop {}
 unsafe impl Sync for CompositionColorGradientStop {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionColorGradientStopCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionColorGradientStopCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -6779,7 +6779,7 @@ impl IntoIterator for &CompositionColorGradientStopCollection {
 unsafe impl Send for CompositionColorGradientStopCollection {}
 unsafe impl Sync for CompositionColorGradientStopCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionCommitBatch(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionCommitBatch, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionCommitBatch, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -6932,7 +6932,7 @@ impl windows_core::RuntimeName for CompositionCommitBatch {
 unsafe impl Send for CompositionCommitBatch {}
 unsafe impl Sync for CompositionCommitBatch {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionContainerShape(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionContainerShape, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionContainerShape, IAnimationObject, super::super::Foundation::IClosable, CompositionShape, CompositionObject);
@@ -7139,7 +7139,7 @@ impl windows_core::RuntimeName for CompositionContainerShape {
 unsafe impl Send for CompositionContainerShape {}
 unsafe impl Sync for CompositionContainerShape {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionDrawingSurface(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionDrawingSurface, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionDrawingSurface, IAnimationObject, super::super::Foundation::IClosable, ICompositionSurface, CompositionObject);
@@ -7320,7 +7320,7 @@ impl windows_core::RuntimeName for CompositionDrawingSurface {
 unsafe impl Send for CompositionDrawingSurface {}
 unsafe impl Sync for CompositionDrawingSurface {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -7550,7 +7550,7 @@ impl windows_core::RuntimeName for CompositionEasingFunction {
 unsafe impl Send for CompositionEasingFunction {}
 unsafe impl Sync for CompositionEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionEffectBrush(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionEffectBrush, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionEffectBrush, IAnimationObject, super::super::Foundation::IClosable, CompositionBrush, CompositionObject);
@@ -7689,7 +7689,7 @@ impl windows_core::RuntimeName for CompositionEffectBrush {
 unsafe impl Send for CompositionEffectBrush {}
 unsafe impl Sync for CompositionEffectBrush {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionEffectFactory(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionEffectFactory, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionEffectFactory, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -7835,7 +7835,7 @@ impl windows_core::RuntimeName for CompositionEffectFactory {
 unsafe impl Send for CompositionEffectFactory {}
 unsafe impl Sync for CompositionEffectFactory {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionEffectSourceParameter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionEffectSourceParameter, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Graphics_Effects")]
@@ -7873,7 +7873,7 @@ impl windows_core::RuntimeName for CompositionEffectSourceParameter {
 unsafe impl Send for CompositionEffectSourceParameter {}
 unsafe impl Sync for CompositionEffectSourceParameter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionEllipseGeometry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionEllipseGeometry, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionEllipseGeometry, IAnimationObject, super::super::Foundation::IClosable, CompositionGeometry, CompositionObject);
@@ -8057,7 +8057,7 @@ impl windows_core::RuntimeName for CompositionEllipseGeometry {
 unsafe impl Send for CompositionEllipseGeometry {}
 unsafe impl Sync for CompositionEllipseGeometry {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionGeometricClip(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionGeometricClip, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionGeometricClip, IAnimationObject, super::super::Foundation::IClosable, CompositionClip, CompositionObject);
@@ -8297,7 +8297,7 @@ impl windows_core::RuntimeName for CompositionGeometricClip {
 unsafe impl Send for CompositionGeometricClip {}
 unsafe impl Sync for CompositionGeometricClip {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionGeometry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionGeometry, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionGeometry, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -8455,7 +8455,7 @@ impl windows_core::RuntimeName for CompositionGeometry {
 unsafe impl Send for CompositionGeometry {}
 unsafe impl Sync for CompositionGeometry {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionGradientBrush(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionGradientBrush, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionGradientBrush, IAnimationObject, super::super::Foundation::IClosable, CompositionBrush, CompositionObject);
@@ -8707,7 +8707,7 @@ impl windows_core::RuntimeName for CompositionGradientBrush {
 unsafe impl Send for CompositionGradientBrush {}
 unsafe impl Sync for CompositionGradientBrush {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionGraphicsDevice(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionGraphicsDevice, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionGraphicsDevice, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -8893,7 +8893,7 @@ impl windows_core::RuntimeName for CompositionGraphicsDevice {
 unsafe impl Send for CompositionGraphicsDevice {}
 unsafe impl Sync for CompositionGraphicsDevice {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionLight(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionLight, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionLight, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -9043,7 +9043,7 @@ impl windows_core::RuntimeName for CompositionLight {
 unsafe impl Send for CompositionLight {}
 unsafe impl Sync for CompositionLight {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionLineGeometry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionLineGeometry, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionLineGeometry, IAnimationObject, super::super::Foundation::IClosable, CompositionGeometry, CompositionObject);
@@ -9227,7 +9227,7 @@ impl windows_core::RuntimeName for CompositionLineGeometry {
 unsafe impl Send for CompositionLineGeometry {}
 unsafe impl Sync for CompositionLineGeometry {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionLinearGradientBrush(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionLinearGradientBrush, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionLinearGradientBrush, IAnimationObject, super::super::Foundation::IClosable, CompositionGradientBrush, CompositionBrush, CompositionObject);
@@ -9505,7 +9505,7 @@ impl windows_core::RuntimeName for CompositionLinearGradientBrush {
 unsafe impl Send for CompositionLinearGradientBrush {}
 unsafe impl Sync for CompositionLinearGradientBrush {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionMaskBrush(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionMaskBrush, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionMaskBrush, IAnimationObject, super::super::Foundation::IClosable, CompositionBrush, CompositionObject);
@@ -9658,7 +9658,7 @@ impl windows_core::RuntimeName for CompositionMaskBrush {
 unsafe impl Send for CompositionMaskBrush {}
 unsafe impl Sync for CompositionMaskBrush {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionMipmapSurface(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionMipmapSurface, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionMipmapSurface, IAnimationObject, super::super::Foundation::IClosable, ICompositionSurface, CompositionObject);
@@ -9821,7 +9821,7 @@ impl windows_core::RuntimeName for CompositionMipmapSurface {
 unsafe impl Send for CompositionMipmapSurface {}
 unsafe impl Sync for CompositionMipmapSurface {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionNineGridBrush(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionNineGridBrush, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionNineGridBrush, IAnimationObject, super::super::Foundation::IClosable, CompositionBrush, CompositionObject);
@@ -10075,7 +10075,7 @@ impl windows_core::RuntimeName for CompositionNineGridBrush {
 unsafe impl Send for CompositionNineGridBrush {}
 unsafe impl Sync for CompositionNineGridBrush {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionObject(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionObject, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionObject, IAnimationObject, super::super::Foundation::IClosable);
@@ -10219,7 +10219,7 @@ impl windows_core::RuntimeName for CompositionObject {
 unsafe impl Send for CompositionObject {}
 unsafe impl Sync for CompositionObject {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionPath(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionPath, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Graphics")]
@@ -10254,7 +10254,7 @@ impl windows_core::RuntimeName for CompositionPath {
 unsafe impl Send for CompositionPath {}
 unsafe impl Sync for CompositionPath {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionPathGeometry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionPathGeometry, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionPathGeometry, IAnimationObject, super::super::Foundation::IClosable, CompositionGeometry, CompositionObject);
@@ -10426,7 +10426,7 @@ impl windows_core::RuntimeName for CompositionPathGeometry {
 unsafe impl Send for CompositionPathGeometry {}
 unsafe impl Sync for CompositionPathGeometry {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionProjectedShadow(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionProjectedShadow, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionProjectedShadow, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -10612,7 +10612,7 @@ impl windows_core::RuntimeName for CompositionProjectedShadow {
 unsafe impl Send for CompositionProjectedShadow {}
 unsafe impl Sync for CompositionProjectedShadow {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionProjectedShadowCaster(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionProjectedShadowCaster, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionProjectedShadowCaster, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -10765,7 +10765,7 @@ impl windows_core::RuntimeName for CompositionProjectedShadowCaster {
 unsafe impl Send for CompositionProjectedShadowCaster {}
 unsafe impl Sync for CompositionProjectedShadowCaster {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionProjectedShadowCasterCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionProjectedShadowCasterCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -10974,7 +10974,7 @@ impl IntoIterator for &CompositionProjectedShadowCasterCollection {
 unsafe impl Send for CompositionProjectedShadowCasterCollection {}
 unsafe impl Sync for CompositionProjectedShadowCasterCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionProjectedShadowReceiver(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionProjectedShadowReceiver, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionProjectedShadowReceiver, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -11113,7 +11113,7 @@ impl windows_core::RuntimeName for CompositionProjectedShadowReceiver {
 unsafe impl Send for CompositionProjectedShadowReceiver {}
 unsafe impl Sync for CompositionProjectedShadowReceiver {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionProjectedShadowReceiverUnorderedCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionProjectedShadowReceiverUnorderedCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -11288,7 +11288,7 @@ impl IntoIterator for &CompositionProjectedShadowReceiverUnorderedCollection {
 unsafe impl Send for CompositionProjectedShadowReceiverUnorderedCollection {}
 unsafe impl Sync for CompositionProjectedShadowReceiverUnorderedCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionPropertySet(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionPropertySet, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionPropertySet, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -11524,7 +11524,7 @@ impl windows_core::RuntimeName for CompositionPropertySet {
 unsafe impl Send for CompositionPropertySet {}
 unsafe impl Sync for CompositionPropertySet {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionRadialGradientBrush(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionRadialGradientBrush, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionRadialGradientBrush, IAnimationObject, super::super::Foundation::IClosable, CompositionGradientBrush, CompositionBrush, CompositionObject);
@@ -11815,7 +11815,7 @@ impl windows_core::RuntimeName for CompositionRadialGradientBrush {
 unsafe impl Send for CompositionRadialGradientBrush {}
 unsafe impl Sync for CompositionRadialGradientBrush {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionRectangleGeometry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionRectangleGeometry, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionRectangleGeometry, IAnimationObject, super::super::Foundation::IClosable, CompositionGeometry, CompositionObject);
@@ -11999,7 +11999,7 @@ impl windows_core::RuntimeName for CompositionRectangleGeometry {
 unsafe impl Send for CompositionRectangleGeometry {}
 unsafe impl Sync for CompositionRectangleGeometry {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionRoundedRectangleGeometry(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionRoundedRectangleGeometry, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionRoundedRectangleGeometry, IAnimationObject, super::super::Foundation::IClosable, CompositionGeometry, CompositionObject);
@@ -12196,7 +12196,7 @@ impl windows_core::RuntimeName for CompositionRoundedRectangleGeometry {
 unsafe impl Send for CompositionRoundedRectangleGeometry {}
 unsafe impl Sync for CompositionRoundedRectangleGeometry {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionScopedBatch(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionScopedBatch, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionScopedBatch, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -12361,7 +12361,7 @@ impl windows_core::RuntimeName for CompositionScopedBatch {
 unsafe impl Send for CompositionScopedBatch {}
 unsafe impl Sync for CompositionScopedBatch {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionShadow(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionShadow, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionShadow, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -12486,7 +12486,7 @@ impl windows_core::RuntimeName for CompositionShadow {
 unsafe impl Send for CompositionShadow {}
 unsafe impl Sync for CompositionShadow {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionShape(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionShape, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionShape, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -12686,7 +12686,7 @@ unsafe impl Send for CompositionShape {}
 unsafe impl Sync for CompositionShape {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionShapeCollection(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(CompositionShapeCollection, windows_core::IUnknown, windows_core::IInspectable);
@@ -12930,7 +12930,7 @@ unsafe impl Send for CompositionShapeCollection {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for CompositionShapeCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionSpriteShape(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionSpriteShape, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionSpriteShape, IAnimationObject, super::super::Foundation::IClosable, CompositionShape, CompositionObject);
@@ -13268,7 +13268,7 @@ unsafe impl Send for CompositionSpriteShape {}
 unsafe impl Sync for CompositionSpriteShape {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionStrokeDashArray(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(CompositionStrokeDashArray, windows_core::IUnknown, windows_core::IInspectable);
@@ -13500,7 +13500,7 @@ unsafe impl Send for CompositionStrokeDashArray {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for CompositionStrokeDashArray {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionSurfaceBrush(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionSurfaceBrush, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionSurfaceBrush, IAnimationObject, super::super::Foundation::IClosable, CompositionBrush, CompositionObject);
@@ -13781,7 +13781,7 @@ impl windows_core::RuntimeName for CompositionSurfaceBrush {
 unsafe impl Send for CompositionSurfaceBrush {}
 unsafe impl Sync for CompositionSurfaceBrush {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionTarget(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionTarget, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionTarget, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -13920,7 +13920,7 @@ impl windows_core::RuntimeName for CompositionTarget {
 unsafe impl Send for CompositionTarget {}
 unsafe impl Sync for CompositionTarget {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionTexture(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionTexture, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionTexture, IAnimationObject, super::super::Foundation::IClosable, ICompositionSurface, CompositionObject);
@@ -14084,7 +14084,7 @@ impl windows_core::RuntimeName for CompositionTexture {
 unsafe impl Send for CompositionTexture {}
 unsafe impl Sync for CompositionTexture {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionTransform(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionTransform, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionTransform, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -14209,7 +14209,7 @@ impl windows_core::RuntimeName for CompositionTransform {
 unsafe impl Send for CompositionTransform {}
 unsafe impl Sync for CompositionTransform {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionViewBox(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionViewBox, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionViewBox, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -14393,7 +14393,7 @@ impl windows_core::RuntimeName for CompositionViewBox {
 unsafe impl Send for CompositionViewBox {}
 unsafe impl Sync for CompositionViewBox {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionVirtualDrawingSurface(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionVirtualDrawingSurface, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionVirtualDrawingSurface, IAnimationObject, super::super::Foundation::IClosable, ICompositionSurface, CompositionDrawingSurface, CompositionObject);
@@ -14579,7 +14579,7 @@ impl windows_core::RuntimeName for CompositionVirtualDrawingSurface {
 unsafe impl Send for CompositionVirtualDrawingSurface {}
 unsafe impl Sync for CompositionVirtualDrawingSurface {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompositionVisualSurface(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompositionVisualSurface, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompositionVisualSurface, IAnimationObject, super::super::Foundation::IClosable, ICompositionSurface, CompositionObject);
@@ -14744,7 +14744,7 @@ impl windows_core::RuntimeName for CompositionVisualSurface {
 unsafe impl Send for CompositionVisualSurface {}
 unsafe impl Sync for CompositionVisualSurface {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Compositor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Compositor, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Compositor, super::super::Foundation::IClosable);
@@ -15379,7 +15379,7 @@ impl windows_core::RuntimeName for Compositor {
 unsafe impl Send for Compositor {}
 unsafe impl Sync for Compositor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContainerVisual(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContainerVisual, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ContainerVisual, IAnimationObject, super::super::Foundation::IClosable, Visual, CompositionObject);
@@ -15775,7 +15775,7 @@ impl windows_core::RuntimeName for ContainerVisual {
 unsafe impl Send for ContainerVisual {}
 unsafe impl Sync for ContainerVisual {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CubicBezierEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CubicBezierEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CubicBezierEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionEasingFunction, CompositionObject);
@@ -15916,7 +15916,7 @@ impl windows_core::RuntimeName for CubicBezierEasingFunction {
 unsafe impl Send for CubicBezierEasingFunction {}
 unsafe impl Sync for CubicBezierEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DelegatedInkTrailVisual(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DelegatedInkTrailVisual, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DelegatedInkTrailVisual, IAnimationObject, super::super::Foundation::IClosable, Visual, CompositionObject);
@@ -16351,7 +16351,7 @@ impl windows_core::RuntimeName for DelegatedInkTrailVisual {
 unsafe impl Send for DelegatedInkTrailVisual {}
 unsafe impl Sync for DelegatedInkTrailVisual {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DistantLight(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DistantLight, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DistantLight, IAnimationObject, super::super::Foundation::IClosable, CompositionLight, CompositionObject);
@@ -16550,7 +16550,7 @@ impl windows_core::RuntimeName for DistantLight {
 unsafe impl Send for DistantLight {}
 unsafe impl Sync for DistantLight {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DropShadow(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DropShadow, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DropShadow, IAnimationObject, super::super::Foundation::IClosable, CompositionShadow, CompositionObject);
@@ -16746,7 +16746,7 @@ impl windows_core::RuntimeName for DropShadow {
 unsafe impl Send for DropShadow {}
 unsafe impl Sync for DropShadow {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ElasticEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ElasticEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ElasticEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionEasingFunction, CompositionObject);
@@ -16892,7 +16892,7 @@ impl windows_core::RuntimeName for ElasticEasingFunction {
 unsafe impl Send for ElasticEasingFunction {}
 unsafe impl Sync for ElasticEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExponentialEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ExponentialEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ExponentialEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionEasingFunction, CompositionObject);
@@ -17031,7 +17031,7 @@ impl windows_core::RuntimeName for ExponentialEasingFunction {
 unsafe impl Send for ExponentialEasingFunction {}
 unsafe impl Sync for ExponentialEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ExpressionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ExpressionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ExpressionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, CompositionAnimation, CompositionObject);
@@ -17250,7 +17250,7 @@ impl windows_core::RuntimeName for ExpressionAnimation {
 unsafe impl Send for ExpressionAnimation {}
 unsafe impl Sync for ExpressionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ImplicitAnimationCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ImplicitAnimationCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -17454,7 +17454,7 @@ unsafe impl Send for ImplicitAnimationCollection {}
 unsafe impl Sync for ImplicitAnimationCollection {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InitialValueExpressionCollection(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(InitialValueExpressionCollection, windows_core::IUnknown, windows_core::IInspectable);
@@ -17661,7 +17661,7 @@ unsafe impl Send for InitialValueExpressionCollection {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for InitialValueExpressionCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InsetClip(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InsetClip, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InsetClip, IAnimationObject, super::super::Foundation::IClosable, CompositionClip, CompositionObject);
@@ -17917,7 +17917,7 @@ impl windows_core::RuntimeName for InsetClip {
 unsafe impl Send for InsetClip {}
 unsafe impl Sync for InsetClip {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeyFrameAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeyFrameAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(KeyFrameAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, CompositionAnimation, CompositionObject);
@@ -18220,7 +18220,7 @@ impl windows_core::RuntimeName for KeyFrameAnimation {
 unsafe impl Send for KeyFrameAnimation {}
 unsafe impl Sync for KeyFrameAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LayerVisual(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LayerVisual, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LayerVisual, IAnimationObject, super::super::Foundation::IClosable, ContainerVisual, Visual, CompositionObject);
@@ -18644,7 +18644,7 @@ impl windows_core::RuntimeName for LayerVisual {
 unsafe impl Send for LayerVisual {}
 unsafe impl Sync for LayerVisual {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LinearEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(LinearEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(LinearEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionEasingFunction, CompositionObject);
@@ -18769,7 +18769,7 @@ impl windows_core::RuntimeName for LinearEasingFunction {
 unsafe impl Send for LinearEasingFunction {}
 unsafe impl Sync for LinearEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NaturalMotionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NaturalMotionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(NaturalMotionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, CompositionAnimation, CompositionObject);
@@ -19010,7 +19010,7 @@ impl windows_core::RuntimeName for NaturalMotionAnimation {
 unsafe impl Send for NaturalMotionAnimation {}
 unsafe impl Sync for NaturalMotionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PathKeyFrameAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PathKeyFrameAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PathKeyFrameAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, KeyFrameAnimation, CompositionAnimation, CompositionObject);
@@ -19328,7 +19328,7 @@ impl windows_core::RuntimeName for PathKeyFrameAnimation {
 unsafe impl Send for PathKeyFrameAnimation {}
 unsafe impl Sync for PathKeyFrameAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PointLight(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PointLight, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PointLight, IAnimationObject, super::super::Foundation::IClosable, CompositionLight, CompositionObject);
@@ -19582,7 +19582,7 @@ impl windows_core::RuntimeName for PointLight {
 unsafe impl Send for PointLight {}
 unsafe impl Sync for PointLight {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PowerEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PowerEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PowerEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionEasingFunction, CompositionObject);
@@ -19721,7 +19721,7 @@ impl windows_core::RuntimeName for PowerEasingFunction {
 unsafe impl Send for PowerEasingFunction {}
 unsafe impl Sync for PowerEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct QuaternionKeyFrameAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(QuaternionKeyFrameAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(QuaternionKeyFrameAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, KeyFrameAnimation, CompositionAnimation, CompositionObject);
@@ -20037,7 +20037,7 @@ impl windows_core::RuntimeName for QuaternionKeyFrameAnimation {
 unsafe impl Send for QuaternionKeyFrameAnimation {}
 unsafe impl Sync for QuaternionKeyFrameAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RectangleClip(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RectangleClip, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RectangleClip, IAnimationObject, super::super::Foundation::IClosable, CompositionClip, CompositionObject);
@@ -20345,7 +20345,7 @@ impl windows_core::RuntimeName for RectangleClip {
 unsafe impl Send for RectangleClip {}
 unsafe impl Sync for RectangleClip {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RedirectVisual(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RedirectVisual, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RedirectVisual, IAnimationObject, super::super::Foundation::IClosable, ContainerVisual, Visual, CompositionObject);
@@ -20755,7 +20755,7 @@ impl windows_core::RuntimeName for RedirectVisual {
 unsafe impl Send for RedirectVisual {}
 unsafe impl Sync for RedirectVisual {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RenderingDeviceReplacedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RenderingDeviceReplacedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RenderingDeviceReplacedEventArgs, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -20887,7 +20887,7 @@ impl windows_core::RuntimeName for RenderingDeviceReplacedEventArgs {
 unsafe impl Send for RenderingDeviceReplacedEventArgs {}
 unsafe impl Sync for RenderingDeviceReplacedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ScalarKeyFrameAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ScalarKeyFrameAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ScalarKeyFrameAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, KeyFrameAnimation, CompositionAnimation, CompositionObject);
@@ -21201,7 +21201,7 @@ impl windows_core::RuntimeName for ScalarKeyFrameAnimation {
 unsafe impl Send for ScalarKeyFrameAnimation {}
 unsafe impl Sync for ScalarKeyFrameAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ScalarNaturalMotionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ScalarNaturalMotionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ScalarNaturalMotionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, NaturalMotionAnimation, CompositionAnimation, CompositionObject);
@@ -21481,7 +21481,7 @@ impl windows_core::RuntimeName for ScalarNaturalMotionAnimation {
 unsafe impl Send for ScalarNaturalMotionAnimation {}
 unsafe impl Sync for ScalarNaturalMotionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShapeVisual(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShapeVisual, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ShapeVisual, IAnimationObject, super::super::Foundation::IClosable, ContainerVisual, Visual, CompositionObject);
@@ -21899,7 +21899,7 @@ impl windows_core::RuntimeName for ShapeVisual {
 unsafe impl Send for ShapeVisual {}
 unsafe impl Sync for ShapeVisual {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SineEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SineEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SineEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionEasingFunction, CompositionObject);
@@ -22031,7 +22031,7 @@ impl windows_core::RuntimeName for SineEasingFunction {
 unsafe impl Send for SineEasingFunction {}
 unsafe impl Sync for SineEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpotLight(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpotLight, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpotLight, IAnimationObject, super::super::Foundation::IClosable, CompositionLight, CompositionObject);
@@ -22364,7 +22364,7 @@ impl windows_core::RuntimeName for SpotLight {
 unsafe impl Send for SpotLight {}
 unsafe impl Sync for SpotLight {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpringScalarNaturalMotionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpringScalarNaturalMotionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpringScalarNaturalMotionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, ScalarNaturalMotionAnimation, NaturalMotionAnimation, CompositionAnimation, CompositionObject);
@@ -22666,7 +22666,7 @@ impl windows_core::RuntimeName for SpringScalarNaturalMotionAnimation {
 unsafe impl Send for SpringScalarNaturalMotionAnimation {}
 unsafe impl Sync for SpringScalarNaturalMotionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpringVector2NaturalMotionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpringVector2NaturalMotionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpringVector2NaturalMotionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, Vector2NaturalMotionAnimation, NaturalMotionAnimation, CompositionAnimation, CompositionObject);
@@ -22974,7 +22974,7 @@ impl windows_core::RuntimeName for SpringVector2NaturalMotionAnimation {
 unsafe impl Send for SpringVector2NaturalMotionAnimation {}
 unsafe impl Sync for SpringVector2NaturalMotionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpringVector3NaturalMotionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpringVector3NaturalMotionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpringVector3NaturalMotionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, Vector3NaturalMotionAnimation, NaturalMotionAnimation, CompositionAnimation, CompositionObject);
@@ -23282,7 +23282,7 @@ impl windows_core::RuntimeName for SpringVector3NaturalMotionAnimation {
 unsafe impl Send for SpringVector3NaturalMotionAnimation {}
 unsafe impl Sync for SpringVector3NaturalMotionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpriteVisual(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpriteVisual, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SpriteVisual, IAnimationObject, super::super::Foundation::IClosable, ContainerVisual, Visual, CompositionObject);
@@ -23706,7 +23706,7 @@ impl windows_core::RuntimeName for SpriteVisual {
 unsafe impl Send for SpriteVisual {}
 unsafe impl Sync for SpriteVisual {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StepEasingFunction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StepEasingFunction, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(StepEasingFunction, IAnimationObject, super::super::Foundation::IClosable, CompositionEasingFunction, CompositionObject);
@@ -23886,7 +23886,7 @@ impl windows_core::RuntimeName for StepEasingFunction {
 unsafe impl Send for StepEasingFunction {}
 unsafe impl Sync for StepEasingFunction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Vector2KeyFrameAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Vector2KeyFrameAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Vector2KeyFrameAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, KeyFrameAnimation, CompositionAnimation, CompositionObject);
@@ -24202,7 +24202,7 @@ impl windows_core::RuntimeName for Vector2KeyFrameAnimation {
 unsafe impl Send for Vector2KeyFrameAnimation {}
 unsafe impl Sync for Vector2KeyFrameAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Vector2NaturalMotionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Vector2NaturalMotionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Vector2NaturalMotionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, NaturalMotionAnimation, CompositionAnimation, CompositionObject);
@@ -24488,7 +24488,7 @@ impl windows_core::RuntimeName for Vector2NaturalMotionAnimation {
 unsafe impl Send for Vector2NaturalMotionAnimation {}
 unsafe impl Sync for Vector2NaturalMotionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Vector3KeyFrameAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Vector3KeyFrameAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Vector3KeyFrameAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, KeyFrameAnimation, CompositionAnimation, CompositionObject);
@@ -24804,7 +24804,7 @@ impl windows_core::RuntimeName for Vector3KeyFrameAnimation {
 unsafe impl Send for Vector3KeyFrameAnimation {}
 unsafe impl Sync for Vector3KeyFrameAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Vector3NaturalMotionAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Vector3NaturalMotionAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Vector3NaturalMotionAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, NaturalMotionAnimation, CompositionAnimation, CompositionObject);
@@ -25090,7 +25090,7 @@ impl windows_core::RuntimeName for Vector3NaturalMotionAnimation {
 unsafe impl Send for Vector3NaturalMotionAnimation {}
 unsafe impl Sync for Vector3NaturalMotionAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Vector4KeyFrameAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Vector4KeyFrameAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Vector4KeyFrameAnimation, IAnimationObject, super::super::Foundation::IClosable, ICompositionAnimationBase, KeyFrameAnimation, CompositionAnimation, CompositionObject);
@@ -25406,7 +25406,7 @@ impl windows_core::RuntimeName for Vector4KeyFrameAnimation {
 unsafe impl Send for Vector4KeyFrameAnimation {}
 unsafe impl Sync for Vector4KeyFrameAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Visual(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Visual, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Visual, IAnimationObject, super::super::Foundation::IClosable, CompositionObject);
@@ -25795,7 +25795,7 @@ impl windows_core::RuntimeName for Visual {
 unsafe impl Send for Visual {}
 unsafe impl Sync for Visual {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VisualCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VisualCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -25993,7 +25993,7 @@ impl IntoIterator for &VisualCollection {
 unsafe impl Send for VisualCollection {}
 unsafe impl Sync for VisualCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VisualUnorderedCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VisualUnorderedCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]

--- a/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/mod.rs
@@ -104,7 +104,7 @@ pub struct IScaleAnimation_Vtbl {
     pub NormalizedOrigin: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::Point) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AnimationDescription(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AnimationDescription, windows_core::IUnknown, windows_core::IInspectable);
 impl AnimationDescription {
@@ -169,7 +169,7 @@ impl windows_core::RuntimeName for AnimationDescription {
 unsafe impl Send for AnimationDescription {}
 unsafe impl Sync for AnimationDescription {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct OpacityAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(OpacityAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(OpacityAnimation, IPropertyAnimation);
@@ -237,7 +237,7 @@ impl windows_core::RuntimeName for OpacityAnimation {
 unsafe impl Send for OpacityAnimation {}
 unsafe impl Sync for OpacityAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PropertyAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PropertyAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PropertyAnimation, IPropertyAnimation);
@@ -291,7 +291,7 @@ impl windows_core::RuntimeName for PropertyAnimation {
 unsafe impl Send for PropertyAnimation {}
 unsafe impl Sync for PropertyAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ScaleAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ScaleAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(ScaleAnimation, IPropertyAnimation);
@@ -380,7 +380,7 @@ impl windows_core::RuntimeName for ScaleAnimation {
 unsafe impl Send for ScaleAnimation {}
 unsafe impl Sync for ScaleAnimation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TranslationAnimation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TranslationAnimation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TranslationAnimation, IPropertyAnimation);

--- a/crates/libs/windows/src/Windows/UI/Core/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/Preview/mod.rs
@@ -49,7 +49,7 @@ pub struct ISystemNavigationManagerPreviewStatics_Vtbl {
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreAppWindowPreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreAppWindowPreview, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreAppWindowPreview {
@@ -82,7 +82,7 @@ impl windows_core::RuntimeName for CoreAppWindowPreview {
 unsafe impl Send for CoreAppWindowPreview {}
 unsafe impl Sync for CoreAppWindowPreview {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemNavigationCloseRequestedPreviewEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemNavigationCloseRequestedPreviewEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemNavigationCloseRequestedPreviewEventArgs {
@@ -118,7 +118,7 @@ impl windows_core::RuntimeName for SystemNavigationCloseRequestedPreviewEventArg
 unsafe impl Send for SystemNavigationCloseRequestedPreviewEventArgs {}
 unsafe impl Sync for SystemNavigationCloseRequestedPreviewEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemNavigationManagerPreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemNavigationManagerPreview, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemNavigationManagerPreview {

--- a/crates/libs/windows/src/Windows/UI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/mod.rs
@@ -1501,7 +1501,7 @@ pub struct IWindowSizeChangedEventArgs_Vtbl {
     pub Size: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::Size) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AcceleratorKeyEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AcceleratorKeyEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AcceleratorKeyEventArgs, ICoreWindowEventArgs);
@@ -1560,7 +1560,7 @@ impl windows_core::RuntimeName for AcceleratorKeyEventArgs {
 unsafe impl Send for AcceleratorKeyEventArgs {}
 unsafe impl Sync for AcceleratorKeyEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AutomationProviderRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AutomationProviderRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AutomationProviderRequestedEventArgs, ICoreWindowEventArgs);
@@ -1602,7 +1602,7 @@ impl windows_core::RuntimeName for AutomationProviderRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.AutomationProviderRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BackRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl BackRequestedEventArgs {
@@ -1631,7 +1631,7 @@ impl windows_core::RuntimeName for BackRequestedEventArgs {
 unsafe impl Send for BackRequestedEventArgs {}
 unsafe impl Sync for BackRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CharacterReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CharacterReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CharacterReceivedEventArgs, ICoreWindowEventArgs);
@@ -1673,7 +1673,7 @@ impl windows_core::RuntimeName for CharacterReceivedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.CharacterReceivedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ClosestInteractiveBoundsRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClosestInteractiveBoundsRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClosestInteractiveBoundsRequestedEventArgs {
@@ -1714,7 +1714,7 @@ impl windows_core::RuntimeName for ClosestInteractiveBoundsRequestedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.ClosestInteractiveBoundsRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreAcceleratorKeys(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreAcceleratorKeys, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CoreAcceleratorKeys, ICoreAcceleratorKeys);
@@ -1747,7 +1747,7 @@ impl windows_core::RuntimeName for CoreAcceleratorKeys {
 unsafe impl Send for CoreAcceleratorKeys {}
 unsafe impl Sync for CoreAcceleratorKeys {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreComponentInputSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreComponentInputSource, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CoreComponentInputSource, ICoreInputSourceBase, ICorePointerInputSource, ICorePointerInputSource2);
@@ -2060,7 +2060,7 @@ impl windows_core::RuntimeName for CoreComponentInputSource {
 unsafe impl Send for CoreComponentInputSource {}
 unsafe impl Sync for CoreComponentInputSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreCursor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreCursor, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreCursor {
@@ -2103,7 +2103,7 @@ impl windows_core::RuntimeName for CoreCursor {
 unsafe impl Send for CoreCursor {}
 unsafe impl Sync for CoreCursor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreDispatcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreDispatcher, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CoreDispatcher, ICoreAcceleratorKeys);
@@ -2216,7 +2216,7 @@ impl windows_core::RuntimeName for CoreDispatcher {
 unsafe impl Send for CoreDispatcher {}
 unsafe impl Sync for CoreDispatcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreIndependentInputSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreIndependentInputSource, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CoreIndependentInputSource, ICoreInputSourceBase, ICorePointerInputSource, ICorePointerInputSource2, ICorePointerRedirector);
@@ -2451,7 +2451,7 @@ impl windows_core::RuntimeName for CoreIndependentInputSource {
 unsafe impl Send for CoreIndependentInputSource {}
 unsafe impl Sync for CoreIndependentInputSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreIndependentInputSourceController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreIndependentInputSourceController, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CoreIndependentInputSourceController, super::super::Foundation::IClosable);
@@ -2536,7 +2536,7 @@ impl windows_core::RuntimeName for CoreIndependentInputSourceController {
 unsafe impl Send for CoreIndependentInputSourceController {}
 unsafe impl Sync for CoreIndependentInputSourceController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreWindow(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreWindow, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CoreWindow, ICorePointerRedirector, ICoreWindow);
@@ -3030,7 +3030,7 @@ impl windows_core::RuntimeName for CoreWindow {
     const NAME: &'static str = "Windows.UI.Core.CoreWindow";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreWindowDialog(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreWindowDialog, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreWindowDialog {
@@ -3168,7 +3168,7 @@ impl windows_core::RuntimeName for CoreWindowDialog {
     const NAME: &'static str = "Windows.UI.Core.CoreWindowDialog";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreWindowEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreWindowEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CoreWindowEventArgs, ICoreWindowEventArgs);
@@ -3196,7 +3196,7 @@ impl windows_core::RuntimeName for CoreWindowEventArgs {
     const NAME: &'static str = "Windows.UI.Core.CoreWindowEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreWindowFlyout(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreWindowFlyout, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreWindowFlyout {
@@ -3322,7 +3322,7 @@ impl windows_core::RuntimeName for CoreWindowFlyout {
     const NAME: &'static str = "Windows.UI.Core.CoreWindowFlyout";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreWindowPopupShowingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreWindowPopupShowingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreWindowPopupShowingEventArgs {
@@ -3342,7 +3342,7 @@ impl windows_core::RuntimeName for CoreWindowPopupShowingEventArgs {
     const NAME: &'static str = "Windows.UI.Core.CoreWindowPopupShowingEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreWindowResizeManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreWindowResizeManager, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreWindowResizeManager {
@@ -3386,7 +3386,7 @@ impl windows_core::RuntimeName for CoreWindowResizeManager {
 unsafe impl Send for CoreWindowResizeManager {}
 unsafe impl Sync for CoreWindowResizeManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IdleDispatchedHandlerArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(IdleDispatchedHandlerArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl IdleDispatchedHandlerArgs {
@@ -3409,7 +3409,7 @@ impl windows_core::RuntimeName for IdleDispatchedHandlerArgs {
     const NAME: &'static str = "Windows.UI.Core.IdleDispatchedHandlerArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InputEnabledEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InputEnabledEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InputEnabledEventArgs, ICoreWindowEventArgs);
@@ -3444,7 +3444,7 @@ impl windows_core::RuntimeName for InputEnabledEventArgs {
     const NAME: &'static str = "Windows.UI.Core.InputEnabledEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeyEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeyEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(KeyEventArgs, ICoreWindowEventArgs);
@@ -3494,7 +3494,7 @@ impl windows_core::RuntimeName for KeyEventArgs {
     const NAME: &'static str = "Windows.UI.Core.KeyEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PointerEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PointerEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PointerEventArgs, ICoreWindowEventArgs);
@@ -3546,7 +3546,7 @@ impl windows_core::RuntimeName for PointerEventArgs {
     const NAME: &'static str = "Windows.UI.Core.PointerEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemNavigationManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemNavigationManager, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemNavigationManager {
@@ -3600,7 +3600,7 @@ impl windows_core::RuntimeName for SystemNavigationManager {
 unsafe impl Send for SystemNavigationManager {}
 unsafe impl Sync for SystemNavigationManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TouchHitTestingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TouchHitTestingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(TouchHitTestingEventArgs, ICoreWindowEventArgs);
@@ -3667,7 +3667,7 @@ impl windows_core::RuntimeName for TouchHitTestingEventArgs {
     const NAME: &'static str = "Windows.UI.Core.TouchHitTestingEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VisibilityChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VisibilityChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(VisibilityChangedEventArgs, ICoreWindowEventArgs);
@@ -3702,7 +3702,7 @@ impl windows_core::RuntimeName for VisibilityChangedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.VisibilityChangedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WindowActivatedEventArgs, ICoreWindowEventArgs);
@@ -3737,7 +3737,7 @@ impl windows_core::RuntimeName for WindowActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.Core.WindowActivatedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowSizeChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowSizeChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WindowSizeChangedEventArgs, ICoreWindowEventArgs);

--- a/crates/libs/windows/src/Windows/UI/Input/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Core/mod.rs
@@ -36,7 +36,7 @@ pub struct IRadialControllerIndependentInputSourceStatics_Vtbl {
     CreateForView: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerIndependentInputSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerIndependentInputSource, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerIndependentInputSource {

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/mod.rs
@@ -228,7 +228,7 @@ pub struct IInkAnalyzerFactory_Vtbl {
     pub CreateAnalyzer: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalysisInkBullet(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalysisInkBullet, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkAnalysisInkBullet, IInkAnalysisNode);
@@ -306,7 +306,7 @@ impl windows_core::RuntimeName for InkAnalysisInkBullet {
 unsafe impl Send for InkAnalysisInkBullet {}
 unsafe impl Sync for InkAnalysisInkBullet {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalysisInkDrawing(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalysisInkDrawing, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkAnalysisInkDrawing, IInkAnalysisNode);
@@ -399,7 +399,7 @@ impl windows_core::RuntimeName for InkAnalysisInkDrawing {
 unsafe impl Send for InkAnalysisInkDrawing {}
 unsafe impl Sync for InkAnalysisInkDrawing {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalysisInkWord(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalysisInkWord, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkAnalysisInkWord, IInkAnalysisNode);
@@ -485,7 +485,7 @@ impl windows_core::RuntimeName for InkAnalysisInkWord {
 unsafe impl Send for InkAnalysisInkWord {}
 unsafe impl Sync for InkAnalysisInkWord {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalysisLine(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalysisLine, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkAnalysisLine, IInkAnalysisNode);
@@ -570,7 +570,7 @@ impl windows_core::RuntimeName for InkAnalysisLine {
 unsafe impl Send for InkAnalysisLine {}
 unsafe impl Sync for InkAnalysisLine {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalysisListItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalysisListItem, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkAnalysisListItem, IInkAnalysisNode);
@@ -648,7 +648,7 @@ impl windows_core::RuntimeName for InkAnalysisListItem {
 unsafe impl Send for InkAnalysisListItem {}
 unsafe impl Sync for InkAnalysisListItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalysisNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalysisNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkAnalysisNode, IInkAnalysisNode);
@@ -719,7 +719,7 @@ impl windows_core::RuntimeName for InkAnalysisNode {
 unsafe impl Send for InkAnalysisNode {}
 unsafe impl Sync for InkAnalysisNode {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalysisParagraph(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalysisParagraph, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkAnalysisParagraph, IInkAnalysisNode);
@@ -797,7 +797,7 @@ impl windows_core::RuntimeName for InkAnalysisParagraph {
 unsafe impl Send for InkAnalysisParagraph {}
 unsafe impl Sync for InkAnalysisParagraph {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalysisResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalysisResult, windows_core::IUnknown, windows_core::IInspectable);
 impl InkAnalysisResult {
@@ -822,7 +822,7 @@ impl windows_core::RuntimeName for InkAnalysisResult {
 unsafe impl Send for InkAnalysisResult {}
 unsafe impl Sync for InkAnalysisResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalysisRoot(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalysisRoot, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkAnalysisRoot, IInkAnalysisNode);
@@ -908,7 +908,7 @@ impl windows_core::RuntimeName for InkAnalysisRoot {
 unsafe impl Send for InkAnalysisRoot {}
 unsafe impl Sync for InkAnalysisRoot {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalysisWritingRegion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalysisWritingRegion, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkAnalysisWritingRegion, IInkAnalysisNode);
@@ -986,7 +986,7 @@ impl windows_core::RuntimeName for InkAnalysisWritingRegion {
 unsafe impl Send for InkAnalysisWritingRegion {}
 unsafe impl Sync for InkAnalysisWritingRegion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkAnalyzer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkAnalyzer, windows_core::IUnknown, windows_core::IInspectable);
 impl InkAnalyzer {

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Core/mod.rs
@@ -159,7 +159,7 @@ pub struct ICoreWetStrokeUpdateSourceStatics_Vtbl {
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreIncrementalInkStroke(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreIncrementalInkStroke, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreIncrementalInkStroke {
@@ -232,7 +232,7 @@ impl windows_core::RuntimeName for CoreIncrementalInkStroke {
 unsafe impl Send for CoreIncrementalInkStroke {}
 unsafe impl Sync for CoreIncrementalInkStroke {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreInkIndependentInputSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreInkIndependentInputSource, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreInkIndependentInputSource {
@@ -392,7 +392,7 @@ impl windows_core::RuntimeName for CoreInkIndependentInputSource {
 unsafe impl Send for CoreInkIndependentInputSource {}
 unsafe impl Sync for CoreInkIndependentInputSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreInkPresenterHost(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreInkPresenterHost, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreInkPresenterHost {
@@ -440,7 +440,7 @@ impl windows_core::RuntimeName for CoreInkPresenterHost {
 unsafe impl Send for CoreInkPresenterHost {}
 unsafe impl Sync for CoreInkPresenterHost {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreWetStrokeUpdateEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreWetStrokeUpdateEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreWetStrokeUpdateEventArgs {
@@ -484,7 +484,7 @@ impl windows_core::RuntimeName for CoreWetStrokeUpdateEventArgs {
 unsafe impl Send for CoreWetStrokeUpdateEventArgs {}
 unsafe impl Sync for CoreWetStrokeUpdateEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreWetStrokeUpdateSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreWetStrokeUpdateSource, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreWetStrokeUpdateSource {

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Preview/mod.rs
@@ -23,7 +23,7 @@ pub struct IPalmRejectionDelayZonePreviewStatics_Vtbl {
     CreateForVisualWithViewportClip: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PalmRejectionDelayZonePreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PalmRejectionDelayZonePreview, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(PalmRejectionDelayZonePreview, super::super::super::super::Foundation::IClosable);

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/mod.rs
@@ -957,7 +957,7 @@ pub struct IPenAndInkSettingsStatics_Vtbl {
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkDrawingAttributes(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkDrawingAttributes, windows_core::IUnknown, windows_core::IInspectable);
 impl InkDrawingAttributes {
@@ -1104,7 +1104,7 @@ impl windows_core::RuntimeName for InkDrawingAttributes {
 unsafe impl Send for InkDrawingAttributes {}
 unsafe impl Sync for InkDrawingAttributes {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkDrawingAttributesPencilProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkDrawingAttributesPencilProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl InkDrawingAttributesPencilProperties {
@@ -1133,7 +1133,7 @@ impl windows_core::RuntimeName for InkDrawingAttributesPencilProperties {
 unsafe impl Send for InkDrawingAttributesPencilProperties {}
 unsafe impl Sync for InkDrawingAttributesPencilProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkInputConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkInputConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl InkInputConfiguration {
@@ -1184,7 +1184,7 @@ impl windows_core::RuntimeName for InkInputConfiguration {
 unsafe impl Send for InkInputConfiguration {}
 unsafe impl Sync for InkInputConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkInputProcessingConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkInputProcessingConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl InkInputProcessingConfiguration {
@@ -1224,7 +1224,7 @@ impl windows_core::RuntimeName for InkInputProcessingConfiguration {
 unsafe impl Send for InkInputProcessingConfiguration {}
 unsafe impl Sync for InkInputProcessingConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkManager, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkManager, IInkRecognizerContainer, IInkStrokeContainer);
@@ -1437,7 +1437,7 @@ impl windows_core::RuntimeName for InkManager {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkModelerAttributes(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkModelerAttributes, windows_core::IUnknown, windows_core::IInspectable);
 impl InkModelerAttributes {
@@ -1488,7 +1488,7 @@ impl windows_core::RuntimeName for InkModelerAttributes {
 unsafe impl Send for InkModelerAttributes {}
 unsafe impl Sync for InkModelerAttributes {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkPoint(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkPoint, windows_core::IUnknown, windows_core::IInspectable);
 impl InkPoint {
@@ -1563,7 +1563,7 @@ impl windows_core::RuntimeName for InkPoint {
 unsafe impl Send for InkPoint {}
 unsafe impl Sync for InkPoint {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkPresenter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkPresenter, windows_core::IUnknown, windows_core::IInspectable);
 impl InkPresenter {
@@ -1711,7 +1711,7 @@ impl windows_core::RuntimeName for InkPresenter {
 unsafe impl Send for InkPresenter {}
 unsafe impl Sync for InkPresenter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkPresenterProtractor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkPresenterProtractor, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkPresenterProtractor, IInkPresenterStencil);
@@ -1874,7 +1874,7 @@ impl windows_core::RuntimeName for InkPresenterProtractor {
 unsafe impl Send for InkPresenterProtractor {}
 unsafe impl Sync for InkPresenterProtractor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkPresenterRuler(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkPresenterRuler, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkPresenterRuler, IInkPresenterStencil);
@@ -2004,7 +2004,7 @@ impl windows_core::RuntimeName for InkPresenterRuler {
 unsafe impl Send for InkPresenterRuler {}
 unsafe impl Sync for InkPresenterRuler {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkRecognitionResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkRecognitionResult, windows_core::IUnknown, windows_core::IInspectable);
 impl InkRecognitionResult {
@@ -2045,7 +2045,7 @@ impl windows_core::RuntimeName for InkRecognitionResult {
 unsafe impl Send for InkRecognitionResult {}
 unsafe impl Sync for InkRecognitionResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkRecognizer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkRecognizer, windows_core::IUnknown, windows_core::IInspectable);
 impl InkRecognizer {
@@ -2068,7 +2068,7 @@ impl windows_core::RuntimeName for InkRecognizer {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkRecognizer";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkRecognizerContainer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkRecognizerContainer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkRecognizerContainer, IInkRecognizerContainer);
@@ -2118,7 +2118,7 @@ impl windows_core::RuntimeName for InkRecognizerContainer {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkRecognizerContainer";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkStroke(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkStroke, windows_core::IUnknown, windows_core::IInspectable);
 impl InkStroke {
@@ -2253,7 +2253,7 @@ impl windows_core::RuntimeName for InkStroke {
 unsafe impl Send for InkStroke {}
 unsafe impl Sync for InkStroke {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkStrokeBuilder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkStrokeBuilder, windows_core::IUnknown, windows_core::IInspectable);
 impl InkStrokeBuilder {
@@ -2345,7 +2345,7 @@ impl windows_core::RuntimeName for InkStrokeBuilder {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStrokeBuilder";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkStrokeContainer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkStrokeContainer, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InkStrokeContainer, IInkStrokeContainer);
@@ -2509,7 +2509,7 @@ impl windows_core::RuntimeName for InkStrokeContainer {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStrokeContainer";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkStrokeInput(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkStrokeInput, windows_core::IUnknown, windows_core::IInspectable);
 impl InkStrokeInput {
@@ -2594,7 +2594,7 @@ impl windows_core::RuntimeName for InkStrokeInput {
 unsafe impl Send for InkStrokeInput {}
 unsafe impl Sync for InkStrokeInput {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkStrokeRenderingSegment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkStrokeRenderingSegment, windows_core::IUnknown, windows_core::IInspectable);
 impl InkStrokeRenderingSegment {
@@ -2661,7 +2661,7 @@ impl windows_core::RuntimeName for InkStrokeRenderingSegment {
 unsafe impl Send for InkStrokeRenderingSegment {}
 unsafe impl Sync for InkStrokeRenderingSegment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkStrokesCollectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkStrokesCollectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InkStrokesCollectedEventArgs {
@@ -2685,7 +2685,7 @@ impl windows_core::RuntimeName for InkStrokesCollectedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStrokesCollectedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkStrokesErasedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkStrokesErasedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InkStrokesErasedEventArgs {
@@ -2709,7 +2709,7 @@ impl windows_core::RuntimeName for InkStrokesErasedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkStrokesErasedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkSynchronizer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkSynchronizer, windows_core::IUnknown, windows_core::IInspectable);
 impl InkSynchronizer {
@@ -2737,7 +2737,7 @@ impl windows_core::RuntimeName for InkSynchronizer {
     const NAME: &'static str = "Windows.UI.Input.Inking.InkSynchronizer";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InkUnprocessedInput(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InkUnprocessedInput, windows_core::IUnknown, windows_core::IInspectable);
 impl InkUnprocessedInput {
@@ -2867,7 +2867,7 @@ impl windows_core::RuntimeName for InkUnprocessedInput {
 unsafe impl Send for InkUnprocessedInput {}
 unsafe impl Sync for InkUnprocessedInput {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PenAndInkSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenAndInkSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl PenAndInkSettings {

--- a/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
@@ -166,7 +166,7 @@ pub struct IInputInjectorStatics2_Vtbl {
     pub TryCreateForAppBroadcastOnly: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InjectedInputGamepadInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InjectedInputGamepadInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl InjectedInputGamepadInfo {
@@ -280,7 +280,7 @@ impl windows_core::RuntimeName for InjectedInputGamepadInfo {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InjectedInputGamepadInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InjectedInputKeyboardInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InjectedInputKeyboardInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl InjectedInputKeyboardInfo {
@@ -336,7 +336,7 @@ impl windows_core::RuntimeName for InjectedInputKeyboardInfo {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InjectedInputKeyboardInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InjectedInputMouseInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InjectedInputMouseInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl InjectedInputMouseInfo {
@@ -414,7 +414,7 @@ impl windows_core::RuntimeName for InjectedInputMouseInfo {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InjectedInputPenInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InjectedInputPenInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl InjectedInputPenInfo {
@@ -514,7 +514,7 @@ impl windows_core::RuntimeName for InjectedInputPenInfo {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InjectedInputPenInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InjectedInputTouchInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InjectedInputTouchInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl InjectedInputTouchInfo {
@@ -592,7 +592,7 @@ impl windows_core::RuntimeName for InjectedInputTouchInfo {
     const NAME: &'static str = "Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InputInjector(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InputInjector, windows_core::IUnknown, windows_core::IInspectable);
 impl InputInjector {

--- a/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
@@ -612,7 +612,7 @@ pub struct ISpatialTappedEventArgs_Vtbl {
     pub TapCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialGestureRecognizer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialGestureRecognizer, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialGestureRecognizer {
@@ -862,7 +862,7 @@ impl windows_core::RuntimeName for SpatialGestureRecognizer {
 unsafe impl Send for SpatialGestureRecognizer {}
 unsafe impl Sync for SpatialGestureRecognizer {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialHoldCanceledEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialHoldCanceledEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialHoldCanceledEventArgs {
@@ -887,7 +887,7 @@ impl windows_core::RuntimeName for SpatialHoldCanceledEventArgs {
 unsafe impl Send for SpatialHoldCanceledEventArgs {}
 unsafe impl Sync for SpatialHoldCanceledEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialHoldCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialHoldCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialHoldCompletedEventArgs {
@@ -912,7 +912,7 @@ impl windows_core::RuntimeName for SpatialHoldCompletedEventArgs {
 unsafe impl Send for SpatialHoldCompletedEventArgs {}
 unsafe impl Sync for SpatialHoldCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialHoldStartedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialHoldStartedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialHoldStartedEventArgs {
@@ -948,7 +948,7 @@ impl windows_core::RuntimeName for SpatialHoldStartedEventArgs {
 unsafe impl Send for SpatialHoldStartedEventArgs {}
 unsafe impl Sync for SpatialHoldStartedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialInteraction(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialInteraction, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialInteraction {
@@ -973,7 +973,7 @@ impl windows_core::RuntimeName for SpatialInteraction {
 unsafe impl Send for SpatialInteraction {}
 unsafe impl Sync for SpatialInteraction {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialInteractionController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialInteractionController, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialInteractionController {
@@ -1050,7 +1050,7 @@ impl windows_core::RuntimeName for SpatialInteractionController {
 unsafe impl Send for SpatialInteractionController {}
 unsafe impl Sync for SpatialInteractionController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialInteractionControllerProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialInteractionControllerProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialInteractionControllerProperties {
@@ -1117,7 +1117,7 @@ impl windows_core::RuntimeName for SpatialInteractionControllerProperties {
 unsafe impl Send for SpatialInteractionControllerProperties {}
 unsafe impl Sync for SpatialInteractionControllerProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialInteractionDetectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialInteractionDetectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialInteractionDetectedEventArgs {
@@ -1167,7 +1167,7 @@ impl windows_core::RuntimeName for SpatialInteractionDetectedEventArgs {
 unsafe impl Send for SpatialInteractionDetectedEventArgs {}
 unsafe impl Sync for SpatialInteractionDetectedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialInteractionManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialInteractionManager, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialInteractionManager {
@@ -1302,7 +1302,7 @@ impl windows_core::RuntimeName for SpatialInteractionManager {
 unsafe impl Send for SpatialInteractionManager {}
 unsafe impl Sync for SpatialInteractionManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialInteractionSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialInteractionSource, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialInteractionSource {
@@ -1396,7 +1396,7 @@ impl windows_core::RuntimeName for SpatialInteractionSource {
 unsafe impl Send for SpatialInteractionSource {}
 unsafe impl Sync for SpatialInteractionSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialInteractionSourceEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialInteractionSourceEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialInteractionSourceEventArgs {
@@ -1428,7 +1428,7 @@ impl windows_core::RuntimeName for SpatialInteractionSourceEventArgs {
 unsafe impl Send for SpatialInteractionSourceEventArgs {}
 unsafe impl Sync for SpatialInteractionSourceEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialInteractionSourceLocation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialInteractionSourceLocation, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialInteractionSourceLocation {
@@ -1492,7 +1492,7 @@ impl windows_core::RuntimeName for SpatialInteractionSourceLocation {
 unsafe impl Send for SpatialInteractionSourceLocation {}
 unsafe impl Sync for SpatialInteractionSourceLocation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialInteractionSourceProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialInteractionSourceProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialInteractionSourceProperties {
@@ -1539,7 +1539,7 @@ impl windows_core::RuntimeName for SpatialInteractionSourceProperties {
 unsafe impl Send for SpatialInteractionSourceProperties {}
 unsafe impl Sync for SpatialInteractionSourceProperties {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialInteractionSourceState(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialInteractionSourceState, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialInteractionSourceState {
@@ -1640,7 +1640,7 @@ impl windows_core::RuntimeName for SpatialInteractionSourceState {
 unsafe impl Send for SpatialInteractionSourceState {}
 unsafe impl Sync for SpatialInteractionSourceState {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialManipulationCanceledEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialManipulationCanceledEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialManipulationCanceledEventArgs {
@@ -1665,7 +1665,7 @@ impl windows_core::RuntimeName for SpatialManipulationCanceledEventArgs {
 unsafe impl Send for SpatialManipulationCanceledEventArgs {}
 unsafe impl Sync for SpatialManipulationCanceledEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialManipulationCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialManipulationCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialManipulationCompletedEventArgs {
@@ -1701,7 +1701,7 @@ impl windows_core::RuntimeName for SpatialManipulationCompletedEventArgs {
 unsafe impl Send for SpatialManipulationCompletedEventArgs {}
 unsafe impl Sync for SpatialManipulationCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialManipulationDelta(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialManipulationDelta, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialManipulationDelta {
@@ -1727,7 +1727,7 @@ impl windows_core::RuntimeName for SpatialManipulationDelta {
 unsafe impl Send for SpatialManipulationDelta {}
 unsafe impl Sync for SpatialManipulationDelta {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialManipulationStartedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialManipulationStartedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialManipulationStartedEventArgs {
@@ -1763,7 +1763,7 @@ impl windows_core::RuntimeName for SpatialManipulationStartedEventArgs {
 unsafe impl Send for SpatialManipulationStartedEventArgs {}
 unsafe impl Sync for SpatialManipulationStartedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialManipulationUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialManipulationUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialManipulationUpdatedEventArgs {
@@ -1799,7 +1799,7 @@ impl windows_core::RuntimeName for SpatialManipulationUpdatedEventArgs {
 unsafe impl Send for SpatialManipulationUpdatedEventArgs {}
 unsafe impl Sync for SpatialManipulationUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialNavigationCanceledEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialNavigationCanceledEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialNavigationCanceledEventArgs {
@@ -1824,7 +1824,7 @@ impl windows_core::RuntimeName for SpatialNavigationCanceledEventArgs {
 unsafe impl Send for SpatialNavigationCanceledEventArgs {}
 unsafe impl Sync for SpatialNavigationCanceledEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialNavigationCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialNavigationCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialNavigationCompletedEventArgs {
@@ -1857,7 +1857,7 @@ impl windows_core::RuntimeName for SpatialNavigationCompletedEventArgs {
 unsafe impl Send for SpatialNavigationCompletedEventArgs {}
 unsafe impl Sync for SpatialNavigationCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialNavigationStartedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialNavigationStartedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialNavigationStartedEventArgs {
@@ -1914,7 +1914,7 @@ impl windows_core::RuntimeName for SpatialNavigationStartedEventArgs {
 unsafe impl Send for SpatialNavigationStartedEventArgs {}
 unsafe impl Sync for SpatialNavigationStartedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialNavigationUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialNavigationUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialNavigationUpdatedEventArgs {
@@ -1947,7 +1947,7 @@ impl windows_core::RuntimeName for SpatialNavigationUpdatedEventArgs {
 unsafe impl Send for SpatialNavigationUpdatedEventArgs {}
 unsafe impl Sync for SpatialNavigationUpdatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialPointerInteractionSourcePose(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialPointerInteractionSourcePose, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialPointerInteractionSourcePose {
@@ -2004,7 +2004,7 @@ impl windows_core::RuntimeName for SpatialPointerInteractionSourcePose {
 unsafe impl Send for SpatialPointerInteractionSourcePose {}
 unsafe impl Sync for SpatialPointerInteractionSourcePose {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialPointerPose(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialPointerPose, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialPointerPose {
@@ -2079,7 +2079,7 @@ impl windows_core::RuntimeName for SpatialPointerPose {
 unsafe impl Send for SpatialPointerPose {}
 unsafe impl Sync for SpatialPointerPose {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialRecognitionEndedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialRecognitionEndedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialRecognitionEndedEventArgs {
@@ -2104,7 +2104,7 @@ impl windows_core::RuntimeName for SpatialRecognitionEndedEventArgs {
 unsafe impl Send for SpatialRecognitionEndedEventArgs {}
 unsafe impl Sync for SpatialRecognitionEndedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialRecognitionStartedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialRecognitionStartedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialRecognitionStartedEventArgs {
@@ -2147,7 +2147,7 @@ impl windows_core::RuntimeName for SpatialRecognitionStartedEventArgs {
 unsafe impl Send for SpatialRecognitionStartedEventArgs {}
 unsafe impl Sync for SpatialRecognitionStartedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SpatialTappedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SpatialTappedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SpatialTappedEventArgs {

--- a/crates/libs/windows/src/Windows/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/mod.rs
@@ -953,7 +953,7 @@ pub struct ITappedEventArgs2_Vtbl {
     pub ContactCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AttachableInputObject(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AttachableInputObject, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AttachableInputObject, super::super::Foundation::IClosable);
@@ -976,7 +976,7 @@ impl windows_core::RuntimeName for AttachableInputObject {
 unsafe impl Send for AttachableInputObject {}
 unsafe impl Sync for AttachableInputObject {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CrossSlidingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CrossSlidingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CrossSlidingEventArgs {
@@ -1021,7 +1021,7 @@ impl windows_core::RuntimeName for CrossSlidingEventArgs {
     const NAME: &'static str = "Windows.UI.Input.CrossSlidingEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DraggingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DraggingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl DraggingEventArgs {
@@ -1066,7 +1066,7 @@ impl windows_core::RuntimeName for DraggingEventArgs {
     const NAME: &'static str = "Windows.UI.Input.DraggingEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EdgeGesture(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EdgeGesture, windows_core::IUnknown, windows_core::IInspectable);
 impl EdgeGesture {
@@ -1135,7 +1135,7 @@ impl windows_core::RuntimeName for EdgeGesture {
     const NAME: &'static str = "Windows.UI.Input.EdgeGesture";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EdgeGestureEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EdgeGestureEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl EdgeGestureEventArgs {
@@ -1158,7 +1158,7 @@ impl windows_core::RuntimeName for EdgeGestureEventArgs {
     const NAME: &'static str = "Windows.UI.Input.EdgeGestureEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GestureRecognizer(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(GestureRecognizer, windows_core::IUnknown, windows_core::IInspectable);
 impl GestureRecognizer {
@@ -1628,7 +1628,7 @@ impl windows_core::RuntimeName for GestureRecognizer {
     const NAME: &'static str = "Windows.UI.Input.GestureRecognizer";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HoldingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HoldingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HoldingEventArgs {
@@ -1680,7 +1680,7 @@ impl windows_core::RuntimeName for HoldingEventArgs {
     const NAME: &'static str = "Windows.UI.Input.HoldingEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InputActivationListener(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InputActivationListener, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(InputActivationListener, super::super::Foundation::IClosable, AttachableInputObject);
@@ -1724,7 +1724,7 @@ impl windows_core::RuntimeName for InputActivationListener {
 unsafe impl Send for InputActivationListener {}
 unsafe impl Sync for InputActivationListener {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InputActivationListenerActivationChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InputActivationListenerActivationChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InputActivationListenerActivationChangedEventArgs {
@@ -1749,7 +1749,7 @@ impl windows_core::RuntimeName for InputActivationListenerActivationChangedEvent
 unsafe impl Send for InputActivationListenerActivationChangedEventArgs {}
 unsafe impl Sync for InputActivationListenerActivationChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KeyboardDeliveryInterceptor(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(KeyboardDeliveryInterceptor, windows_core::IUnknown, windows_core::IInspectable);
 impl KeyboardDeliveryInterceptor {
@@ -1819,7 +1819,7 @@ impl windows_core::RuntimeName for KeyboardDeliveryInterceptor {
 unsafe impl Send for KeyboardDeliveryInterceptor {}
 unsafe impl Sync for KeyboardDeliveryInterceptor {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ManipulationCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ManipulationCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ManipulationCompletedEventArgs {
@@ -1878,7 +1878,7 @@ impl windows_core::RuntimeName for ManipulationCompletedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.ManipulationCompletedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ManipulationInertiaStartingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ManipulationInertiaStartingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ManipulationInertiaStartingEventArgs {
@@ -1937,7 +1937,7 @@ impl windows_core::RuntimeName for ManipulationInertiaStartingEventArgs {
     const NAME: &'static str = "Windows.UI.Input.ManipulationInertiaStartingEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ManipulationStartedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ManipulationStartedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ManipulationStartedEventArgs {
@@ -1982,7 +1982,7 @@ impl windows_core::RuntimeName for ManipulationStartedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.ManipulationStartedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ManipulationUpdatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ManipulationUpdatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ManipulationUpdatedEventArgs {
@@ -2048,7 +2048,7 @@ impl windows_core::RuntimeName for ManipulationUpdatedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.ManipulationUpdatedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MouseWheelParameters(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MouseWheelParameters, windows_core::IUnknown, windows_core::IInspectable);
 impl MouseWheelParameters {
@@ -2108,7 +2108,7 @@ impl windows_core::RuntimeName for MouseWheelParameters {
     const NAME: &'static str = "Windows.UI.Input.MouseWheelParameters";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PointerPoint(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PointerPoint, windows_core::IUnknown, windows_core::IInspectable);
 impl PointerPoint {
@@ -2218,7 +2218,7 @@ impl windows_core::RuntimeName for PointerPoint {
     const NAME: &'static str = "Windows.UI.Input.PointerPoint";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PointerPointProperties(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PointerPointProperties, windows_core::IUnknown, windows_core::IInspectable);
 impl PointerPointProperties {
@@ -2409,7 +2409,7 @@ impl windows_core::RuntimeName for PointerPointProperties {
     const NAME: &'static str = "Windows.UI.Input.PointerPointProperties";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PointerVisualizationSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PointerVisualizationSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl PointerVisualizationSettings {
@@ -2460,7 +2460,7 @@ impl windows_core::RuntimeName for PointerVisualizationSettings {
 unsafe impl Send for PointerVisualizationSettings {}
 unsafe impl Sync for PointerVisualizationSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialController, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialController {
@@ -2664,7 +2664,7 @@ impl windows_core::RuntimeName for RadialController {
 unsafe impl Send for RadialController {}
 unsafe impl Sync for RadialController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerButtonClickedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerButtonClickedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerButtonClickedEventArgs {
@@ -2697,7 +2697,7 @@ impl windows_core::RuntimeName for RadialControllerButtonClickedEventArgs {
 unsafe impl Send for RadialControllerButtonClickedEventArgs {}
 unsafe impl Sync for RadialControllerButtonClickedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerButtonHoldingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerButtonHoldingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerButtonHoldingEventArgs {
@@ -2730,7 +2730,7 @@ impl windows_core::RuntimeName for RadialControllerButtonHoldingEventArgs {
 unsafe impl Send for RadialControllerButtonHoldingEventArgs {}
 unsafe impl Sync for RadialControllerButtonHoldingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerButtonPressedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerButtonPressedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerButtonPressedEventArgs {
@@ -2763,7 +2763,7 @@ impl windows_core::RuntimeName for RadialControllerButtonPressedEventArgs {
 unsafe impl Send for RadialControllerButtonPressedEventArgs {}
 unsafe impl Sync for RadialControllerButtonPressedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerButtonReleasedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerButtonReleasedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerButtonReleasedEventArgs {
@@ -2796,7 +2796,7 @@ impl windows_core::RuntimeName for RadialControllerButtonReleasedEventArgs {
 unsafe impl Send for RadialControllerButtonReleasedEventArgs {}
 unsafe impl Sync for RadialControllerButtonReleasedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerConfiguration {
@@ -2895,7 +2895,7 @@ impl windows_core::RuntimeName for RadialControllerConfiguration {
 unsafe impl Send for RadialControllerConfiguration {}
 unsafe impl Sync for RadialControllerConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerControlAcquiredEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerControlAcquiredEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerControlAcquiredEventArgs {
@@ -2935,7 +2935,7 @@ impl windows_core::RuntimeName for RadialControllerControlAcquiredEventArgs {
 unsafe impl Send for RadialControllerControlAcquiredEventArgs {}
 unsafe impl Sync for RadialControllerControlAcquiredEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerMenu(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerMenu, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerMenu {
@@ -2993,7 +2993,7 @@ impl windows_core::RuntimeName for RadialControllerMenu {
 unsafe impl Send for RadialControllerMenu {}
 unsafe impl Sync for RadialControllerMenu {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerMenuItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerMenuItem, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerMenuItem {
@@ -3087,7 +3087,7 @@ impl windows_core::RuntimeName for RadialControllerMenuItem {
 unsafe impl Send for RadialControllerMenuItem {}
 unsafe impl Sync for RadialControllerMenuItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerRotationChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerRotationChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerRotationChangedEventArgs {
@@ -3134,7 +3134,7 @@ impl windows_core::RuntimeName for RadialControllerRotationChangedEventArgs {
 unsafe impl Send for RadialControllerRotationChangedEventArgs {}
 unsafe impl Sync for RadialControllerRotationChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerScreenContact(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerScreenContact, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerScreenContact {
@@ -3166,7 +3166,7 @@ impl windows_core::RuntimeName for RadialControllerScreenContact {
 unsafe impl Send for RadialControllerScreenContact {}
 unsafe impl Sync for RadialControllerScreenContact {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerScreenContactContinuedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerScreenContactContinuedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerScreenContactContinuedEventArgs {
@@ -3206,7 +3206,7 @@ impl windows_core::RuntimeName for RadialControllerScreenContactContinuedEventAr
 unsafe impl Send for RadialControllerScreenContactContinuedEventArgs {}
 unsafe impl Sync for RadialControllerScreenContactContinuedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerScreenContactEndedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerScreenContactEndedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerScreenContactEndedEventArgs {
@@ -3239,7 +3239,7 @@ impl windows_core::RuntimeName for RadialControllerScreenContactEndedEventArgs {
 unsafe impl Send for RadialControllerScreenContactEndedEventArgs {}
 unsafe impl Sync for RadialControllerScreenContactEndedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RadialControllerScreenContactStartedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RadialControllerScreenContactStartedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RadialControllerScreenContactStartedEventArgs {
@@ -3279,7 +3279,7 @@ impl windows_core::RuntimeName for RadialControllerScreenContactStartedEventArgs
 unsafe impl Send for RadialControllerScreenContactStartedEventArgs {}
 unsafe impl Sync for RadialControllerScreenContactStartedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RightTappedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RightTappedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RightTappedEventArgs {
@@ -3317,7 +3317,7 @@ impl windows_core::RuntimeName for RightTappedEventArgs {
     const NAME: &'static str = "Windows.UI.Input.RightTappedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemButtonEventController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemButtonEventController, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SystemButtonEventController, super::super::Foundation::IClosable, AttachableInputObject);
@@ -3411,7 +3411,7 @@ impl windows_core::RuntimeName for SystemButtonEventController {
 unsafe impl Send for SystemButtonEventController {}
 unsafe impl Sync for SystemButtonEventController {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemFunctionButtonEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemFunctionButtonEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemFunctionButtonEventArgs {
@@ -3447,7 +3447,7 @@ impl windows_core::RuntimeName for SystemFunctionButtonEventArgs {
 unsafe impl Send for SystemFunctionButtonEventArgs {}
 unsafe impl Sync for SystemFunctionButtonEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemFunctionLockChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemFunctionLockChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemFunctionLockChangedEventArgs {
@@ -3490,7 +3490,7 @@ impl windows_core::RuntimeName for SystemFunctionLockChangedEventArgs {
 unsafe impl Send for SystemFunctionLockChangedEventArgs {}
 unsafe impl Sync for SystemFunctionLockChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SystemFunctionLockIndicatorChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SystemFunctionLockIndicatorChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SystemFunctionLockIndicatorChangedEventArgs {
@@ -3533,7 +3533,7 @@ impl windows_core::RuntimeName for SystemFunctionLockIndicatorChangedEventArgs {
 unsafe impl Send for SystemFunctionLockIndicatorChangedEventArgs {}
 unsafe impl Sync for SystemFunctionLockIndicatorChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TappedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TappedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TappedEventArgs {

--- a/crates/libs/windows/src/Windows/UI/Notifications/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/Management/mod.rs
@@ -27,7 +27,7 @@ pub struct IUserNotificationListenerStatics_Vtbl {
     pub Current: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserNotificationListener(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserNotificationListener, windows_core::IUnknown, windows_core::IInspectable);
 impl UserNotificationListener {

--- a/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
@@ -917,7 +917,7 @@ pub struct IUserNotificationChangedEventArgs_Vtbl {
     pub UserNotificationId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AdaptiveNotificationText(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AdaptiveNotificationText, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(AdaptiveNotificationText, IAdaptiveNotificationContent);
@@ -980,7 +980,7 @@ impl windows_core::RuntimeName for AdaptiveNotificationText {
 unsafe impl Send for AdaptiveNotificationText {}
 unsafe impl Sync for AdaptiveNotificationText {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BadgeNotification(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BadgeNotification, windows_core::IUnknown, windows_core::IInspectable);
 impl BadgeNotification {
@@ -1086,7 +1086,7 @@ impl windows_core::RuntimeName for BadgeUpdateManager {
     const NAME: &'static str = "Windows.UI.Notifications.BadgeUpdateManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BadgeUpdateManagerForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BadgeUpdateManagerForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl BadgeUpdateManagerForUser {
@@ -1133,7 +1133,7 @@ impl windows_core::RuntimeName for BadgeUpdateManagerForUser {
 unsafe impl Send for BadgeUpdateManagerForUser {}
 unsafe impl Sync for BadgeUpdateManagerForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BadgeUpdater(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(BadgeUpdater, windows_core::IUnknown, windows_core::IInspectable);
 impl BadgeUpdater {
@@ -1369,7 +1369,7 @@ impl windows_core::RuntimeName for KnownNotificationBindings {
     const NAME: &'static str = "Windows.UI.Notifications.KnownNotificationBindings";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Notification(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Notification, windows_core::IUnknown, windows_core::IInspectable);
 impl Notification {
@@ -1422,7 +1422,7 @@ impl windows_core::RuntimeName for Notification {
 unsafe impl Send for Notification {}
 unsafe impl Sync for Notification {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NotificationBinding(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NotificationBinding, windows_core::IUnknown, windows_core::IInspectable);
 impl NotificationBinding {
@@ -1478,7 +1478,7 @@ impl windows_core::RuntimeName for NotificationBinding {
 unsafe impl Send for NotificationBinding {}
 unsafe impl Sync for NotificationBinding {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NotificationData(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NotificationData, windows_core::IUnknown, windows_core::IInspectable);
 impl NotificationData {
@@ -1547,7 +1547,7 @@ impl windows_core::RuntimeName for NotificationData {
 unsafe impl Send for NotificationData {}
 unsafe impl Sync for NotificationData {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NotificationVisual(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NotificationVisual, windows_core::IUnknown, windows_core::IInspectable);
 impl NotificationVisual {
@@ -1591,7 +1591,7 @@ impl windows_core::RuntimeName for NotificationVisual {
 unsafe impl Send for NotificationVisual {}
 unsafe impl Sync for NotificationVisual {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ScheduledTileNotification(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ScheduledTileNotification, windows_core::IUnknown, windows_core::IInspectable);
 impl ScheduledTileNotification {
@@ -1675,7 +1675,7 @@ impl windows_core::RuntimeName for ScheduledTileNotification {
 unsafe impl Send for ScheduledTileNotification {}
 unsafe impl Sync for ScheduledTileNotification {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ScheduledToastNotification(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ScheduledToastNotification, windows_core::IUnknown, windows_core::IInspectable);
 impl ScheduledToastNotification {
@@ -1827,7 +1827,7 @@ impl windows_core::RuntimeName for ScheduledToastNotification {
 unsafe impl Send for ScheduledToastNotification {}
 unsafe impl Sync for ScheduledToastNotification {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ScheduledToastNotificationShowingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ScheduledToastNotificationShowingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ScheduledToastNotificationShowingEventArgs {
@@ -1870,7 +1870,7 @@ impl windows_core::RuntimeName for ScheduledToastNotificationShowingEventArgs {
 unsafe impl Send for ScheduledToastNotificationShowingEventArgs {}
 unsafe impl Sync for ScheduledToastNotificationShowingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShownTileNotification(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShownTileNotification, windows_core::IUnknown, windows_core::IInspectable);
 impl ShownTileNotification {
@@ -1895,7 +1895,7 @@ impl windows_core::RuntimeName for ShownTileNotification {
 unsafe impl Send for ShownTileNotification {}
 unsafe impl Sync for ShownTileNotification {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TileFlyoutNotification(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TileFlyoutNotification, windows_core::IUnknown, windows_core::IInspectable);
 impl TileFlyoutNotification {
@@ -1986,7 +1986,7 @@ impl windows_core::RuntimeName for TileFlyoutUpdateManager {
     const NAME: &'static str = "Windows.UI.Notifications.TileFlyoutUpdateManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TileFlyoutUpdater(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TileFlyoutUpdater, windows_core::IUnknown, windows_core::IInspectable);
 impl TileFlyoutUpdater {
@@ -2038,7 +2038,7 @@ impl windows_core::RuntimeName for TileFlyoutUpdater {
     const NAME: &'static str = "Windows.UI.Notifications.TileFlyoutUpdater";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TileNotification(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TileNotification, windows_core::IUnknown, windows_core::IInspectable);
 impl TileNotification {
@@ -2155,7 +2155,7 @@ impl windows_core::RuntimeName for TileUpdateManager {
     const NAME: &'static str = "Windows.UI.Notifications.TileUpdateManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TileUpdateManagerForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TileUpdateManagerForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl TileUpdateManagerForUser {
@@ -2202,7 +2202,7 @@ impl windows_core::RuntimeName for TileUpdateManagerForUser {
 unsafe impl Send for TileUpdateManagerForUser {}
 unsafe impl Sync for TileUpdateManagerForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TileUpdater(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TileUpdater, windows_core::IUnknown, windows_core::IInspectable);
 impl TileUpdater {
@@ -2310,7 +2310,7 @@ impl windows_core::RuntimeName for TileUpdater {
 unsafe impl Send for TileUpdater {}
 unsafe impl Sync for TileUpdater {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastActivatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastActivatedEventArgs {
@@ -2341,7 +2341,7 @@ impl windows_core::RuntimeName for ToastActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.Notifications.ToastActivatedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastCollection, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastCollection {
@@ -2416,7 +2416,7 @@ impl windows_core::RuntimeName for ToastCollection {
 unsafe impl Send for ToastCollection {}
 unsafe impl Sync for ToastCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastCollectionManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastCollectionManager, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastCollectionManager {
@@ -2488,7 +2488,7 @@ impl windows_core::RuntimeName for ToastCollectionManager {
 unsafe impl Send for ToastCollectionManager {}
 unsafe impl Sync for ToastCollectionManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastDismissedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastDismissedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastDismissedEventArgs {
@@ -2513,7 +2513,7 @@ impl windows_core::RuntimeName for ToastDismissedEventArgs {
 unsafe impl Send for ToastDismissedEventArgs {}
 unsafe impl Sync for ToastDismissedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastFailedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastFailedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastFailedEventArgs {
@@ -2538,7 +2538,7 @@ impl windows_core::RuntimeName for ToastFailedEventArgs {
 unsafe impl Send for ToastFailedEventArgs {}
 unsafe impl Sync for ToastFailedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastNotification(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastNotification, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastNotification {
@@ -2726,7 +2726,7 @@ impl windows_core::RuntimeName for ToastNotification {
 unsafe impl Send for ToastNotification {}
 unsafe impl Sync for ToastNotification {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastNotificationActionTriggerDetail(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastNotificationActionTriggerDetail, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastNotificationActionTriggerDetail {
@@ -2757,7 +2757,7 @@ impl windows_core::RuntimeName for ToastNotificationActionTriggerDetail {
     const NAME: &'static str = "Windows.UI.Notifications.ToastNotificationActionTriggerDetail";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastNotificationHistory(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastNotificationHistory, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastNotificationHistory {
@@ -2817,7 +2817,7 @@ impl windows_core::RuntimeName for ToastNotificationHistory {
     const NAME: &'static str = "Windows.UI.Notifications.ToastNotificationHistory";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastNotificationHistoryChangedTriggerDetail(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastNotificationHistoryChangedTriggerDetail, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastNotificationHistoryChangedTriggerDetail {
@@ -2917,7 +2917,7 @@ impl windows_core::RuntimeName for ToastNotificationManager {
     const NAME: &'static str = "Windows.UI.Notifications.ToastNotificationManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastNotificationManagerForUser(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastNotificationManagerForUser, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastNotificationManagerForUser {
@@ -3013,7 +3013,7 @@ impl windows_core::RuntimeName for ToastNotificationManagerForUser {
 unsafe impl Send for ToastNotificationManagerForUser {}
 unsafe impl Sync for ToastNotificationManagerForUser {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ToastNotifier(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ToastNotifier, windows_core::IUnknown, windows_core::IInspectable);
 impl ToastNotifier {
@@ -3108,7 +3108,7 @@ impl windows_core::RuntimeName for ToastNotifier {
 unsafe impl Send for ToastNotifier {}
 unsafe impl Sync for ToastNotifier {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserNotification(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserNotification, windows_core::IUnknown, windows_core::IInspectable);
 impl UserNotification {
@@ -3155,7 +3155,7 @@ impl windows_core::RuntimeName for UserNotification {
 unsafe impl Send for UserNotification {}
 unsafe impl Sync for UserNotification {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UserNotificationChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UserNotificationChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UserNotificationChangedEventArgs {

--- a/crates/libs/windows/src/Windows/UI/Popups/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Popups/mod.rs
@@ -120,7 +120,7 @@ pub struct IUICommandFactory_Vtbl {
     pub CreateWithHandlerAndId: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct MessageDialog(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MessageDialog, windows_core::IUnknown, windows_core::IInspectable);
 impl MessageDialog {
@@ -223,7 +223,7 @@ impl windows_core::RuntimeName for MessageDialog {
     const NAME: &'static str = "Windows.UI.Popups.MessageDialog";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct PopupMenu(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PopupMenu, windows_core::IUnknown, windows_core::IInspectable);
 impl PopupMenu {
@@ -275,7 +275,7 @@ impl windows_core::RuntimeName for PopupMenu {
     const NAME: &'static str = "Windows.UI.Popups.PopupMenu";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UICommand(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UICommand, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UICommand, IUICommand);
@@ -370,7 +370,7 @@ impl windows_core::RuntimeName for UICommand {
 unsafe impl Send for UICommand {}
 unsafe impl Sync for UICommand {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UICommandSeparator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UICommandSeparator, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(UICommandSeparator, IUICommand);

--- a/crates/libs/windows/src/Windows/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Shell/mod.rs
@@ -342,7 +342,7 @@ impl windows_core::RuntimeName for AdaptiveCardBuilder {
     const NAME: &'static str = "Windows.UI.Shell.AdaptiveCardBuilder";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FocusSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FocusSession, windows_core::IUnknown, windows_core::IInspectable);
 impl FocusSession {
@@ -371,7 +371,7 @@ impl windows_core::RuntimeName for FocusSession {
 unsafe impl Send for FocusSession {}
 unsafe impl Sync for FocusSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FocusSessionManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FocusSessionManager, windows_core::IUnknown, windows_core::IInspectable);
 impl FocusSessionManager {
@@ -452,7 +452,7 @@ impl windows_core::RuntimeName for FocusSessionManager {
 unsafe impl Send for FocusSessionManager {}
 unsafe impl Sync for FocusSessionManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SecurityAppManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SecurityAppManager, windows_core::IUnknown, windows_core::IInspectable);
 impl SecurityAppManager {
@@ -498,7 +498,7 @@ impl windows_core::RuntimeName for SecurityAppManager {
 unsafe impl Send for SecurityAppManager {}
 unsafe impl Sync for SecurityAppManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShareWindowCommandEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShareWindowCommandEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ShareWindowCommandEventArgs {
@@ -534,7 +534,7 @@ impl windows_core::RuntimeName for ShareWindowCommandEventArgs {
 unsafe impl Send for ShareWindowCommandEventArgs {}
 unsafe impl Sync for ShareWindowCommandEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ShareWindowCommandSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ShareWindowCommandSource, windows_core::IUnknown, windows_core::IInspectable);
 impl ShareWindowCommandSource {
@@ -603,7 +603,7 @@ impl windows_core::RuntimeName for ShareWindowCommandSource {
 unsafe impl Send for ShareWindowCommandSource {}
 unsafe impl Sync for ShareWindowCommandSource {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TaskbarManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TaskbarManager, windows_core::IUnknown, windows_core::IInspectable);
 impl TaskbarManager {
@@ -707,7 +707,7 @@ impl windows_core::RuntimeName for TaskbarManager {
 unsafe impl Send for TaskbarManager {}
 unsafe impl Sync for TaskbarManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowTab(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowTab, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowTab {
@@ -800,7 +800,7 @@ impl windows_core::RuntimeName for WindowTab {
 unsafe impl Send for WindowTab {}
 unsafe impl Sync for WindowTab {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowTabCloseRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowTabCloseRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowTabCloseRequestedEventArgs {
@@ -825,7 +825,7 @@ impl windows_core::RuntimeName for WindowTabCloseRequestedEventArgs {
 unsafe impl Send for WindowTabCloseRequestedEventArgs {}
 unsafe impl Sync for WindowTabCloseRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowTabCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowTabCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -963,7 +963,7 @@ impl IntoIterator for &WindowTabCollection {
 unsafe impl Send for WindowTabCollection {}
 unsafe impl Sync for WindowTabCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowTabGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowTabGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowTabGroup {
@@ -1013,7 +1013,7 @@ impl windows_core::RuntimeName for WindowTabGroup {
 unsafe impl Send for WindowTabGroup {}
 unsafe impl Sync for WindowTabGroup {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowTabIcon(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowTabIcon, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowTabIcon {
@@ -1061,7 +1061,7 @@ impl windows_core::RuntimeName for WindowTabIcon {
 unsafe impl Send for WindowTabIcon {}
 unsafe impl Sync for WindowTabIcon {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowTabManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowTabManager, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowTabManager {
@@ -1172,7 +1172,7 @@ impl windows_core::RuntimeName for WindowTabManager {
 unsafe impl Send for WindowTabManager {}
 unsafe impl Sync for WindowTabManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowTabSwitchRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowTabSwitchRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowTabSwitchRequestedEventArgs {
@@ -1197,7 +1197,7 @@ impl windows_core::RuntimeName for WindowTabSwitchRequestedEventArgs {
 unsafe impl Send for WindowTabSwitchRequestedEventArgs {}
 unsafe impl Sync for WindowTabSwitchRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowTabTearOutRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowTabTearOutRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowTabTearOutRequestedEventArgs {
@@ -1240,7 +1240,7 @@ impl windows_core::RuntimeName for WindowTabTearOutRequestedEventArgs {
 unsafe impl Send for WindowTabTearOutRequestedEventArgs {}
 unsafe impl Sync for WindowTabTearOutRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowTabThumbnailRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowTabThumbnailRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowTabThumbnailRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
@@ -381,7 +381,7 @@ pub struct IVisualElementsRequestedEventArgs_Vtbl {
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct JumpList(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(JumpList, windows_core::IUnknown, windows_core::IInspectable);
 impl JumpList {
@@ -442,7 +442,7 @@ impl windows_core::RuntimeName for JumpList {
 unsafe impl Send for JumpList {}
 unsafe impl Sync for JumpList {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct JumpListItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(JumpListItem, windows_core::IUnknown, windows_core::IInspectable);
 impl JumpListItem {
@@ -545,7 +545,7 @@ impl windows_core::RuntimeName for JumpListItem {
 unsafe impl Send for JumpListItem {}
 unsafe impl Sync for JumpListItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SecondaryTile(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SecondaryTile, windows_core::IUnknown, windows_core::IInspectable);
 impl SecondaryTile {
@@ -914,7 +914,7 @@ impl windows_core::RuntimeName for SecondaryTile {
 unsafe impl Send for SecondaryTile {}
 unsafe impl Sync for SecondaryTile {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SecondaryTileVisualElements(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SecondaryTileVisualElements, windows_core::IUnknown, windows_core::IInspectable);
 impl SecondaryTileVisualElements {
@@ -1096,7 +1096,7 @@ impl windows_core::RuntimeName for SecondaryTileVisualElements {
 unsafe impl Send for SecondaryTileVisualElements {}
 unsafe impl Sync for SecondaryTileVisualElements {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StartScreenManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StartScreenManager, windows_core::IUnknown, windows_core::IInspectable);
 impl StartScreenManager {
@@ -1190,7 +1190,7 @@ impl windows_core::RuntimeName for StartScreenManager {
 unsafe impl Send for StartScreenManager {}
 unsafe impl Sync for StartScreenManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TileMixedRealityModel(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TileMixedRealityModel, windows_core::IUnknown, windows_core::IInspectable);
 impl TileMixedRealityModel {
@@ -1249,7 +1249,7 @@ impl windows_core::RuntimeName for TileMixedRealityModel {
 unsafe impl Send for TileMixedRealityModel {}
 unsafe impl Sync for TileMixedRealityModel {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VisualElementsRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VisualElementsRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl VisualElementsRequest {
@@ -1296,7 +1296,7 @@ impl windows_core::RuntimeName for VisualElementsRequest {
 unsafe impl Send for VisualElementsRequest {}
 unsafe impl Sync for VisualElementsRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VisualElementsRequestDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VisualElementsRequestDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl VisualElementsRequestDeferral {
@@ -1318,7 +1318,7 @@ impl windows_core::RuntimeName for VisualElementsRequestDeferral {
 unsafe impl Send for VisualElementsRequestDeferral {}
 unsafe impl Sync for VisualElementsRequestDeferral {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct VisualElementsRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(VisualElementsRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl VisualElementsRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/UI/Text/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/Core/mod.rs
@@ -259,7 +259,7 @@ pub struct ICoreTextTextUpdatingEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextCompositionCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextCompositionCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextCompositionCompletedEventArgs {
@@ -299,7 +299,7 @@ impl windows_core::RuntimeName for CoreTextCompositionCompletedEventArgs {
 unsafe impl Send for CoreTextCompositionCompletedEventArgs {}
 unsafe impl Sync for CoreTextCompositionCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextCompositionSegment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextCompositionSegment, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextCompositionSegment {
@@ -331,7 +331,7 @@ impl windows_core::RuntimeName for CoreTextCompositionSegment {
 unsafe impl Send for CoreTextCompositionSegment {}
 unsafe impl Sync for CoreTextCompositionSegment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextCompositionStartedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextCompositionStartedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextCompositionStartedEventArgs {
@@ -363,7 +363,7 @@ impl windows_core::RuntimeName for CoreTextCompositionStartedEventArgs {
 unsafe impl Send for CoreTextCompositionStartedEventArgs {}
 unsafe impl Sync for CoreTextCompositionStartedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextEditContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextEditContext, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextEditContext {
@@ -585,7 +585,7 @@ impl windows_core::RuntimeName for CoreTextEditContext {
 unsafe impl Send for CoreTextEditContext {}
 unsafe impl Sync for CoreTextEditContext {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextFormatUpdatingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextFormatUpdatingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextFormatUpdatingEventArgs {
@@ -673,7 +673,7 @@ impl windows_core::RuntimeName for CoreTextFormatUpdatingEventArgs {
 unsafe impl Send for CoreTextFormatUpdatingEventArgs {}
 unsafe impl Sync for CoreTextFormatUpdatingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextLayoutBounds(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextLayoutBounds, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextLayoutBounds {
@@ -713,7 +713,7 @@ impl windows_core::RuntimeName for CoreTextLayoutBounds {
 unsafe impl Send for CoreTextLayoutBounds {}
 unsafe impl Sync for CoreTextLayoutBounds {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextLayoutRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextLayoutRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextLayoutRequest {
@@ -766,7 +766,7 @@ impl windows_core::RuntimeName for CoreTextLayoutRequest {
 unsafe impl Send for CoreTextLayoutRequest {}
 unsafe impl Sync for CoreTextLayoutRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextLayoutRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextLayoutRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextLayoutRequestedEventArgs {
@@ -791,7 +791,7 @@ impl windows_core::RuntimeName for CoreTextLayoutRequestedEventArgs {
 unsafe impl Send for CoreTextLayoutRequestedEventArgs {}
 unsafe impl Sync for CoreTextLayoutRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextSelectionRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextSelectionRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextSelectionRequest {
@@ -834,7 +834,7 @@ impl windows_core::RuntimeName for CoreTextSelectionRequest {
 unsafe impl Send for CoreTextSelectionRequest {}
 unsafe impl Sync for CoreTextSelectionRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextSelectionRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextSelectionRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextSelectionRequestedEventArgs {
@@ -859,7 +859,7 @@ impl windows_core::RuntimeName for CoreTextSelectionRequestedEventArgs {
 unsafe impl Send for CoreTextSelectionRequestedEventArgs {}
 unsafe impl Sync for CoreTextSelectionRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextSelectionUpdatingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextSelectionUpdatingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextSelectionUpdatingEventArgs {
@@ -926,7 +926,7 @@ impl windows_core::RuntimeName for CoreTextServicesConstants {
     const NAME: &'static str = "Windows.UI.Text.Core.CoreTextServicesConstants";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextServicesManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextServicesManager, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextServicesManager {
@@ -984,7 +984,7 @@ impl windows_core::RuntimeName for CoreTextServicesManager {
 unsafe impl Send for CoreTextServicesManager {}
 unsafe impl Sync for CoreTextServicesManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextTextRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextTextRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextTextRequest {
@@ -1034,7 +1034,7 @@ impl windows_core::RuntimeName for CoreTextTextRequest {
 unsafe impl Send for CoreTextTextRequest {}
 unsafe impl Sync for CoreTextTextRequest {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextTextRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextTextRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextTextRequestedEventArgs {
@@ -1059,7 +1059,7 @@ impl windows_core::RuntimeName for CoreTextTextRequestedEventArgs {
 unsafe impl Send for CoreTextTextRequestedEventArgs {}
 unsafe impl Sync for CoreTextTextRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreTextTextUpdatingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreTextTextUpdatingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreTextTextUpdatingEventArgs {

--- a/crates/libs/windows/src/Windows/UI/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/mod.rs
@@ -1800,7 +1800,7 @@ pub struct ITextSelection_Vtbl {
     pub TypeText: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ContentLinkInfo(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContentLinkInfo, windows_core::IUnknown, windows_core::IInspectable);
 impl ContentLinkInfo {
@@ -1883,7 +1883,7 @@ impl windows_core::RuntimeName for ContentLinkInfo {
 unsafe impl Send for ContentLinkInfo {}
 unsafe impl Sync for ContentLinkInfo {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FontWeights(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FontWeights, windows_core::IUnknown, windows_core::IInspectable);
 impl FontWeights {
@@ -1972,7 +1972,7 @@ impl windows_core::RuntimeName for FontWeights {
 unsafe impl Send for FontWeights {}
 unsafe impl Sync for FontWeights {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RichEditTextDocument(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RichEditTextDocument, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RichEditTextDocument, ITextDocument);
@@ -2193,7 +2193,7 @@ impl windows_core::RuntimeName for RichEditTextDocument {
 unsafe impl Send for RichEditTextDocument {}
 unsafe impl Sync for RichEditTextDocument {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RichEditTextRange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RichEditTextRange, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(RichEditTextRange, ITextRange);

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/Core/mod.rs
@@ -179,7 +179,7 @@ pub struct IRemoteAutomationWindow_Vtbl {
     pub UnregisterAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AutomationRemoteOperationResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AutomationRemoteOperationResult, windows_core::IUnknown, windows_core::IInspectable);
 impl AutomationRemoteOperationResult {
@@ -252,7 +252,7 @@ impl windows_core::RuntimeName for CoreAutomationRegistrar {
     const NAME: &'static str = "Windows.UI.UIAutomation.Core.CoreAutomationRegistrar";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreAutomationRemoteOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreAutomationRemoteOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreAutomationRemoteOperation {
@@ -316,7 +316,7 @@ impl windows_core::RuntimeName for CoreAutomationRemoteOperation {
 unsafe impl Send for CoreAutomationRemoteOperation {}
 unsafe impl Sync for CoreAutomationRemoteOperation {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreAutomationRemoteOperationContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreAutomationRemoteOperationContext, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreAutomationRemoteOperationContext {
@@ -355,7 +355,7 @@ impl windows_core::RuntimeName for CoreAutomationRemoteOperationContext {
 unsafe impl Send for CoreAutomationRemoteOperationContext {}
 unsafe impl Sync for CoreAutomationRemoteOperationContext {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteAutomationClientSession(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteAutomationClientSession, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteAutomationClientSession {
@@ -443,7 +443,7 @@ impl windows_core::RuntimeName for RemoteAutomationClientSession {
 unsafe impl Send for RemoteAutomationClientSession {}
 unsafe impl Sync for RemoteAutomationClientSession {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteAutomationConnectionRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteAutomationConnectionRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteAutomationConnectionRequestedEventArgs {
@@ -475,7 +475,7 @@ impl windows_core::RuntimeName for RemoteAutomationConnectionRequestedEventArgs 
 unsafe impl Send for RemoteAutomationConnectionRequestedEventArgs {}
 unsafe impl Sync for RemoteAutomationConnectionRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteAutomationDisconnectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteAutomationDisconnectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteAutomationDisconnectedEventArgs {
@@ -514,7 +514,7 @@ impl windows_core::RuntimeName for RemoteAutomationServer {
     const NAME: &'static str = "Windows.UI.UIAutomation.Core.RemoteAutomationServer";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RemoteAutomationWindow(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteAutomationWindow, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteAutomationWindow {

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/mod.rs
@@ -40,7 +40,7 @@ pub struct IAutomationTextRange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AutomationConnection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AutomationConnection, windows_core::IUnknown, windows_core::IInspectable);
 impl AutomationConnection {
@@ -81,7 +81,7 @@ impl windows_core::RuntimeName for AutomationConnection {
 unsafe impl Send for AutomationConnection {}
 unsafe impl Sync for AutomationConnection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AutomationConnectionBoundObject(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AutomationConnectionBoundObject, windows_core::IUnknown, windows_core::IInspectable);
 impl AutomationConnectionBoundObject {
@@ -106,7 +106,7 @@ impl windows_core::RuntimeName for AutomationConnectionBoundObject {
 unsafe impl Send for AutomationConnectionBoundObject {}
 unsafe impl Sync for AutomationConnectionBoundObject {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AutomationElement(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AutomationElement, windows_core::IUnknown, windows_core::IInspectable);
 impl AutomationElement {
@@ -147,7 +147,7 @@ impl windows_core::RuntimeName for AutomationElement {
 unsafe impl Send for AutomationElement {}
 unsafe impl Sync for AutomationElement {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AutomationTextRange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AutomationTextRange, windows_core::IUnknown, windows_core::IInspectable);
 impl AutomationTextRange {}

--- a/crates/libs/windows/src/Windows/UI/ViewManagement/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ViewManagement/Core/mod.rs
@@ -224,7 +224,7 @@ pub struct IUISettingsControllerStatics_Vtbl {
     pub RequestDefaultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreFrameworkInputView(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreFrameworkInputView, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreFrameworkInputView {
@@ -290,7 +290,7 @@ impl windows_core::RuntimeName for CoreFrameworkInputView {
 unsafe impl Send for CoreFrameworkInputView {}
 unsafe impl Sync for CoreFrameworkInputView {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreFrameworkInputViewAnimationStartingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreFrameworkInputViewAnimationStartingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreFrameworkInputViewAnimationStartingEventArgs {
@@ -330,7 +330,7 @@ impl windows_core::RuntimeName for CoreFrameworkInputViewAnimationStartingEventA
 unsafe impl Send for CoreFrameworkInputViewAnimationStartingEventArgs {}
 unsafe impl Sync for CoreFrameworkInputViewAnimationStartingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreFrameworkInputViewOcclusionsChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreFrameworkInputViewOcclusionsChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreFrameworkInputViewOcclusionsChangedEventArgs {
@@ -363,7 +363,7 @@ impl windows_core::RuntimeName for CoreFrameworkInputViewOcclusionsChangedEventA
 unsafe impl Send for CoreFrameworkInputViewOcclusionsChangedEventArgs {}
 unsafe impl Sync for CoreFrameworkInputViewOcclusionsChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreInputView(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreInputView, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreInputView {
@@ -561,7 +561,7 @@ impl windows_core::RuntimeName for CoreInputView {
 unsafe impl Send for CoreInputView {}
 unsafe impl Sync for CoreInputView {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreInputViewAnimationStartingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreInputViewAnimationStartingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreInputViewAnimationStartingEventArgs {
@@ -605,7 +605,7 @@ impl windows_core::RuntimeName for CoreInputViewAnimationStartingEventArgs {
 unsafe impl Send for CoreInputViewAnimationStartingEventArgs {}
 unsafe impl Sync for CoreInputViewAnimationStartingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreInputViewHidingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreInputViewHidingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreInputViewHidingEventArgs {
@@ -630,7 +630,7 @@ impl windows_core::RuntimeName for CoreInputViewHidingEventArgs {
 unsafe impl Send for CoreInputViewHidingEventArgs {}
 unsafe impl Sync for CoreInputViewHidingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreInputViewOcclusion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreInputViewOcclusion, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreInputViewOcclusion {
@@ -662,7 +662,7 @@ impl windows_core::RuntimeName for CoreInputViewOcclusion {
 unsafe impl Send for CoreInputViewOcclusion {}
 unsafe impl Sync for CoreInputViewOcclusion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreInputViewOcclusionsChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreInputViewOcclusionsChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreInputViewOcclusionsChangedEventArgs {
@@ -699,7 +699,7 @@ impl windows_core::RuntimeName for CoreInputViewOcclusionsChangedEventArgs {
 unsafe impl Send for CoreInputViewOcclusionsChangedEventArgs {}
 unsafe impl Sync for CoreInputViewOcclusionsChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreInputViewShowingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreInputViewShowingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreInputViewShowingEventArgs {
@@ -724,7 +724,7 @@ impl windows_core::RuntimeName for CoreInputViewShowingEventArgs {
 unsafe impl Send for CoreInputViewShowingEventArgs {}
 unsafe impl Sync for CoreInputViewShowingEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CoreInputViewTransferringXYFocusEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CoreInputViewTransferringXYFocusEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CoreInputViewTransferringXYFocusEventArgs {
@@ -778,7 +778,7 @@ impl windows_core::RuntimeName for CoreInputViewTransferringXYFocusEventArgs {
 unsafe impl Send for CoreInputViewTransferringXYFocusEventArgs {}
 unsafe impl Sync for CoreInputViewTransferringXYFocusEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UISettingsController(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UISettingsController, windows_core::IUnknown, windows_core::IInspectable);
 impl UISettingsController {

--- a/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
@@ -613,7 +613,7 @@ pub struct IViewModePreferencesStatics_Vtbl {
     pub CreateDefault: unsafe extern "system" fn(*mut core::ffi::c_void, ApplicationViewMode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AccessibilitySettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AccessibilitySettings, windows_core::IUnknown, windows_core::IInspectable);
 impl AccessibilitySettings {
@@ -666,7 +666,7 @@ impl windows_core::RuntimeName for AccessibilitySettings {
 unsafe impl Send for AccessibilitySettings {}
 unsafe impl Sync for AccessibilitySettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivationViewSwitcher(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivationViewSwitcher, windows_core::IUnknown, windows_core::IInspectable);
 impl ActivationViewSwitcher {
@@ -705,7 +705,7 @@ impl windows_core::RuntimeName for ActivationViewSwitcher {
 unsafe impl Send for ActivationViewSwitcher {}
 unsafe impl Sync for ActivationViewSwitcher {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationView(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ApplicationView, windows_core::IUnknown, windows_core::IInspectable);
 impl ApplicationView {
@@ -1075,7 +1075,7 @@ impl windows_core::RuntimeName for ApplicationView {
 unsafe impl Send for ApplicationView {}
 unsafe impl Sync for ApplicationView {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationViewConsolidatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ApplicationViewConsolidatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ApplicationViewConsolidatedEventArgs {
@@ -1107,7 +1107,7 @@ impl windows_core::RuntimeName for ApplicationViewConsolidatedEventArgs {
 unsafe impl Send for ApplicationViewConsolidatedEventArgs {}
 unsafe impl Sync for ApplicationViewConsolidatedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationViewScaling(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ApplicationViewScaling, windows_core::IUnknown, windows_core::IInspectable);
 impl ApplicationViewScaling {
@@ -1224,7 +1224,7 @@ impl windows_core::RuntimeName for ApplicationViewSwitcher {
     const NAME: &'static str = "Windows.UI.ViewManagement.ApplicationViewSwitcher";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationViewTitleBar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ApplicationViewTitleBar, windows_core::IUnknown, windows_core::IInspectable);
 impl ApplicationViewTitleBar {
@@ -1410,7 +1410,7 @@ impl windows_core::RuntimeName for ApplicationViewTitleBar {
 unsafe impl Send for ApplicationViewTitleBar {}
 unsafe impl Sync for ApplicationViewTitleBar {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ApplicationViewTransferContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ApplicationViewTransferContext, windows_core::IUnknown, windows_core::IInspectable);
 impl ApplicationViewTransferContext {
@@ -1455,7 +1455,7 @@ impl windows_core::RuntimeName for ApplicationViewTransferContext {
     const NAME: &'static str = "Windows.UI.ViewManagement.ApplicationViewTransferContext";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InputPane(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InputPane, windows_core::IUnknown, windows_core::IInspectable);
 impl InputPane {
@@ -1556,7 +1556,7 @@ impl windows_core::RuntimeName for InputPane {
     const NAME: &'static str = "Windows.UI.ViewManagement.InputPane";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct InputPaneVisibilityEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(InputPaneVisibilityEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl InputPaneVisibilityEventArgs {
@@ -1671,7 +1671,7 @@ impl windows_core::RuntimeName for ProjectionManager {
     const NAME: &'static str = "Windows.UI.ViewManagement.ProjectionManager";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StatusBar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StatusBar, windows_core::IUnknown, windows_core::IInspectable);
 impl StatusBar {
@@ -1795,7 +1795,7 @@ impl windows_core::RuntimeName for StatusBar {
 unsafe impl Send for StatusBar {}
 unsafe impl Sync for StatusBar {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StatusBarProgressIndicator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(StatusBarProgressIndicator, windows_core::IUnknown, windows_core::IInspectable);
 impl StatusBarProgressIndicator {
@@ -1852,7 +1852,7 @@ impl windows_core::RuntimeName for StatusBarProgressIndicator {
 unsafe impl Send for StatusBarProgressIndicator {}
 unsafe impl Sync for StatusBarProgressIndicator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UISettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UISettings, windows_core::IUnknown, windows_core::IInspectable);
 impl UISettings {
@@ -2080,7 +2080,7 @@ impl windows_core::RuntimeName for UISettings {
 unsafe impl Send for UISettings {}
 unsafe impl Sync for UISettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UISettingsAnimationsEnabledChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UISettingsAnimationsEnabledChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UISettingsAnimationsEnabledChangedEventArgs {}
@@ -2097,7 +2097,7 @@ impl windows_core::RuntimeName for UISettingsAnimationsEnabledChangedEventArgs {
 unsafe impl Send for UISettingsAnimationsEnabledChangedEventArgs {}
 unsafe impl Sync for UISettingsAnimationsEnabledChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UISettingsAutoHideScrollBarsChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UISettingsAutoHideScrollBarsChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UISettingsAutoHideScrollBarsChangedEventArgs {}
@@ -2114,7 +2114,7 @@ impl windows_core::RuntimeName for UISettingsAutoHideScrollBarsChangedEventArgs 
 unsafe impl Send for UISettingsAutoHideScrollBarsChangedEventArgs {}
 unsafe impl Sync for UISettingsAutoHideScrollBarsChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UISettingsMessageDurationChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UISettingsMessageDurationChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UISettingsMessageDurationChangedEventArgs {}
@@ -2131,7 +2131,7 @@ impl windows_core::RuntimeName for UISettingsMessageDurationChangedEventArgs {
 unsafe impl Send for UISettingsMessageDurationChangedEventArgs {}
 unsafe impl Sync for UISettingsMessageDurationChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UIViewSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UIViewSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl UIViewSettings {
@@ -2167,7 +2167,7 @@ impl windows_core::RuntimeName for UIViewSettings {
 unsafe impl Send for UIViewSettings {}
 unsafe impl Sync for UIViewSettings {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ViewModePreferences(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ViewModePreferences, windows_core::IUnknown, windows_core::IInspectable);
 impl ViewModePreferences {

--- a/crates/libs/windows/src/Windows/UI/WebUI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/Core/mod.rs
@@ -163,7 +163,7 @@ pub struct IWebUICommandBarSymbolIconFactory_Vtbl {
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUICommandBar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUICommandBar, windows_core::IUnknown, windows_core::IInspectable);
 impl WebUICommandBar {
@@ -323,7 +323,7 @@ impl windows_core::RuntimeName for WebUICommandBar {
 unsafe impl Send for WebUICommandBar {}
 unsafe impl Sync for WebUICommandBar {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUICommandBarBitmapIcon(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUICommandBarBitmapIcon, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebUICommandBarBitmapIcon, IWebUICommandBarIcon);
@@ -377,7 +377,7 @@ impl windows_core::RuntimeName for WebUICommandBarBitmapIcon {
 unsafe impl Send for WebUICommandBarBitmapIcon {}
 unsafe impl Sync for WebUICommandBarBitmapIcon {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUICommandBarConfirmationButton(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUICommandBarConfirmationButton, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebUICommandBarConfirmationButton, IWebUICommandBarElement);
@@ -428,7 +428,7 @@ impl windows_core::RuntimeName for WebUICommandBarConfirmationButton {
 unsafe impl Send for WebUICommandBarConfirmationButton {}
 unsafe impl Sync for WebUICommandBarConfirmationButton {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUICommandBarIconButton(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUICommandBarIconButton, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebUICommandBarIconButton, IWebUICommandBarElement);
@@ -526,7 +526,7 @@ impl windows_core::RuntimeName for WebUICommandBarIconButton {
 unsafe impl Send for WebUICommandBarIconButton {}
 unsafe impl Sync for WebUICommandBarIconButton {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUICommandBarItemInvokedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUICommandBarItemInvokedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebUICommandBarItemInvokedEventArgs {
@@ -551,7 +551,7 @@ impl windows_core::RuntimeName for WebUICommandBarItemInvokedEventArgs {
 unsafe impl Send for WebUICommandBarItemInvokedEventArgs {}
 unsafe impl Sync for WebUICommandBarItemInvokedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUICommandBarSizeChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUICommandBarSizeChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebUICommandBarSizeChangedEventArgs {
@@ -576,7 +576,7 @@ impl windows_core::RuntimeName for WebUICommandBarSizeChangedEventArgs {
 unsafe impl Send for WebUICommandBarSizeChangedEventArgs {}
 unsafe impl Sync for WebUICommandBarSizeChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUICommandBarSymbolIcon(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUICommandBarSymbolIcon, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebUICommandBarSymbolIcon, IWebUICommandBarIcon);

--- a/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
@@ -267,7 +267,7 @@ pub struct IWebUIViewStatics_Vtbl {
     pub CreateWithUriAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivatedDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivatedDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl ActivatedDeferral {
@@ -287,7 +287,7 @@ impl windows_core::RuntimeName for ActivatedDeferral {
     const NAME: &'static str = "Windows.UI.WebUI.ActivatedDeferral";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ActivatedOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ActivatedOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl ActivatedOperation {
@@ -311,7 +311,7 @@ impl windows_core::RuntimeName for ActivatedOperation {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct BackgroundActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(BackgroundActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -347,7 +347,7 @@ unsafe impl Send for BackgroundActivatedEventArgs {}
 unsafe impl Sync for BackgroundActivatedEventArgs {}
 #[cfg(feature = "ApplicationModel")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct EnteredBackgroundEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel")]
 windows_core::imp::interface_hierarchy!(EnteredBackgroundEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -382,7 +382,7 @@ unsafe impl Send for EnteredBackgroundEventArgs {}
 #[cfg(feature = "ApplicationModel")]
 unsafe impl Sync for EnteredBackgroundEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HtmlPrintDocumentSource(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HtmlPrintDocumentSource, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Graphics_Printing")]
@@ -509,7 +509,7 @@ unsafe impl Send for HtmlPrintDocumentSource {}
 unsafe impl Sync for HtmlPrintDocumentSource {}
 #[cfg(feature = "ApplicationModel")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct LeavingBackgroundEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel")]
 windows_core::imp::interface_hierarchy!(LeavingBackgroundEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -544,7 +544,7 @@ unsafe impl Send for LeavingBackgroundEventArgs {}
 #[cfg(feature = "ApplicationModel")]
 unsafe impl Sync for LeavingBackgroundEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct NewWebUIViewCreatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(NewWebUIViewCreatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl NewWebUIViewCreatedEventArgs {
@@ -590,7 +590,7 @@ impl windows_core::RuntimeName for NewWebUIViewCreatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SuspendingDeferral(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel")]
 windows_core::imp::interface_hierarchy!(SuspendingDeferral, windows_core::IUnknown, windows_core::IInspectable);
@@ -619,7 +619,7 @@ impl windows_core::RuntimeName for SuspendingDeferral {
 }
 #[cfg(feature = "ApplicationModel")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SuspendingEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel")]
 windows_core::imp::interface_hierarchy!(SuspendingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -651,7 +651,7 @@ impl windows_core::RuntimeName for SuspendingEventArgs {
 }
 #[cfg(feature = "ApplicationModel")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SuspendingOperation(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel")]
 windows_core::imp::interface_hierarchy!(SuspendingOperation, windows_core::IUnknown, windows_core::IInspectable);
@@ -838,7 +838,7 @@ impl windows_core::RuntimeName for WebUIApplication {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIAppointmentsProviderAddAppointmentActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIAppointmentsProviderAddAppointmentActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -917,7 +917,7 @@ impl windows_core::RuntimeName for WebUIAppointmentsProviderAddAppointmentActiva
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -996,7 +996,7 @@ impl windows_core::RuntimeName for WebUIAppointmentsProviderRemoveAppointmentAct
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1075,7 +1075,7 @@ impl windows_core::RuntimeName for WebUIAppointmentsProviderReplaceAppointmentAc
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1170,7 +1170,7 @@ impl windows_core::RuntimeName for WebUIAppointmentsProviderShowAppointmentDetai
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1273,7 +1273,7 @@ impl windows_core::RuntimeName for WebUIBackgroundTaskInstance {
     const NAME: &'static str = "Windows.UI.WebUI.WebUIBackgroundTaskInstance";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIBackgroundTaskInstanceRuntimeClass(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUIBackgroundTaskInstanceRuntimeClass, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "ApplicationModel_Background")]
@@ -1372,7 +1372,7 @@ impl windows_core::RuntimeName for WebUIBackgroundTaskInstanceRuntimeClass {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIBarcodeScannerPreviewActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIBarcodeScannerPreviewActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1447,7 +1447,7 @@ unsafe impl Send for WebUIBarcodeScannerPreviewActivatedEventArgs {}
 unsafe impl Sync for WebUIBarcodeScannerPreviewActivatedEventArgs {}
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUICachedFileUpdaterActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUICachedFileUpdaterActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1518,7 +1518,7 @@ impl windows_core::RuntimeName for WebUICachedFileUpdaterActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUICameraSettingsActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUICameraSettingsActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1589,7 +1589,7 @@ impl windows_core::RuntimeName for WebUICameraSettingsActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUICommandLineActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUICommandLineActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1664,7 +1664,7 @@ unsafe impl Send for WebUICommandLineActivatedEventArgs {}
 unsafe impl Sync for WebUICommandLineActivatedEventArgs {}
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIContactCallActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIContactCallActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1751,7 +1751,7 @@ impl windows_core::RuntimeName for WebUIContactCallActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIContactMapActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIContactMapActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1830,7 +1830,7 @@ impl windows_core::RuntimeName for WebUIContactMapActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIContactMessageActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIContactMessageActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -1917,7 +1917,7 @@ impl windows_core::RuntimeName for WebUIContactMessageActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIContactPanelActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIContactPanelActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2000,7 +2000,7 @@ unsafe impl Send for WebUIContactPanelActivatedEventArgs {}
 unsafe impl Sync for WebUIContactPanelActivatedEventArgs {}
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIContactPickerActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIContactPickerActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2063,7 +2063,7 @@ impl windows_core::RuntimeName for WebUIContactPickerActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIContactPostActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIContactPostActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2150,7 +2150,7 @@ impl windows_core::RuntimeName for WebUIContactPostActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIContactVideoCallActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIContactVideoCallActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2237,7 +2237,7 @@ impl windows_core::RuntimeName for WebUIContactVideoCallActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIDeviceActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIDeviceActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2324,7 +2324,7 @@ impl windows_core::RuntimeName for WebUIDeviceActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIDevicePairingActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIDevicePairingActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2395,7 +2395,7 @@ impl windows_core::RuntimeName for WebUIDevicePairingActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIDialReceiverActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIDialReceiverActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2490,7 +2490,7 @@ impl windows_core::RuntimeName for WebUIDialReceiverActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIFileActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIFileActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2585,7 +2585,7 @@ impl windows_core::RuntimeName for WebUIFileActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIFileOpenPickerActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIFileOpenPickerActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2664,7 +2664,7 @@ impl windows_core::RuntimeName for WebUIFileOpenPickerActivatedEventArgs {
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIFileOpenPickerContinuationEventArgs(windows_core::IUnknown);
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 windows_core::imp::interface_hierarchy!(WebUIFileOpenPickerContinuationEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2743,7 +2743,7 @@ impl windows_core::RuntimeName for WebUIFileOpenPickerContinuationEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIFileSavePickerActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIFileSavePickerActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2830,7 +2830,7 @@ impl windows_core::RuntimeName for WebUIFileSavePickerActivatedEventArgs {
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIFileSavePickerContinuationEventArgs(windows_core::IUnknown);
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 windows_core::imp::interface_hierarchy!(WebUIFileSavePickerContinuationEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2909,7 +2909,7 @@ impl windows_core::RuntimeName for WebUIFileSavePickerContinuationEventArgs {
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIFolderPickerContinuationEventArgs(windows_core::IUnknown);
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 windows_core::imp::interface_hierarchy!(WebUIFolderPickerContinuationEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -2988,7 +2988,7 @@ impl windows_core::RuntimeName for WebUIFolderPickerContinuationEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUILaunchActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUILaunchActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3100,7 +3100,7 @@ impl windows_core::RuntimeName for WebUILaunchActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUILockScreenActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUILockScreenActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3179,7 +3179,7 @@ impl windows_core::RuntimeName for WebUILockScreenActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUILockScreenCallActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUILockScreenCallActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3266,7 +3266,7 @@ impl windows_core::RuntimeName for WebUILockScreenCallActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUILockScreenComponentActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUILockScreenComponentActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3320,7 +3320,7 @@ impl windows_core::RuntimeName for WebUILockScreenComponentActivatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUILockScreenComponentActivatedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUINavigatedDeferral(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUINavigatedDeferral, windows_core::IUnknown, windows_core::IInspectable);
 impl WebUINavigatedDeferral {
@@ -3340,7 +3340,7 @@ impl windows_core::RuntimeName for WebUINavigatedDeferral {
     const NAME: &'static str = "Windows.UI.WebUI.WebUINavigatedDeferral";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUINavigatedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUINavigatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebUINavigatedEventArgs, IWebUINavigatedEventArgs);
@@ -3364,7 +3364,7 @@ impl windows_core::RuntimeName for WebUINavigatedEventArgs {
     const NAME: &'static str = "Windows.UI.WebUI.WebUINavigatedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUINavigatedOperation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUINavigatedOperation, windows_core::IUnknown, windows_core::IInspectable);
 impl WebUINavigatedOperation {
@@ -3388,7 +3388,7 @@ impl windows_core::RuntimeName for WebUINavigatedOperation {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIPhoneCallActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIPhoneCallActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3463,7 +3463,7 @@ unsafe impl Send for WebUIPhoneCallActivatedEventArgs {}
 unsafe impl Sync for WebUIPhoneCallActivatedEventArgs {}
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIPrint3DWorkflowActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIPrint3DWorkflowActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3526,7 +3526,7 @@ impl windows_core::RuntimeName for WebUIPrint3DWorkflowActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIPrintTaskSettingsActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIPrintTaskSettingsActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3589,7 +3589,7 @@ impl windows_core::RuntimeName for WebUIPrintTaskSettingsActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIPrintWorkflowForegroundTaskActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIPrintWorkflowForegroundTaskActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3644,7 +3644,7 @@ impl windows_core::RuntimeName for WebUIPrintWorkflowForegroundTaskActivatedEven
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIProtocolActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIProtocolActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3739,7 +3739,7 @@ impl windows_core::RuntimeName for WebUIProtocolActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIProtocolForResultsActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIProtocolForResultsActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3851,7 +3851,7 @@ impl windows_core::RuntimeName for WebUIProtocolForResultsActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIRestrictedLaunchActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIRestrictedLaunchActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -3922,7 +3922,7 @@ impl windows_core::RuntimeName for WebUIRestrictedLaunchActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUISearchActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUISearchActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -4009,7 +4009,7 @@ impl windows_core::RuntimeName for WebUISearchActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIShareTargetActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIShareTargetActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -4080,7 +4080,7 @@ impl windows_core::RuntimeName for WebUIShareTargetActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIStartupTaskActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIStartupTaskActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -4155,7 +4155,7 @@ unsafe impl Send for WebUIStartupTaskActivatedEventArgs {}
 unsafe impl Sync for WebUIStartupTaskActivatedEventArgs {}
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIToastNotificationActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIToastNotificationActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -4234,7 +4234,7 @@ impl windows_core::RuntimeName for WebUIToastNotificationActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIUserDataAccountProviderActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIUserDataAccountProviderActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -4296,7 +4296,7 @@ impl windows_core::RuntimeName for WebUIUserDataAccountProviderActivatedEventArg
     const NAME: &'static str = "Windows.UI.WebUI.WebUIUserDataAccountProviderActivatedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIView(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebUIView, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Web_UI")]
@@ -4829,7 +4829,7 @@ impl windows_core::RuntimeName for WebUIView {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIVoiceCommandActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIVoiceCommandActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -4900,7 +4900,7 @@ impl windows_core::RuntimeName for WebUIVoiceCommandActivatedEventArgs {
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIWalletActionActivatedEventArgs(windows_core::IUnknown);
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 windows_core::imp::interface_hierarchy!(WebUIWalletActionActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -4979,7 +4979,7 @@ impl windows_core::RuntimeName for WebUIWalletActionActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIWebAccountProviderActivatedEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIWebAccountProviderActivatedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
@@ -5050,7 +5050,7 @@ impl windows_core::RuntimeName for WebUIWebAccountProviderActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebUIWebAuthenticationBrokerContinuationEventArgs(windows_core::IUnknown);
 #[cfg(feature = "ApplicationModel_Activation")]
 windows_core::imp::interface_hierarchy!(WebUIWebAuthenticationBrokerContinuationEventArgs, windows_core::IUnknown, windows_core::IInspectable);

--- a/crates/libs/windows/src/Windows/UI/WindowManagement/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WindowManagement/Preview/mod.rs
@@ -16,7 +16,7 @@ pub struct IWindowManagementPreviewStatics_Vtbl {
     pub SetPreferredMinSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, super::super::super::Foundation::Size) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowManagementPreview(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowManagementPreview, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowManagementPreview {

--- a/crates/libs/windows/src/Windows/UI/WindowManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WindowManagement/mod.rs
@@ -322,7 +322,7 @@ pub struct IWindowingEnvironmentStatics_Vtbl {
     FindAllWithKind: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppWindow(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppWindow, windows_core::IUnknown, windows_core::IInspectable);
 impl AppWindow {
@@ -547,7 +547,7 @@ impl windows_core::RuntimeName for AppWindow {
 unsafe impl Send for AppWindow {}
 unsafe impl Sync for AppWindow {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppWindowChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppWindowChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppWindowChangedEventArgs {
@@ -621,7 +621,7 @@ impl windows_core::RuntimeName for AppWindowChangedEventArgs {
 unsafe impl Send for AppWindowChangedEventArgs {}
 unsafe impl Sync for AppWindowChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppWindowCloseRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppWindowCloseRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppWindowCloseRequestedEventArgs {
@@ -657,7 +657,7 @@ impl windows_core::RuntimeName for AppWindowCloseRequestedEventArgs {
 unsafe impl Send for AppWindowCloseRequestedEventArgs {}
 unsafe impl Sync for AppWindowCloseRequestedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppWindowClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppWindowClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppWindowClosedEventArgs {
@@ -682,7 +682,7 @@ impl windows_core::RuntimeName for AppWindowClosedEventArgs {
 unsafe impl Send for AppWindowClosedEventArgs {}
 unsafe impl Sync for AppWindowClosedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppWindowFrame(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppWindowFrame, windows_core::IUnknown, windows_core::IInspectable);
 impl AppWindowFrame {
@@ -719,7 +719,7 @@ impl windows_core::RuntimeName for AppWindowFrame {
 unsafe impl Send for AppWindowFrame {}
 unsafe impl Sync for AppWindowFrame {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppWindowPlacement(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppWindowPlacement, windows_core::IUnknown, windows_core::IInspectable);
 impl AppWindowPlacement {
@@ -758,7 +758,7 @@ impl windows_core::RuntimeName for AppWindowPlacement {
 unsafe impl Send for AppWindowPlacement {}
 unsafe impl Sync for AppWindowPlacement {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppWindowPresentationConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppWindowPresentationConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 impl AppWindowPresentationConfiguration {
@@ -783,7 +783,7 @@ impl windows_core::RuntimeName for AppWindowPresentationConfiguration {
 unsafe impl Send for AppWindowPresentationConfiguration {}
 unsafe impl Sync for AppWindowPresentationConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppWindowPresenter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppWindowPresenter, windows_core::IUnknown, windows_core::IInspectable);
 impl AppWindowPresenter {
@@ -832,7 +832,7 @@ impl windows_core::RuntimeName for AppWindowPresenter {
 unsafe impl Send for AppWindowPresenter {}
 unsafe impl Sync for AppWindowPresenter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppWindowTitleBar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppWindowTitleBar, windows_core::IUnknown, windows_core::IInspectable);
 impl AppWindowTitleBar {
@@ -1055,7 +1055,7 @@ impl windows_core::RuntimeName for AppWindowTitleBar {
 unsafe impl Send for AppWindowTitleBar {}
 unsafe impl Sync for AppWindowTitleBar {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AppWindowTitleBarOcclusion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppWindowTitleBarOcclusion, windows_core::IUnknown, windows_core::IInspectable);
 impl AppWindowTitleBarOcclusion {
@@ -1080,7 +1080,7 @@ impl windows_core::RuntimeName for AppWindowTitleBarOcclusion {
 unsafe impl Send for AppWindowTitleBarOcclusion {}
 unsafe impl Sync for AppWindowTitleBarOcclusion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct CompactOverlayPresentationConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CompactOverlayPresentationConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(CompactOverlayPresentationConfiguration, AppWindowPresentationConfiguration);
@@ -1113,7 +1113,7 @@ impl windows_core::RuntimeName for CompactOverlayPresentationConfiguration {
 unsafe impl Send for CompactOverlayPresentationConfiguration {}
 unsafe impl Sync for CompactOverlayPresentationConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DefaultPresentationConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DefaultPresentationConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(DefaultPresentationConfiguration, AppWindowPresentationConfiguration);
@@ -1146,7 +1146,7 @@ impl windows_core::RuntimeName for DefaultPresentationConfiguration {
 unsafe impl Send for DefaultPresentationConfiguration {}
 unsafe impl Sync for DefaultPresentationConfiguration {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DisplayRegion(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayRegion, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayRegion {
@@ -1213,7 +1213,7 @@ impl windows_core::RuntimeName for DisplayRegion {
 unsafe impl Send for DisplayRegion {}
 unsafe impl Sync for DisplayRegion {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct FullScreenPresentationConfiguration(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(FullScreenPresentationConfiguration, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(FullScreenPresentationConfiguration, AppWindowPresentationConfiguration);
@@ -1275,7 +1275,7 @@ impl windows_core::RuntimeName for WindowServices {
     const NAME: &'static str = "Windows.UI.WindowManagement.WindowServices";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowingEnvironment(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowingEnvironment, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowingEnvironment {
@@ -1348,7 +1348,7 @@ impl windows_core::RuntimeName for WindowingEnvironment {
 unsafe impl Send for WindowingEnvironment {}
 unsafe impl Sync for WindowingEnvironment {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowingEnvironmentAddedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowingEnvironmentAddedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowingEnvironmentAddedEventArgs {
@@ -1373,7 +1373,7 @@ impl windows_core::RuntimeName for WindowingEnvironmentAddedEventArgs {
 unsafe impl Send for WindowingEnvironmentAddedEventArgs {}
 unsafe impl Sync for WindowingEnvironmentAddedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowingEnvironmentChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowingEnvironmentChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowingEnvironmentChangedEventArgs {}
@@ -1390,7 +1390,7 @@ impl windows_core::RuntimeName for WindowingEnvironmentChangedEventArgs {
 unsafe impl Send for WindowingEnvironmentChangedEventArgs {}
 unsafe impl Sync for WindowingEnvironmentChangedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WindowingEnvironmentRemovedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowingEnvironmentRemovedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowingEnvironmentRemovedEventArgs {

--- a/crates/libs/windows/src/Windows/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/mod.rs
@@ -227,7 +227,7 @@ pub struct IUIContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ColorHelper(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ColorHelper, windows_core::IUnknown, windows_core::IInspectable);
 impl ColorHelper {
@@ -267,7 +267,7 @@ impl windows_core::RuntimeName for ColorHelper {
 unsafe impl Send for ColorHelper {}
 unsafe impl Sync for ColorHelper {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Colors(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Colors, windows_core::IUnknown, windows_core::IInspectable);
 impl Colors {
@@ -1136,7 +1136,7 @@ impl windows_core::RuntimeName for Colors {
 unsafe impl Send for Colors {}
 unsafe impl Sync for Colors {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UIContentRoot(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UIContentRoot, windows_core::IUnknown, windows_core::IInspectable);
 impl UIContentRoot {
@@ -1161,7 +1161,7 @@ impl windows_core::RuntimeName for UIContentRoot {
 unsafe impl Send for UIContentRoot {}
 unsafe impl Sync for UIContentRoot {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct UIContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UIContext, windows_core::IUnknown, windows_core::IInspectable);
 impl UIContext {}

--- a/crates/libs/windows/src/Windows/Web/AtomPub/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/AtomPub/mod.rs
@@ -109,7 +109,7 @@ pub struct IWorkspace_Vtbl {
     Collections: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct AtomPubClient(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AtomPubClient, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Web_Syndication")]
@@ -356,7 +356,7 @@ impl windows_core::RuntimeName for AtomPubClient {
 unsafe impl Send for AtomPubClient {}
 unsafe impl Sync for AtomPubClient {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ResourceCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ResourceCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Web_Syndication")]
@@ -499,7 +499,7 @@ impl windows_core::RuntimeName for ResourceCollection {
 unsafe impl Send for ResourceCollection {}
 unsafe impl Sync for ResourceCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ServiceDocument(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ServiceDocument, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Web_Syndication")]
@@ -619,7 +619,7 @@ impl windows_core::RuntimeName for ServiceDocument {
 unsafe impl Send for ServiceDocument {}
 unsafe impl Sync for ServiceDocument {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Workspace(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Workspace, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Web_Syndication")]

--- a/crates/libs/windows/src/Windows/Web/Http/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Diagnostics/mod.rs
@@ -102,7 +102,7 @@ pub struct IHttpDiagnosticSourceLocation_Vtbl {
     pub ColumnNumber: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpDiagnosticProvider(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpDiagnosticProvider, windows_core::IUnknown, windows_core::IInspectable);
 impl HttpDiagnosticProvider {
@@ -185,7 +185,7 @@ impl windows_core::RuntimeName for HttpDiagnosticProvider {
 unsafe impl Send for HttpDiagnosticProvider {}
 unsafe impl Sync for HttpDiagnosticProvider {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpDiagnosticProviderRequestResponseCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpDiagnosticProviderRequestResponseCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HttpDiagnosticProviderRequestResponseCompletedEventArgs {
@@ -253,7 +253,7 @@ impl windows_core::RuntimeName for HttpDiagnosticProviderRequestResponseComplete
 unsafe impl Send for HttpDiagnosticProviderRequestResponseCompletedEventArgs {}
 unsafe impl Sync for HttpDiagnosticProviderRequestResponseCompletedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpDiagnosticProviderRequestResponseTimestamps(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpDiagnosticProviderRequestResponseTimestamps, windows_core::IUnknown, windows_core::IInspectable);
 impl HttpDiagnosticProviderRequestResponseTimestamps {
@@ -334,7 +334,7 @@ impl windows_core::RuntimeName for HttpDiagnosticProviderRequestResponseTimestam
 unsafe impl Send for HttpDiagnosticProviderRequestResponseTimestamps {}
 unsafe impl Sync for HttpDiagnosticProviderRequestResponseTimestamps {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpDiagnosticProviderRequestSentEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpDiagnosticProviderRequestSentEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HttpDiagnosticProviderRequestSentEventArgs {
@@ -402,7 +402,7 @@ impl windows_core::RuntimeName for HttpDiagnosticProviderRequestSentEventArgs {
 unsafe impl Send for HttpDiagnosticProviderRequestSentEventArgs {}
 unsafe impl Sync for HttpDiagnosticProviderRequestSentEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpDiagnosticProviderResponseReceivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpDiagnosticProviderResponseReceivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HttpDiagnosticProviderResponseReceivedEventArgs {
@@ -441,7 +441,7 @@ impl windows_core::RuntimeName for HttpDiagnosticProviderResponseReceivedEventAr
 unsafe impl Send for HttpDiagnosticProviderResponseReceivedEventArgs {}
 unsafe impl Sync for HttpDiagnosticProviderResponseReceivedEventArgs {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpDiagnosticSourceLocation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpDiagnosticSourceLocation, windows_core::IUnknown, windows_core::IInspectable);
 impl HttpDiagnosticSourceLocation {

--- a/crates/libs/windows/src/Windows/Web/Http/Filters/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Filters/mod.rs
@@ -174,7 +174,7 @@ pub struct IHttpServerCustomValidationRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpBaseProtocolFilter(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpBaseProtocolFilter, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpBaseProtocolFilter, super::super::super::Foundation::IClosable, IHttpFilter);
@@ -402,7 +402,7 @@ impl windows_core::RuntimeName for HttpBaseProtocolFilter {
 unsafe impl Send for HttpBaseProtocolFilter {}
 unsafe impl Sync for HttpBaseProtocolFilter {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpCacheControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpCacheControl, windows_core::IUnknown, windows_core::IInspectable);
 impl HttpCacheControl {
@@ -442,7 +442,7 @@ impl windows_core::RuntimeName for HttpCacheControl {
 unsafe impl Send for HttpCacheControl {}
 unsafe impl Sync for HttpCacheControl {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpServerCustomValidationRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpServerCustomValidationRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl HttpServerCustomValidationRequestedEventArgs {

--- a/crates/libs/windows/src/Windows/Web/Http/Headers/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Headers/mod.rs
@@ -779,7 +779,7 @@ pub struct IHttpTransferCodingHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpCacheDirectiveHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpCacheDirectiveHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -984,7 +984,7 @@ impl IntoIterator for &HttpCacheDirectiveHeaderValueCollection {
 unsafe impl Send for HttpCacheDirectiveHeaderValueCollection {}
 unsafe impl Sync for HttpCacheDirectiveHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpChallengeHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpChallengeHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpChallengeHeaderValue, super::super::super::Foundation::IStringable);
@@ -1066,7 +1066,7 @@ impl windows_core::RuntimeName for HttpChallengeHeaderValue {
 unsafe impl Send for HttpChallengeHeaderValue {}
 unsafe impl Sync for HttpChallengeHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpChallengeHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpChallengeHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -1215,7 +1215,7 @@ impl IntoIterator for &HttpChallengeHeaderValueCollection {
 unsafe impl Send for HttpChallengeHeaderValueCollection {}
 unsafe impl Sync for HttpChallengeHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpConnectionOptionHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpConnectionOptionHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpConnectionOptionHeaderValue, super::super::super::Foundation::IStringable);
@@ -1276,7 +1276,7 @@ impl windows_core::RuntimeName for HttpConnectionOptionHeaderValue {
 unsafe impl Send for HttpConnectionOptionHeaderValue {}
 unsafe impl Sync for HttpConnectionOptionHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpConnectionOptionHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpConnectionOptionHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -1425,7 +1425,7 @@ impl IntoIterator for &HttpConnectionOptionHeaderValueCollection {
 unsafe impl Send for HttpConnectionOptionHeaderValueCollection {}
 unsafe impl Sync for HttpConnectionOptionHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpContentCodingHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpContentCodingHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpContentCodingHeaderValue, super::super::super::Foundation::IStringable);
@@ -1486,7 +1486,7 @@ impl windows_core::RuntimeName for HttpContentCodingHeaderValue {
 unsafe impl Send for HttpContentCodingHeaderValue {}
 unsafe impl Sync for HttpContentCodingHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpContentCodingHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpContentCodingHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -1635,7 +1635,7 @@ impl IntoIterator for &HttpContentCodingHeaderValueCollection {
 unsafe impl Send for HttpContentCodingHeaderValueCollection {}
 unsafe impl Sync for HttpContentCodingHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpContentCodingWithQualityHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpContentCodingWithQualityHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpContentCodingWithQualityHeaderValue, super::super::super::Foundation::IStringable);
@@ -1709,7 +1709,7 @@ impl windows_core::RuntimeName for HttpContentCodingWithQualityHeaderValue {
 unsafe impl Send for HttpContentCodingWithQualityHeaderValue {}
 unsafe impl Sync for HttpContentCodingWithQualityHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpContentCodingWithQualityHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpContentCodingWithQualityHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -1858,7 +1858,7 @@ impl IntoIterator for &HttpContentCodingWithQualityHeaderValueCollection {
 unsafe impl Send for HttpContentCodingWithQualityHeaderValueCollection {}
 unsafe impl Sync for HttpContentCodingWithQualityHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpContentDispositionHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpContentDispositionHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpContentDispositionHeaderValue, super::super::super::Foundation::IStringable);
@@ -1978,7 +1978,7 @@ impl windows_core::RuntimeName for HttpContentDispositionHeaderValue {
 unsafe impl Send for HttpContentDispositionHeaderValue {}
 unsafe impl Sync for HttpContentDispositionHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpContentHeaderCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpContentHeaderCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -2225,7 +2225,7 @@ impl IntoIterator for &HttpContentHeaderCollection {
 unsafe impl Send for HttpContentHeaderCollection {}
 unsafe impl Sync for HttpContentHeaderCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpContentRangeHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpContentRangeHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpContentRangeHeaderValue, super::super::super::Foundation::IStringable);
@@ -2323,7 +2323,7 @@ impl windows_core::RuntimeName for HttpContentRangeHeaderValue {
 unsafe impl Send for HttpContentRangeHeaderValue {}
 unsafe impl Sync for HttpContentRangeHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpCookiePairHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpCookiePairHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpCookiePairHeaderValue, super::super::super::Foundation::IStringable);
@@ -2401,7 +2401,7 @@ impl windows_core::RuntimeName for HttpCookiePairHeaderValue {
 unsafe impl Send for HttpCookiePairHeaderValue {}
 unsafe impl Sync for HttpCookiePairHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpCookiePairHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpCookiePairHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -2550,7 +2550,7 @@ impl IntoIterator for &HttpCookiePairHeaderValueCollection {
 unsafe impl Send for HttpCookiePairHeaderValueCollection {}
 unsafe impl Sync for HttpCookiePairHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpCredentialsHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpCredentialsHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpCredentialsHeaderValue, super::super::super::Foundation::IStringable);
@@ -2632,7 +2632,7 @@ impl windows_core::RuntimeName for HttpCredentialsHeaderValue {
 unsafe impl Send for HttpCredentialsHeaderValue {}
 unsafe impl Sync for HttpCredentialsHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpDateOrDeltaHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpDateOrDeltaHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpDateOrDeltaHeaderValue, super::super::super::Foundation::IStringable);
@@ -2689,7 +2689,7 @@ impl windows_core::RuntimeName for HttpDateOrDeltaHeaderValue {
 unsafe impl Send for HttpDateOrDeltaHeaderValue {}
 unsafe impl Sync for HttpDateOrDeltaHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpExpectationHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpExpectationHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpExpectationHeaderValue, super::super::super::Foundation::IStringable);
@@ -2775,7 +2775,7 @@ impl windows_core::RuntimeName for HttpExpectationHeaderValue {
 unsafe impl Send for HttpExpectationHeaderValue {}
 unsafe impl Sync for HttpExpectationHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpExpectationHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpExpectationHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -2924,7 +2924,7 @@ impl IntoIterator for &HttpExpectationHeaderValueCollection {
 unsafe impl Send for HttpExpectationHeaderValueCollection {}
 unsafe impl Sync for HttpExpectationHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpLanguageHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpLanguageHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(all(feature = "Foundation_Collections", feature = "Globalization"))]
@@ -3073,7 +3073,7 @@ impl IntoIterator for &HttpLanguageHeaderValueCollection {
 unsafe impl Send for HttpLanguageHeaderValueCollection {}
 unsafe impl Sync for HttpLanguageHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpLanguageRangeWithQualityHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpLanguageRangeWithQualityHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpLanguageRangeWithQualityHeaderValue, super::super::super::Foundation::IStringable);
@@ -3147,7 +3147,7 @@ impl windows_core::RuntimeName for HttpLanguageRangeWithQualityHeaderValue {
 unsafe impl Send for HttpLanguageRangeWithQualityHeaderValue {}
 unsafe impl Sync for HttpLanguageRangeWithQualityHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpLanguageRangeWithQualityHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpLanguageRangeWithQualityHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -3296,7 +3296,7 @@ impl IntoIterator for &HttpLanguageRangeWithQualityHeaderValueCollection {
 unsafe impl Send for HttpLanguageRangeWithQualityHeaderValueCollection {}
 unsafe impl Sync for HttpLanguageRangeWithQualityHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpMediaTypeHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpMediaTypeHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpMediaTypeHeaderValue, super::super::super::Foundation::IStringable);
@@ -3380,7 +3380,7 @@ impl windows_core::RuntimeName for HttpMediaTypeHeaderValue {
 unsafe impl Send for HttpMediaTypeHeaderValue {}
 unsafe impl Sync for HttpMediaTypeHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpMediaTypeWithQualityHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpMediaTypeWithQualityHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpMediaTypeWithQualityHeaderValue, super::super::super::Foundation::IStringable);
@@ -3484,7 +3484,7 @@ impl windows_core::RuntimeName for HttpMediaTypeWithQualityHeaderValue {
 unsafe impl Send for HttpMediaTypeWithQualityHeaderValue {}
 unsafe impl Sync for HttpMediaTypeWithQualityHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpMediaTypeWithQualityHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpMediaTypeWithQualityHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -3633,7 +3633,7 @@ impl IntoIterator for &HttpMediaTypeWithQualityHeaderValueCollection {
 unsafe impl Send for HttpMediaTypeWithQualityHeaderValueCollection {}
 unsafe impl Sync for HttpMediaTypeWithQualityHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpMethodHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpMethodHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -3782,7 +3782,7 @@ impl IntoIterator for &HttpMethodHeaderValueCollection {
 unsafe impl Send for HttpMethodHeaderValueCollection {}
 unsafe impl Sync for HttpMethodHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpNameValueHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpNameValueHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpNameValueHeaderValue, super::super::super::Foundation::IStringable);
@@ -3860,7 +3860,7 @@ impl windows_core::RuntimeName for HttpNameValueHeaderValue {
 unsafe impl Send for HttpNameValueHeaderValue {}
 unsafe impl Sync for HttpNameValueHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpProductHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpProductHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpProductHeaderValue, super::super::super::Foundation::IStringable);
@@ -3934,7 +3934,7 @@ impl windows_core::RuntimeName for HttpProductHeaderValue {
 unsafe impl Send for HttpProductHeaderValue {}
 unsafe impl Sync for HttpProductHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpProductInfoHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpProductInfoHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpProductInfoHeaderValue, super::super::super::Foundation::IStringable);
@@ -4008,7 +4008,7 @@ impl windows_core::RuntimeName for HttpProductInfoHeaderValue {
 unsafe impl Send for HttpProductInfoHeaderValue {}
 unsafe impl Sync for HttpProductInfoHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpProductInfoHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpProductInfoHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -4157,7 +4157,7 @@ impl IntoIterator for &HttpProductInfoHeaderValueCollection {
 unsafe impl Send for HttpProductInfoHeaderValueCollection {}
 unsafe impl Sync for HttpProductInfoHeaderValueCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpRequestHeaderCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpRequestHeaderCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -4457,7 +4457,7 @@ impl IntoIterator for &HttpRequestHeaderCollection {
 unsafe impl Send for HttpRequestHeaderCollection {}
 unsafe impl Sync for HttpRequestHeaderCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpResponseHeaderCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpResponseHeaderCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -4667,7 +4667,7 @@ impl IntoIterator for &HttpResponseHeaderCollection {
 unsafe impl Send for HttpResponseHeaderCollection {}
 unsafe impl Sync for HttpResponseHeaderCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpTransferCodingHeaderValue(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpTransferCodingHeaderValue, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpTransferCodingHeaderValue, super::super::super::Foundation::IStringable);
@@ -4736,7 +4736,7 @@ impl windows_core::RuntimeName for HttpTransferCodingHeaderValue {
 unsafe impl Send for HttpTransferCodingHeaderValue {}
 unsafe impl Sync for HttpTransferCodingHeaderValue {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpTransferCodingHeaderValueCollection(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpTransferCodingHeaderValueCollection, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]

--- a/crates/libs/windows/src/Windows/Web/Http/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/mod.rs
@@ -500,7 +500,7 @@ pub struct IHttpTransportInformation_Vtbl {
     ServerIntermediateCertificates: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpBufferContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpBufferContent, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpBufferContent, super::super::Foundation::IClosable, IHttpContent, super::super::Foundation::IStringable);
@@ -611,7 +611,7 @@ impl windows_core::RuntimeName for HttpBufferContent {
 unsafe impl Send for HttpBufferContent {}
 unsafe impl Sync for HttpBufferContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpClient(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpClient, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpClient, super::super::Foundation::IClosable, super::super::Foundation::IStringable);
@@ -888,7 +888,7 @@ impl windows_core::RuntimeName for HttpClient {
 unsafe impl Send for HttpClient {}
 unsafe impl Sync for HttpClient {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpCookie(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpCookie, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpCookie, super::super::Foundation::IStringable);
@@ -994,7 +994,7 @@ unsafe impl Send for HttpCookie {}
 unsafe impl Sync for HttpCookie {}
 #[cfg(feature = "Foundation_Collections")]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpCookieCollection(windows_core::IUnknown);
 #[cfg(feature = "Foundation_Collections")]
 windows_core::imp::interface_hierarchy!(HttpCookieCollection, windows_core::IUnknown, windows_core::IInspectable);
@@ -1080,7 +1080,7 @@ unsafe impl Send for HttpCookieCollection {}
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl Sync for HttpCookieCollection {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpCookieManager(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpCookieManager, windows_core::IUnknown, windows_core::IInspectable);
 impl HttpCookieManager {
@@ -1136,7 +1136,7 @@ impl windows_core::RuntimeName for HttpCookieManager {
 unsafe impl Send for HttpCookieManager {}
 unsafe impl Sync for HttpCookieManager {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpFormUrlEncodedContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpFormUrlEncodedContent, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpFormUrlEncodedContent, super::super::Foundation::IClosable, IHttpContent, super::super::Foundation::IStringable);
@@ -1237,7 +1237,7 @@ impl windows_core::RuntimeName for HttpFormUrlEncodedContent {
 unsafe impl Send for HttpFormUrlEncodedContent {}
 unsafe impl Sync for HttpFormUrlEncodedContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpGetBufferResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpGetBufferResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpGetBufferResult, super::super::Foundation::IClosable, super::super::Foundation::IStringable);
@@ -1303,7 +1303,7 @@ impl windows_core::RuntimeName for HttpGetBufferResult {
 unsafe impl Send for HttpGetBufferResult {}
 unsafe impl Sync for HttpGetBufferResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpGetInputStreamResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpGetInputStreamResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpGetInputStreamResult, super::super::Foundation::IClosable, super::super::Foundation::IStringable);
@@ -1369,7 +1369,7 @@ impl windows_core::RuntimeName for HttpGetInputStreamResult {
 unsafe impl Send for HttpGetInputStreamResult {}
 unsafe impl Sync for HttpGetInputStreamResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpGetStringResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpGetStringResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpGetStringResult, super::super::Foundation::IClosable, super::super::Foundation::IStringable);
@@ -1434,7 +1434,7 @@ impl windows_core::RuntimeName for HttpGetStringResult {
 unsafe impl Send for HttpGetStringResult {}
 unsafe impl Sync for HttpGetStringResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpMethod(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpMethod, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpMethod, super::super::Foundation::IStringable);
@@ -1525,7 +1525,7 @@ impl windows_core::RuntimeName for HttpMethod {
 unsafe impl Send for HttpMethod {}
 unsafe impl Sync for HttpMethod {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpMultipartContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpMultipartContent, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -1667,7 +1667,7 @@ impl IntoIterator for &HttpMultipartContent {
 unsafe impl Send for HttpMultipartContent {}
 unsafe impl Sync for HttpMultipartContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpMultipartFormDataContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpMultipartFormDataContent, windows_core::IUnknown, windows_core::IInspectable);
 #[cfg(feature = "Foundation_Collections")]
@@ -1817,7 +1817,7 @@ impl IntoIterator for &HttpMultipartFormDataContent {
 unsafe impl Send for HttpMultipartFormDataContent {}
 unsafe impl Sync for HttpMultipartFormDataContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpRequestMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpRequestMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpRequestMessage, super::super::Foundation::IClosable, super::super::Foundation::IStringable);
@@ -1945,7 +1945,7 @@ impl windows_core::RuntimeName for HttpRequestMessage {
 unsafe impl Send for HttpRequestMessage {}
 unsafe impl Sync for HttpRequestMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpRequestResult(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpRequestResult, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpRequestResult, super::super::Foundation::IClosable, super::super::Foundation::IStringable);
@@ -2003,7 +2003,7 @@ impl windows_core::RuntimeName for HttpRequestResult {
 unsafe impl Send for HttpRequestResult {}
 unsafe impl Sync for HttpRequestResult {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpResponseMessage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpResponseMessage, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpResponseMessage, super::super::Foundation::IClosable, super::super::Foundation::IStringable);
@@ -2145,7 +2145,7 @@ impl windows_core::RuntimeName for HttpResponseMessage {
 unsafe impl Send for HttpResponseMessage {}
 unsafe impl Sync for HttpResponseMessage {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpStreamContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpStreamContent, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpStreamContent, super::super::Foundation::IClosable, IHttpContent, super::super::Foundation::IStringable);
@@ -2246,7 +2246,7 @@ impl windows_core::RuntimeName for HttpStreamContent {
 unsafe impl Send for HttpStreamContent {}
 unsafe impl Sync for HttpStreamContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpStringContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpStringContent, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpStringContent, super::super::Foundation::IClosable, IHttpContent, super::super::Foundation::IStringable);
@@ -2357,7 +2357,7 @@ impl windows_core::RuntimeName for HttpStringContent {
 unsafe impl Send for HttpStringContent {}
 unsafe impl Sync for HttpStringContent {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct HttpTransportInformation(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(HttpTransportInformation, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(HttpTransportInformation, super::super::Foundation::IStringable);

--- a/crates/libs/windows/src/Windows/Web/Syndication/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Syndication/mod.rs
@@ -697,7 +697,7 @@ pub struct ISyndicationTextFactory_Vtbl {
     pub CreateSyndicationTextEx: unsafe extern "system" fn(*mut core::ffi::c_void, core::mem::MaybeUninit<windows_core::HSTRING>, SyndicationTextType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationAttribute(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationAttribute, windows_core::IUnknown, windows_core::IInspectable);
 impl SyndicationAttribute {
@@ -766,7 +766,7 @@ impl windows_core::RuntimeName for SyndicationAttribute {
 unsafe impl Send for SyndicationAttribute {}
 unsafe impl Sync for SyndicationAttribute {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationCategory(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationCategory, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SyndicationCategory, ISyndicationNode);
@@ -924,7 +924,7 @@ impl windows_core::RuntimeName for SyndicationCategory {
 unsafe impl Send for SyndicationCategory {}
 unsafe impl Sync for SyndicationCategory {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationClient(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationClient, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SyndicationClient, ISyndicationClient);
@@ -1044,7 +1044,7 @@ impl windows_core::RuntimeName for SyndicationClient {
 unsafe impl Send for SyndicationClient {}
 unsafe impl Sync for SyndicationClient {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationContent(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationContent, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SyndicationContent, ISyndicationNode, ISyndicationText);
@@ -1241,7 +1241,7 @@ impl windows_core::RuntimeName for SyndicationError {
     const NAME: &'static str = "Windows.Web.Syndication.SyndicationError";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationFeed(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationFeed, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SyndicationFeed, ISyndicationNode);
@@ -1556,7 +1556,7 @@ impl windows_core::RuntimeName for SyndicationFeed {
 unsafe impl Send for SyndicationFeed {}
 unsafe impl Sync for SyndicationFeed {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationGenerator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationGenerator, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SyndicationGenerator, ISyndicationNode);
@@ -1711,7 +1711,7 @@ impl windows_core::RuntimeName for SyndicationGenerator {
 unsafe impl Send for SyndicationGenerator {}
 unsafe impl Sync for SyndicationGenerator {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationItem(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationItem, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SyndicationItem, ISyndicationNode);
@@ -2023,7 +2023,7 @@ impl windows_core::RuntimeName for SyndicationItem {
 unsafe impl Send for SyndicationItem {}
 unsafe impl Sync for SyndicationItem {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationLink(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationLink, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SyndicationLink, ISyndicationNode);
@@ -2223,7 +2223,7 @@ impl windows_core::RuntimeName for SyndicationLink {
 unsafe impl Send for SyndicationLink {}
 unsafe impl Sync for SyndicationLink {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationNode(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationNode, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SyndicationNode, ISyndicationNode);
@@ -2342,7 +2342,7 @@ impl windows_core::RuntimeName for SyndicationNode {
 unsafe impl Send for SyndicationNode {}
 unsafe impl Sync for SyndicationNode {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationPerson(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationPerson, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SyndicationPerson, ISyndicationNode);
@@ -2506,7 +2506,7 @@ impl windows_core::RuntimeName for SyndicationPerson {
 unsafe impl Send for SyndicationPerson {}
 unsafe impl Sync for SyndicationPerson {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct SyndicationText(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SyndicationText, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(SyndicationText, ISyndicationNode, ISyndicationText);

--- a/crates/libs/windows/src/Windows/Web/UI/Interop/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/UI/Interop/mod.rs
@@ -104,7 +104,7 @@ pub struct IWebViewControlSite2_Vtbl {
     pub RemoveLostFocus: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControl(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControl, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(WebViewControl, super::IWebViewControl, super::IWebViewControl2);
@@ -621,7 +621,7 @@ impl windows_core::RuntimeName for WebViewControl {
     const NAME: &'static str = "Windows.Web.UI.Interop.WebViewControl";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlAcceleratorKeyPressedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlAcceleratorKeyPressedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlAcceleratorKeyPressedEventArgs {
@@ -679,7 +679,7 @@ impl windows_core::RuntimeName for WebViewControlAcceleratorKeyPressedEventArgs 
     const NAME: &'static str = "Windows.Web.UI.Interop.WebViewControlAcceleratorKeyPressedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlMoveFocusRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlMoveFocusRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlMoveFocusRequestedEventArgs {
@@ -702,7 +702,7 @@ impl windows_core::RuntimeName for WebViewControlMoveFocusRequestedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.Interop.WebViewControlMoveFocusRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlProcess(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlProcess, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlProcess {
@@ -793,7 +793,7 @@ impl windows_core::RuntimeName for WebViewControlProcess {
     const NAME: &'static str = "Windows.Web.UI.Interop.WebViewControlProcess";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlProcessOptions(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlProcessOptions, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlProcessOptions {

--- a/crates/libs/windows/src/Windows/Web/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/UI/mod.rs
@@ -688,7 +688,7 @@ pub struct IWebViewControlWebResourceRequestedEventArgs_Vtbl {
     Response: usize,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlContentLoadingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlContentLoadingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlContentLoadingEventArgs {
@@ -711,7 +711,7 @@ impl windows_core::RuntimeName for WebViewControlContentLoadingEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlContentLoadingEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlDOMContentLoadedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlDOMContentLoadedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlDOMContentLoadedEventArgs {
@@ -734,7 +734,7 @@ impl windows_core::RuntimeName for WebViewControlDOMContentLoadedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlDOMContentLoadedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlDeferredPermissionRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlDeferredPermissionRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlDeferredPermissionRequest {
@@ -779,7 +779,7 @@ impl windows_core::RuntimeName for WebViewControlDeferredPermissionRequest {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlDeferredPermissionRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlLongRunningScriptDetectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlLongRunningScriptDetectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlLongRunningScriptDetectedEventArgs {
@@ -813,7 +813,7 @@ impl windows_core::RuntimeName for WebViewControlLongRunningScriptDetectedEventA
     const NAME: &'static str = "Windows.Web.UI.WebViewControlLongRunningScriptDetectedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlNavigationCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlNavigationCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlNavigationCompletedEventArgs {
@@ -850,7 +850,7 @@ impl windows_core::RuntimeName for WebViewControlNavigationCompletedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlNavigationCompletedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlNavigationStartingEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlNavigationStartingEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlNavigationStartingEventArgs {
@@ -884,7 +884,7 @@ impl windows_core::RuntimeName for WebViewControlNavigationStartingEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlNavigationStartingEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlNewWindowRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlNewWindowRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlNewWindowRequestedEventArgs {
@@ -946,7 +946,7 @@ impl windows_core::RuntimeName for WebViewControlNewWindowRequestedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlNewWindowRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlPermissionRequest(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlPermissionRequest, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlPermissionRequest {
@@ -1002,7 +1002,7 @@ impl windows_core::RuntimeName for WebViewControlPermissionRequest {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlPermissionRequest";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlPermissionRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlPermissionRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlPermissionRequestedEventArgs {
@@ -1025,7 +1025,7 @@ impl windows_core::RuntimeName for WebViewControlPermissionRequestedEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlPermissionRequestedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlScriptNotifyEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlScriptNotifyEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlScriptNotifyEventArgs {
@@ -1055,7 +1055,7 @@ impl windows_core::RuntimeName for WebViewControlScriptNotifyEventArgs {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlScriptNotifyEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlSettings(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlSettings, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlSettings {
@@ -1104,7 +1104,7 @@ impl windows_core::RuntimeName for WebViewControlSettings {
     const NAME: &'static str = "Windows.Web.UI.WebViewControlSettings";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlUnsupportedUriSchemeIdentifiedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlUnsupportedUriSchemeIdentifiedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlUnsupportedUriSchemeIdentifiedEventArgs {
@@ -1138,7 +1138,7 @@ impl windows_core::RuntimeName for WebViewControlUnsupportedUriSchemeIdentifiedE
     const NAME: &'static str = "Windows.Web.UI.WebViewControlUnsupportedUriSchemeIdentifiedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlUnviewableContentIdentifiedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlUnviewableContentIdentifiedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlUnviewableContentIdentifiedEventArgs {
@@ -1175,7 +1175,7 @@ impl windows_core::RuntimeName for WebViewControlUnviewableContentIdentifiedEven
     const NAME: &'static str = "Windows.Web.UI.WebViewControlUnviewableContentIdentifiedEventArgs";
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WebViewControlWebResourceRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WebViewControlWebResourceRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WebViewControlWebResourceRequestedEventArgs {

--- a/crates/samples/components/json_validator_winrt/src/bindings.rs
+++ b/crates/samples/components/json_validator_winrt/src/bindings.rs
@@ -44,7 +44,7 @@ pub struct IJsonValidatorFactory_Vtbl {
     ) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct JsonValidator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(
     JsonValidator,

--- a/crates/samples/components/json_validator_winrt_client/src/bindings.rs
+++ b/crates/samples/components/json_validator_winrt_client/src/bindings.rs
@@ -44,7 +44,7 @@ pub struct IJsonValidatorFactory_Vtbl {
     ) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct JsonValidator(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(
     JsonValidator,

--- a/crates/tests/component/src/bindings.rs
+++ b/crates/tests/component/src/bindings.rs
@@ -121,7 +121,7 @@ pub struct IClass_Vtbl {
     ) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Class(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Class, windows_core::IUnknown, windows_core::IInspectable);
 impl Class {

--- a/crates/tests/component_client/src/bindings.rs
+++ b/crates/tests/component_client/src/bindings.rs
@@ -88,7 +88,7 @@ pub struct IClass_Vtbl {
     ) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Class(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Class, windows_core::IUnknown, windows_core::IInspectable);
 impl Class {

--- a/crates/tests/riddle/src/generic_interfaces.rs
+++ b/crates/tests/riddle/src/generic_interfaces.rs
@@ -6,7 +6,7 @@
     clippy::all
 )]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IIterable<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -65,7 +65,7 @@ where
     pub T: core::marker::PhantomData<T>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IIterator<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -150,7 +150,7 @@ where
     pub T: core::marker::PhantomData<T>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IKeyValuePair<K, V>(
     windows_core::IUnknown,
     core::marker::PhantomData<K>,
@@ -241,7 +241,7 @@ where
     pub V: core::marker::PhantomData<V>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IMapView<K, V>(
     windows_core::IUnknown,
     core::marker::PhantomData<K>,

--- a/crates/tests/standalone/src/b_calendar.rs
+++ b/crates/tests/standalone/src/b_calendar.rs
@@ -6,7 +6,7 @@
     clippy::all
 )]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Calendar(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(
     Calendar,
@@ -1625,7 +1625,7 @@ pub struct ICalendarFactory2_Vtbl {
     ) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IIterable<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -1698,7 +1698,7 @@ where
     pub T: core::marker::PhantomData<T>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IIterator<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -1845,7 +1845,7 @@ pub struct ITimeZoneOnCalendar_Vtbl {
     ) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IVectorView<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;

--- a/crates/tests/standalone/src/b_uri.rs
+++ b/crates/tests/standalone/src/b_uri.rs
@@ -6,7 +6,7 @@
     clippy::all
 )]
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IIterable<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -79,7 +79,7 @@ where
     pub T: core::marker::PhantomData<T>,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IIterator<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -383,7 +383,7 @@ pub struct IUriRuntimeClassWithAbsoluteCanonicalUri_Vtbl {
     ) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct IVectorView<T>(windows_core::IUnknown, core::marker::PhantomData<T>)
 where
     T: windows_core::RuntimeType + 'static;
@@ -646,7 +646,7 @@ pub struct IWwwFormUrlDecoderRuntimeClassFactory_Vtbl {
     ) -> windows_core::HRESULT,
 }
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Uri(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(Uri, windows_core::IUnknown, windows_core::IInspectable);
 windows_core::imp::required_hierarchy!(Uri, IStringable);
@@ -964,7 +964,7 @@ impl windows_core::RuntimeName for Uri {
 unsafe impl Send for Uri {}
 unsafe impl Sync for Uri {}
 #[repr(transparent)]
-#[derive(PartialEq, Eq, core::fmt::Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct WwwFormUrlDecoder(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(
     WwwFormUrlDecoder,


### PR DESCRIPTION
The `windows-bindgen` crate was inconsistently generating this derive macro due to some previous refactoring. This just switches to consistently using the unqualified form in all cases. 