### PR TITLE
Consistent allocation failure for `windows-registry`

### DIFF
--- a/crates/libs/registry/src/bindings.rs
+++ b/crates/libs/registry/src/bindings.rs
@@ -21,7 +21,6 @@ windows_targets::link!("kernel32.dll" "system" fn HeapFree(hheap : HANDLE, dwfla
 pub type BOOL = i32;
 pub const ERROR_INVALID_DATA: WIN32_ERROR = 13u32;
 pub const ERROR_NO_MORE_ITEMS: WIN32_ERROR = 259u32;
-pub const ERROR_OUTOFMEMORY: WIN32_ERROR = 14u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct FILETIME {

--- a/crates/libs/registry/src/key.rs
+++ b/crates/libs/registry/src/key.rs
@@ -144,7 +144,7 @@ impl Key {
     pub fn get_value<T: AsRef<str>>(&self, name: T) -> Result<Value> {
         let name = pcwstr(name);
         let (ty, len) = unsafe { self.raw_get_info(name.as_raw())? };
-        let mut data = Data::new(len)?;
+        let mut data = Data::new(len);
         unsafe { self.raw_get_bytes(name.as_raw(), &mut data)? };
         Ok(Value { data, ty })
     }

--- a/crates/libs/registry/src/value.rs
+++ b/crates/libs/registry/src/value.rs
@@ -38,13 +38,12 @@ impl AsRef<[u8]> for Value {
     }
 }
 
-impl TryFrom<u32> for Value {
-    type Error = Error;
-    fn try_from(from: u32) -> Result<Self> {
-        Ok(Self {
-            data: from.to_le_bytes().try_into()?,
+impl From<u32> for Value {
+    fn from(from: u32) -> Self {
+        Self {
+            data: from.to_le_bytes().into(),
             ty: Type::U32,
-        })
+        }
     }
 }
 
@@ -55,13 +54,12 @@ impl TryFrom<Value> for u32 {
     }
 }
 
-impl TryFrom<u64> for Value {
-    type Error = Error;
-    fn try_from(from: u64) -> Result<Self> {
-        Ok(Self {
-            data: from.to_le_bytes().try_into()?,
+impl From<u64> for Value {
+    fn from(from: u64) -> Self {
+        Self {
+            data: from.to_le_bytes().into(),
             ty: Type::U64,
-        })
+        }
     }
 }
 
@@ -82,13 +80,12 @@ impl TryFrom<Value> for String {
     }
 }
 
-impl TryFrom<&str> for Value {
-    type Error = Error;
-    fn try_from(from: &str) -> Result<Self> {
-        Ok(Self {
-            data: Data::from_slice(pcwstr(from).as_bytes())?,
+impl From<&str> for Value {
+    fn from(from: &str) -> Self {
+        Self {
+            data: Data::from_slice(pcwstr(from).as_bytes()),
             ty: Type::String,
-        })
+        }
     }
 }
 
@@ -117,33 +114,30 @@ impl TryFrom<Value> for HSTRING {
     }
 }
 
-impl TryFrom<&HSTRING> for Value {
-    type Error = Error;
-    fn try_from(from: &HSTRING) -> Result<Self> {
-        Ok(Self {
-            data: Data::from_slice(as_bytes(from))?,
+impl From<&HSTRING> for Value {
+    fn from(from: &HSTRING) -> Self {
+        Self {
+            data: Data::from_slice(as_bytes(from)),
             ty: Type::String,
-        })
+        }
     }
 }
 
-impl TryFrom<&[u8]> for Value {
-    type Error = Error;
-    fn try_from(from: &[u8]) -> Result<Self> {
-        Ok(Self {
-            data: Data::from_slice(from)?,
+impl From<&[u8]> for Value {
+    fn from(from: &[u8]) -> Self {
+        Self {
+            data: Data::from_slice(from),
             ty: Type::Bytes,
-        })
+        }
     }
 }
 
-impl<const N: usize> TryFrom<[u8; N]> for Value {
-    type Error = Error;
-    fn try_from(from: [u8; N]) -> Result<Self> {
-        Ok(Self {
-            data: Data::from_slice(&from)?,
+impl<const N: usize> From<[u8; N]> for Value {
+    fn from(from: [u8; N]) -> Self {
+        Self {
+            data: Data::from_slice(&from),
             ty: Type::Bytes,
-        })
+        }
     }
 }
 

--- a/crates/libs/registry/src/value_iterator.rs
+++ b/crates/libs/registry/src/value_iterator.rs
@@ -37,7 +37,7 @@ impl<'a> ValueIterator<'a> {
             key,
             range: 0..count as usize,
             name: vec![0; name_max_len as usize + 1],
-            data: Data::new(value_max_len as usize)?,
+            data: Data::new(value_max_len as usize),
         })
     }
 }
@@ -72,7 +72,7 @@ impl<'a> Iterator for ValueIterator<'a> {
                 Some((
                     name,
                     Value {
-                        data: Data::from_slice(&self.data[0..data_len as usize]).unwrap(),
+                        data: Data::from_slice(&self.data[0..data_len as usize]),
                         ty: ty.into(),
                     },
                 ))

--- a/crates/tests/registry/tests/value.rs
+++ b/crates/tests/registry/tests/value.rs
@@ -7,27 +7,27 @@ fn value() -> Result<()> {
     _ = CURRENT_USER.remove_tree(test_key);
     let key = CURRENT_USER.create(test_key)?;
 
-    key.set_value("u32", &Value::try_from(123u32)?)?;
+    key.set_value("u32", &Value::from(123u32))?;
     assert_eq!(key.get_type("u32")?, Type::U32);
-    assert_eq!(key.get_value("u32")?, Value::try_from(123u32)?);
+    assert_eq!(key.get_value("u32")?, Value::from(123u32));
     assert_eq!(key.get_u32("u32")?, 123u32);
     assert_eq!(key.get_u64("u32")?, 123u64);
     assert_eq!(u32::try_from(key.get_value("u32")?)?, 123u32);
 
     assert_eq!(unsafe { key.raw_get_info(w!("u32"))? }, (Type::U32, 4));
 
-    key.set_value("u64", &Value::try_from(123u64)?)?;
+    key.set_value("u64", &Value::from(123u64))?;
     assert_eq!(key.get_type("u64")?, Type::U64);
-    assert_eq!(key.get_value("u64")?, Value::try_from(123u64)?);
+    assert_eq!(key.get_value("u64")?, Value::from(123u64));
     assert_eq!(key.get_u32("u64")?, 123u32);
     assert_eq!(key.get_u64("u64")?, 123u64);
     assert_eq!(u64::try_from(key.get_value("u64")?)?, 123u64);
 
     assert_eq!(unsafe { key.raw_get_info(w!("u64"))? }, (Type::U64, 8));
 
-    key.set_value("string", &Value::try_from("string")?)?;
+    key.set_value("string", &Value::from("string"))?;
     assert_eq!(key.get_type("string")?, Type::String);
-    assert_eq!(key.get_value("string")?, Value::try_from("string")?);
+    assert_eq!(key.get_value("string")?, Value::from("string"));
     assert_eq!(key.get_string("string")?, "string");
     assert_eq!(String::try_from(key.get_value("string")?)?, "string");
 
@@ -36,7 +36,7 @@ fn value() -> Result<()> {
         (Type::String, 14)
     );
 
-    let mut value = Value::try_from("expand")?;
+    let mut value = Value::from("expand");
     value.set_ty(Type::ExpandString);
     assert_eq!(value.ty(), Type::ExpandString);
     key.set_value("expand", &value)?;
@@ -49,13 +49,13 @@ fn value() -> Result<()> {
         (Type::ExpandString, 14)
     );
 
-    key.set_value("bytes", &Value::try_from([1u8, 2u8, 3u8])?)?;
+    key.set_value("bytes", &Value::from([1u8, 2u8, 3u8]))?;
     assert_eq!(key.get_type("bytes")?, Type::Bytes);
-    assert_eq!(key.get_value("bytes")?, Value::try_from([1, 2, 3])?);
+    assert_eq!(key.get_value("bytes")?, Value::from([1, 2, 3]));
 
     assert_eq!(unsafe { key.raw_get_info(w!("bytes"))? }, (Type::Bytes, 3));
 
-    let mut value = Value::try_from([1u8, 2u8, 3u8, 4u8].as_slice())?;
+    let mut value = Value::from([1u8, 2u8, 3u8, 4u8].as_slice());
     value.set_ty(Type::Other(1234));
     key.set_value("slice", &value)?;
     assert_eq!(key.get_type("slice")?, Type::Other(1234));
@@ -66,9 +66,9 @@ fn value() -> Result<()> {
         (Type::Other(1234), 4)
     );
 
-    key.set_value("hstring", &Value::try_from(h!("HSTRING"))?)?;
+    key.set_value("hstring", &Value::from(h!("HSTRING")))?;
     assert_eq!(key.get_type("hstring")?, Type::String);
-    assert_eq!(key.get_value("hstring")?, Value::try_from(h!("HSTRING"))?);
+    assert_eq!(key.get_value("hstring")?, Value::from(h!("HSTRING")));
     assert_eq!(key.get_string("hstring")?, "HSTRING");
     assert_eq!(HSTRING::try_from(key.get_value("hstring")?)?, "HSTRING");
 
@@ -77,9 +77,9 @@ fn value() -> Result<()> {
         (Type::String, 16)
     );
 
-    let abc = Value::try_from("abc")?;
+    let abc = Value::from("abc");
     assert_eq!(abc.as_wide(), &[97, 98, 99, 0]);
-    let abc = Value::try_from(h!("abcd"))?;
+    let abc = Value::from(h!("abcd"));
     assert_eq!(abc.as_wide(), &[97, 98, 99, 100, 0]);
 
     Ok(())

--- a/crates/tests/registry/tests/values.rs
+++ b/crates/tests/registry/tests/values.rs
@@ -16,9 +16,9 @@ fn values() -> Result<()> {
     assert_eq!(
         names,
         [
-            ("u32".to_string(), Value::try_from(123u32)?),
-            ("u64".to_string(), Value::try_from(456u64)?),
-            ("string".to_string(), Value::try_from("hello world")?),
+            ("u32".to_string(), Value::from(123u32)),
+            ("u64".to_string(), Value::from(456u64)),
+            ("string".to_string(), Value::from("hello world")),
         ]
     );
 

--- a/crates/tools/bindings/src/registry.txt
+++ b/crates/tools/bindings/src/registry.txt
@@ -4,7 +4,6 @@
 --filter
     Windows.Win32.Foundation.ERROR_INVALID_DATA
     Windows.Win32.Foundation.ERROR_NO_MORE_ITEMS
-    Windows.Win32.Foundation.ERROR_OUTOFMEMORY
     Windows.Win32.System.Memory.GetProcessHeap
     Windows.Win32.System.Memory.HeapAlloc
     Windows.Win32.System.Memory.HeapFree


### PR DESCRIPTION
Following on from #3209, this just further brings the `windows-registry` crate in line with the same allocation failure policy.