### PR TITLE
Remove uneeded feature dependencies

### DIFF
--- a/crates/samples/components/json_validator/Cargo.toml
+++ b/crates/samples/components/json_validator/Cargo.toml
@@ -14,6 +14,5 @@ serde_json = {version = "1.0", default-features = false }
 [dependencies.windows]
 path = "../../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_System_Com",
 ]

--- a/crates/samples/components/json_validator_winrt/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt/Cargo.toml
@@ -16,7 +16,6 @@ serde_json = {version = "1.0", default-features = false }
 path = "../../../libs/windows"
 features = [
     "implement",
-    "Win32_Foundation",
     "Win32_System_WinRT",
 ]
 

--- a/crates/tests/agile_reference/Cargo.toml
+++ b/crates/tests/agile_reference/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Foundation",
     "Media_Control",
     "Foundation_Collections"
 ]

--- a/crates/tests/alternate_success_code/Cargo.toml
+++ b/crates/tests/alternate_success_code/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_System_Ole",
     "Win32_System_Com",
 ]

--- a/crates/tests/bcrypt/Cargo.toml
+++ b/crates/tests/bcrypt/Cargo.toml
@@ -11,13 +11,11 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_Security_Cryptography",
 ]
 
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_Security_Cryptography",
 ]

--- a/crates/tests/calling_convention/Cargo.toml
+++ b/crates/tests/calling_convention/Cargo.toml
@@ -14,7 +14,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib)'] }
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_Networking_Ldap",
     "Win32_System_SystemInformation",
 ]
@@ -22,7 +21,6 @@ features = [
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_Networking_Ldap",
     "Win32_System_SystemInformation",
     "Win32_UI_WindowsAndMessaging",

--- a/crates/tests/component/Cargo.toml
+++ b/crates/tests/component/Cargo.toml
@@ -17,7 +17,6 @@ path = "../../libs/windows"
 features = [
     "implement",
     "Foundation",
-    "Win32_Foundation",
     "Win32_System_WinRT",
 ]
 

--- a/crates/tests/const_fields/Cargo.toml
+++ b/crates/tests/const_fields/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 path = "../../libs/windows"
 features = [
     "Win32_Storage_CloudFilters", 
-    "Win32_Foundation", 
     "Win32_System_CorrelationVector",
 ]
 
@@ -20,6 +19,5 @@ features = [
 path = "../../libs/sys"
 features = [
     "Win32_Storage_CloudFilters", 
-    "Win32_Foundation", 
     "Win32_System_CorrelationVector",
 ]

--- a/crates/tests/const_params/Cargo.toml
+++ b/crates/tests/const_params/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_UI_Shell",
     "Win32_System_WinRT",
     "Win32_System_Com",
@@ -20,6 +19,5 @@ features = [
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_UI_Shell",
 ]

--- a/crates/tests/const_ptrs/Cargo.toml
+++ b/crates/tests/const_ptrs/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_Variant",
     "Win32_UI_Shell_PropertiesSystem",

--- a/crates/tests/core/Cargo.toml
+++ b/crates/tests/core/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 path = "../../libs/windows"
 features = [
     "implement",
-    "Win32_Foundation",
     "Win32_System_WinRT",
     "Win32_System_Ole",
     "Win32_System_Com",

--- a/crates/tests/debugger_visualizer/Cargo.toml
+++ b/crates/tests/debugger_visualizer/Cargo.toml
@@ -16,7 +16,6 @@ path = "../../libs/windows"
 features = [
     "implement",
     "Win32_System_Com",
-    "Win32_Foundation",
 ]
 
 [dependencies.windows-core]

--- a/crates/tests/dispatch/Cargo.toml
+++ b/crates/tests/dispatch/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_System_Com",
     "Win32_System_Ole",
     "Win32_System_RemoteManagement",

--- a/crates/tests/enums/Cargo.toml
+++ b/crates/tests/enums/Cargo.toml
@@ -12,14 +12,12 @@ doctest = false
 path = "../../libs/windows"
 features = [
     "Storage_Streams",
-    "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
 ]
 
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
 ]
 

--- a/crates/tests/error/Cargo.toml
+++ b/crates/tests/error/Cargo.toml
@@ -13,7 +13,6 @@ path = "../../libs/windows"
 features = [
     "implement",
     "Foundation",
-    "Win32_Foundation",
     "Win32_System_Rpc",
 ]
 

--- a/crates/tests/extensions/Cargo.toml
+++ b/crates/tests/extensions/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_Security_Cryptography",   
     "Win32_NetworkManagement_IpHelper",
     "Win32_NetworkManagement_Ndis",

--- a/crates/tests/handles/Cargo.toml
+++ b/crates/tests/handles/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_System_Registry",
     "Win32_Devices_Bluetooth",
@@ -22,6 +21,5 @@ features = [
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_Graphics_Gdi",
 ]

--- a/crates/tests/implement/Cargo.toml
+++ b/crates/tests/implement/Cargo.toml
@@ -16,7 +16,6 @@ features = [
     "ApplicationModel_Background",
     "Foundation_Collections",
     "Storage_Streams",
-    "Win32_Foundation",
     "Win32_Graphics_Gdi", 
     "Win32_System_Com_StructuredStorage",
     "Win32_System_Ole",

--- a/crates/tests/interface/Cargo.toml
+++ b/crates/tests/interface/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 path = "../../libs/windows"
 features = [
     "implement",
-    "Win32_Foundation",
     "Win32_Graphics_Direct3D",
     "Win32_Graphics_Direct3D10",
     "Win32_Graphics_Direct3D12",

--- a/crates/tests/lib/Cargo.toml
+++ b/crates/tests/lib/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_Graphics_Direct3D_Fxc",
     "Win32_Graphics_Direct3D11",
     "Win32_Graphics_Gdi",
@@ -22,7 +21,6 @@ features = [
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_Security",
     "Win32_System_ProcessStatus",

--- a/crates/tests/metadata/Cargo.toml
+++ b/crates/tests/metadata/Cargo.toml
@@ -16,7 +16,6 @@ path = "../../libs/windows"
 features = [
     "Win32_Graphics_Gdi",
     "Win32_System_SystemServices",
-    "Win32_Foundation",
 ]
 
 [dependencies.windows-sys]
@@ -24,7 +23,6 @@ path = "../../libs/sys"
 features = [
     "Win32_Graphics_Gdi",
     "Win32_System_SystemServices",
-    "Win32_Foundation",
 ]
 
 [dependencies.tool_lib]

--- a/crates/tests/msrv/Cargo.toml
+++ b/crates/tests/msrv/Cargo.toml
@@ -11,8 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Foundation",
     "Globalization",
-    "Win32_Foundation",
     "Win32_Graphics_Direct2D",
 ]

--- a/crates/tests/not_dll/Cargo.toml
+++ b/crates/tests/not_dll/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 path = "../../libs/windows"
 features = [
     "Win32_Graphics_Printing",
-    "Win32_Foundation",
     "Win32_Graphics_Gdi",
 ]
 
@@ -20,6 +19,5 @@ features = [
 path = "../../libs/sys"
 features = [
     "Win32_Graphics_Printing",
-    "Win32_Foundation",
     "Win32_Graphics_Gdi",
 ]

--- a/crates/tests/readme/Cargo.toml
+++ b/crates/tests/readme/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 path = "../../libs/windows"
 features = [
     "Data_Xml_Dom",
-    "Win32_Foundation",
     "Win32_Security",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
@@ -17,7 +16,6 @@ features = [
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_Security",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",

--- a/crates/tests/reserved/Cargo.toml
+++ b/crates/tests/reserved/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_System_Registry",
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_Threading",
@@ -20,7 +19,6 @@ features = [
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_System_Registry",
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_Threading",

--- a/crates/tests/resources/Cargo.toml
+++ b/crates/tests/resources/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_UI_Controls",
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_Com",
@@ -20,7 +19,6 @@ features = [
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_UI_Controls",
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_Com",

--- a/crates/tests/return_handle/Cargo.toml
+++ b/crates/tests/return_handle/Cargo.toml
@@ -12,6 +12,5 @@ doctest = false
 path = "../../libs/windows"
 features = [
     "Win32_System_Threading",
-    "Win32_Foundation",
     "Win32_Security",
 ]

--- a/crates/tests/string_param/Cargo.toml
+++ b/crates/tests/string_param/Cargo.toml
@@ -11,6 +11,5 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_UI_Shell",
 ]

--- a/crates/tests/structs/Cargo.toml
+++ b/crates/tests/structs/Cargo.toml
@@ -14,7 +14,6 @@ features = [
     "implement",
     "Storage_Search",
     "Win32_Devices_Properties",
-    "Win32_Foundation",
     "Win32_System_Diagnostics_Debug",
     "Win32_UI_Shell_PropertiesSystem",
     "Win32_UI_WindowsAndMessaging",

--- a/crates/tests/sys/Cargo.toml
+++ b/crates/tests/sys/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_Security",
     "Win32_System_Threading",

--- a/crates/tests/targets/Cargo.toml
+++ b/crates/tests/targets/Cargo.toml
@@ -13,11 +13,11 @@ path = "../../libs/targets"
 
 [dependencies.windows]
 path = "../../libs/windows"
-features = [ "Win32_Foundation", "Win32_Security_Authentication_Identity" ]
+features = [ "Win32_Security_Authentication_Identity" ]
 
 [dependencies.windows-sys]
 path = "../../libs/sys"
-features = [ "Win32_Foundation", "Win32_Security_Authentication_Identity" ]
+features = [ "Win32_Security_Authentication_Identity" ]
 
 [dependencies.tool_lib]
 path = "../../tools/lib"

--- a/crates/tests/unions/Cargo.toml
+++ b/crates/tests/unions/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_Graphics_Direct3D12",
     "Win32_System_IO",
 ]
@@ -19,6 +18,5 @@ features = [
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_System_IO",
 ]

--- a/crates/tests/variant/Cargo.toml
+++ b/crates/tests/variant/Cargo.toml
@@ -15,6 +15,5 @@ path = "../../libs/core"
 path = "../../libs/windows"
 features = [
     "Foundation",
-    "Win32_Foundation",
     "Win32_System_Com_Events",
 ]

--- a/crates/tests/wdk/Cargo.toml
+++ b/crates/tests/wdk/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Wdk_System_SystemServices",
     "Wdk_System_OfflineRegistry",
 ]
@@ -19,7 +18,6 @@ features = [
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Wdk_System_SystemServices",
     "Wdk_System_OfflineRegistry",
 ]

--- a/crates/tests/win32/Cargo.toml
+++ b/crates/tests/win32/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_Gaming",
     "Win32_Graphics_Direct2D",
     "Win32_Graphics_Direct3D",

--- a/crates/tests/win32_arrays/Cargo.toml
+++ b/crates/tests/win32_arrays/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Gdi",
     "Win32_NetworkManagement_IpHelper",

--- a/crates/tests/window_long/Cargo.toml
+++ b/crates/tests/window_long/Cargo.toml
@@ -11,13 +11,11 @@ doctest = false
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
-    "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
 ]
 
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
-    "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
 ]


### PR DESCRIPTION
Following #2735, these are no longer required. 