### PR TITLE
Cleanup doc testing

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,13 +20,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Check
         run: cargo doc --no-deps -p windows
-      - name: Doctests
-        run: >
-          cargo test --doc -p windows
-          -F Data_Xml_Dom
-          -F Win32_Security
-          -F Win32_System_Threading
-          -F Win32_UI_WindowsAndMessaging
 
   windows-sys:
     name: windows-sys
@@ -36,12 +29,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Check
         run: cargo doc --no-deps -p windows-sys
-      - name: Doctests
-        run: >
-          cargo test --doc -p windows-sys
-          -F Win32_Security
-          -F Win32_System_Threading
-          -F Win32_UI_WindowsAndMessaging
 
   other-crates:
     runs-on: windows-latest
@@ -52,21 +39,6 @@ jobs:
       - name: Check
         run: >
           cargo doc --no-deps
-          -p windows-bindgen
-          -p windows-core
-          -p cppwinrt
-          -p windows-implement
-          -p windows-interface
-          -p windows-metadata
-          -p windows-registry
-          -p windows-result
-          -p windows-strings
-          -p windows-targets
-          -p windows-version
-
-      - name: Doctests
-        run: >
-          cargo test --doc
           -p windows-bindgen
           -p windows-core
           -p cppwinrt


### PR DESCRIPTION
**What's this all about?**

Removes the duplicate doctests. I kept the `cargo doc` to ensure the documentation always builds.

Fixes: #3204