### PR TITLE
Update main.rs with `CoInitializeEx`

### DIFF
--- a/crates/samples/windows/com_uri/src/main.rs
+++ b/crates/samples/windows/com_uri/src/main.rs
@@ -3,6 +3,8 @@ use windows::Win32::System::Com::*;
 
 fn main() -> windows::core::Result<()> {
     unsafe {
+        CoInitializeEx(None, COINIT_MULTITHREADED).ok()?;
+        
         let uri = CreateUri(w!("http://kennykerr.ca"), URI_CREATE_FLAGS::default(), 0)?;
 
         let domain = uri.GetDomain()?;


### PR DESCRIPTION
This is part PR, part question. My understanding is that one needs to call `CoInitialize`/`CoInitializeEx` to initialize COM for a given process/thread before making use of any COM interfaces. I see this happening in some examples, however not this one targeted directly at COM.

Can anybody clarify this topic for me? This example seems to run fine for me on my machine, however all documentation I can find seems to suggest that such a call is _required_. So how are we getting away without it here?