### PR TITLE
Clarify support for non-Windows targets

### DIFF
--- a/crates/libs/core/src/imp/factory_cache.rs
+++ b/crates/libs/core/src/imp/factory_cache.rs
@@ -127,7 +127,7 @@ where
     F: FnMut(crate::PCSTR) -> crate::Result<R>,
 {
     let suffix = b".dll\0";
-    let mut library = vec![0; path.len() + suffix.len()];
+    let mut library = alloc::vec![0; path.len() + suffix.len()];
     while let Some(pos) = path.rfind('.') {
         path = &path[..pos];
         library.truncate(path.len() + suffix.len());

--- a/crates/libs/core/src/imp/mod.rs
+++ b/crates/libs/core/src/imp/mod.rs
@@ -1,21 +1,16 @@
-mod bindings;
+#[cfg(windows)]
+include!("windows.rs");
+
 mod can_into;
 mod com_bindings;
-mod factory_cache;
-mod generic_factory;
 mod ref_count;
 mod sha1;
-mod waiter;
 mod weak_ref_count;
 
-pub use bindings::*;
 pub use can_into::*;
 pub use com_bindings::*;
-pub use factory_cache::*;
-pub use generic_factory::*;
 pub use ref_count::*;
 pub use sha1::*;
-pub use waiter::*;
 pub use weak_ref_count::*;
 
 #[doc(hidden)]

--- a/crates/libs/core/src/imp/windows.rs
+++ b/crates/libs/core/src/imp/windows.rs
@@ -1,0 +1,11 @@
+mod factory_cache;
+pub use factory_cache::*;
+
+mod generic_factory;
+pub use generic_factory::*;
+
+mod waiter;
+pub use waiter::*;
+
+mod bindings;
+pub use bindings::*;

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -10,9 +10,11 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 )]
 #![cfg_attr(all(not(feature = "std")), no_std)]
 
+#[cfg(windows)]
+include!("windows.rs");
+
 extern crate self as windows_core;
 
-#[macro_use]
 extern crate alloc;
 
 use alloc::boxed::Box;
@@ -20,14 +22,9 @@ use alloc::boxed::Box;
 #[doc(hidden)]
 pub mod imp;
 
-mod agile_reference;
-mod array;
 mod as_impl;
 mod com_object;
-#[cfg(feature = "std")]
-mod event;
 mod guid;
-mod handles;
 mod inspectable;
 mod interface;
 mod out_param;
@@ -40,17 +37,11 @@ mod runtime_type;
 mod scoped_interface;
 mod r#type;
 mod unknown;
-mod variant;
 mod weak;
 
-pub use agile_reference::*;
-pub use array::*;
 pub use as_impl::*;
 pub use com_object::*;
-#[cfg(feature = "std")]
-pub use event::*;
 pub use guid::*;
-pub use handles::*;
 pub use inspectable::*;
 pub use interface::*;
 pub use out_param::*;
@@ -63,15 +54,8 @@ pub use runtime_name::*;
 pub use runtime_type::*;
 pub use scoped_interface::*;
 pub use unknown::*;
-pub use variant::*;
 pub use weak::*;
 pub use windows_implement::implement;
 pub use windows_interface::interface;
 pub use windows_result::*;
 pub use windows_strings::*;
-
-/// Attempts to load the factory object for the given WinRT class.
-/// This can be used to access COM interfaces implemented on a Windows Runtime class factory.
-pub fn factory<C: RuntimeName, I: Interface>() -> Result<I> {
-    imp::factory::<C, I>()
-}

--- a/crates/libs/core/src/windows.rs
+++ b/crates/libs/core/src/windows.rs
@@ -1,0 +1,22 @@
+mod agile_reference;
+pub use agile_reference::*;
+
+mod array;
+pub use array::*;
+
+#[cfg(feature = "std")]
+mod event;
+#[cfg(feature = "std")]
+pub use event::*;
+
+mod handles;
+pub use handles::*;
+
+mod variant;
+pub use variant::*;
+
+/// Attempts to load the factory object for the given WinRT class.
+/// This can be used to access COM interfaces implemented on a Windows Runtime class factory.
+pub fn factory<C: RuntimeName, I: Interface>() -> Result<I> {
+    imp::factory::<C, I>()
+}

--- a/crates/libs/cppwinrt/src/lib.rs
+++ b/crates/libs/cppwinrt/src/lib.rs
@@ -2,6 +2,8 @@
 Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs>
 */
 
+#![cfg(windows)]
+
 const VERSION: &str = "2.0.240405.15";
 
 /// Calls the C++/WinRT compiler with the given arguments.

--- a/crates/libs/registry/src/lib.rs
+++ b/crates/libs/registry/src/lib.rs
@@ -2,6 +2,7 @@
 Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs>
 */
 
+#![cfg(windows)]
 #![no_std]
 
 #[macro_use]

--- a/crates/libs/version/src/lib.rs
+++ b/crates/libs/version/src/lib.rs
@@ -2,6 +2,7 @@
 Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs>
 */
 
+#![cfg(windows)]
 #![cfg_attr(not(test), no_std)]
 
 mod bindings;


### PR DESCRIPTION
The windows-rs project is focused on bringing the best of Windows to Rust developers. Various efforts to support non-Windows targets continue to make it too difficult to support Windows, which is the whole point of this project. 

The position we're taking is to provide basic non-Windows compatibility for `windows-core` only to support COM and nothing more. Even this adds regrettable complexity to the `windows-core` crate, but this update at least attempts to make that complexity manageable by providing a simple way for us to partition what parts of `windows-core` is specific to Windows and what is cross-platform. Subsequent updates will limit more of the code that isn't required for COM support.

The [test_linux](https://github.com/microsoft/windows-rs/tree/master/crates/tests/linux) crate covers what little support we offer for non-Windows targets. This is limited to `windows-core` and `windows-result` and is tested in [linux.yml](https://github.com/microsoft/windows-rs/blob/master/.github/workflows/linux.yml) as part of each build. 

Fixes: #3101
Fixes: #3083
Related: #3125