### PR TITLE
Add registry `Value` to/from `HSTRING` conversion

### DIFF
--- a/crates/libs/registry/src/data.rs
+++ b/crates/libs/registry/src/data.rs
@@ -20,19 +20,12 @@ impl Data {
         }
     }
 
-    // Returns the buffer as a slice of u16 for reading wide characters. The slice trims off any trailing zero bytes.
+    // Returns the buffer as a slice of u16 for reading wide characters.
     pub fn as_wide(&self) -> &[u16] {
         if self.ptr.is_null() {
             &[]
         } else {
-            let mut wide =
-                unsafe { core::slice::from_raw_parts(self.ptr as *const u16, self.len / 2) };
-
-            while wide.last() == Some(&0) {
-                wide = &wide[..wide.len() - 1];
-            }
-
-            wide
+            unsafe { core::slice::from_raw_parts(self.ptr as *const u16, self.len / 2) }
         }
     }
 

--- a/crates/libs/registry/src/lib.rs
+++ b/crates/libs/registry/src/lib.rs
@@ -76,3 +76,8 @@ fn from_le_bytes(ty: Type, from: &[u8]) -> Result<u64> {
         _ => Err(invalid_data()),
     }
 }
+
+// Get the string as 8-bit bytes including the two terminating null bytes.
+fn as_bytes(value: &HSTRING) -> &[u8] {
+    unsafe { core::slice::from_raw_parts(value.as_ptr() as *const _, (value.len() + 1) * 2) }
+}

--- a/crates/libs/registry/src/pcwstr.rs
+++ b/crates/libs/registry/src/pcwstr.rs
@@ -31,6 +31,7 @@ impl OwnedPcwstr {
         self.0.as_ptr()
     }
 
+    // Get the string as 8-bit bytes including the two terminating null bytes.
     pub fn as_bytes(&self) -> &[u8] {
         unsafe { core::slice::from_raw_parts(self.as_ptr() as *const _, self.0.len() * 2) }
     }

--- a/crates/libs/registry/src/value.rs
+++ b/crates/libs/registry/src/value.rs
@@ -76,9 +76,7 @@ impl TryFrom<Value> for String {
     type Error = Error;
     fn try_from(from: Value) -> Result<Self> {
         match from.ty {
-            Type::String | Type::ExpandString => {
-                Ok(Self::from_utf16(trim(trim(from.data.as_wide())))?)
-            }
+            Type::String | Type::ExpandString => Ok(Self::from_utf16(trim(from.data.as_wide()))?),
             _ => Err(invalid_data()),
         }
     }

--- a/crates/libs/registry/src/value.rs
+++ b/crates/libs/registry/src/value.rs
@@ -17,6 +17,11 @@ impl Value {
     pub fn set_ty(&mut self, ty: Type) {
         self.ty = ty;
     }
+
+    /// Gets the value as a slice of u16 for raw wide characters.
+    pub fn as_wide(&self) -> &[u16] {
+        self.data.as_wide()
+    }
 }
 
 impl core::ops::Deref for Value {

--- a/crates/libs/registry/src/value.rs
+++ b/crates/libs/registry/src/value.rs
@@ -71,7 +71,9 @@ impl TryFrom<Value> for String {
     type Error = Error;
     fn try_from(from: Value) -> Result<Self> {
         match from.ty {
-            Type::String | Type::ExpandString => Ok(Self::from_utf16(from.data.as_wide())?),
+            Type::String | Type::ExpandString => {
+                Ok(Self::from_utf16(trim(trim(from.data.as_wide())))?)
+            }
             _ => Err(invalid_data()),
         }
     }
@@ -106,7 +108,7 @@ impl TryFrom<Value> for HSTRING {
     type Error = Error;
     fn try_from(from: Value) -> Result<Self> {
         match from.ty {
-            Type::String | Type::ExpandString => Ok(Self::from_wide(from.data.as_wide())?),
+            Type::String | Type::ExpandString => Ok(Self::from_wide(trim(from.data.as_wide()))?),
             _ => Err(invalid_data()),
         }
     }
@@ -116,7 +118,7 @@ impl TryFrom<&HSTRING> for Value {
     type Error = Error;
     fn try_from(from: &HSTRING) -> Result<Self> {
         Ok(Self {
-            data: Data::from_slice(from.as_bytes())?,
+            data: Data::from_slice(as_bytes(from))?,
             ty: Type::String,
         })
     }
@@ -140,4 +142,12 @@ impl<const N: usize> TryFrom<[u8; N]> for Value {
             ty: Type::Bytes,
         })
     }
+}
+
+fn trim(mut wide: &[u16]) -> &[u16] {
+    while wide.last() == Some(&0) {
+        wide = &wide[..wide.len() - 1];
+    }
+
+    wide
 }

--- a/crates/libs/registry/src/value.rs
+++ b/crates/libs/registry/src/value.rs
@@ -102,6 +102,26 @@ impl TryFrom<Value> for Vec<String> {
     }
 }
 
+impl TryFrom<Value> for HSTRING {
+    type Error = Error;
+    fn try_from(from: Value) -> Result<Self> {
+        match from.ty {
+            Type::String | Type::ExpandString => Ok(Self::from_wide(from.data.as_wide())?),
+            _ => Err(invalid_data()),
+        }
+    }
+}
+
+impl TryFrom<&HSTRING> for Value {
+    type Error = Error;
+    fn try_from(from: &HSTRING) -> Result<Self> {
+        Ok(Self {
+            data: Data::from_slice(from.as_bytes())?,
+            ty: Type::String,
+        })
+    }
+}
+
 impl TryFrom<&[u8]> for Value {
     type Error = Error;
     fn try_from(from: &[u8]) -> Result<Self> {

--- a/crates/libs/strings/src/hstring.rs
+++ b/crates/libs/strings/src/hstring.rs
@@ -33,11 +33,6 @@ impl HSTRING {
         unsafe { core::slice::from_raw_parts(self.as_ptr(), self.len()) }
     }
 
-    /// Get the string as 8-bit bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        unsafe { core::slice::from_raw_parts(self.as_ptr() as *const _, self.len() * 2) }
-    }
-
     /// Returns a raw pointer to the `HSTRING` buffer.
     pub fn as_ptr(&self) -> *const u16 {
         if let Some(header) = self.as_header() {

--- a/crates/tests/registry/tests/bytes.rs
+++ b/crates/tests/registry/tests/bytes.rs
@@ -1,4 +1,5 @@
 use windows_registry::*;
+use windows_strings::*;
 
 #[test]
 fn bytes() -> Result<()> {
@@ -19,6 +20,11 @@ fn bytes() -> Result<()> {
     let value = key.get_value("other")?;
     assert_eq!(value.ty(), Type::Other(1234));
     assert_eq!(*value, [1, 2, 3, 4]);
+
+    assert_eq!(
+        unsafe { key.raw_get_info(w!("other"))? },
+        (Type::Other(1234), 4)
+    );
 
     Ok(())
 }

--- a/crates/tests/registry/tests/hstring.rs
+++ b/crates/tests/registry/tests/hstring.rs
@@ -1,5 +1,5 @@
 use windows_registry::*;
-use windows_strings::h;
+use windows_strings::*;
 
 #[test]
 fn hstring() -> Result<()> {
@@ -9,6 +9,10 @@ fn hstring() -> Result<()> {
 
     key.set_hstring("hstring", h!("simple"))?;
     assert_eq!(&key.get_hstring("hstring")?, h!("simple"));
+    assert_eq!(
+        unsafe { key.raw_get_info(w!("hstring"))? },
+        (Type::String, 14)
+    );
 
     // You can embed nulls.
     key.set_hstring("hstring", h!("hstring\0value\0"))?;

--- a/crates/tests/registry/tests/u32.rs
+++ b/crates/tests/registry/tests/u32.rs
@@ -1,4 +1,5 @@
 use windows_registry::*;
+use windows_strings::*;
 
 #[test]
 fn u32() -> Result<()> {
@@ -10,6 +11,8 @@ fn u32() -> Result<()> {
     assert_eq!(key.get_type("u32")?, Type::U32);
     assert_eq!(key.get_u32("u32")?, 123u32);
     assert_eq!(key.get_u64("u32")?, 123u64);
+
+    assert_eq!(unsafe { key.raw_get_info(w!("u32"))? }, (Type::U32, 4));
 
     Ok(())
 }

--- a/crates/tests/registry/tests/u64.rs
+++ b/crates/tests/registry/tests/u64.rs
@@ -1,4 +1,5 @@
 use windows_registry::*;
+use windows_strings::*;
 
 #[test]
 fn u64() -> Result<()> {
@@ -10,6 +11,8 @@ fn u64() -> Result<()> {
     assert_eq!(key.get_type("u64")?, Type::U64);
     assert_eq!(key.get_u32("u64")?, 123u32);
     assert_eq!(key.get_u64("u64")?, 123u64);
+
+    assert_eq!(unsafe { key.raw_get_info(w!("u64"))? }, (Type::U64, 8));
 
     Ok(())
 }

--- a/crates/tests/registry/tests/value.rs
+++ b/crates/tests/registry/tests/value.rs
@@ -1,4 +1,5 @@
 use windows_registry::*;
+use windows_strings::h;
 
 #[test]
 fn value() -> Result<()> {
@@ -11,17 +12,20 @@ fn value() -> Result<()> {
     assert_eq!(key.get_value("u32")?, Value::try_from(123u32)?);
     assert_eq!(key.get_u32("u32")?, 123u32);
     assert_eq!(key.get_u64("u32")?, 123u64);
+    assert_eq!(u32::try_from(key.get_value("u32")?)?, 123u32);
 
     key.set_value("u64", &Value::try_from(123u64)?)?;
     assert_eq!(key.get_type("u64")?, Type::U64);
     assert_eq!(key.get_value("u64")?, Value::try_from(123u64)?);
     assert_eq!(key.get_u32("u64")?, 123u32);
     assert_eq!(key.get_u64("u64")?, 123u64);
+    assert_eq!(u64::try_from(key.get_value("u64")?)?, 123u64);
 
     key.set_value("string", &Value::try_from("string")?)?;
     assert_eq!(key.get_type("string")?, Type::String);
     assert_eq!(key.get_value("string")?, Value::try_from("string")?);
     assert_eq!(key.get_string("string")?, "string");
+    assert_eq!(String::try_from(key.get_value("string")?)?, "string");
 
     let mut value = Value::try_from("expand")?;
     value.set_ty(Type::ExpandString);
@@ -40,6 +44,12 @@ fn value() -> Result<()> {
     key.set_value("slice", &value)?;
     assert_eq!(key.get_type("slice")?, Type::Other(1234));
     assert_eq!(key.get_value("slice")?, value);
+
+    key.set_value("hstring", &Value::try_from(h!("HSTRING"))?)?;
+    assert_eq!(key.get_type("hstring")?, Type::String);
+    assert_eq!(key.get_value("hstring")?, Value::try_from(h!("HSTRING"))?);
+    assert_eq!(key.get_string("hstring")?, "HSTRING");
+    assert_eq!(HSTRING::try_from(key.get_value("hstring")?)?, "HSTRING");
 
     Ok(())
 }

--- a/crates/tests/registry/tests/value.rs
+++ b/crates/tests/registry/tests/value.rs
@@ -77,5 +77,10 @@ fn value() -> Result<()> {
         (Type::String, 16)
     );
 
+    let abc = Value::try_from("abc")?;
+    assert_eq!(abc.as_wide(), &[97, 98, 99, 0]);
+    let abc = Value::try_from(h!("abcd"))?;
+    assert_eq!(abc.as_wide(), &[97, 98, 99, 100, 0]);
+
     Ok(())
 }

--- a/crates/tests/registry/tests/value.rs
+++ b/crates/tests/registry/tests/value.rs
@@ -1,5 +1,5 @@
 use windows_registry::*;
-use windows_strings::h;
+use windows_strings::*;
 
 #[test]
 fn value() -> Result<()> {
@@ -14,6 +14,8 @@ fn value() -> Result<()> {
     assert_eq!(key.get_u64("u32")?, 123u64);
     assert_eq!(u32::try_from(key.get_value("u32")?)?, 123u32);
 
+    assert_eq!(unsafe { key.raw_get_info(w!("u32"))? }, (Type::U32, 4));
+
     key.set_value("u64", &Value::try_from(123u64)?)?;
     assert_eq!(key.get_type("u64")?, Type::U64);
     assert_eq!(key.get_value("u64")?, Value::try_from(123u64)?);
@@ -21,11 +23,18 @@ fn value() -> Result<()> {
     assert_eq!(key.get_u64("u64")?, 123u64);
     assert_eq!(u64::try_from(key.get_value("u64")?)?, 123u64);
 
+    assert_eq!(unsafe { key.raw_get_info(w!("u64"))? }, (Type::U64, 8));
+
     key.set_value("string", &Value::try_from("string")?)?;
     assert_eq!(key.get_type("string")?, Type::String);
     assert_eq!(key.get_value("string")?, Value::try_from("string")?);
     assert_eq!(key.get_string("string")?, "string");
     assert_eq!(String::try_from(key.get_value("string")?)?, "string");
+
+    assert_eq!(
+        unsafe { key.raw_get_info(w!("string"))? },
+        (Type::String, 14)
+    );
 
     let mut value = Value::try_from("expand")?;
     value.set_ty(Type::ExpandString);
@@ -35,9 +44,16 @@ fn value() -> Result<()> {
     assert_eq!(key.get_value("expand")?, value);
     assert_eq!(key.get_string("expand")?, "expand");
 
+    assert_eq!(
+        unsafe { key.raw_get_info(w!("expand"))? },
+        (Type::ExpandString, 14)
+    );
+
     key.set_value("bytes", &Value::try_from([1u8, 2u8, 3u8])?)?;
     assert_eq!(key.get_type("bytes")?, Type::Bytes);
     assert_eq!(key.get_value("bytes")?, Value::try_from([1, 2, 3])?);
+
+    assert_eq!(unsafe { key.raw_get_info(w!("bytes"))? }, (Type::Bytes, 3));
 
     let mut value = Value::try_from([1u8, 2u8, 3u8, 4u8].as_slice())?;
     value.set_ty(Type::Other(1234));
@@ -45,11 +61,21 @@ fn value() -> Result<()> {
     assert_eq!(key.get_type("slice")?, Type::Other(1234));
     assert_eq!(key.get_value("slice")?, value);
 
+    assert_eq!(
+        unsafe { key.raw_get_info(w!("slice"))? },
+        (Type::Other(1234), 4)
+    );
+
     key.set_value("hstring", &Value::try_from(h!("HSTRING"))?)?;
     assert_eq!(key.get_type("hstring")?, Type::String);
     assert_eq!(key.get_value("hstring")?, Value::try_from(h!("HSTRING"))?);
     assert_eq!(key.get_string("hstring")?, "HSTRING");
     assert_eq!(HSTRING::try_from(key.get_value("hstring")?)?, "HSTRING");
+
+    assert_eq!(
+        unsafe { key.raw_get_info(w!("hstring"))? },
+        (Type::String, 16)
+    );
 
     Ok(())
 }

--- a/crates/tests/strings/tests/hstring.rs
+++ b/crates/tests/strings/tests/hstring.rs
@@ -4,6 +4,7 @@ use windows_strings::*;
 fn hstring() -> Result<()> {
     let s = HSTRING::from("hello");
     assert_eq!(s.len(), 5);
+    assert_eq!(s.as_wide().len(), 5);
 
     Ok(())
 }


### PR DESCRIPTION
Building on #3184, this update just makes it easier to convert safely between the generic `Value` representation and `HSTRING` for accurate wide string (`[u16]`) representation. It's generally more efficient to query for `HSTRING` directly but at least if you need to deal with `Value` you can now safely and correctly convert to `HSTRING` without first converting to `String` or bytes. 

I also added some missing test coverage. 