### PR TITLE
Remove `mio` dependency

### DIFF
--- a/crates/tests/lib/Cargo.toml
+++ b/crates/tests/lib/Cargo.toml
@@ -32,6 +32,3 @@ features = [
 
 [dependencies.windows-targets]
 path = "../../libs/targets"
-
-[dependencies.mio]
-version = "0.8.6"


### PR DESCRIPTION
This was added a long time ago to smoke out some build edge cases. 

Fixes: #3106