### PR TITLE
Remove unnecessary test cfg checks

### DIFF
--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -8,7 +8,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
     windows_debugger_visualizer,
     debugger_visualizer(natvis_file = "../.natvis")
 )]
-#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![cfg_attr(all(not(feature = "std")), no_std)]
 
 extern crate self as windows_core;
 

--- a/crates/libs/registry/Cargo.toml
+++ b/crates/libs/registry/Cargo.toml
@@ -9,7 +9,6 @@ description = "Windows registry"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
-exclude = ["tests"]
 
 [lints]
 workspace = true

--- a/crates/libs/registry/src/lib.rs
+++ b/crates/libs/registry/src/lib.rs
@@ -2,7 +2,7 @@
 Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs>
 */
 
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 
 #[macro_use]
 extern crate alloc;

--- a/crates/libs/result/Cargo.toml
+++ b/crates/libs/result/Cargo.toml
@@ -9,7 +9,6 @@ description = "Windows error handling"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
-exclude = ["tests"]
 
 [features]
 default = ["std"]

--- a/crates/libs/result/src/lib.rs
+++ b/crates/libs/result/src/lib.rs
@@ -6,7 +6,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
     windows_debugger_visualizer,
     debugger_visualizer(natvis_file = "../.natvis")
 )]
-#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![cfg_attr(all(not(feature = "std")), no_std)]
 #![cfg_attr(not(windows), allow(unused_imports))]
 
 extern crate alloc;


### PR DESCRIPTION
Following the CI failures in https://github.com/microsoft/windows-rs/pull/3121#issuecomment-2186660351 this is just a small PR to confirm we have good build support. 

Previously, #3102 removed the in-crate test code so this just removes the remaining cfg checks and exclusions. 