### PR TITLE
Add flexible registry type and byte query support

### DIFF
--- a/crates/libs/registry/src/lib.rs
+++ b/crates/libs/registry/src/lib.rs
@@ -24,6 +24,9 @@ pub use key_iterator::KeyIterator;
 mod value_iterator;
 pub use value_iterator::ValueIterator;
 
+mod r#type;
+pub use r#type::Type;
+
 pub use windows_result::Result;
 use windows_result::*;
 

--- a/crates/libs/registry/src/type.rs
+++ b/crates/libs/registry/src/type.rs
@@ -1,0 +1,21 @@
+/// The possible types that a registry value could have.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Type {
+    /// A 32-bit unsigned integer value.
+    U32,
+
+    /// A 64-bit unsigned integer value.
+    U64,
+
+    /// A string value.
+    String,
+
+    /// An array u8 bytes.
+    Bytes,
+
+    /// An array of string values.
+    MultiString,
+
+    /// An unknown or unsupported type.
+    Unknown(u32),
+}

--- a/crates/tests/registry/tests/bad_string.rs
+++ b/crates/tests/registry/tests/bad_string.rs
@@ -1,0 +1,36 @@
+use windows::{core::w, Win32::System::Registry::*};
+use windows_registry::*;
+
+#[test]
+fn bad_string() -> Result<()> {
+    let bad_string_bytes = vec![
+        0x00, 0xD8, // leading surrogate
+        0x01, 0x01, // bogus trailing surrogate
+        0x00, 0x00, // null
+    ];
+
+    let test_key = "software\\windows-rs\\tests\\bad_string";
+    _ = CURRENT_USER.remove_tree(test_key);
+    let key = CURRENT_USER.create(test_key)?;
+
+    unsafe {
+        RegSetValueExW(
+            HKEY(key.as_raw()),
+            w!("name"),
+            0,
+            REG_SZ,
+            Some(&bad_string_bytes),
+        )
+        .ok()?
+    };
+
+    let ty = key.get_type("name")?;
+    assert_eq!(ty, Type::String);
+
+    let value_as_string = key.get_string("name")?;
+    assert_eq!(value_as_string, "�ā");
+
+    let value_as_bytes = key.get_bytes("name")?;
+    assert_eq!(value_as_bytes, bad_string_bytes);
+    Ok(())
+}


### PR DESCRIPTION
The `windows-registry` crate is currently pretty strict when it comes to mapping registry values and types. You cannot for example read the bytes from a registry value unless the type of that value is `REG_BINARY`. This makes it a little difficult to gracefully deal with invalid registry values.

This update adds the `get_type` methods and the resulting `Type` enum so that the actual type of a value can be queried directly. It also updates the `get_bytes` method to support returning the raw byte value even if the type isn't known to be bytes.

Related: #3119