### PR TITLE
Directly invoke bindgen instead of recursively calling `cargo run ...`

### DIFF
--- a/crates/tests/component/Cargo.toml
+++ b/crates/tests/component/Cargo.toml
@@ -20,3 +20,6 @@ features = [
     "Win32_Foundation",
     "Win32_System_WinRT",
 ]
+
+[build-dependencies.windows-bindgen]
+path = "../../libs/bindgen"

--- a/crates/tests/component/build.rs
+++ b/crates/tests/component/build.rs
@@ -22,28 +22,23 @@ fn main() {
 
     // TODO: this looks more complicated but soon the midlrt step above should disappear and then overall it should be simpler...
 
-    let mut command = std::process::Command::new("cargo");
+    let command: Vec<String> = vec![
+        "--in".to_owned(),
+        "component.winmd".to_owned(),
+        metadata_dir.to_owned(),
+        "--out".to_owned(),
+        "src/bindings.rs".to_owned(),
+        "--filter".to_owned(),
+        "test_component".to_owned(),
+        "--config".to_owned(),
+        "implement".to_owned(),
+        "no-bindgen-comment".to_owned(),
+    ];
 
-    command.args([
-        "run",
-        "-p",
-        "riddle",
-        "--target-dir",
-        "../../../target/test_component", // TODO: workaround for https://github.com/rust-lang/cargo/issues/6412
-        "--",
-        "--in",
-        "component.winmd",
-        &metadata_dir,
-        "--out",
-        "src/bindings.rs",
-        "--filter",
-        "test_component",
-        "--config",
-        "implement",
-        "no-bindgen-comment",
-    ]);
-
-    if !command.status().unwrap().success() {
-        panic!("Failed to run riddle");
-    }
+    windows_bindgen::bindgen(&command).unwrap_or_else(|e| {
+        panic!(
+            "Failed to run bindgen: {e:?}\nArgs: riddle.exe {args}",
+            args = command.join(" ")
+        )
+    });
 }

--- a/crates/tests/component_client/Cargo.toml
+++ b/crates/tests/component_client/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 doc = false
 doctest = false
 
+[build-dependencies.windows-bindgen]
+path = "../../libs/bindgen"
+
 [dependencies.windows-core]
 path = "../../libs/core"
 

--- a/crates/tests/component_client/build.rs
+++ b/crates/tests/component_client/build.rs
@@ -1,25 +1,20 @@
 fn main() {
-    let mut command = std::process::Command::new("cargo");
+    let command: Vec<String> = vec![
+        "--in".to_owned(),
+        "../component/component.winmd".to_owned(),
+        format!("{}\\System32\\WinMetadata", env!("windir")),
+        "--out".to_owned(),
+        "src/bindings.rs".to_owned(),
+        "--filter".to_owned(),
+        "test_component".to_owned(),
+        "--config".to_owned(),
+        "no-bindgen-comment".to_owned(),
+    ];
 
-    command.args([
-        "run",
-        "-p",
-        "riddle",
-        "--target-dir",
-        "../../../target/test_component_client", // TODO: workaround for https://github.com/rust-lang/cargo/issues/6412
-        "--",
-        "--in",
-        "../component/component.winmd",
-        &format!("{}\\System32\\WinMetadata", env!("windir")),
-        "--out",
-        "src/bindings.rs",
-        "--filter",
-        "test_component",
-        "--config",
-        "no-bindgen-comment",
-    ]);
-
-    if !command.status().unwrap().success() {
-        panic!("Failed to run riddle");
-    }
+    windows_bindgen::bindgen(&command).unwrap_or_else(|e| {
+        panic!(
+            "Failed to run bindgen: {e:?}\nArgs: riddle.exe {args}",
+            args = command.join(" ")
+        )
+    });
 }

--- a/crates/tests/riddle/Cargo.toml
+++ b/crates/tests/riddle/Cargo.toml
@@ -16,3 +16,6 @@ path = "../../libs/metadata"
 
 [dependencies.tool_lib]
 path = "../../tools/lib"
+
+[dependencies.windows-bindgen]
+path = "../../libs/bindgen"

--- a/crates/tests/riddle/src/lib.rs
+++ b/crates/tests/riddle/src/lib.rs
@@ -8,61 +8,80 @@ mod r#struct;
 mod win32_struct;
 mod winrt_struct;
 
-use std::process::Command;
-
 pub fn run_riddle(name: &str, dialect: &str, etc: &[&str]) -> Vec<windows_metadata::File> {
     let rdl = format!("tests/{name}.rdl");
     let winmd = format!("tests/{name}.winmd");
     let rs = format!("src/{name}.rs");
 
-    let before = std::fs::read_to_string(&rdl).expect("Failed to read input");
+    let before = std::fs::read_to_string(&rdl)
+        .unwrap_or_else(|e| panic!("Failed to read input: {rdl} : {e:?}"));
 
     // Convert .rdl to .winmd
     _ = std::fs::remove_file(&winmd);
-    let mut command = Command::new("cargo");
-    command.args([
-        "run", "-p", "riddle", "--", "--in", &rdl, "--out", &winmd, "--filter", "Test",
-    ]);
-    assert!(command.status().unwrap().success());
+    let command: Vec<String> = vec![
+        "--in".to_owned(),
+        rdl.to_owned(),
+        "--out".to_owned(),
+        winmd.to_owned(),
+        "--filter".to_owned(),
+        "Test".to_owned(),
+    ];
+    run_one_bindgen(&command);
 
     // Convert .winmd back to .rdl
-    std::fs::remove_file(&rdl).expect("Failed to delete output");
-    let mut command = Command::new("cargo");
-    command.args([
-        "run", "-p", "riddle", "--", "--in", &winmd, "--out", &rdl, "--filter", "Test", "--config",
-    ]);
-    command.arg(format!("type={dialect}"));
-    assert!(command.status().unwrap().success());
+    std::fs::remove_file(&rdl).unwrap_or_else(|e| panic!("Failed to delete output: {rdl} : {e:?}"));
+    let mut command: Vec<String> = vec![
+        "--in".to_owned(),
+        winmd.to_owned(),
+        "--out".to_owned(),
+        rdl.to_owned(),
+        "--filter".to_owned(),
+        "Test".to_owned(),
+        "--config".to_owned(),
+    ];
+    command.push(format!("type={dialect}"));
+    run_one_bindgen(&command);
 
     // Check that .rdl is unchanged
-    let after = std::fs::read_to_string(&rdl).expect("Failed to read output");
+    let after = std::fs::read_to_string(&rdl)
+        .unwrap_or_else(|e| panic!("Failed to read output: {rdl} : {e:?}"));
     assert_eq!(before, after, "no equal {}", rdl);
 
     // Convert .rdl to .rs
-    std::fs::remove_file(&rs).expect("Failed to delete output");
-    let mut command = Command::new("cargo");
-    command.args([
-        "run",
-        "-p",
-        "riddle",
-        "--",
-        "--in",
-        &rdl,
-        "--out",
-        &rs,
-        "--filter",
-        "Test",
-        "--config",
-        "no-bindgen-comment",
-    ]);
-    command.args(etc);
-    assert!(command.status().unwrap().success());
+    std::fs::remove_file(&rs).unwrap_or_else(|e| panic!("Failed to delete output: {rs} : {e:?}"));
+
+    let mut command: Vec<String> = vec![
+        "--in".to_owned(),
+        rdl.to_owned(),
+        "--out".to_owned(),
+        rs.to_owned(),
+        "--filter".to_owned(),
+        "Test".to_owned(),
+        "--config".to_owned(),
+        "no-bindgen-comment".to_owned(),
+    ];
+    command.extend(etc.iter().map(|&s| s.to_owned()));
+    run_one_bindgen(&command);
 
     // Return winmd file for validation
     let mut files = tool_lib::default_metadata();
+    let winmd_bytes =
+        std::fs::read(&winmd).unwrap_or_else(|e| panic!("Failed to read winmd: {winmd} : {e:?}"));
     files.push(
-        windows_metadata::File::new(std::fs::read(&winmd).expect("failed to read winmd"))
-            .expect("failed to parse winmd"),
+        windows_metadata::File::new(winmd_bytes)
+            .unwrap_or_else(|| panic!("failed to parse winmd: {winmd}")),
     );
     files
+}
+
+fn run_one_bindgen(args: &[String]) -> String {
+    match windows_bindgen::bindgen(args) {
+        Ok(s) => s,
+        Err(e) => {
+            panic!(
+                "Failed to run bindgen: {e:?}\nArgs: riddle.exe {args}",
+                args = args.join(" ")
+            );
+        }
+    }
 }


### PR DESCRIPTION
Recursively calling Cargo causes all sorts of problems and has poor performance. This PR converts the last remaining recursive Cargo calls so that they directly invoke bindgen, instead.  This improves build performance, removes some conflicts with Rust Analyzer, and is easier to debug.
