### PR TITLE
Make users can set string values with `REG_EXPAND_SZ` type

### DIFF
--- a/crates/libs/registry/src/key.rs
+++ b/crates/libs/registry/src/key.rs
@@ -91,20 +91,36 @@ impl Key {
         unsafe { self.set_value(name, REG_QWORD, &value as *const _ as _, 8) }
     }
 
-    /// Sets the name and value in the registry key.
+    /// Sets the name and value in the registry key with `REG_SZ` type.
     pub fn set_string<T: AsRef<str>>(&self, name: T, value: T) -> Result<()> {
         let value = pcwstr(value);
 
         unsafe { self.set_value(name, REG_SZ, value.as_ptr() as _, value.len() * 2) }
     }
 
-    /// Sets the name and value in the registry key.
+    /// Sets the name and value in the registry key with `REG_EXPAND_SZ` type.
+    pub fn set_expand_string<T: AsRef<str>>(&self, name: T, value: T) -> Result<()> {
+        let value = pcwstr(value);
+
+        unsafe { self.set_value(name, REG_EXPAND_SZ, value.as_ptr() as _, value.len() * 2) }
+    }
+
+    /// Sets the name and value in the registry key with `REG_SZ` type.
     pub fn set_hstring<T: AsRef<str>>(
         &self,
         name: T,
         value: &windows_strings::HSTRING,
     ) -> Result<()> {
         unsafe { self.set_value(name, REG_SZ, value.as_ptr() as _, value.len() * 2) }
+    }
+
+    /// Sets the name and value in the registry key with `REG_EXPAND_SZ` type.
+    pub fn set_expand_hstring<T: AsRef<str>>(
+        &self,
+        name: T,
+        value: &windows_strings::HSTRING,
+    ) -> Result<()> {
+        unsafe { self.set_value(name, REG_EXPAND_SZ, value.as_ptr() as _, value.len() * 2) }
     }
 
     /// Sets the name and value in the registry key.
@@ -146,7 +162,8 @@ impl Key {
             REG_DWORD => Type::U32,
             REG_QWORD => Type::U64,
             REG_BINARY => Type::Bytes,
-            REG_SZ | REG_EXPAND_SZ => Type::String,
+            REG_SZ => Type::String,
+            REG_EXPAND_SZ => Type::ExpandString,
             REG_MULTI_SZ => Type::MultiString,
             rest => Type::Unknown(rest),
         })

--- a/crates/libs/registry/src/type.rs
+++ b/crates/libs/registry/src/type.rs
@@ -7,8 +7,11 @@ pub enum Type {
     /// A 64-bit unsigned integer value.
     U64,
 
-    /// A string value.
+    /// A string value which has `REG_SZ` type.
     String,
+
+    /// A string value which has `REG_EXPAND_SZ` type.
+    ExpandString,
 
     /// An array u8 bytes.
     Bytes,


### PR DESCRIPTION
What's this all about?

Fixes: #3148.

As sometimes users need to set string values with `REG_EXPAND_SZ` (e.g. when setting `PATH` values, see https://github.com/rust-lang/rustup/pull/3896 for more details), I think it is necessary to add relevant support for this.

In addition, users can now identify whether a string value has a `REG_EXPAND_SZ` type.