### PR TITLE
Allow `Error` and `Result<()>` to be the same size as `HRESULT`

### DIFF
--- a/.github/workflows/msrv-windows-result.yml
+++ b/.github/workflows/msrv-windows-result.yml
@@ -27,3 +27,5 @@ jobs:
         run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - name: Check
         run: cargo check -p windows-result --all-features
+      - name: Check Default Features
+        run: cargo check -p windows-result

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -32,3 +32,4 @@ windows-interface = { path = "../interface",  version = "0.57.0" }
 [features]
 default = ["std"]
 std = []
+slim-errors = ["windows-result/slim-errors"]

--- a/crates/libs/result/Cargo.toml
+++ b/crates/libs/result/Cargo.toml
@@ -11,9 +11,10 @@ readme = "readme.md"
 categories = ["os::windows-apis"]
 
 [features]
-default = ["std", "error-info"]
+default = ["std"]
 std = []
-error-info = []
+# slim-errors reduces the size of Error (and Result<()>) to that of a single HRESULT
+slim-errors = []
 
 [lints]
 workspace = true

--- a/crates/libs/result/Cargo.toml
+++ b/crates/libs/result/Cargo.toml
@@ -11,8 +11,9 @@ readme = "readme.md"
 categories = ["os::windows-apis"]
 
 [features]
-default = ["std"]
+default = ["std", "error-info"]
 std = []
+error-info = []
 
 [lints]
 workspace = true
@@ -20,6 +21,9 @@ workspace = true
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
+
+[dependencies]
+static_assertions = "1.0"
 
 [dependencies.windows-targets]
 version = "0.52.5"

--- a/crates/libs/result/src/bstr.rs
+++ b/crates/libs/result/src/bstr.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+#[repr(transparent)]
+pub struct BasicString(*const u16);
+
+impl BasicString {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        if self.0.is_null() {
+            0
+        } else {
+            unsafe { SysStringLen(self.0) as usize }
+        }
+    }
+
+    pub fn as_wide(&self) -> &[u16] {
+        let len = self.len();
+        if len != 0 {
+            unsafe { core::slice::from_raw_parts(self.as_ptr(), len) }
+        } else {
+            &[]
+        }
+    }
+
+    pub fn as_ptr(&self) -> *const u16 {
+        if !self.is_empty() {
+            self.0
+        } else {
+            const EMPTY: [u16; 1] = [0];
+            EMPTY.as_ptr()
+        }
+    }
+}
+
+impl Default for BasicString {
+    fn default() -> Self {
+        Self(core::ptr::null_mut())
+    }
+}
+
+impl Drop for BasicString {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { SysFreeString(self.0) }
+        }
+    }
+}

--- a/crates/libs/result/src/error.rs
+++ b/crates/libs/result/src/error.rs
@@ -1,52 +1,245 @@
 use super::*;
-use core::ffi::c_void;
+#[allow(unused_imports)]
+use core::mem::size_of;
 
 /// An error object consists of both an error code as well as detailed error information for debugging.
-#[derive(Clone, PartialEq, Eq)]
-pub struct Error {
-    code: HRESULT,
-    #[cfg(windows)]
-    info: Option<ComPtr>,
+///
+/// # Extended error info and the `error-info` feature
+///
+/// The `Error` contains an `HRESULT` value that describes the error, as well as an optional
+/// `IErrorInfo` object. The `IErrorInfo` object is a COM object that can provide detailed information
+/// about an error, such as a text string, a `ProgID` of the originator, etc. If the error object
+/// was originated in an WinRT component, then additional information such as a stack track may be
+/// captured.
+///
+/// However, many systems based on COM do not use `IErrorInfo`. For these systems, the optional error
+/// info within `Error` has no benefits, but has substantial costs because it increases the size of
+/// the `Error` object, which also increases the size of `Result<T>`.
+///
+/// The `windows-result` crate provides the `error-info` feature, which gives developers control over
+/// the costs of using `Error`.
+#[derive(Clone)]
+pub struct ErrorT<Detail = DefaultDetail>
+where
+    Detail: ErrorDetail,
+{
+    code: NonZeroHRESULT,
+
+    /// Contains details about the error, such as error text.
+    ///
+    /// Note; We cannot use `Option<Detail>` here, because that would increase the size of `Error`
+    /// even when `Detail` contains no information at all (a ZST).  The `Detail` type itself must
+    /// be a ZST for `Error` to be a slim type.
+    detail: Detail,
 }
 
-impl Error {
+/// An error object consists of both an error code as well as detailed error information for debugging.
+///
+/// # Extended error info and the `error-info` feature
+///
+/// The `Error` contains an `HRESULT` value that describes the error, as well as an optional
+/// `IErrorInfo` object. The `IErrorInfo` object is a COM object that can provide detailed information
+/// about an error, such as a text string, a `ProgID` of the originator, etc. If the error object
+/// was originated in an WinRT component, then additional information such as a stack track may be
+/// captured.
+///
+/// However, many systems based on COM do not use `IErrorInfo`. For these systems, the optional error
+/// info within `Error` has no benefits, but has substantial costs because it increases the size of
+/// the `Error` object, which also increases the size of `Result<T>`.
+///
+/// The `windows-result` crate provides the `error-info` feature, which gives developers control over
+/// the costs of using `Error`.
+pub type Error = ErrorT<DefaultDetail>;
+
+/// Specifies the default error detail for the `Error` type.
+#[cfg(all(windows, feature = "error-info"))]
+pub type DefaultDetail = ErrorInfo;
+
+/// Specifies the default error detail for the `Error` type.
+#[cfg(not(all(windows, feature = "error-info")))]
+pub type DefaultDetail = NoDetail;
+
+/// This type implements `ErrorDetail`, by containing no error information at all. This type allows
+/// for "slim" `Error` objects, which have the same size as `HRESULT`.
+#[derive(Default, Clone)]
+pub struct NoDetail;
+
+/// Defines the behavior of error detail objects, which are stored within `Error`.
+pub trait ErrorDetail: Sized {
+    /// Returns an empty error detail.
+    fn empty() -> Self;
+
+    /// If this implementation stores error detail in ambient (thread-local) storage, then this
+    /// function transfers the error detail from ambient storage and returns it.
+    fn from_ambient() -> Self;
+
+    /// If this implementation stores error detail in ambient (thread-local) storage, then this
+    /// function tranfers `self` into that ambient storage.
+    ///
+    /// If this implementation does not store error detail in ambient storage, then this function
+    /// discards the error detail.
+    fn into_ambient(self);
+
+    /// If this implementation stores error detail in ambient (thread-local) storage, then this
+    /// function creates a new error detail object, given the `HRESULT` and a message string,
+    /// and stores the new error detail object in the ambient storage.
+    fn originate_error(code: HRESULT, message: &str);
+
+    /// Returns a message describing the error, if available.
+    fn message(&self) -> Option<String>;
+}
+
+impl ErrorDetail for NoDetail {
+    fn empty() -> Self {
+        Self
+    }
+    fn from_ambient() -> Self {
+        Self
+    }
+    fn into_ambient(self) {}
+    fn originate_error(_code: HRESULT, _message: &str) {}
+    fn message(&self) -> Option<String> {
+        None
+    }
+}
+
+#[cfg(windows)]
+pub use win_impl::ErrorInfo;
+
+#[cfg(windows)]
+mod win_impl {
+    use super::*;
+    use crate::bstr::BasicString;
+    use crate::com::ComPtr;
+
+    /// This type stores error detail, represented by a COM `IErrorInfo` object.
+    ///
+    /// # References
+    ///
+    /// * [`IErrorInfo`](https://learn.microsoft.com/en-us/windows/win32/api/oaidl/nn-oaidl-ierrorinfo)
+    #[derive(Clone, Default)]
+    pub struct ErrorInfo {
+        pub(super) ptr: Option<ComPtr>,
+    }
+
+    unsafe impl Send for ErrorInfo {}
+    unsafe impl Sync for ErrorInfo {}
+
+    impl ErrorInfo {
+        /// Gets a raw pointer to the `IErrorInfo` COM object stored in this `ErrorInfo`.
+        pub fn as_ptr(&self) -> *mut core::ffi::c_void {
+            self.ptr
+                .as_ref()
+                .map_or(core::ptr::null_mut(), |info| info.as_raw())
+        }
+    }
+
+    impl ErrorDetail for ErrorInfo {
+        fn empty() -> Self {
+            Self { ptr: None }
+        }
+
+        fn from_ambient() -> Self {
+            unsafe {
+                let mut ptr = None;
+                GetErrorInfo(0, &mut ptr as *mut _ as _);
+                Self { ptr }
+            }
+        }
+
+        fn into_ambient(self) {
+            if let Some(ptr) = self.ptr {
+                unsafe {
+                    SetErrorInfo(0, ptr.as_raw());
+                }
+            }
+        }
+
+        fn originate_error(code: HRESULT, message: &str) {
+            if message.is_empty() {
+                return;
+            }
+
+            let mut wide_message: Vec<u16> = Vec::with_capacity(message.encode_utf16().count() + 1);
+            wide_message.extend(message.encode_utf16());
+            let wide_message_len = wide_message.len(); // does not count NUL
+            wide_message.push(0);
+
+            unsafe {
+                RoOriginateErrorW(code.0, wide_message_len as u32, wide_message.as_ptr());
+            }
+        }
+
+        fn message(&self) -> Option<String> {
+            let info = self.ptr.as_ref()?;
+
+            let mut message = BasicString::default();
+
+            // First attempt to retrieve the restricted error information.
+            if let Some(info) = info.cast(&IID_IRestrictedErrorInfo) {
+                let mut fallback = BasicString::default();
+                let mut code = 0;
+
+                unsafe {
+                    com_call!(
+                        IRestrictedErrorInfo_Vtbl,
+                        info.GetErrorDetails(
+                            &mut fallback as *mut _ as _,
+                            &mut code,
+                            &mut message as *mut _ as _,
+                            &mut BasicString::default() as *mut _ as _
+                        )
+                    );
+                }
+
+                if message.is_empty() {
+                    message = fallback
+                };
+            }
+
+            // Next attempt to retrieve the regular error information.
+            if message.is_empty() {
+                unsafe {
+                    com_call!(
+                        IErrorInfo_Vtbl,
+                        info.GetDescription(&mut message as *mut _ as _)
+                    );
+                }
+            }
+
+            if message.is_empty() {
+                return None;
+            }
+
+            Some(String::from_utf16_lossy(crate::strings::wide_trim_end(
+                message.as_wide(),
+            )))
+        }
+    }
+}
+
+impl<Detail: ErrorDetail> ErrorT<Detail> {
     /// Creates an error object without any failure information.
-    pub const fn empty() -> Self {
+    pub fn empty() -> Self {
         Self {
-            code: HRESULT(0),
-            #[cfg(windows)]
-            info: None,
+            code: NonZeroHRESULT::E_FAIL,
+            detail: Detail::empty(),
         }
     }
 
     /// Creates a new error object, capturing the stack and other information about the
     /// point of failure.
     pub fn new<T: AsRef<str>>(code: HRESULT, message: T) -> Self {
-        #[cfg(windows)]
-        {
-            let message: Vec<_> = message.as_ref().encode_utf16().collect();
-            if message.is_empty() {
-                Self::from_hresult(code)
-            } else {
-                unsafe {
-                    RoOriginateErrorW(code.0, message.len() as u32, message.as_ptr());
-                }
-                code.into()
-            }
-        }
-        #[cfg(not(windows))]
-        {
-            let _ = message;
-            Self::from_hresult(code)
-        }
+        Detail::originate_error(code, message.as_ref());
+        // This into() call will take the ambient thread-local error object, if any.
+        Self::from(code)
     }
 
     /// Creates a new error object with an error code, but without additional error information.
     pub fn from_hresult(code: HRESULT) -> Self {
         Self {
-            code,
-            #[cfg(windows)]
-            info: None,
+            code: NonZeroHRESULT::from_hresult_or_fail(code),
+            detail: Detail::empty(),
         }
     }
 
@@ -54,10 +247,8 @@ impl Error {
     pub fn from_win32() -> Self {
         #[cfg(windows)]
         {
-            Self {
-                code: HRESULT::from_win32(unsafe { GetLastError() }),
-                info: None,
-            }
+            let hr = HRESULT::from_win32(unsafe { GetLastError() });
+            Self::from_hresult(hr)
         }
         #[cfg(not(windows))]
         {
@@ -67,107 +258,64 @@ impl Error {
 
     /// The error code describing the error.
     pub const fn code(&self) -> HRESULT {
-        self.code
+        self.code.to_hresult()
     }
 
     /// The error message describing the error.
     pub fn message(&self) -> String {
-        #[cfg(windows)]
-        {
-            if let Some(info) = &self.info {
-                let mut message = BasicString::default();
-
-                // First attempt to retrieve the restricted error information.
-                if let Some(info) = info.cast(&IID_IRestrictedErrorInfo) {
-                    let mut fallback = BasicString::default();
-                    let mut code = 0;
-
-                    unsafe {
-                        com_call!(
-                            IRestrictedErrorInfo_Vtbl,
-                            info.GetErrorDetails(
-                                &mut fallback as *mut _ as _,
-                                &mut code,
-                                &mut message as *mut _ as _,
-                                &mut BasicString::default() as *mut _ as _
-                            )
-                        );
-                    }
-
-                    if message.is_empty() {
-                        message = fallback
-                    };
-                }
-
-                // Next attempt to retrieve the regular error information.
-                if message.is_empty() {
-                    unsafe {
-                        com_call!(
-                            IErrorInfo_Vtbl,
-                            info.GetDescription(&mut message as *mut _ as _)
-                        );
-                    }
-                }
-
-                return String::from_utf16_lossy(wide_trim_end(message.as_wide()));
-            }
+        if let Some(message) = self.detail.message() {
+            return message;
         }
 
         // Otherwise fallback to a generic error code description.
         self.code.message()
     }
 
+    /// Gets access to the error detail stored in this `Error`.
+    pub fn detail(&self) -> &Detail {
+        &self.detail
+    }
+
+    /*
     /// The error object describing the error.
-    #[cfg(windows)]
-    pub fn as_ptr(&self) -> *mut c_void {
+    #[cfg(all(windows, feature = "error-info"))]
+    pub fn as_ptr(&self) -> *mut core::ffi::c_void {
         self.info
+            .ptr
             .as_ref()
             .map_or(core::ptr::null_mut(), |info| info.as_raw())
     }
+    */
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {}
-unsafe impl Send for Error {}
-unsafe impl Sync for Error {}
+impl<Detail: ErrorDetail> std::error::Error for ErrorT<Detail> {}
 
-impl From<Error> for HRESULT {
-    fn from(error: Error) -> Self {
-        #[cfg(windows)]
-        {
-            if let Some(info) = error.info {
-                unsafe {
-                    SetErrorInfo(0, info.as_raw());
-                }
-            }
-        }
-        error.code
+impl<Detail: ErrorDetail> From<ErrorT<Detail>> for HRESULT {
+    fn from(error: ErrorT<Detail>) -> Self {
+        error.detail.into_ambient();
+        error.code.into()
     }
 }
 
-impl From<HRESULT> for Error {
+impl<Detail: ErrorDetail> From<HRESULT> for ErrorT<Detail> {
     fn from(code: HRESULT) -> Self {
         Self {
-            code,
-            #[cfg(windows)]
-            info: {
-                let mut info = None;
-                unsafe { GetErrorInfo(0, &mut info as *mut _ as _) };
-                info
-            },
+            code: NonZeroHRESULT::from_hresult_or_fail(code),
+            detail: Detail::from_ambient(),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl From<Error> for std::io::Error {
-    fn from(from: Error) -> Self {
-        Self::from_raw_os_error(from.code.0)
+impl<Detail: ErrorDetail> From<ErrorT<Detail>> for std::io::Error {
+    fn from(from: ErrorT<Detail>) -> Self {
+        Self::from_raw_os_error(from.code.0.get())
     }
 }
 
 #[cfg(feature = "std")]
-impl From<std::io::Error> for Error {
+impl<Detail: ErrorDetail> From<std::io::Error> for ErrorT<Detail> {
     fn from(from: std::io::Error) -> Self {
         match from.raw_os_error() {
             Some(status) => HRESULT::from_win32(status as u32).into(),
@@ -176,37 +324,25 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<alloc::string::FromUtf16Error> for Error {
+impl<Detail: ErrorDetail> From<alloc::string::FromUtf16Error> for ErrorT<Detail> {
     fn from(_: alloc::string::FromUtf16Error) -> Self {
-        Self {
-            code: HRESULT::from_win32(ERROR_NO_UNICODE_TRANSLATION),
-            #[cfg(windows)]
-            info: None,
-        }
+        Self::from_hresult(HRESULT::from_win32(ERROR_NO_UNICODE_TRANSLATION))
     }
 }
 
-impl From<alloc::string::FromUtf8Error> for Error {
+impl<Detail: ErrorDetail> From<alloc::string::FromUtf8Error> for ErrorT<Detail> {
     fn from(_: alloc::string::FromUtf8Error) -> Self {
-        Self {
-            code: HRESULT::from_win32(ERROR_NO_UNICODE_TRANSLATION),
-            #[cfg(windows)]
-            info: None,
-        }
+        Self::from_hresult(HRESULT::from_win32(ERROR_NO_UNICODE_TRANSLATION))
     }
 }
 
-impl From<core::num::TryFromIntError> for Error {
+impl<Detail: ErrorDetail> From<core::num::TryFromIntError> for ErrorT<Detail> {
     fn from(_: core::num::TryFromIntError) -> Self {
-        Self {
-            code: HRESULT::from_win32(ERROR_INVALID_DATA),
-            #[cfg(windows)]
-            info: None,
-        }
+        Self::from_hresult(HRESULT::from_win32(ERROR_INVALID_DATA))
     }
 }
 
-impl core::fmt::Debug for Error {
+impl<Detail: ErrorDetail> core::fmt::Debug for ErrorT<Detail> {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut debug = fmt.debug_struct("Error");
         debug
@@ -216,7 +352,7 @@ impl core::fmt::Debug for Error {
     }
 }
 
-impl core::fmt::Display for Error {
+impl<Detail: ErrorDetail> core::fmt::Display for ErrorT<Detail> {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let message = self.message();
         if message.is_empty() {
@@ -226,3 +362,21 @@ impl core::fmt::Display for Error {
         }
     }
 }
+
+// Equality tests only the HRESULT, not the error info (if any).
+impl<Detail: ErrorDetail> PartialEq for ErrorT<Detail> {
+    fn eq(&self, other: &Self) -> bool {
+        self.code == other.code
+    }
+}
+
+impl<Detail: ErrorDetail> Eq for ErrorT<Detail> {}
+
+// If we are using "slim" Error objects, then we can rely on Result<()>
+// having a representation that is equivalent to HRESULT.
+static_assertions::const_assert_eq!(
+    size_of::<core::result::Result<(), ErrorT<NoDetail>>>(),
+    size_of::<HRESULT>()
+);
+
+static_assertions::assert_impl_all!(Error: Send, Sync);

--- a/crates/libs/result/src/hresult.rs
+++ b/crates/libs/result/src/hresult.rs
@@ -219,13 +219,13 @@ impl NonZeroHRESULT {
     pub fn ok(self) -> Result<()> {
         // SAFETY: We use a static assertion to check that the size of these two types are identical.
         // Since there is only one possible niche, that niche must be used for the Ok(()) value.
-        #[cfg(not(all(windows, feature = "error-info")))]
+        #[cfg(any(feature = "slim-error", not(windows)))]
         unsafe {
             core::mem::transmute(self)
         }
 
         // If we are not using slim Error, then we take the slow path.
-        #[cfg(all(windows, feature = "error-info"))]
+        #[cfg(not(any(feature = "slim-error", not(windows))))]
         HRESULT::from(self).ok()
     }
 

--- a/crates/libs/result/src/hresult.rs
+++ b/crates/libs/result/src/hresult.rs
@@ -1,8 +1,11 @@
 use super::*;
+use core::mem::size_of;
+use core::num::NonZeroI32;
+use static_assertions::const_assert_eq;
 
 /// An error code value returned by most COM functions.
 #[repr(transparent)]
-#[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[must_use]
 #[allow(non_camel_case_types)]
 pub struct HRESULT(pub i32);
@@ -63,10 +66,10 @@ impl HRESULT {
     }
 
     /// The error message describing the error.
-    pub fn message(&self) -> String {
+    pub fn message(self) -> String {
         #[cfg(windows)]
         {
-            let mut message = HeapString::default();
+            let mut message = crate::strings::HeapString::default();
             let mut code = self.0;
             let mut module = core::ptr::null_mut();
 
@@ -97,10 +100,8 @@ impl HRESULT {
                 );
 
                 if !message.0.is_null() && size > 0 {
-                    String::from_utf16_lossy(wide_trim_end(core::slice::from_raw_parts(
-                        message.0,
-                        size as usize,
-                    )))
+                    let message_slice = core::slice::from_raw_parts(message.0, size as usize);
+                    String::from_utf16_lossy(crate::strings::wide_trim_end(message_slice))
                 } else {
                     String::default()
                 }
@@ -150,5 +151,163 @@ impl core::fmt::Display for HRESULT {
 impl core::fmt::Debug for HRESULT {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!("HRESULT({})", self))
+    }
+}
+
+impl core::fmt::Display for NonZeroHRESULT {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        <HRESULT as core::fmt::Display>::fmt(&HRESULT::from(*self), f)
+    }
+}
+
+impl core::fmt::Debug for NonZeroHRESULT {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        <HRESULT as core::fmt::Debug>::fmt(&HRESULT::from(*self), f)
+    }
+}
+
+/// An error code value returned by most COM functions.
+///
+/// This type cannot represent `S_OK`. This type is intended for use with either
+/// `Option` or `Result` so that the unused 0 bit pattern can be used as a "niche",
+/// which allows `Option` and `Result` to use the bit pattern and conserve space.
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[must_use]
+#[allow(non_camel_case_types)]
+pub struct NonZeroHRESULT(pub NonZeroI32);
+
+const_assert_eq!(size_of::<NonZeroHRESULT>(), size_of::<HRESULT>());
+
+// Check the Option niche optimization.
+const_assert_eq!(size_of::<Option<NonZeroHRESULT>>(), size_of::<HRESULT>());
+
+// Check the Result niche optimization.
+const_assert_eq!(
+    size_of::<core::result::Result<(), NonZeroHRESULT>>(),
+    size_of::<HRESULT>()
+);
+
+impl NonZeroHRESULT {
+    /// Returns [`true`] if `self` is a success code.
+    ///
+    /// Although `NonZeroHRESULT` cannot represent `S_OK`, it can represent other success values
+    /// such as `S_FALSE`.
+    #[inline]
+    pub const fn is_ok(self) -> bool {
+        self.0.get() >= 0
+    }
+
+    /// Returns [`true`] if `self` is a failure code.
+    #[inline]
+    pub const fn is_err(self) -> bool {
+        self.0.get() < 0
+    }
+
+    /// Asserts that `self` is a success code.
+    ///
+    /// This will invoke the [`panic!`] macro if `self` is a failure code and display
+    /// the [`HRESULT`] value for diagnostics.
+    #[inline]
+    #[track_caller]
+    pub fn unwrap(self) {
+        assert!(self.is_ok(), "HRESULT 0x{:X}", self.0.get());
+    }
+
+    /// Converts the [`HRESULT`] to [`Result<()>`][Result<_>].
+    #[inline]
+    pub fn ok(self) -> Result<()> {
+        // SAFETY: We use a static assertion to check that the size of these two types are identical.
+        // Since there is only one possible niche, that niche must be used for the Ok(()) value.
+        #[cfg(not(all(windows, feature = "error-info")))]
+        unsafe {
+            core::mem::transmute(self)
+        }
+
+        // If we are not using slim Error, then we take the slow path.
+        #[cfg(all(windows, feature = "error-info"))]
+        HRESULT::from(self).ok()
+    }
+
+    /// Calls `op` if `self` is a success code, otherwise returns [`HRESULT`]
+    /// converted to [`Result<T>`].
+    #[inline]
+    pub fn map<F, T>(self, op: F) -> Result<T>
+    where
+        F: FnOnce() -> T,
+    {
+        self.ok()?;
+        Ok(op())
+    }
+
+    /// Calls `op` if `self` is a success code, otherwise returns [`HRESULT`]
+    /// converted to [`Result<T>`].
+    #[inline]
+    pub fn and_then<F, T>(self, op: F) -> Result<T>
+    where
+        F: FnOnce() -> Result<T>,
+    {
+        self.ok()?;
+        op()
+    }
+
+    /// The error message describing the error.
+    pub fn message(self) -> String {
+        HRESULT::from(self).message()
+    }
+
+    /// Converts `hr` to `NonZeroHRESULT`. If `hr` is `S_OK` (zero), then this returns `None`.
+    pub const fn from_hresult_opt(hr: HRESULT) -> Option<Self> {
+        // SAFETY: The niche optimization is guaranteed for Option<NonZeroI32>. This transmute
+        // exploits the same niche optimization, only for an HRESULT that wraps an i32.
+        unsafe { core::mem::transmute(hr) }
+    }
+
+    /// Converts `HRESULT` to `NonZeroHRESULT`.
+    ///
+    /// This is intended only for use in constant declarations. This will panic if `error` is 0.
+    pub const fn from_hresult_unwrap(hr: HRESULT) -> Self {
+        if let Some(nz) = NonZeroI32::new(hr.0) {
+            Self(nz)
+        } else {
+            panic!("`hr` cannot be S_OK (zero)");
+        }
+    }
+
+    /// The well-known `E_FAIL` constant.
+    pub const E_FAIL: NonZeroHRESULT = Self::from_hresult_unwrap(HRESULT(0x80004005_u32 as i32));
+
+    /// Converts `hr` to `NonZeroHRESULT`. If `hr` is `S_OK`, then this returns `E_FAIL`.
+    pub const fn from_hresult_or_fail(hr: HRESULT) -> Self {
+        if let Some(nz) = NonZeroI32::new(hr.0) {
+            Self(nz)
+        } else {
+            Self::E_FAIL
+        }
+    }
+
+    /// Maps a Win32 error code to a NonZeroHRESULT value. If `error` is 0, then this will
+    /// return `E_FAIL`.
+    pub const fn from_win32(error: u32) -> Self {
+        Self::from_hresult_or_fail(HRESULT::from_win32(error))
+    }
+
+    /// Maps an NT error code to an HRESULT value.
+    ///
+    /// This is intended only for use in constant declarations. If `error` is 0, then this will
+    /// return `E_FAIL`.
+    pub const fn from_nt(error: i32) -> Self {
+        Self::from_hresult_or_fail(HRESULT::from_nt(error))
+    }
+
+    /// Converts this `NonZeroHRESULT` to an `HRESULT`. This is usable in `const fn`.
+    pub const fn to_hresult(self) -> HRESULT {
+        HRESULT(self.0.get())
+    }
+}
+
+impl From<NonZeroHRESULT> for HRESULT {
+    fn from(hr: NonZeroHRESULT) -> Self {
+        Self(hr.0.get())
     }
 }

--- a/crates/libs/result/src/lib.rs
+++ b/crates/libs/result/src/lib.rs
@@ -11,27 +11,29 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 extern crate alloc;
 
-use alloc::string::String;
-use alloc::vec::Vec;
+#[allow(unused_imports)]
+use alloc::{string::String, vec::Vec};
 
 mod bindings;
 use bindings::*;
 
 #[cfg(windows)]
 mod com;
-#[cfg(windows)]
-use com::*;
 
 #[cfg(windows)]
 mod strings;
-#[cfg(windows)]
-use strings::*;
+
+#[cfg(all(windows, feature = "error-info"))]
+mod bstr;
 
 mod error;
-pub use error::Error;
+pub use error::*;
 
 mod hresult;
-pub use hresult::HRESULT;
+pub use hresult::{NonZeroHRESULT, HRESULT};
 
 /// A specialized [`Result`] type that provides Windows error information.
 pub type Result<T> = core::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests;

--- a/crates/libs/result/src/lib.rs
+++ b/crates/libs/result/src/lib.rs
@@ -23,7 +23,7 @@ mod com;
 #[cfg(windows)]
 mod strings;
 
-#[cfg(all(windows, feature = "error-info"))]
+#[cfg(windows)]
 mod bstr;
 
 mod error;

--- a/crates/libs/result/src/strings.rs
+++ b/crates/libs/result/src/strings.rs
@@ -18,55 +18,6 @@ impl Drop for HeapString {
     }
 }
 
-#[repr(transparent)]
-pub struct BasicString(*const u16);
-
-impl BasicString {
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn len(&self) -> usize {
-        if self.0.is_null() {
-            0
-        } else {
-            unsafe { SysStringLen(self.0) as usize }
-        }
-    }
-
-    pub fn as_wide(&self) -> &[u16] {
-        let len = self.len();
-        if len != 0 {
-            unsafe { core::slice::from_raw_parts(self.as_ptr(), len) }
-        } else {
-            &[]
-        }
-    }
-
-    pub fn as_ptr(&self) -> *const u16 {
-        if !self.is_empty() {
-            self.0
-        } else {
-            const EMPTY: [u16; 1] = [0];
-            EMPTY.as_ptr()
-        }
-    }
-}
-
-impl Default for BasicString {
-    fn default() -> Self {
-        Self(core::ptr::null_mut())
-    }
-}
-
-impl Drop for BasicString {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            unsafe { SysFreeString(self.0) }
-        }
-    }
-}
-
 pub fn wide_trim_end(mut wide: &[u16]) -> &[u16] {
     while let Some(last) = wide.last() {
         match last {

--- a/crates/libs/result/src/tests.rs
+++ b/crates/libs/result/src/tests.rs
@@ -1,0 +1,18 @@
+use crate::*;
+
+#[test]
+fn show_sizes() {
+    use core::mem::size_of;
+
+    macro_rules! show_size {
+        ($t:ty) => {
+            println!("size_of {} = {}", stringify!($t), size_of::<$t>());
+        };
+    }
+
+    println!("sizes:");
+    show_size!(Error);
+    show_size!(Result<()>);
+    show_size!(Result<u32>);
+    show_size!(Result<String>);
+}

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -36,6 +36,7 @@ docs = []
 deprecated = []
 implement = []
 std = ["windows-core/std"]
+slim-errors = ["windows-core/slim-errors"]
 # generated features
 AI = ["Foundation"]
 AI_MachineLearning = ["AI"]

--- a/crates/tests/core/tests/error.rs
+++ b/crates/tests/core/tests/error.rs
@@ -67,5 +67,5 @@ fn suppressed_error_info() -> Result<()> {
 fn just_hresult() {
     let e: Error = E_NOTIMPL.into();
     assert!(e.code() == E_NOTIMPL);
-    assert!(e.as_ptr().is_null());
+    assert!(e.detail().as_ptr().is_null());
 }

--- a/crates/tests/implement/tests/data_object.rs
+++ b/crates/tests/implement/tests/data_object.rs
@@ -99,7 +99,7 @@ fn test() -> Result<()> {
         let r = d.EnumFormatEtc(0);
         assert!(r.is_err());
         let e = r.unwrap_err();
-        assert!(e.code() == S_OK);
+        assert!(e.code() == E_FAIL);
         assert!(e.detail().as_ptr().is_null());
 
         d.DAdvise(&Default::default(), 0, None)?;

--- a/crates/tests/implement/tests/data_object.rs
+++ b/crates/tests/implement/tests/data_object.rs
@@ -100,7 +100,7 @@ fn test() -> Result<()> {
         assert!(r.is_err());
         let e = r.unwrap_err();
         assert!(e.code() == S_OK);
-        assert!(e.as_ptr().is_null());
+        assert!(e.detail().as_ptr().is_null());
 
         d.DAdvise(&Default::default(), 0, None)?;
 

--- a/crates/tests/implement/tests/vector.rs
+++ b/crates/tests/implement/tests/vector.rs
@@ -184,7 +184,7 @@ fn GetAt() -> Result<()> {
     ])
     .into();
     assert_eq!(v.GetAt(0)?.ToString()?, "http://test/");
-    assert_eq!(v.GetAt(1).unwrap_err().code(), S_OK);
+    assert_eq!(v.GetAt(1).unwrap_err().code(), E_FAIL);
 
     Ok(())
 }

--- a/crates/tests/result/tests/error.rs
+++ b/crates/tests/result/tests/error.rs
@@ -1,7 +1,7 @@
 use windows_result::*;
 
-const S_OK: HRESULT = HRESULT(0);
 const E_INVALIDARG: HRESULT = HRESULT(-2147024809i32);
+const E_FAIL: HRESULT = HRESULT(0x80004005_u32 as i32);
 const ERROR_CANCELLED: u32 = 1223;
 const ERROR_INVALID_DATA: u32 = 13;
 const E_CANCELLED: HRESULT = HRESULT::from_win32(ERROR_CANCELLED);
@@ -10,21 +10,22 @@ windows_targets::link!("kernel32.dll" "system" fn SetLastError(code: u32));
 
 #[test]
 fn empty() {
-    const EMPTY: Error = Error::empty();
-    assert_eq!(EMPTY.code(), S_OK);
-    assert!(EMPTY.as_ptr().is_null());
-    assert_eq!(EMPTY.message(), "The operation completed successfully.");
+    let e: Error = Error::empty();
+    assert_eq!(e.code(), E_FAIL);
+    assert!(e.detail().as_ptr().is_null());
+    assert_eq!(e.message(), "Unspecified error");
 }
 
 #[test]
 fn new() {
     let e = Error::new(E_INVALIDARG, "");
     assert_eq!(e.code(), E_INVALIDARG);
-    assert!(e.as_ptr().is_null());
+    assert!(e.detail().as_ptr().is_null());
+    assert_eq!(e.message(), "The parameter is incorrect.");
 
     let e = Error::new(E_INVALIDARG, "test message");
     assert_eq!(e.code(), E_INVALIDARG);
-    assert!(!e.as_ptr().is_null());
+    assert!(!e.detail().as_ptr().is_null());
     assert_eq!(e.message(), "test message");
 }
 
@@ -32,7 +33,7 @@ fn new() {
 fn from_hresult() {
     let e = Error::from_hresult(E_INVALIDARG);
     assert_eq!(e.code(), E_INVALIDARG);
-    assert!(e.as_ptr().is_null());
+    assert!(e.detail().as_ptr().is_null());
     assert_eq!(e.message(), "The parameter is incorrect.");
 }
 
@@ -41,13 +42,13 @@ fn from_win32() {
     unsafe { SetLastError(0) };
 
     let e = Error::from_win32();
-    assert_eq!(e.code(), S_OK);
-    assert!(e.as_ptr().is_null());
+    assert_eq!(e.code(), E_FAIL);
+    assert!(e.detail().as_ptr().is_null());
 
     unsafe { SetLastError(ERROR_CANCELLED) };
 
     let e = Error::from_win32();
-    assert!(e.as_ptr().is_null());
+    assert!(e.detail().as_ptr().is_null());
     assert_eq!(e.code(), E_CANCELLED);
 }
 


### PR DESCRIPTION
Many codebases use `HRESULT` (whether they use COM or not) and yet never use `IErrorInfo`. For those codebases, the size of the `Result<()>` object can be a substantial cost.  Currently on 64-bit platforms, `size_of<Result<()>>` is 16 bytes, when ideally it would be basically a smartly-typed version of `HRESULT`.  For example, Direct3D, DirectWrite, etc. never use `IErrorInfo` (they don't set any error info objects on failures), so all of the code that uses these codebases will suffer in performance.

This PR allows you to statically disable the error info within `Error`, by enabling the `slim-errors` feature in the `windows-result` crate.  (The `windows` and `windows-core` crates will also propagate the feature to `windows-result`, so that you don't need to add an extra crate dependency.)

The performance costs come from the larger code and larger stack area needed.  There is also a significant penalty because `IErrorInfo` requires that the `Error` object have a `Drop` implementation. This requires the compiler to precisely track the lifetime of `Error` values and even of the `Result<()>` value.  This adds a lot of extra code that almost never runs, to many function bodies.

This PR also adds a new `NonZeroHRESULT`, which is equivalent to `HRESULT` except that it contains a `NonZeroI32`, not an `i32`. This means that it cannot represent `S_OK`, which is fine.  This gives the Rust compiler a "niche", which is a byte pattern that cannot be represented by one variant of an enum, which frees up that byte pattern for a different variant or for enum's "tag".  In our case, the compiler will generate type layouts for `Option<NonZeroHRESULT>` and `Result<(), NonZeroHRESULT>` that are the same size and alignment as the underlying `HRESULT`.  This is great because it allows them to be stored in a single register, and in many situations the compiler can totally avoid type layout conversions and can produce much better code.

The `Error` type now uses `NonZeroHRESULT`.  When the `slim-errors` feature is enabled, `size_of::<Error>() == 4` and `size_of::<Result<()>>() == 4`.  Before this change, `size_of::<Error>() == 16` and `size_of::<Result<()>>() == 24`.

This PR improves these types even when not using `slim-errors`.  After this PR, with `slim-errors` disabled, `size_of::<Result<()>>() == 16`, 8 bytes less, because of the niche optimization relating to `NonZeroHRESULT`.