### PR TITLE
Make new `windows-strings` crate Windows-only

### DIFF
--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -58,4 +58,3 @@ pub use weak::*;
 pub use windows_implement::implement;
 pub use windows_interface::interface;
 pub use windows_result::*;
-pub use windows_strings::*;

--- a/crates/libs/core/src/param.rs
+++ b/crates/libs/core/src/param.rs
@@ -61,27 +61,3 @@ where
         ParamValue::Owned(transmute_copy(&self))
     }
 }
-
-impl Param<PCWSTR> for &BSTR {
-    unsafe fn param(self) -> ParamValue<PCWSTR> {
-        ParamValue::Owned(PCWSTR(self.as_ptr()))
-    }
-}
-
-impl Param<PCWSTR> for &HSTRING {
-    unsafe fn param(self) -> ParamValue<PCWSTR> {
-        ParamValue::Owned(PCWSTR(self.as_ptr()))
-    }
-}
-
-impl Param<PCWSTR> for PWSTR {
-    unsafe fn param(self) -> ParamValue<PCWSTR> {
-        ParamValue::Owned(PCWSTR(self.0))
-    }
-}
-
-impl Param<PCSTR> for PSTR {
-    unsafe fn param(self) -> ParamValue<PCSTR> {
-        ParamValue::Owned(PCSTR(self.0))
-    }
-}

--- a/crates/libs/core/src/runtime_type.rs
+++ b/crates/libs/core/src/runtime_type.rs
@@ -28,7 +28,3 @@ primitives! {
     (f32, b"f4"),
     (f64, b"f8")
 }
-
-impl RuntimeType for HSTRING {
-    const SIGNATURE: imp::ConstBuffer = imp::ConstBuffer::from_slice(b"string");
-}

--- a/crates/libs/core/src/type.rs
+++ b/crates/libs/core/src/type.rs
@@ -98,27 +98,3 @@ primitives!(bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, usize, isize);
 
 #[doc(hidden)]
 pub type AbiType<T> = <T as Type<T>>::Abi;
-
-impl TypeKind for PWSTR {
-    type TypeKind = CopyType;
-}
-
-impl TypeKind for PSTR {
-    type TypeKind = CopyType;
-}
-
-impl TypeKind for PCWSTR {
-    type TypeKind = CopyType;
-}
-
-impl TypeKind for PCSTR {
-    type TypeKind = CopyType;
-}
-
-impl TypeKind for HSTRING {
-    type TypeKind = CloneType;
-}
-
-impl TypeKind for BSTR {
-    type TypeKind = CloneType;
-}

--- a/crates/libs/core/src/windows.rs
+++ b/crates/libs/core/src/windows.rs
@@ -15,8 +15,62 @@ pub use handles::*;
 mod variant;
 pub use variant::*;
 
+pub use windows_strings::*;
+
 /// Attempts to load the factory object for the given WinRT class.
 /// This can be used to access COM interfaces implemented on a Windows Runtime class factory.
 pub fn factory<C: RuntimeName, I: Interface>() -> Result<I> {
     imp::factory::<C, I>()
+}
+
+impl Param<PCWSTR> for &BSTR {
+    unsafe fn param(self) -> ParamValue<PCWSTR> {
+        ParamValue::Owned(PCWSTR(self.as_ptr()))
+    }
+}
+
+impl Param<PCWSTR> for &HSTRING {
+    unsafe fn param(self) -> ParamValue<PCWSTR> {
+        ParamValue::Owned(PCWSTR(self.as_ptr()))
+    }
+}
+
+impl Param<PCWSTR> for PWSTR {
+    unsafe fn param(self) -> ParamValue<PCWSTR> {
+        ParamValue::Owned(PCWSTR(self.0))
+    }
+}
+
+impl Param<PCSTR> for PSTR {
+    unsafe fn param(self) -> ParamValue<PCSTR> {
+        ParamValue::Owned(PCSTR(self.0))
+    }
+}
+
+impl RuntimeType for HSTRING {
+    const SIGNATURE: imp::ConstBuffer = imp::ConstBuffer::from_slice(b"string");
+}
+
+impl TypeKind for PWSTR {
+    type TypeKind = CopyType;
+}
+
+impl TypeKind for PSTR {
+    type TypeKind = CopyType;
+}
+
+impl TypeKind for PCWSTR {
+    type TypeKind = CopyType;
+}
+
+impl TypeKind for PCSTR {
+    type TypeKind = CopyType;
+}
+
+impl TypeKind for HSTRING {
+    type TypeKind = CloneType;
+}
+
+impl TypeKind for BSTR {
+    type TypeKind = CloneType;
 }

--- a/crates/libs/strings/src/hstring.rs
+++ b/crates/libs/strings/src/hstring.rs
@@ -54,7 +54,7 @@ impl HSTRING {
     }
 
     /// Get the contents of this `HSTRING` as a OsString.
-    #[cfg(all(feature = "std", windows))]
+    #[cfg(feature = "std")]
     pub fn to_os_string(&self) -> std::ffi::OsString {
         std::os::windows::ffi::OsStringExt::from_wide(self.as_wide())
     }
@@ -154,14 +154,14 @@ impl From<&String> for HSTRING {
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl From<&std::path::Path> for HSTRING {
     fn from(value: &std::path::Path) -> Self {
         value.as_os_str().into()
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl From<&std::ffi::OsStr> for HSTRING {
     fn from(value: &std::ffi::OsStr) -> Self {
         unsafe {
@@ -174,14 +174,14 @@ impl From<&std::ffi::OsStr> for HSTRING {
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl From<std::ffi::OsString> for HSTRING {
     fn from(value: std::ffi::OsString) -> Self {
         value.as_os_str().into()
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl From<&std::ffi::OsString> for HSTRING {
     fn from(value: &std::ffi::OsString) -> Self {
         value.as_os_str().into()
@@ -286,28 +286,28 @@ impl PartialEq<&HSTRING> for String {
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<std::ffi::OsString> for HSTRING {
     fn eq(&self, other: &std::ffi::OsString) -> bool {
         *self == **other
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<std::ffi::OsString> for &HSTRING {
     fn eq(&self, other: &std::ffi::OsString) -> bool {
         **self == **other
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<&std::ffi::OsString> for HSTRING {
     fn eq(&self, other: &&std::ffi::OsString) -> bool {
         *self == ***other
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<std::ffi::OsStr> for HSTRING {
     fn eq(&self, other: &std::ffi::OsStr) -> bool {
         self.as_wide()
@@ -317,56 +317,56 @@ impl PartialEq<std::ffi::OsStr> for HSTRING {
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<std::ffi::OsStr> for &HSTRING {
     fn eq(&self, other: &std::ffi::OsStr) -> bool {
         **self == *other
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<&std::ffi::OsStr> for HSTRING {
     fn eq(&self, other: &&std::ffi::OsStr) -> bool {
         *self == **other
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<HSTRING> for std::ffi::OsStr {
     fn eq(&self, other: &HSTRING) -> bool {
         *other == *self
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<HSTRING> for &std::ffi::OsStr {
     fn eq(&self, other: &HSTRING) -> bool {
         *other == **self
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<&HSTRING> for std::ffi::OsStr {
     fn eq(&self, other: &&HSTRING) -> bool {
         **other == *self
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<HSTRING> for std::ffi::OsString {
     fn eq(&self, other: &HSTRING) -> bool {
         *other == **self
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<HSTRING> for &std::ffi::OsString {
     fn eq(&self, other: &HSTRING) -> bool {
         *other == ***self
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl PartialEq<&HSTRING> for std::ffi::OsString {
     fn eq(&self, other: &&HSTRING) -> bool {
         **other == **self
@@ -389,14 +389,14 @@ impl TryFrom<HSTRING> for String {
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl<'a> From<&'a HSTRING> for std::ffi::OsString {
     fn from(hstring: &HSTRING) -> Self {
         hstring.to_os_string()
     }
 }
 
-#[cfg(all(feature = "std", windows))]
+#[cfg(feature = "std")]
 impl From<HSTRING> for std::ffi::OsString {
     fn from(hstring: HSTRING) -> Self {
         Self::from(&hstring)

--- a/crates/libs/strings/src/hstring_header.rs
+++ b/crates/libs/strings/src/hstring_header.rs
@@ -23,18 +23,8 @@ impl HStringHeader {
         // The space for the terminating null character is already accounted for inside of `HStringHeader`.
         let bytes = core::mem::size_of::<Self>() + 2 * len as usize;
 
-        #[cfg(windows)]
         let header =
             unsafe { bindings::HeapAlloc(bindings::GetProcessHeap(), 0, bytes) } as *mut Self;
-
-        #[cfg(not(windows))]
-        let header = unsafe {
-            extern "C" {
-                fn malloc(bytes: usize) -> *mut core::ffi::c_void;
-            }
-
-            malloc(bytes) as *mut Self
-        };
 
         if header.is_null() {
             return Err(Error::from_hresult(HRESULT(bindings::E_OUTOFMEMORY)));
@@ -56,17 +46,7 @@ impl HStringHeader {
             return;
         }
 
-        #[cfg(windows)]
         bindings::HeapFree(bindings::GetProcessHeap(), 0, header as *mut _);
-
-        #[cfg(not(windows))]
-        {
-            extern "C" {
-                fn free(ptr: *mut core::ffi::c_void);
-            }
-
-            free(header as *mut _);
-        }
     }
 
     pub fn duplicate(&self) -> Result<*mut Self> {

--- a/crates/libs/strings/src/lib.rs
+++ b/crates/libs/strings/src/lib.rs
@@ -2,6 +2,7 @@
 Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs>
 */
 
+#![cfg(windows)]
 #![allow(non_snake_case)]
 #![cfg_attr(
     windows_debugger_visualizer,

--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -6,6 +6,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 [Feature search](https://microsoft.github.io/windows-rs/features/#/0.57.0)
 */
 
+#![cfg(windows)]
 #![doc(html_no_source)]
 #![allow(non_snake_case, clashing_extern_declarations, non_upper_case_globals, non_camel_case_types, missing_docs, clippy::all)]
 #![cfg_attr(not(feature = "docs"), doc(hidden))]


### PR DESCRIPTION
This is a new crate, and I don't want the headache of non-Windows compatibility right out of the gate. 

The only crates that continue to support limited non-Windows builds are:

* `windows-bindgen` and `windows-metadata` for code generation on non-Windows platforms.
* `windows-core` and `windows-result` for COM support on non-Windows platforms.
