### PR TITLE
Implement `Send` and `Sync` for `Weak<T>`

### DIFF
--- a/crates/libs/core/src/weak.rs
+++ b/crates/libs/core/src/weak.rs
@@ -23,3 +23,6 @@ impl<I: Interface> Weak<I> {
         Ok(Self(reference, PhantomData))
     }
 }
+
+unsafe impl<I: Interface> Send for Weak<I> {}
+unsafe impl<I: Interface> Sync for Weak<I> {}


### PR DESCRIPTION
`IWeakReference` and `IWeakReferenceSource` are designed and implemented to be completely thread safe. 

Fixes: #3137