### PR TITLE
Support some edge cases for the next Win32 metadata update

### DIFF
--- a/crates/libs/core/src/imp/waiter.rs
+++ b/crates/libs/core/src/imp/waiter.rs
@@ -1,8 +1,10 @@
 use super::*;
 
 #[doc(hidden)]
-pub struct Waiter(isize);
-pub struct WaiterSignaler(isize);
+pub struct Waiter(HANDLE);
+pub struct WaiterSignaler(HANDLE);
+
+unsafe impl Send for WaiterSignaler {}
 
 impl Waiter {
     pub fn new() -> crate::Result<(Waiter, WaiterSignaler)> {

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -10688,7 +10688,7 @@ impl windows_core::TypeKind for HANDLE_PTR {
 pub struct HGLOBAL(pub *mut core::ffi::c_void);
 impl HGLOBAL {
     pub fn is_invalid(&self) -> bool {
-        self.0.is_null()
+        self.0 == -1 as _ || self.0 == 0 as _
     }
 }
 impl windows_core::Free for HGLOBAL {
@@ -10740,7 +10740,7 @@ impl From<HINSTANCE> for HMODULE {
 pub struct HLOCAL(pub *mut core::ffi::c_void);
 impl HLOCAL {
     pub fn is_invalid(&self) -> bool {
-        self.0.is_null()
+        self.0 == -1 as _ || self.0 == 0 as _
     }
 }
 impl windows_core::Free for HLOCAL {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
@@ -14306,7 +14306,7 @@ impl windows_core::TypeKind for HCERTCHAINENGINE {
 pub struct HCERTSTORE(pub *mut core::ffi::c_void);
 impl HCERTSTORE {
     pub fn is_invalid(&self) -> bool {
-        self.0.is_null()
+        self.0 == -1 as _ || self.0 == 0 as _
     }
 }
 impl Default for HCERTSTORE {
@@ -14322,7 +14322,7 @@ impl windows_core::TypeKind for HCERTSTORE {
 pub struct HCERTSTOREPROV(pub *mut core::ffi::c_void);
 impl HCERTSTOREPROV {
     pub fn is_invalid(&self) -> bool {
-        self.0.is_null()
+        self.0 == -1 as _ || self.0 == 0 as _
     }
 }
 impl Default for HCERTSTOREPROV {

--- a/crates/libs/windows/src/Windows/Win32/Security/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/mod.rs
@@ -2671,7 +2671,7 @@ impl Default for PRIVILEGE_SET {
 pub struct PSECURITY_DESCRIPTOR(pub *mut core::ffi::c_void);
 impl PSECURITY_DESCRIPTOR {
     pub fn is_invalid(&self) -> bool {
-        self.0.is_null()
+        self.0 == -1 as _ || self.0 == 0 as _
     }
 }
 impl Default for PSECURITY_DESCRIPTOR {

--- a/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -8227,7 +8227,7 @@ impl From<HCURSOR> for HICON {
 pub struct HDEVNOTIFY(pub *mut core::ffi::c_void);
 impl HDEVNOTIFY {
     pub fn is_invalid(&self) -> bool {
-        self.0.is_null()
+        self.0 == -1 as _ || self.0 == 0 as _
     }
 }
 impl windows_core::Free for HDEVNOTIFY {


### PR DESCRIPTION
There's a bit of a hiccup on the build, but these changes are needed to support the next metadata drop. Hopefully out soon. 

* Properly handle empty structs that make a reappearance 
* Better support pointer handles and invalid values 
