### PR TITLE
Improve sample binary build dependencies

### DIFF
--- a/crates/samples/components/json_validator_winrt_client/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt_client/Cargo.toml
@@ -18,5 +18,5 @@ path = "../../../libs/bindgen"
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[dependencies.sample_component_json_validator_winrt]
+[build-dependencies.sample_component_json_validator_winrt]
 path = "../json_validator_winrt"

--- a/crates/samples/components/json_validator_winrt_client_cpp/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt_client_cpp/Cargo.toml
@@ -15,5 +15,5 @@ path = "../../../../crates/libs/targets"
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[dependencies.sample_component_json_validator_winrt]
+[build-dependencies.sample_component_json_validator_winrt]
 path = "../json_validator_winrt"


### PR DESCRIPTION
Binary crate dependencies continue to be a weak point in Cargo. This just attempts to make the binary component samples build a little bit more reliably. In these two cases, the dependent (client) crates need the component (server) crates built ahead of their build scripts as it relies on the component to produce the .winmd files that the build scripts use to generate bindings. 