### PR TITLE
Build `cdylib` dependencies

### DIFF
--- a/crates/samples/components/json_validator_client/Cargo.toml
+++ b/crates/samples/components/json_validator_client/Cargo.toml
@@ -12,5 +12,5 @@ path = "../../../../crates/libs/targets"
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[dependencies.sample_component_json_validator]
+[build-dependencies.sample_component_json_validator]
 path = "../json_validator"

--- a/crates/samples/components/json_validator_winrt_client/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt_client/Cargo.toml
@@ -18,5 +18,5 @@ path = "../../../libs/bindgen"
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[dependencies.sample_component_json_validator_winrt]
+[build-dependencies.sample_component_json_validator_winrt]
 path = "../json_validator_winrt"

--- a/crates/samples/components/json_validator_winrt_client_cpp/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt_client_cpp/Cargo.toml
@@ -15,5 +15,5 @@ path = "../../../../crates/libs/targets"
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[dependencies.sample_component_json_validator_winrt]
+[build-dependencies.sample_component_json_validator_winrt]
 path = "../json_validator_winrt"

--- a/crates/tests/component_client/Cargo.toml
+++ b/crates/tests/component_client/Cargo.toml
@@ -24,5 +24,5 @@ features = [
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[dependencies.test_component]
+[build-dependencies.test_component]
 path = "../component"


### PR DESCRIPTION
These `cdylib` dependencies weren't building too reliably locally at least. This seems to avoid the local failures. 

Note that the warnings about a lack of linkage target seem to have gone away but the issue has no mention of it so it may be accidental... https://github.com/rust-lang/cargo/issues/7825

