### PR TITLE
Implement static COM objects

### DIFF
--- a/crates/libs/core/src/com_object.rs
+++ b/crates/libs/core/src/com_object.rs
@@ -343,7 +343,7 @@ impl<T: ComObjectInner> Borrow<T> for ComObject<T> {
 ///
 /// # Example
 ///
-/// ```rust,no_test
+/// ```rust,ignore
 /// #[implement(IFoo)]
 /// struct MyApp {
 ///     // ...

--- a/crates/libs/core/src/com_object.rs
+++ b/crates/libs/core/src/com_object.rs
@@ -330,3 +330,68 @@ impl<T: ComObjectInner> Borrow<T> for ComObject<T> {
         self.get()
     }
 }
+
+/// Enables applications to define COM objects using static storage. This is useful for factory
+/// objects, stateless objects, or objects which use need to contain or use mutable global state.
+///
+/// COM objects that are defined using `StaticComObject` have their storage placed directly in
+/// static storage; they are not stored in the heap.
+///
+/// COM objects defined using `StaticComObject` do have a reference count and this reference
+/// count is adjusted when owned COM interface references (e.g. `IFoo` and `IUnknown`) are created
+/// for the object. The reference count is initialized to 1.
+///
+/// # Example
+///
+/// ```rust,no_test
+/// #[implement(IFoo)]
+/// struct MyApp {
+///     // ...
+/// }
+///
+/// static MY_STATIC_APP: StaticComObject<MyApp> = MyApp { ... }.into_static();
+///
+/// fn get_my_static_ifoo() -> IFoo {
+///     MY_STATIC_APP.to_interface()
+/// }
+/// ```
+pub struct StaticComObject<T>
+where
+    T: ComObjectInner,
+{
+    outer: T::Outer,
+}
+
+// IMPORTANT: Do not expose any methods that return mutable access to the contents of StaticComObject.
+// Doing so would violate our safety invariants. For example, we provide a Deref impl but it would
+// be unsound to provide a DerefMut impl.
+impl<T> StaticComObject<T>
+where
+    T: ComObjectInner,
+{
+    /// Wraps `outer` in a `StaticComObject`.
+    pub const fn from_outer(outer: T::Outer) -> Self {
+        Self { outer }
+    }
+}
+
+impl<T> StaticComObject<T>
+where
+    T: ComObjectInner,
+{
+    /// Gets access to the contained value.
+    pub const fn get(&'static self) -> &'static T::Outer {
+        &self.outer
+    }
+}
+
+impl<T> core::ops::Deref for StaticComObject<T>
+where
+    T: ComObjectInner,
+{
+    type Target = T::Outer;
+
+    fn deref(&self) -> &Self::Target {
+        &self.outer
+    }
+}

--- a/crates/libs/core/src/imp/ref_count.rs
+++ b/crates/libs/core/src/imp/ref_count.rs
@@ -6,7 +6,7 @@ pub struct RefCount(pub(crate) AtomicI32);
 
 impl RefCount {
     /// Creates a new `RefCount` with an initial value of `1`.
-    pub fn new(count: u32) -> Self {
+    pub const fn new(count: u32) -> Self {
         Self(AtomicI32::new(count as i32))
     }
 

--- a/crates/libs/core/src/imp/weak_ref_count.rs
+++ b/crates/libs/core/src/imp/weak_ref_count.rs
@@ -10,7 +10,7 @@ use core::sync::atomic::{AtomicIsize, Ordering};
 pub struct WeakRefCount(AtomicIsize);
 
 impl WeakRefCount {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(AtomicIsize::new(1))
     }
 

--- a/crates/libs/core/src/weak.rs
+++ b/crates/libs/core/src/weak.rs
@@ -7,7 +7,7 @@ pub struct Weak<I: Interface>(Option<imp::IWeakReference>, PhantomData<I>);
 
 impl<I: Interface> Weak<I> {
     /// Creates a new `Weak` object without any backing object.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(None, PhantomData)
     }
 

--- a/crates/tests/implement_core/src/lib.rs
+++ b/crates/tests/implement_core/src/lib.rs
@@ -5,3 +5,4 @@
 
 mod com_chain;
 mod com_object;
+mod static_com_object;

--- a/crates/tests/implement_core/src/static_com_object.rs
+++ b/crates/tests/implement_core/src/static_com_object.rs
@@ -1,0 +1,77 @@
+//! Unit tests for `windows_core::StaticComObject`
+
+use std::sync::atomic::{AtomicU32, Ordering::SeqCst};
+use windows_core::{
+    implement, interface, ComObject, IUnknown, IUnknownImpl, IUnknown_Vtbl, InterfaceRef,
+    StaticComObject,
+};
+
+#[interface("818f2fd1-d479-4398-b286-a93c4c7904d1")]
+unsafe trait INumberFactory: IUnknown {
+    fn next(&self) -> u32;
+
+    fn add(&self, x: u32, y: u32) -> u32;
+}
+
+#[implement(INumberFactory)]
+struct MyFactory {
+    x: AtomicU32,
+}
+
+impl INumberFactory_Impl for MyFactory_Impl {
+    unsafe fn next(&self) -> u32 {
+        self.x.fetch_add(1, SeqCst)
+    }
+
+    unsafe fn add(&self, x: u32, y: u32) -> u32 {
+        x + y
+    }
+}
+
+static NUMBER_FACTORY_INSTANCE: StaticComObject<MyFactory> = MyFactory {
+    x: AtomicU32::new(100),
+}
+.into_static();
+
+#[test]
+fn as_interface() {
+    let factory_outer: &MyFactory_Impl = NUMBER_FACTORY_INSTANCE.get();
+    let ifactory: InterfaceRef<INumberFactory> = factory_outer.as_interface::<INumberFactory>();
+
+    // Produce the next number. We don't verify the value since tests are multi-threaded.
+    // This just demonstrates that you can have shared state with interior mutability (such as
+    // atomics) in a static COM object.
+    let n = unsafe { ifactory.next() };
+    println!("n = {n:?}");
+
+    assert_eq!(unsafe { ifactory.add(333, 444) }, 777);
+}
+
+// This tests that we can safely AddRef/Release a StaticComObject.
+#[test]
+fn to_interface() {
+    let factory_outer: &MyFactory_Impl = NUMBER_FACTORY_INSTANCE.get();
+    let ifactory: INumberFactory = factory_outer.to_interface::<INumberFactory>();
+    assert_eq!(unsafe { ifactory.add(333, 444) }, 777);
+    drop(ifactory);
+}
+
+#[test]
+fn to_object() {
+    let factory_outer: &MyFactory_Impl = NUMBER_FACTORY_INSTANCE.get();
+    let factory_object: ComObject<MyFactory> = factory_outer.to_object();
+    assert_eq!(unsafe { factory_object.add(333, 444) }, 777);
+}
+
+// This tests the behavior when dropping a StaticComObject. Since static variables are never
+// dropped, this isn't relevant to normal usage. However, if app code constructs a StaticComObject
+// in local variables (not statics) and them drops them, then we still need well-defined behavior.
+// Basically, we are testing that the refererence-count field does not panic when being dropped
+// with a non-zero reference count.
+#[test]
+fn drop_half_constructed() {
+    let _static_com_object: StaticComObject<MyFactory> = MyFactory {
+        x: AtomicU32::new(0),
+    }
+    .into_static();
+}


### PR DESCRIPTION
This allows you to define "static COM objects".  Static COM objects are COM objects that are stored in static fields.  This avoids the need for a separate heap allocation for stateless COM objects.  It also allows `const fn` initialization of static COM objects.

A static COM object is _not_ the same as a `ComObject<T>` stored in a static field.  `ComObject<T>` is a pointer, which owns 1 reference count, to an allocated COM object.  `StaticComObject<T>` _directly_ contains the COM object's data, its reference count, and its vtable pointers.

Just like `ComObject<T>`, `StaticComObject<T>` allows you to cast it to any interface chain or interface pointer, and even to create a `ComObject<T>` that points to the `StaticComObject<T>`. This is safe because creating the `ComObject<T>` increases the reference count of the static object; dropping the `ComObject<T>` decreases the reference count, but it will never reach zero so it will never be "freed" (which would be wrong).

This feature is intended to support and simplify apps that need to define factory objects and other stateless objects. There is no need to heap-allocate these objects. This also simplifies their initialization because we simply never need to run any initialization logic at all, so we eliminate "order of initialization" bugs.
