### PR TITLE
Always treat warnings as errors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,7 @@
 [build]
 rustflags = [
+    "-D", "warnings",
+
     # "--cfg", "windows_debugger_visualizer",
     # "--cfg", "windows_raw_dylib",
     # "--cfg", "windows_slim_errors",

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     runs-on: windows-2022

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -9,7 +9,6 @@ on:
       - master
 
 env:
-  RUSTFLAGS: -Dwarnings
   LLVM-MINGW-TOOLCHAIN-NAME: llvm-mingw-20220906-ucrt-ubuntu-18.04-x86_64
 
 jobs:

--- a/.github/workflows/debugger_visualizer.yml
+++ b/.github/workflows/debugger_visualizer.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  RUSTFLAGS: -Dwarnings --cfg windows_debugger_visualizer
+  RUSTFLAGS: --cfg windows_debugger_visualizer
 
 jobs:
   check:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   windows:
     name: windows

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     name: tool_${{ matrix.tool }}

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     runs-on: windows-2022

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/msrv-windows-bindgen.yml
+++ b/.github/workflows/msrv-windows-bindgen.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     strategy:

--- a/.github/workflows/msrv-windows-core.yml
+++ b/.github/workflows/msrv-windows-core.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     strategy:

--- a/.github/workflows/msrv-windows-metadata.yml
+++ b/.github/workflows/msrv-windows-metadata.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     strategy:

--- a/.github/workflows/msrv-windows-registry.yml
+++ b/.github/workflows/msrv-windows-registry.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     strategy:

--- a/.github/workflows/msrv-windows-result.yml
+++ b/.github/workflows/msrv-windows-result.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     strategy:

--- a/.github/workflows/msrv-windows-strings.yml
+++ b/.github/workflows/msrv-windows-strings.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     strategy:

--- a/.github/workflows/msrv-windows-sys.yml
+++ b/.github/workflows/msrv-windows-sys.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     strategy:

--- a/.github/workflows/msrv-windows-version.yml
+++ b/.github/workflows/msrv-windows-version.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     strategy:

--- a/.github/workflows/msrv-windows.yml
+++ b/.github/workflows/msrv-windows.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     strategy:

--- a/.github/workflows/no-default-features.yml
+++ b/.github/workflows/no-default-features.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     runs-on: windows-2022

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     strategy:

--- a/.github/workflows/raw_dylib.yml
+++ b/.github/workflows/raw_dylib.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  RUSTFLAGS: -Dwarnings --cfg windows_raw_dylib
+  RUSTFLAGS: --cfg windows_raw_dylib
 
 jobs:
   check:

--- a/.github/workflows/slim_errors.yml
+++ b/.github/workflows/slim_errors.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  RUSTFLAGS: -Dwarnings --cfg windows_slim_errors
+  RUSTFLAGS: --cfg windows_slim_errors
 
 jobs:
   check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     runs-on: windows-2022

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -17,9 +17,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     runs-on: windows-2022
@@ -114,9 +111,6 @@ on:
     branches:
       - master
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   check:
     runs-on: windows-2022
@@ -165,9 +159,6 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
     branches:
       - master
-
-env:
-  RUSTFLAGS: -Dwarnings
 
 jobs:
   check:


### PR DESCRIPTION
Previously, warnings were treated as errors only for PR validation. This just makes it easier to catch such issues during development and avoid unnecessary PR validation failure.