### PR TITLE
Implement `IntoFuture` for WinRT async types

### DIFF
--- a/crates/libs/bindgen/src/rust/writer.rs
+++ b/crates/libs/bindgen/src/rust/writer.rs
@@ -712,6 +712,9 @@ impl Writer {
                     fn get_results(&self) -> windows_core::Result<Self::Output> {
                         self.GetResults()
                     }
+                    fn cancel(&self) {
+                        let _ = self.Cancel();
+                    }
                 }
                 #features
                 impl<#constraints> std::future::IntoFuture for #ident {

--- a/crates/libs/bindgen/src/rust/writer.rs
+++ b/crates/libs/bindgen/src/rust/writer.rs
@@ -697,6 +697,31 @@ impl Writer {
                         self.GetResults()
                     }
                 }
+                #features
+                impl<#constraints> windows_core::AsyncOperation for #ident {
+                    type Output = #return_type;
+                    fn is_complete(&self) -> windows_core::Result<bool> {
+                        Ok(self.Status()? != #namespace AsyncStatus::Started)
+                    }
+                    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+                        self.SetCompleted(&#namespace #handler::new(move |_sender, _args| {
+                            f();
+                            Ok(())
+                        }))
+                    }
+                    fn get_results(&self) -> windows_core::Result<Self::Output> {
+                        self.GetResults()
+                    }
+                }
+                #features
+                impl<#constraints> std::future::IntoFuture for #ident {
+                    type Output = windows_core::Result<#return_type>;
+                    type IntoFuture = windows_core::FutureWrapper<#ident>;
+
+                    fn into_future(self) -> Self::IntoFuture {
+                        windows_core::FutureWrapper::new(self)
+                    }
+                }
             }
         }
     }

--- a/crates/libs/core/src/future.rs
+++ b/crates/libs/core/src/future.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "std")]
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Poll, Waker},
+};
+
+/// Wraps an `IAsyncOperation`, `IAsyncOperationWithProgress`, `IAsyncAction`, or `IAsyncActionWithProgress`.
+/// Impls for this trait are generated automatically by windows-bindgen.
+pub trait AsyncOperation {
+    /// The type produced when the operation finishes.
+    type Output;
+    /// Returns whether the operation is finished, in which case `self.get_results()` can be used to get the returned data.
+    /// Wraps `self.Status() != AsyncStatus::Started`.
+    fn is_complete(&self) -> crate::Result<bool>;
+    /// Register a callback that will be called once the operation is finished.
+    /// This can only be called once.
+    /// Wraps `self.SetCompleted(f)`.
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> crate::Result<()>;
+    /// Get the result value from a completed operation.
+    /// Wraps `self.GetResults()`.
+    fn get_results(&self) -> crate::Result<Self::Output>;
+}
+
+/// A wrapper around an `AsyncOperation` that implements `std::future::Future`.
+/// This is used by generated `IntoFuture` impls. It shouldn't be necessary to use this type manually.
+pub struct FutureWrapper<T> {
+    inner: T,
+    waker: Option<Arc<Mutex<Waker>>>,
+}
+
+impl<T> FutureWrapper<T> {
+    /// Creates a `FutureWrapper`, which implements `std::future::Future`.
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            waker: None,
+        }
+    }
+}
+
+impl<T> Unpin for FutureWrapper<T> {}
+
+impl<T: AsyncOperation> Future for FutureWrapper<T> {
+    type Output = crate::Result<T::Output>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        if self.inner.is_complete()? {
+            Poll::Ready(self.inner.get_results())
+        } else {
+            if let Some(saved_waker) = &self.waker {
+                // Update the saved waker, in case the future has been transferred to a different executor.
+                // (e.g. if using `select`.)
+                let mut saved_waker = saved_waker.lock().unwrap();
+                saved_waker.clone_from(cx.waker());
+            } else {
+                let saved_waker = Arc::new(Mutex::new(cx.waker().clone()));
+                self.waker = Some(saved_waker.clone());
+                self.inner.set_completed(move || {
+                    saved_waker.lock().unwrap().wake_by_ref();
+                })?;
+            }
+            Poll::Pending
+        }
+    }
+}

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod imp;
 
 mod as_impl;
 mod com_object;
+mod future;
 mod guid;
 mod inspectable;
 mod interface;
@@ -41,6 +42,7 @@ mod weak;
 
 pub use as_impl::*;
 pub use com_object::*;
+pub use future::*;
 pub use guid::*;
 pub use inspectable::*;
 pub use interface::*;

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -1036,6 +1036,30 @@ impl DeleteSmsMessageOperation {
     }
 }
 #[cfg(feature = "deprecated")]
+impl windows_core::AsyncOperation for DeleteSmsMessageOperation {
+    type Output = ();
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != super::super::Foundation::AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&super::super::Foundation::AsyncActionCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+#[cfg(feature = "deprecated")]
+impl std::future::IntoFuture for DeleteSmsMessageOperation {
+    type Output = windows_core::Result<()>;
+    type IntoFuture = windows_core::FutureWrapper<DeleteSmsMessageOperation>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
+    }
+}
+#[cfg(feature = "deprecated")]
 #[repr(transparent)]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DeleteSmsMessagesOperation(windows_core::IUnknown);
@@ -1119,6 +1143,30 @@ impl DeleteSmsMessagesOperation {
             }))?;
         }
         self.GetResults()
+    }
+}
+#[cfg(feature = "deprecated")]
+impl windows_core::AsyncOperation for DeleteSmsMessagesOperation {
+    type Output = ();
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != super::super::Foundation::AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&super::super::Foundation::AsyncActionCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+#[cfg(feature = "deprecated")]
+impl std::future::IntoFuture for DeleteSmsMessagesOperation {
+    type Output = windows_core::Result<()>;
+    type IntoFuture = windows_core::FutureWrapper<DeleteSmsMessagesOperation>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
     }
 }
 #[cfg(feature = "deprecated")]
@@ -1211,6 +1259,30 @@ impl GetSmsDeviceOperation {
     }
 }
 #[cfg(feature = "deprecated")]
+impl windows_core::AsyncOperation for GetSmsDeviceOperation {
+    type Output = SmsDevice;
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != super::super::Foundation::AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&super::super::Foundation::AsyncOperationCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+#[cfg(feature = "deprecated")]
+impl std::future::IntoFuture for GetSmsDeviceOperation {
+    type Output = windows_core::Result<SmsDevice>;
+    type IntoFuture = windows_core::FutureWrapper<GetSmsDeviceOperation>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
+    }
+}
+#[cfg(feature = "deprecated")]
 #[repr(transparent)]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct GetSmsMessageOperation(windows_core::IUnknown);
@@ -1297,6 +1369,30 @@ impl GetSmsMessageOperation {
             }))?;
         }
         self.GetResults()
+    }
+}
+#[cfg(feature = "deprecated")]
+impl windows_core::AsyncOperation for GetSmsMessageOperation {
+    type Output = ISmsMessage;
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != super::super::Foundation::AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&super::super::Foundation::AsyncOperationCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+#[cfg(feature = "deprecated")]
+impl std::future::IntoFuture for GetSmsMessageOperation {
+    type Output = windows_core::Result<ISmsMessage>;
+    type IntoFuture = windows_core::FutureWrapper<GetSmsMessageOperation>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
     }
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
@@ -1407,6 +1503,30 @@ impl GetSmsMessagesOperation {
         self.GetResults()
     }
 }
+#[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
+impl windows_core::AsyncOperation for GetSmsMessagesOperation {
+    type Output = super::super::Foundation::Collections::IVectorView<ISmsMessage>;
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != super::super::Foundation::AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&super::super::Foundation::AsyncOperationWithProgressCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+#[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
+impl std::future::IntoFuture for GetSmsMessagesOperation {
+    type Output = windows_core::Result<super::super::Foundation::Collections::IVectorView<ISmsMessage>>;
+    type IntoFuture = windows_core::FutureWrapper<GetSmsMessagesOperation>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
+    }
+}
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -1491,6 +1611,30 @@ impl SendSmsMessageOperation {
             }))?;
         }
         self.GetResults()
+    }
+}
+#[cfg(feature = "deprecated")]
+impl windows_core::AsyncOperation for SendSmsMessageOperation {
+    type Output = ();
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != super::super::Foundation::AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&super::super::Foundation::AsyncActionCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+#[cfg(feature = "deprecated")]
+impl std::future::IntoFuture for SendSmsMessageOperation {
+    type Output = windows_core::Result<()>;
+    type IntoFuture = windows_core::FutureWrapper<SendSmsMessageOperation>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
     }
 }
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -1050,6 +1050,9 @@ impl windows_core::AsyncOperation for DeleteSmsMessageOperation {
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
     }
+    fn cancel(&self) {
+        let _ = self.Cancel();
+    }
 }
 #[cfg(feature = "deprecated")]
 impl std::future::IntoFuture for DeleteSmsMessageOperation {
@@ -1159,6 +1162,9 @@ impl windows_core::AsyncOperation for DeleteSmsMessagesOperation {
     }
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
+    }
+    fn cancel(&self) {
+        let _ = self.Cancel();
     }
 }
 #[cfg(feature = "deprecated")]
@@ -1273,6 +1279,9 @@ impl windows_core::AsyncOperation for GetSmsDeviceOperation {
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
     }
+    fn cancel(&self) {
+        let _ = self.Cancel();
+    }
 }
 #[cfg(feature = "deprecated")]
 impl std::future::IntoFuture for GetSmsDeviceOperation {
@@ -1385,6 +1394,9 @@ impl windows_core::AsyncOperation for GetSmsMessageOperation {
     }
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
+    }
+    fn cancel(&self) {
+        let _ = self.Cancel();
     }
 }
 #[cfg(feature = "deprecated")]
@@ -1518,6 +1530,9 @@ impl windows_core::AsyncOperation for GetSmsMessagesOperation {
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
     }
+    fn cancel(&self) {
+        let _ = self.Cancel();
+    }
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
 impl std::future::IntoFuture for GetSmsMessagesOperation {
@@ -1627,6 +1642,9 @@ impl windows_core::AsyncOperation for SendSmsMessageOperation {
     }
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
+    }
+    fn cancel(&self) {
+        let _ = self.Cancel();
     }
 }
 #[cfg(feature = "deprecated")]

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -92,6 +92,9 @@ impl windows_core::AsyncOperation for IAsyncAction {
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
     }
+    fn cancel(&self) {
+        let _ = self.Cancel();
+    }
 }
 impl std::future::IntoFuture for IAsyncAction {
     type Output = windows_core::Result<()>;
@@ -218,6 +221,9 @@ impl<TProgress: windows_core::RuntimeType + 'static> windows_core::AsyncOperatio
     }
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
+    }
+    fn cancel(&self) {
+        let _ = self.Cancel();
     }
 }
 impl<TProgress: windows_core::RuntimeType + 'static> std::future::IntoFuture for IAsyncActionWithProgress<TProgress> {
@@ -396,6 +402,9 @@ impl<TResult: windows_core::RuntimeType + 'static> windows_core::AsyncOperation 
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
     }
+    fn cancel(&self) {
+        let _ = self.Cancel();
+    }
 }
 impl<TResult: windows_core::RuntimeType + 'static> std::future::IntoFuture for IAsyncOperation<TResult> {
     type Output = windows_core::Result<TResult>;
@@ -534,6 +543,9 @@ impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::Runt
     }
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
+    }
+    fn cancel(&self) {
+        let _ = self.Cancel();
     }
 }
 impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> std::future::IntoFuture for IAsyncOperationWithProgress<TResult, TProgress> {

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -78,6 +78,28 @@ impl IAsyncAction {
         self.GetResults()
     }
 }
+impl windows_core::AsyncOperation for IAsyncAction {
+    type Output = ();
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&AsyncActionCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+impl std::future::IntoFuture for IAsyncAction {
+    type Output = windows_core::Result<()>;
+    type IntoFuture = windows_core::FutureWrapper<IAsyncAction>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
+    }
+}
 unsafe impl Send for IAsyncAction {}
 unsafe impl Sync for IAsyncAction {}
 impl windows_core::RuntimeType for IAsyncAction {
@@ -181,6 +203,28 @@ impl<TProgress: windows_core::RuntimeType + 'static> IAsyncActionWithProgress<TP
             }))?;
         }
         self.GetResults()
+    }
+}
+impl<TProgress: windows_core::RuntimeType + 'static> windows_core::AsyncOperation for IAsyncActionWithProgress<TProgress> {
+    type Output = ();
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&AsyncActionWithProgressCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+impl<TProgress: windows_core::RuntimeType + 'static> std::future::IntoFuture for IAsyncActionWithProgress<TProgress> {
+    type Output = windows_core::Result<()>;
+    type IntoFuture = windows_core::FutureWrapper<IAsyncActionWithProgress<TProgress>>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
     }
 }
 unsafe impl<TProgress: windows_core::RuntimeType + 'static> Send for IAsyncActionWithProgress<TProgress> {}
@@ -338,6 +382,28 @@ impl<TResult: windows_core::RuntimeType + 'static> IAsyncOperation<TResult> {
         self.GetResults()
     }
 }
+impl<TResult: windows_core::RuntimeType + 'static> windows_core::AsyncOperation for IAsyncOperation<TResult> {
+    type Output = TResult;
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&AsyncOperationCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+impl<TResult: windows_core::RuntimeType + 'static> std::future::IntoFuture for IAsyncOperation<TResult> {
+    type Output = windows_core::Result<TResult>;
+    type IntoFuture = windows_core::FutureWrapper<IAsyncOperation<TResult>>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
+    }
+}
 unsafe impl<TResult: windows_core::RuntimeType + 'static> Send for IAsyncOperation<TResult> {}
 unsafe impl<TResult: windows_core::RuntimeType + 'static> Sync for IAsyncOperation<TResult> {}
 impl<TResult: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IAsyncOperation<TResult> {
@@ -453,6 +519,28 @@ impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::Runt
             }))?;
         }
         self.GetResults()
+    }
+}
+impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> windows_core::AsyncOperation for IAsyncOperationWithProgress<TResult, TProgress> {
+    type Output = TResult;
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&AsyncOperationWithProgressCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> std::future::IntoFuture for IAsyncOperationWithProgress<TResult, TProgress> {
+    type Output = windows_core::Result<TResult>;
+    type IntoFuture = windows_core::FutureWrapper<IAsyncOperationWithProgress<TResult, TProgress>>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
     }
 }
 unsafe impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> Send for IAsyncOperationWithProgress<TResult, TProgress> {}

--- a/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
@@ -518,6 +518,9 @@ impl windows_core::AsyncOperation for SignOutUserOperation {
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
     }
+    fn cancel(&self) {
+        let _ = self.Cancel();
+    }
 }
 impl std::future::IntoFuture for SignOutUserOperation {
     type Output = windows_core::Result<()>;
@@ -622,6 +625,9 @@ impl windows_core::AsyncOperation for UserAuthenticationOperation {
     }
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
+    }
+    fn cancel(&self) {
+        let _ = self.Cancel();
     }
 }
 impl std::future::IntoFuture for UserAuthenticationOperation {

--- a/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
@@ -504,6 +504,28 @@ impl SignOutUserOperation {
         self.GetResults()
     }
 }
+impl windows_core::AsyncOperation for SignOutUserOperation {
+    type Output = ();
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != super::super::super::Foundation::AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&super::super::super::Foundation::AsyncActionCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+impl std::future::IntoFuture for SignOutUserOperation {
+    type Output = windows_core::Result<()>;
+    type IntoFuture = windows_core::FutureWrapper<SignOutUserOperation>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
+    }
+}
 unsafe impl Send for SignOutUserOperation {}
 unsafe impl Sync for SignOutUserOperation {}
 #[repr(transparent)]
@@ -585,6 +607,28 @@ impl UserAuthenticationOperation {
             }))?;
         }
         self.GetResults()
+    }
+}
+impl windows_core::AsyncOperation for UserAuthenticationOperation {
+    type Output = UserIdentity;
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != super::super::super::Foundation::AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&super::super::super::Foundation::AsyncOperationCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+impl std::future::IntoFuture for UserAuthenticationOperation {
+    type Output = windows_core::Result<UserIdentity>;
+    type IntoFuture = windows_core::FutureWrapper<UserAuthenticationOperation>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
     }
 }
 unsafe impl Send for UserAuthenticationOperation {}

--- a/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
@@ -1325,6 +1325,28 @@ impl DataReaderLoadOperation {
         self.GetResults()
     }
 }
+impl windows_core::AsyncOperation for DataReaderLoadOperation {
+    type Output = u32;
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != super::super::Foundation::AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&super::super::Foundation::AsyncOperationCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+impl std::future::IntoFuture for DataReaderLoadOperation {
+    type Output = windows_core::Result<u32>;
+    type IntoFuture = windows_core::FutureWrapper<DataReaderLoadOperation>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
+    }
+}
 unsafe impl Send for DataReaderLoadOperation {}
 unsafe impl Sync for DataReaderLoadOperation {}
 #[repr(transparent)]
@@ -1591,6 +1613,28 @@ impl DataWriterStoreOperation {
             }))?;
         }
         self.GetResults()
+    }
+}
+impl windows_core::AsyncOperation for DataWriterStoreOperation {
+    type Output = u32;
+    fn is_complete(&self) -> windows_core::Result<bool> {
+        Ok(self.Status()? != super::super::Foundation::AsyncStatus::Started)
+    }
+    fn set_completed(&self, f: impl Fn() + Send + 'static) -> windows_core::Result<()> {
+        self.SetCompleted(&super::super::Foundation::AsyncOperationCompletedHandler::new(move |_sender, _args| {
+            f();
+            Ok(())
+        }))
+    }
+    fn get_results(&self) -> windows_core::Result<Self::Output> {
+        self.GetResults()
+    }
+}
+impl std::future::IntoFuture for DataWriterStoreOperation {
+    type Output = windows_core::Result<u32>;
+    type IntoFuture = windows_core::FutureWrapper<DataWriterStoreOperation>;
+    fn into_future(self) -> Self::IntoFuture {
+        windows_core::FutureWrapper::new(self)
     }
 }
 unsafe impl Send for DataWriterStoreOperation {}

--- a/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
@@ -1339,6 +1339,9 @@ impl windows_core::AsyncOperation for DataReaderLoadOperation {
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
     }
+    fn cancel(&self) {
+        let _ = self.Cancel();
+    }
 }
 impl std::future::IntoFuture for DataReaderLoadOperation {
     type Output = windows_core::Result<u32>;
@@ -1628,6 +1631,9 @@ impl windows_core::AsyncOperation for DataWriterStoreOperation {
     }
     fn get_results(&self) -> windows_core::Result<Self::Output> {
         self.GetResults()
+    }
+    fn cancel(&self) {
+        let _ = self.Cancel();
     }
 }
 impl std::future::IntoFuture for DataWriterStoreOperation {

--- a/crates/samples/windows/ocr/Cargo.toml
+++ b/crates/samples/windows/ocr/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[dependencies]
+futures = "0.3.5"
+
 [dependencies.windows]
 path = "../../../libs/windows"
 features = [

--- a/crates/samples/windows/ocr/src/main.rs
+++ b/crates/samples/windows/ocr/src/main.rs
@@ -6,18 +6,22 @@ use windows::{
 };
 
 fn main() -> Result<()> {
+    futures::executor::block_on(main_async())
+}
+
+async fn main_async() -> Result<()> {
     let mut message = std::env::current_dir().unwrap();
     message.push("message.png");
 
     let file =
-        StorageFile::GetFileFromPathAsync(&HSTRING::from(message.to_str().unwrap()))?.get()?;
-    let stream = file.OpenAsync(FileAccessMode::Read)?.get()?;
+        StorageFile::GetFileFromPathAsync(&HSTRING::from(message.to_str().unwrap()))?.await?;
+    let stream = file.OpenAsync(FileAccessMode::Read)?.await?;
 
-    let decode = BitmapDecoder::CreateAsync(&stream)?.get()?;
-    let bitmap = decode.GetSoftwareBitmapAsync()?.get()?;
+    let decode = BitmapDecoder::CreateAsync(&stream)?.await?;
+    let bitmap = decode.GetSoftwareBitmapAsync()?.await?;
 
     let engine = OcrEngine::TryCreateFromUserProfileLanguages()?;
-    let result = engine.RecognizeAsync(&bitmap)?.get()?;
+    let result = engine.RecognizeAsync(&bitmap)?.await?;
 
     println!("{}", result.Text()?);
     Ok(())

--- a/crates/tests/winrt/Cargo.toml
+++ b/crates/tests/winrt/Cargo.toml
@@ -23,6 +23,7 @@ features = [
     "Foundation_Numerics",
     "Storage_Streams",
     "System",
+    "System_Threading",
     "UI_Composition",
     "Win32_System_Com",
     "Win32_System_WinRT",

--- a/crates/tests/winrt/Cargo.toml
+++ b/crates/tests/winrt/Cargo.toml
@@ -29,4 +29,5 @@ features = [
 ]
 
 [dev-dependencies]
+futures = "0.3"
 helpers = { package = "test_helpers", path = "../helpers" }

--- a/crates/tests/winrt/tests/async.rs
+++ b/crates/tests/winrt/tests/async.rs
@@ -23,3 +23,33 @@ fn async_get() -> windows::core::Result<()> {
 
     Ok(())
 }
+
+async fn async_await() -> windows::core::Result<()> {
+    use windows::Storage::Streams::*;
+
+    let stream = &InMemoryRandomAccessStream::new()?;
+
+    let writer = DataWriter::CreateDataWriter(stream)?;
+    writer.WriteByte(1)?;
+    writer.WriteByte(2)?;
+    writer.WriteByte(3)?;
+    writer.StoreAsync()?.await?;
+
+    stream.Seek(0)?;
+    let reader = DataReader::CreateDataReader(stream)?;
+    reader.LoadAsync(3)?.await?;
+
+    let mut bytes: [u8; 3] = [0; 3];
+    reader.ReadBytes(&mut bytes)?;
+
+    assert!(bytes[0] == 1);
+    assert!(bytes[1] == 2);
+    assert!(bytes[2] == 3);
+
+    Ok(())
+}
+
+#[test]
+fn test_async_await() -> windows::core::Result<()> {
+    futures::executor::block_on(async_await())
+}


### PR DESCRIPTION
This reverts #3142 while also addressing #342.

I implement `IntoFuture` by wrapping each `IAsyncOperation`/etc into a `windows_core::FutureWrapper` that includes a mutable Waker slot (i.e. `Arc<Mutex<Waker>>`, so that we only need to call `SetCompleted` once. To deduplicate the implementation for the various interfaces that exist, I've added a trait `windows_core::AsyncOperation` that abstracts over the SetCompleted/etc methods.

I believe the `Arc` is necessary as there is no way to cancel a `SetCompleted` callback once it is registered. The `Mutex<Waker>` could be an `AtomicWaker` instead, but that's a fairly complex piece of code that I don't want to pull in.

Additionally, the wrapper future automatically calls `Cancel()` when dropped, as is conventional for Rust futures.