### PR TITLE
Replace `From<&str>` for `GUID` with `TryFrom<&str>`

### DIFF
--- a/crates/libs/core/src/guid.rs
+++ b/crates/libs/core/src/guid.rs
@@ -120,37 +120,29 @@ impl core::fmt::Debug for GUID {
     }
 }
 
-impl From<&str> for GUID {
-    fn from(value: &str) -> Self {
-        assert!(value.len() == 36, "Invalid GUID string");
-        let mut bytes = value.bytes();
+impl TryFrom<&str> for GUID {
+    type Error = Error;
+    fn try_from(from: &str) -> Result<Self> {
+        if from.len() != 36 {
+            return Err(invalid_guid());
+        }
 
-        let a = ((bytes.next_u32() * 16 + bytes.next_u32()) << 24)
-            + ((bytes.next_u32() * 16 + bytes.next_u32()) << 16)
-            + ((bytes.next_u32() * 16 + bytes.next_u32()) << 8)
-            + bytes.next_u32() * 16
-            + bytes.next_u32();
-        assert!(bytes.next().unwrap() == b'-', "Invalid GUID string");
-        let b = ((bytes.next_u16() * 16 + (bytes.next_u16())) << 8)
-            + bytes.next_u16() * 16
-            + bytes.next_u16();
-        assert!(bytes.next().unwrap() == b'-', "Invalid GUID string");
-        let c = ((bytes.next_u16() * 16 + bytes.next_u16()) << 8)
-            + bytes.next_u16() * 16
-            + bytes.next_u16();
-        assert!(bytes.next().unwrap() == b'-', "Invalid GUID string");
-        let d = bytes.next_u8() * 16 + bytes.next_u8();
-        let e = bytes.next_u8() * 16 + bytes.next_u8();
-        assert!(bytes.next().unwrap() == b'-', "Invalid GUID string");
+        let bytes = &mut from.bytes();
 
-        let f = bytes.next_u8() * 16 + bytes.next_u8();
-        let g = bytes.next_u8() * 16 + bytes.next_u8();
-        let h = bytes.next_u8() * 16 + bytes.next_u8();
-        let i = bytes.next_u8() * 16 + bytes.next_u8();
-        let j = bytes.next_u8() * 16 + bytes.next_u8();
-        let k = bytes.next_u8() * 16 + bytes.next_u8();
+        let mut guid = Self::zeroed();
+        guid.data1 = try_u32(bytes, true)?;
+        guid.data2 = try_u16(bytes, true)?;
+        guid.data3 = try_u16(bytes, true)?;
+        guid.data4[0] = try_u8(bytes, false)?;
+        guid.data4[1] = try_u8(bytes, true)?;
+        guid.data4[2] = try_u8(bytes, false)?;
+        guid.data4[3] = try_u8(bytes, false)?;
+        guid.data4[4] = try_u8(bytes, false)?;
+        guid.data4[5] = try_u8(bytes, false)?;
+        guid.data4[6] = try_u8(bytes, false)?;
+        guid.data4[7] = try_u8(bytes, false)?;
 
-        Self::from_values(a, b, c, [d, e, f, g, h, i, j, k])
+        Ok(guid)
     }
 }
 
@@ -166,28 +158,43 @@ impl From<GUID> for u128 {
     }
 }
 
-trait HexReader {
-    fn next_u8(&mut self) -> u8;
-    fn next_u16(&mut self) -> u16;
-    fn next_u32(&mut self) -> u32;
+fn invalid_guid() -> Error {
+    Error::from_hresult(imp::E_INVALIDARG)
 }
 
-impl HexReader for core::str::Bytes<'_> {
-    fn next_u8(&mut self) -> u8 {
-        let value = self.next().unwrap();
-        match value {
-            b'0'..=b'9' => value - b'0',
-            b'A'..=b'F' => 10 + value - b'A',
-            b'a'..=b'f' => 10 + value - b'a',
-            _ => panic!(),
+fn try_u32(bytes: &mut core::str::Bytes<'_>, delimiter: bool) -> Result<u32> {
+    next(bytes, 8, delimiter).ok_or_else(invalid_guid)
+}
+
+fn try_u16(bytes: &mut core::str::Bytes<'_>, delimiter: bool) -> Result<u16> {
+    next(bytes, 4, delimiter)
+        .map(|value| value as u16)
+        .ok_or_else(invalid_guid)
+}
+
+fn try_u8(bytes: &mut core::str::Bytes<'_>, delimiter: bool) -> Result<u8> {
+    next(bytes, 2, delimiter)
+        .map(|value| value as u8)
+        .ok_or_else(invalid_guid)
+}
+
+fn next(bytes: &mut core::str::Bytes<'_>, len: usize, delimiter: bool) -> Option<u32> {
+    let mut value: u32 = 0;
+
+    for _ in 0..len {
+        let digit = bytes.next()?;
+
+        match digit {
+            b'0'..=b'9' => value = (value << 4) + (digit - b'0') as u32,
+            b'A'..=b'F' => value = (value << 4) + (digit - b'A' + 10) as u32,
+            b'a'..=b'f' => value = (value << 4) + (digit - b'a' + 10) as u32,
+            _ => return None,
         }
     }
 
-    fn next_u16(&mut self) -> u16 {
-        self.next_u8().into()
-    }
-
-    fn next_u32(&mut self) -> u32 {
-        self.next_u8().into()
+    if delimiter && bytes.next() != Some(b'-') {
+        None
+    } else {
+        Some(value)
     }
 }

--- a/crates/libs/core/src/guid.rs
+++ b/crates/libs/core/src/guid.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::many_single_char_names)]
-
 use super::*;
 
 /// A globally unique identifier ([GUID](https://docs.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid))

--- a/crates/libs/core/src/guid.rs
+++ b/crates/libs/core/src/guid.rs
@@ -122,14 +122,15 @@ impl core::fmt::Debug for GUID {
 
 impl TryFrom<&str> for GUID {
     type Error = Error;
+
     fn try_from(from: &str) -> Result<Self> {
         if from.len() != 36 {
             return Err(invalid_guid());
         }
 
         let bytes = &mut from.bytes();
-
         let mut guid = Self::zeroed();
+
         guid.data1 = try_u32(bytes, true)?;
         guid.data2 = try_u16(bytes, true)?;
         guid.data3 = try_u16(bytes, true)?;

--- a/crates/libs/core/src/imp/com_bindings.rs
+++ b/crates/libs/core/src/imp/com_bindings.rs
@@ -41,6 +41,7 @@ impl core::fmt::Debug for AgileReferenceOptions {
 }
 pub const CO_E_NOTINITIALIZED: windows_core::HRESULT = windows_core::HRESULT(0x800401F0_u32 as _);
 pub const E_BOUNDS: windows_core::HRESULT = windows_core::HRESULT(0x8000000B_u32 as _);
+pub const E_INVALIDARG: windows_core::HRESULT = windows_core::HRESULT(0x80070057_u32 as _);
 pub const E_NOINTERFACE: windows_core::HRESULT = windows_core::HRESULT(0x80004002_u32 as _);
 pub const E_OUTOFMEMORY: windows_core::HRESULT = windows_core::HRESULT(0x8007000E_u32 as _);
 pub const E_POINTER: windows_core::HRESULT = windows_core::HRESULT(0x80004003_u32 as _);

--- a/crates/libs/core/src/imp/sha1.rs
+++ b/crates/libs/core/src/imp/sha1.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::many_single_char_names)]
-
 pub const fn sha1(data: &ConstBuffer) -> Digest {
     let state: [u32; 5] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0];
     let len: u64 = 0;

--- a/crates/tests/core/tests/guid.rs
+++ b/crates/tests/core/tests/guid.rs
@@ -1,4 +1,4 @@
-use windows::core::GUID;
+use windows::{core::*, Win32::Foundation::E_INVALIDARG};
 
 #[test]
 fn test_new() {
@@ -9,7 +9,7 @@ fn test_new() {
 
 #[test]
 fn from_u128() {
-    let a: GUID = "1FD63FEF-C0D2-42FE-823A-53A4052B8C8F".into();
+    let a: GUID = "1FD63FEF-C0D2-42FE-823A-53A4052B8C8F".try_into().unwrap();
     let b = GUID::from_values(
         0x1fd63fef,
         0xc0d2,
@@ -25,7 +25,51 @@ fn from_u128() {
 #[test]
 fn to_u128() {
     let num: u128 = 0x1fd63fef_c0d2_42fe_823a_53a4052b8c8f;
-    let guid: GUID = "1FD63FEF-C0D2-42FE-823A-53A4052B8C8F".into();
+    let guid: GUID = "1FD63FEF-C0D2-42FE-823A-53A4052B8C8F".try_into().unwrap();
 
     assert_eq!(u128::from(guid), num); // From<GUID>
+}
+
+#[test]
+fn parsing() {
+    assert_eq!(
+        GUID::zeroed(),
+        "00000000-0000-0000-0000-000000000000".try_into().unwrap()
+    );
+
+    // Validate invalid length and expected error information.
+    let e = GUID::try_from("wrong length").unwrap_err();
+    assert_eq!(e.code(), E_INVALIDARG);
+    assert!(e.as_ptr().is_null());
+
+    // Validate delimiter
+    GUID::try_from("00000000?0000-0000-0000-000000000000").unwrap_err();
+    GUID::try_from("00000000-0000?0000-0000-000000000000").unwrap_err();
+    GUID::try_from("00000000-0000-0000?0000-000000000000").unwrap_err();
+    GUID::try_from("00000000-0000-0000-0000?000000000000").unwrap_err();
+
+    // Validate invalid digits
+    GUID::try_from("z0000000-0000-0000-0000-000000000000").unwrap_err();
+    GUID::try_from("00000000-z000-0000-0000-000000000000").unwrap_err();
+    GUID::try_from("00000000-0000-z000-0000-000000000000").unwrap_err();
+    GUID::try_from("00000000-0000-0000-z000-000000000000").unwrap_err();
+    GUID::try_from("00000000-0000-0000-0000-z00000000000").unwrap_err();
+
+    // Validate case insensitivity
+    let value = GUID::from_u128(0x1fd63fef_c0d2_42fe_823a_53a4052b8c8f);
+    assert_eq!(
+        value,
+        "1FD63FEF-C0D2-42FE-823A-53A4052B8C8F".try_into().unwrap()
+    );
+    assert_eq!(
+        value,
+        "1fd63fef-c0d2-42fe-823a-53a4052b8c8f".try_into().unwrap()
+    );
+}
+
+#[test]
+fn debug() {
+    let value = GUID::from_u128(0x1fd63fef_c0d2_42fe_823a_53a4052b8c8f);
+
+    assert_eq!(format!("{value:?}"), "1FD63FEF-C0D2-42FE-823A-53A4052B8C8F");
 }

--- a/crates/tests/interface/tests/com.rs
+++ b/crates/tests/interface/tests/com.rs
@@ -61,7 +61,7 @@ struct PersistState {
 
 impl ICustomPersist_Impl for Persist_Impl {
     unsafe fn GetClassID(&self, clsid: *mut GUID) -> HRESULT {
-        *clsid = "117fb826-2155-483a-b50d-bc99a2c7cca3".into();
+        *clsid = "117fb826-2155-483a-b50d-bc99a2c7cca3".try_into().unwrap();
         S_OK
     }
 }
@@ -136,7 +136,7 @@ fn test_custom_interface() -> windows::core::Result<()> {
         let p: IPersistMemory = p.cast()?;
         assert_eq!(
             p.GetClassID()?,
-            "117fb826-2155-483a-b50d-bc99a2c7cca3".into()
+            "117fb826-2155-483a-b50d-bc99a2c7cca3".try_into()?,
         );
         assert_eq!(p.GetSizeMax()?, 10);
         assert_eq!(p.IsDirty(), S_FALSE);
@@ -165,7 +165,7 @@ fn test_custom_interface() -> windows::core::Result<()> {
         let p: ICustomPersist = p.cast()?;
         let mut b = GUID::default();
         p.GetClassID(&mut b).ok()?;
-        assert_eq!(b, "117fb826-2155-483a-b50d-bc99a2c7cca3".into());
+        assert_eq!(b, "117fb826-2155-483a-b50d-bc99a2c7cca3".try_into()?);
 
         Ok(())
     }

--- a/crates/tests/interface/tests/com_from_existing.rs
+++ b/crates/tests/interface/tests/com_from_existing.rs
@@ -14,7 +14,7 @@ struct Test;
 
 impl IPersist_Impl for Test_Impl {
     fn GetClassID(&self) -> Result<GUID> {
-        Ok("CEE1D356-0860-4262-90D4-C77423F0E352".into())
+        "CEE1D356-0860-4262-90D4-C77423F0E352".try_into()
     }
 }
 
@@ -30,7 +30,7 @@ fn test() -> Result<()> {
         let p: IPersist = Test.into();
         assert_eq!(
             p.GetClassID()?,
-            "CEE1D356-0860-4262-90D4-C77423F0E352".into()
+            "CEE1D356-0860-4262-90D4-C77423F0E352".try_into()?
         );
 
         let m: ITestPersistMemory = p.cast()?;

--- a/crates/tests/interface/tests/no_use.rs
+++ b/crates/tests/interface/tests/no_use.rs
@@ -12,7 +12,7 @@ struct Test;
 
 impl windows::Win32::System::Com::IPersist_Impl for Test_Impl {
     fn GetClassID(&self) -> windows::core::Result<windows::core::GUID> {
-        Ok("CEE1D356-0860-4262-90D4-C77423F0E352".into())
+        "CEE1D356-0860-4262-90D4-C77423F0E352".try_into()
     }
 }
 
@@ -28,7 +28,7 @@ fn test() -> windows::core::Result<()> {
         let p: windows::Win32::System::Com::IPersist = Test.into();
         assert_eq!(
             p.GetClassID()?,
-            "CEE1D356-0860-4262-90D4-C77423F0E352".into()
+            "CEE1D356-0860-4262-90D4-C77423F0E352".try_into()?
         );
 
         let m: ITestPersistMemory = windows_core::Interface::cast(&p)?;

--- a/crates/tests/structs/tests/propertykey.rs
+++ b/crates/tests/structs/tests/propertykey.rs
@@ -2,6 +2,9 @@ use windows::Win32::Devices::Properties::DEVPKEY_Device_BiosDeviceName;
 
 #[test]
 fn test_debug_impl() {
-    assert!(DEVPKEY_Device_BiosDeviceName.fmtid == "540B947E-8B40-45BC-A8A2-6A0B894CBDA2".into());
+    assert!(
+        DEVPKEY_Device_BiosDeviceName.fmtid
+            == "540B947E-8B40-45BC-A8A2-6A0B894CBDA2".try_into().unwrap()
+    );
     assert!(DEVPKEY_Device_BiosDeviceName.pid == 10);
 }

--- a/crates/tests/win32/tests/win32.rs
+++ b/crates/tests/win32/tests/win32.rs
@@ -102,7 +102,7 @@ fn constant() {
     assert!(WM_KEYUP == 257u32);
     assert!(D3D12_DEFAULT_BLEND_FACTOR_ALPHA == 1f32);
     assert!(UIA_ScrollPatternNoScroll == -1f64);
-    assert!(CLSID_D2D1Shadow == GUID::from("C67EA361-1863-4e69-89DB-695D3E9A5B6B"));
+    assert!(CLSID_D2D1Shadow == GUID::try_from("C67EA361-1863-4e69-89DB-695D3E9A5B6B").unwrap());
 
     let b: PCSTR = D3DCOMPILER_DLL_A;
     let c: PCWSTR = D3DCOMPILER_DLL_W;
@@ -264,5 +264,5 @@ fn empty_struct() {
     assert!(ldap.0 == 123);
     assert!(core::mem::size_of::<PLDAPSearch>() == core::mem::size_of::<usize>());
 
-    assert!(UIAnimationManager == GUID::from("4C1FC63A-695C-47E8-A339-1A194BE3D0B8"));
+    assert!(UIAnimationManager == GUID::try_from("4C1FC63A-695C-47E8-A339-1A194BE3D0B8").unwrap());
 }

--- a/crates/tests/winrt/tests/delegates.rs
+++ b/crates/tests/winrt/tests/delegates.rs
@@ -10,7 +10,7 @@ fn non_generic() -> windows::core::Result<()> {
 
     assert_eq!(
         Handler::IID,
-        windows::core::GUID::from("A4ED5C81-76C9-40BD-8BE6-B1D90FB20AE7")
+        windows::core::GUID::try_from("A4ED5C81-76C9-40BD-8BE6-B1D90FB20AE7")?
     );
 
     let (tx, rx) = std::sync::mpsc::channel();
@@ -37,7 +37,7 @@ fn generic() -> windows::core::Result<()> {
 
     assert_eq!(
         Handler::IID,
-        windows::core::GUID::from("DAE18EA9-FCF3-5ACF-BCDD-8C354CBA6D23")
+        windows::core::GUID::try_from("DAE18EA9-FCF3-5ACF-BCDD-8C354CBA6D23")?
     );
 
     let uri = Uri::CreateUri(&windows::core::HSTRING::from("http://kennykerr.ca"))?;

--- a/crates/tests/winrt/tests/generic_guids.rs
+++ b/crates/tests/winrt/tests/generic_guids.rs
@@ -23,62 +23,62 @@ fn generic_guids() {
     //
     assert_eq!(
         IAsyncActionWithProgress::<A>::IID,
-        GUID::from("DD725452-2DA3-5103-9C7D-22EE9BB14AD3")
+        GUID::try_from("DD725452-2DA3-5103-9C7D-22EE9BB14AD3").unwrap()
     );
 
     assert_eq!(
         IAsyncOperationWithProgress::<A, B>::IID,
-        GUID::from("94645425-B9E5-5B91-B509-8DA4DF6A8916")
+        GUID::try_from("94645425-B9E5-5B91-B509-8DA4DF6A8916").unwrap()
     );
 
     assert_eq!(
         IAsyncOperation::<A>::IID,
-        GUID::from("2BD35EE6-72D9-5C5D-9827-05EBB81487AB")
+        GUID::try_from("2BD35EE6-72D9-5C5D-9827-05EBB81487AB").unwrap()
     );
 
     assert_eq!(
         IReferenceArray::<A>::IID,
-        GUID::from("4A33FE03-E8B9-5346-A124-5449913ECA57")
+        GUID::try_from("4A33FE03-E8B9-5346-A124-5449913ECA57").unwrap()
     );
 
     assert_eq!(
         IReference::<A>::IID,
-        GUID::from("F9E4006C-6E8C-56DF-811C-61F9990EBFB0")
+        GUID::try_from("F9E4006C-6E8C-56DF-811C-61F9990EBFB0").unwrap()
     );
 
     assert_eq!(
         AsyncActionProgressHandler::<A>::IID,
-        GUID::from("C261D8D0-71BA-5F38-A239-872342253A18")
+        GUID::try_from("C261D8D0-71BA-5F38-A239-872342253A18").unwrap()
     );
 
     assert_eq!(
         AsyncActionWithProgressCompletedHandler::<A>::IID,
-        GUID::from("9A0D211C-0374-5D23-9E15-EAA3570FAE63")
+        GUID::try_from("9A0D211C-0374-5D23-9E15-EAA3570FAE63").unwrap()
     );
 
     assert_eq!(
         AsyncOperationCompletedHandler::<A>::IID,
-        GUID::from("9D534225-231F-55E7-A6D0-6C938E2D9160")
+        GUID::try_from("9D534225-231F-55E7-A6D0-6C938E2D9160").unwrap()
     );
 
     assert_eq!(
         AsyncOperationProgressHandler::<A, B>::IID,
-        GUID::from("264F1E0C-ABE4-590B-9D37-E1CC118ECC75")
+        GUID::try_from("264F1E0C-ABE4-590B-9D37-E1CC118ECC75").unwrap()
     );
 
     assert_eq!(
         AsyncOperationWithProgressCompletedHandler::<A, B>::IID,
-        GUID::from("C2D078D8-AC47-55AB-83E8-123B2BE5BC5A")
+        GUID::try_from("C2D078D8-AC47-55AB-83E8-123B2BE5BC5A").unwrap()
     );
 
     assert_eq!(
         EventHandler::<A>::IID,
-        GUID::from("FA0B7D80-7EFA-52DF-9B69-0574CE57ADA4")
+        GUID::try_from("FA0B7D80-7EFA-52DF-9B69-0574CE57ADA4").unwrap()
     );
 
     assert_eq!(
         TypedEventHandler::<A, B>::IID,
-        GUID::from("EDB31843-B4CF-56EB-925A-D4D0CE97A08D")
+        GUID::try_from("EDB31843-B4CF-56EB-925A-D4D0CE97A08D").unwrap()
     );
 
     //
@@ -87,62 +87,62 @@ fn generic_guids() {
 
     assert_eq!(
         IIterable::<A>::IID,
-        GUID::from("96565EB9-A692-59C8-BCB5-647CDE4E6C4D")
+        GUID::try_from("96565EB9-A692-59C8-BCB5-647CDE4E6C4D").unwrap()
     );
 
     assert_eq!(
         IIterator::<A>::IID,
-        GUID::from("3C9B1E27-8357-590B-8828-6E917F172390")
+        GUID::try_from("3C9B1E27-8357-590B-8828-6E917F172390").unwrap()
     );
 
     assert_eq!(
         IKeyValuePair::<A, B>::IID,
-        GUID::from("89336CD9-8B66-50A7-9759-EB88CCB2E1FE")
+        GUID::try_from("89336CD9-8B66-50A7-9759-EB88CCB2E1FE").unwrap()
     );
 
     assert_eq!(
         IMapChangedEventArgs::<A>::IID,
-        GUID::from("E1AA5138-12BD-51A1-8558-698DFD070ABE")
+        GUID::try_from("E1AA5138-12BD-51A1-8558-698DFD070ABE").unwrap()
     );
 
     assert_eq!(
         IMapView::<A, B>::IID,
-        GUID::from("B78F0653-FA89-59CF-BA95-726938AAE666")
+        GUID::try_from("B78F0653-FA89-59CF-BA95-726938AAE666").unwrap()
     );
 
     assert_eq!(
         IMap::<A, B>::IID,
-        GUID::from("9962CD50-09D5-5C46-B1E1-3C679C1C8FAE")
+        GUID::try_from("9962CD50-09D5-5C46-B1E1-3C679C1C8FAE").unwrap()
     );
 
     assert_eq!(
         IObservableMap::<A, B>::IID,
-        GUID::from("75F99E2A-137E-537E-A5B1-0B5A6245FC02")
+        GUID::try_from("75F99E2A-137E-537E-A5B1-0B5A6245FC02").unwrap()
     );
 
     assert_eq!(
         IObservableVector::<A>::IID,
-        GUID::from("D24C289F-2341-5128-AAA1-292DD0DC1950")
+        GUID::try_from("D24C289F-2341-5128-AAA1-292DD0DC1950").unwrap()
     );
 
     assert_eq!(
         IVectorView::<A>::IID,
-        GUID::from("5F07498B-8E14-556E-9D2E-2E98D5615DA9")
+        GUID::try_from("5F07498B-8E14-556E-9D2E-2E98D5615DA9").unwrap()
     );
 
     assert_eq!(
         IVector::<A>::IID,
-        GUID::from("0E3F106F-A266-50A1-8043-C90FCF3844F6")
+        GUID::try_from("0E3F106F-A266-50A1-8043-C90FCF3844F6").unwrap()
     );
 
     assert_eq!(
         MapChangedEventHandler::<A, B>::IID,
-        GUID::from("19046F0B-CF81-5DEC-BBB2-7CC250DA8B8B")
+        GUID::try_from("19046F0B-CF81-5DEC-BBB2-7CC250DA8B8B").unwrap()
     );
 
     assert_eq!(
         VectorChangedEventHandler::<A>::IID,
-        GUID::from("A1E9ACD7-E4DF-5A79-AEFA-DE07934AB0FB")
+        GUID::try_from("A1E9ACD7-E4DF-5A79-AEFA-DE07934AB0FB").unwrap()
     );
 
     //
@@ -151,67 +151,67 @@ fn generic_guids() {
 
     assert_eq!(
         IReference::<bool>::IID,
-        GUID::from("3C00FD60-2950-5939-A21A-2D12C5A01B8A")
+        GUID::try_from("3C00FD60-2950-5939-A21A-2D12C5A01B8A").unwrap()
     );
 
     assert_eq!(
         IReference::<i8>::IID,
-        GUID::from("95500129-FBF6-5AFC-89DF-70642D741990")
+        GUID::try_from("95500129-FBF6-5AFC-89DF-70642D741990").unwrap()
     );
 
     assert_eq!(
         IReference::<i16>::IID,
-        GUID::from("6EC9E41B-6709-5647-9918-A1270110FC4E")
+        GUID::try_from("6EC9E41B-6709-5647-9918-A1270110FC4E").unwrap()
     );
 
     assert_eq!(
         IReference::<i32>::IID,
-        GUID::from("548CEFBD-BC8A-5FA0-8DF2-957440FC8BF4")
+        GUID::try_from("548CEFBD-BC8A-5FA0-8DF2-957440FC8BF4").unwrap()
     );
 
     assert_eq!(
         IReference::<i64>::IID,
-        GUID::from("4DDA9E24-E69F-5C6A-A0A6-93427365AF2A")
+        GUID::try_from("4DDA9E24-E69F-5C6A-A0A6-93427365AF2A").unwrap()
     );
 
     assert_eq!(
         IReference::<u8>::IID,
-        GUID::from("e5198cc8-2873-55f5-b0a1-84ff9e4aad62")
+        GUID::try_from("e5198cc8-2873-55f5-b0a1-84ff9e4aad62").unwrap()
     );
 
     assert_eq!(
         IReference::<u16>::IID,
-        GUID::from("5AB7D2C3-6B62-5E71-A4B6-2D49C4F238FD")
+        GUID::try_from("5AB7D2C3-6B62-5E71-A4B6-2D49C4F238FD").unwrap()
     );
 
     assert_eq!(
         IReference::<u32>::IID,
-        GUID::from("513ef3af-e784-5325-a91e-97c2b8111cf3")
+        GUID::try_from("513ef3af-e784-5325-a91e-97c2b8111cf3").unwrap()
     );
 
     assert_eq!(
         IReference::<u64>::IID,
-        GUID::from("6755e376-53bb-568b-a11d-17239868309e")
+        GUID::try_from("6755e376-53bb-568b-a11d-17239868309e").unwrap()
     );
 
     assert_eq!(
         IReference::<f32>::IID,
-        GUID::from("719CC2BA-3E76-5DEF-9F1A-38D85A145EA8")
+        GUID::try_from("719CC2BA-3E76-5DEF-9F1A-38D85A145EA8").unwrap()
     );
 
     assert_eq!(
         IReference::<f64>::IID,
-        GUID::from("2F2D6C29-5473-5F3E-92E7-96572BB990E2")
+        GUID::try_from("2F2D6C29-5473-5F3E-92E7-96572BB990E2").unwrap()
     );
 
     assert_eq!(
         IReference::<GUID>::IID,
-        GUID::from("7D50F649-632C-51F9-849A-EE49428933EA")
+        GUID::try_from("7D50F649-632C-51F9-849A-EE49428933EA").unwrap()
     );
 
     assert_eq!(
         IReference::<HSTRING>::IID,
-        GUID::from("FD416DFB-2A07-52EB-AAE3-DFCE14116C05")
+        GUID::try_from("FD416DFB-2A07-52EB-AAE3-DFCE14116C05").unwrap()
     );
 
     // TODO: structs and enums
@@ -234,7 +234,10 @@ fn generic_class_guid() {
         );
     }
 
-    assert_eq!(Uri::IID, GUID::from("9E365E57-48B2-4160-956F-C7385120BBFC"));
+    assert_eq!(
+        Uri::IID,
+        GUID::try_from("9E365E57-48B2-4160-956F-C7385120BBFC").unwrap()
+    );
 
     // Then the generic case...
 
@@ -246,6 +249,6 @@ fn generic_class_guid() {
 
     assert_eq!(
         DeviceInformationCollection::IID,
-        GUID::from("E170688F-3495-5BF6-AAB5-9CAC17E0F10F")
+        GUID::try_from("E170688F-3495-5BF6-AAB5-9CAC17E0F10F").unwrap()
     );
 }

--- a/crates/tests/winrt/tests/guid.rs
+++ b/crates/tests/winrt/tests/guid.rs
@@ -1,4 +1,3 @@
-use windows::core::GUID;
 use windows::Foundation::GuidHelper;
 
 #[test]
@@ -10,18 +9,4 @@ fn guid_helper() -> windows::core::Result<()> {
     assert!(GuidHelper::Equals(a, a)?);
 
     Ok(())
-}
-
-#[test]
-fn guid_from_string() {
-    let a = GUID::from("CFF52E04-CCA6-4614-A17E-754910C84A99");
-
-    let b = GUID::from_values(
-        0xCFF52E04,
-        0xCCA6,
-        0x4614,
-        [0xA1, 0x7E, 0x75, 0x49, 0x10, 0xC8, 0x4A, 0x99],
-    );
-
-    assert!(a == b);
 }

--- a/crates/tests/winrt/tests/interface.rs
+++ b/crates/tests/winrt/tests/interface.rs
@@ -5,7 +5,7 @@ use windows::Foundation::IStringable;
 fn interface() -> windows::core::Result<()> {
     assert_eq!(
         IStringable::IID,
-        windows::core::GUID::from("96369F54-8EB6-48F0-ABCE-C1B211E627C3")
+        windows::core::GUID::try_from("96369F54-8EB6-48F0-ABCE-C1B211E627C3")?
     );
 
     // TODO: Find an example where the default constructor is not exclusive.

--- a/crates/tests/winrt/tests/uri.rs
+++ b/crates/tests/winrt/tests/uri.rs
@@ -8,7 +8,7 @@ fn uri() -> windows::core::Result<()> {
 
     assert_eq!(
         Uri::IID,
-        windows::core::GUID::from("9E365E57-48B2-4160-956F-C7385120BBFC") // IUriRuntimeClass
+        windows::core::GUID::try_from("9E365E57-48B2-4160-956F-C7385120BBFC")? // IUriRuntimeClass
     );
 
     let uri = &Uri::CreateUri(&windows::core::HSTRING::from("http://kennykerr.ca"))?;

--- a/crates/tools/bindings/src/core_com.txt
+++ b/crates/tools/bindings/src/core_com.txt
@@ -6,6 +6,7 @@
 --filter
     Windows.Win32.Foundation.CO_E_NOTINITIALIZED
     Windows.Win32.Foundation.E_BOUNDS
+    Windows.Win32.Foundation.E_INVALIDARG
     Windows.Win32.Foundation.E_NOINTERFACE
     Windows.Win32.Foundation.E_OUTOFMEMORY
     Windows.Win32.Foundation.E_POINTER


### PR DESCRIPTION
I realized that Rust won't let us have both nor does it really make sense. The `From<&str>` is one of the first bits of Rust I ever wrote as I attempted to begin writing a Rust version of C++/WinRT. It's showing its age and well past time for a more useful replacement.

Fixes: #3174
