### PR TITLE
Add `ToUtf8String` and `ToUtf16String` extensions, as well as `From<String>` trait implementations for `PCSTR` and `PCWSTR`.

### DIFF
--- a/crates/libs/strings/src/lib.rs
+++ b/crates/libs/strings/src/lib.rs
@@ -47,6 +47,9 @@ pub use pstr::*;
 mod pwstr;
 pub use pwstr::*;
 
+mod traits;
+pub use traits::*;
+
 extern "C" {
     fn strlen(s: PCSTR) -> usize;
 }

--- a/crates/libs/strings/src/traits.rs
+++ b/crates/libs/strings/src/traits.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+pub trait ToWideString {
+    fn to_wide_string(&self) -> PCWSTR;
+}
+
+impl ToWideString for String {
+    fn to_wide_string(&self) -> PCWSTR {
+        w!(self)
+    }
+}
+
+impl From<String> for PCWSTR {
+    fn from(s: String) -> PCWSTR {
+        s.to_wide_string()
+    }
+}

--- a/crates/libs/strings/src/traits.rs
+++ b/crates/libs/strings/src/traits.rs
@@ -10,13 +10,13 @@ pub trait ToUtf16String {
 
 impl ToUtf8String for String {
     fn to_utf8_string(&self) -> PCSTR {
-        s!(self)
+        s!(self.as_str())
     }
 }
 
 impl ToUtf16String for String {
     fn to_utf16_string(&self) -> PCWSTR {
-        w!(self)
+        w!(self.as_str())
     }
 }
 

--- a/crates/libs/strings/src/traits.rs
+++ b/crates/libs/strings/src/traits.rs
@@ -1,17 +1,33 @@
 use super::*;
 
-pub trait ToWideString {
-    fn to_wide_string(&self) -> PCWSTR;
+pub trait ToUtf8String {
+    fn to_utf8_string(&self) -> PCSTR;
 }
 
-impl ToWideString for String {
-    fn to_wide_string(&self) -> PCWSTR {
+pub trait ToUtf16String {
+    fn to_utf16_string(&self) -> PCWSTR;
+}
+
+impl ToUtf8String for String {
+    fn to_utf8_string(&self) -> PCSTR {
+        s!(self)
+    }
+}
+
+impl ToUtf16String for String {
+    fn to_utf16_string(&self) -> PCWSTR {
         w!(self)
+    }
+}
+
+impl From<String> for PCSTR {
+    fn from(s: String) -> PCSTR {
+        s.to_utf8_string()
     }
 }
 
 impl From<String> for PCWSTR {
     fn from(s: String) -> PCWSTR {
-        s.to_wide_string()
+        s.to_utf16_string()
     }
 }


### PR DESCRIPTION
This update adds two extension traits and `From<String>` implementations for `PCSTR`/`PCWSTR`.

```rust
use windows::core::{ToUtf8String, ToUtf16String, PCSTR, PCWSTR};

fn main() {
    let source_string = "Hello, World!".to_string();

    let utf8_string = source_string.clone().to_utf8_string();
    let utf16_string = source_string.clone().to_utf16_string();
    
    // Also
    let utf8_string = PCSTR::from(source_string.clone());
    let utf16_string = PCWSTR::from(source_string.clone());
}
```