### PR TITLE
Fix support for `no_std`

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -34,8 +34,6 @@ jobs:
         uses: ./.github/actions/fix-environment
       - name: Clippy cppwinrt
         run:  cargo clippy -p cppwinrt
-      - name: Clippy no_std
-        run:  cargo clippy -p no_std
       - name: Clippy riddle
         run:  cargo clippy -p riddle
       - name: Clippy sample_bits
@@ -204,6 +202,8 @@ jobs:
         run:  cargo clippy -p test_metadata
       - name: Clippy test_msrv
         run:  cargo clippy -p test_msrv
+      - name: Clippy test_no_std
+        run:  cargo clippy -p test_no_std
       - name: Clippy test_no_use
         run:  cargo clippy -p test_no_use
       - name: Clippy test_noexcept

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -16,10 +16,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable, nightly]
-        runs-on:
-          - windows-latest
-          - ubuntu-latest
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -1,0 +1,29 @@
+name: no_std
+
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+    branches:
+      - master
+
+env:
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  check:
+    strategy:
+      matrix:
+        rust: [stable, nightly]
+        runs-on:
+          - windows-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Prepare
+        run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - name: Check
+        run: cargo check -p test_no_std

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,6 @@ jobs:
         run:  cargo clean
       - name: Test cppwinrt
         run:  cargo test -p cppwinrt --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test no_std
-        run:  cargo test -p no_std --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test riddle
         run:  cargo test -p riddle --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_bits
@@ -156,10 +154,10 @@ jobs:
         run:  cargo test -p test_alternate_success_code --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_arch
         run:  cargo test -p test_arch --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Clean
-        run:  cargo clean
       - name: Test test_arch_feature
         run:  cargo test -p test_arch_feature --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Clean
+        run:  cargo clean
       - name: Test test_array
         run:  cargo test -p test_array --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_bcrypt
@@ -230,6 +228,8 @@ jobs:
         run:  cargo test -p test_metadata --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_msrv
         run:  cargo test -p test_msrv --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test test_no_std
+        run:  cargo test -p test_no_std --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_no_use
         run:  cargo test -p test_no_use --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_noexcept

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -292,6 +292,6 @@ fn extension(path: &str) -> &str {
 }
 
 fn directory(path: &str) -> &str {
-    path.rsplit_once(&['/', '\\'])
+    path.rsplit_once(['/', '\\'])
         .map_or("", |(directory, _)| directory)
 }

--- a/crates/libs/bindgen/src/winmd/writer/mod.rs
+++ b/crates/libs/bindgen/src/winmd/writer/mod.rs
@@ -45,9 +45,7 @@ impl Writer {
             MethodList: 0,
         });
 
-        let name = name
-            .rsplit_once(&['/', '\\'])
-            .map_or(name, |(_, name)| name);
+        let name = name.rsplit_once(['/', '\\']).map_or(name, |(_, name)| name);
 
         writer.tables.Module.push(Module {
             Name: writer.strings.insert(name),

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -24,10 +24,12 @@ path = "../targets"
 [dependencies.windows-result]
 version = "0.2.0"
 path = "../result"
+default-features = false
 
 [dependencies.windows-strings]
 version = "0.1.0"
 path = "../strings"
+default-features = false
 
 [dependencies]
 windows-implement = { path = "../implement",  version = "0.58.0" }
@@ -35,4 +37,4 @@ windows-interface = { path = "../interface",  version = "0.58.0" }
 
 [features]
 default = ["std"]
-std = []
+std = ["windows-result/std", "windows-strings/std"]

--- a/crates/libs/registry/Cargo.toml
+++ b/crates/libs/registry/Cargo.toml
@@ -24,7 +24,9 @@ path = "../targets"
 [dependencies.windows-result]
 version = "0.2.0"
 path = "../result"
+default-features = false
 
 [dependencies.windows-strings]
 version = "0.1.0"
 path = "../strings"
+default-features = false

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -26,9 +26,14 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 rustdoc-args = ["--cfg", "docsrs"]
 
-[dependencies]
-windows-core = { path = "../core", version = "0.58.0" }
-windows-targets = { path = "../targets", version = "0.52.6" }
+[dependencies.windows-core]
+version = "0.58.0"
+path = "../core"
+default-features = false
+
+[dependencies.windows-targets]
+version = "0.52.6"
+path = "../targets"
 
 [features]
 default = ["std"]

--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -12,6 +12,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 #![cfg_attr(not(feature = "docs"), doc(hidden))]
 // TODO: workaround for https://github.com/rust-lang/rust/issues/126169
 #![allow(unused)]
+#![cfg_attr(all(not(feature = "std")), no_std)]
 
 #[allow(unused_extern_crates)]
 extern crate self as windows;

--- a/crates/tests/no_std/Cargo.toml
+++ b/crates/tests/no_std/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "no_std"
+name = "test_no_std"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,11 +11,6 @@ doctest = false
 path = "../../libs/core"
 default-features = false
 
-[dependencies.windows]
-path = "../../libs/windows"
-default-features = false
-features = ["implement"]
-
 [dependencies.windows-registry]
 path = "../../libs/registry"
 default-features = false
@@ -23,6 +18,27 @@ default-features = false
 [dependencies.windows-result]
 path = "../../libs/result"
 default-features = false
+
+[dependencies.windows-strings]
+path = "../../libs/strings"
+default-features = false
+
+[dependencies.windows-sys]
+path = "../../libs/sys"
+default-features = false
+
+[dependencies.windows-targets]
+path = "../../libs/targets"
+default-features = false
+
+[dependencies.windows-version]
+path = "../../libs/version"
+default-features = false
+
+[dependencies.windows]
+path = "../../libs/windows"
+default-features = false
+features = ["implement"]
 
 [lints]
 workspace = true

--- a/crates/tests/no_std/src/lib.rs
+++ b/crates/tests/no_std/src/lib.rs
@@ -1,21 +1,21 @@
 //! Test for `#![no_std]` crates.
 //!
 //! Compiling this crate verifies that the Windows crates can be compiled with their "std"
-//! feature disabled.
+//! feature disabled. The tricky part is that `cargo test` depends on `std` so testing
+//! `no_std` requires using `cargo check` instead. That's what the `no_std.yml` is for.
 
 #![no_std]
 
-#[cfg(test)]
-mod tests {
-    use windows::core::{implement, ComObject};
+#[windows::core::implement]
+struct App;
 
-    #[implement]
-    struct App {}
-
-    // Compilation is sufficient to test.
-    #[test]
-    fn basic() {
-        let object = ComObject::new(App {});
-        drop(object);
-    }
+#[cfg(not(test))]
+fn _test() {
+    let _ = windows::core::HRESULT(0);
+    let _ = windows::core::ComObject::new(App);
 }
+
+// #[cfg_attr(not(test), panic_handler)]
+// fn _panic(_: &core::panic::PanicInfo<'_>) -> ! {
+//     loop {}
+// }

--- a/crates/tests/no_std/src/lib.rs
+++ b/crates/tests/no_std/src/lib.rs
@@ -11,6 +11,8 @@ struct App;
 
 #[cfg(not(test))]
 fn _test() {
+    // Pull in something from each library crate that supports `no_std` to ensure they don't
+    // accidentally depend on `std`.
     let _ = windows_core::ComObject::new(App);
     let _ = windows_registry::CURRENT_USER.create("software\\windows-rs");
     let _ = windows_result::HRESULT(0);

--- a/crates/tests/no_std/src/lib.rs
+++ b/crates/tests/no_std/src/lib.rs
@@ -11,11 +11,16 @@ struct App;
 
 #[cfg(not(test))]
 fn _test() {
-    let _ = windows::core::HRESULT(0);
+    let _ = windows_core::ComObject::new(App);
+    let _ = windows_registry::CURRENT_USER.create("software\\windows-rs");
+    let _ = windows_result::HRESULT(0);
+    let _ = windows_strings::BSTR::new();
+    let _ = windows_sys::core::GUID::from_u128(0);
+    let _ = windows_version::OsVersion::current();
     let _ = windows::core::ComObject::new(App);
 }
 
-// #[cfg_attr(not(test), panic_handler)]
-// fn _panic(_: &core::panic::PanicInfo<'_>) -> ! {
-//     loop {}
-// }
+#[cfg_attr(not(test), panic_handler)]
+fn _panic(_: &core::panic::PanicInfo<'_>) -> ! {
+    loop {}
+}

--- a/crates/tests/no_std/src/lib.rs
+++ b/crates/tests/no_std/src/lib.rs
@@ -22,6 +22,8 @@ fn _test() {
     let _ = windows::core::ComObject::new(App);
 }
 
+// This panic handler will cause a build error if an indirect `std` dependency exists as `std`
+// will include its own panic handler and conflict with this one.
 #[cfg_attr(not(test), panic_handler)]
 fn _panic(_: &core::panic::PanicInfo<'_>) -> ! {
     loop {}


### PR DESCRIPTION
Rust's `no_std` feature doesn't actually verify that dependencies don't silently add a `std` dependency. It just prevents the current package from taking a direct dependency. This isn't particularly easy to test. 

This PR includes a sequence of commits that will verify success/failure before completion. 

Fixes: #3163 
Fixes: #3164 