### PR TITLE
Don't compile `windows` and `windows-sys` in unit test mode

### DIFF
--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -15,9 +15,6 @@ exclude = ["features.json"]
 # This crate does not contain tests. All tests are in separate crates.
 test = false
 doctest = false
-# This crate does not generate docs because it is too large (rustdoc has problems with very large
-# crates) and because the Windows API is documented elsewhere.
-doc = false
 
 [lints]
 workspace = true

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -11,6 +11,14 @@ readme = "readme.md"
 categories = ["os::windows-apis"]
 exclude = ["features.json"]
 
+[lib]
+# This crate does not contain tests. All tests are in separate crates.
+test = false
+doctest = false
+# This crate does not generate docs because it is too large (rustdoc has problems with very large
+# crates) and because the Windows API is documented elsewhere.
+doc = false
+
 [lints]
 workspace = true
 

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -13,6 +13,14 @@ readme = "readme.md"
 categories = ["os::windows-apis"]
 exclude = ["features.json"]
 
+[lib]
+# This crate does not contain tests. All tests are in separate crates.
+test = false
+doctest = false
+# This crate does not generate docs because it is too large (rustdoc has problems with very large
+# crates) and because the Windows API is documented elsewhere.
+doc = false
+
 [lints]
 workspace = true
 

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -17,9 +17,6 @@ exclude = ["features.json"]
 # This crate does not contain tests. All tests are in separate crates.
 test = false
 doctest = false
-# This crate does not generate docs because it is too large (rustdoc has problems with very large
-# crates) and because the Windows API is documented elsewhere.
-doc = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
This PR improves cycle time for running `cargo test --all`.

The `windows` and `windows-sys` crates do not contain unit tests or doc tests.  Cargo doesn't know that, so it compiles these two very large crates in the `#[cfg(test)]` mode and wastes time scanning for doc tests.

This PR simply disables unit tests and doc tests in both of these crates.  This saves a significant amount of time in running tests.