### PR TITLE
Consistent allocation failure for stock collections

### DIFF
--- a/crates/libs/windows/src/extensions/Foundation/Collections/Iterable.rs
+++ b/crates/libs/windows/src/extensions/Foundation/Collections/Iterable.rs
@@ -76,14 +76,12 @@ where
     }
 }
 
-impl<T> TryFrom<Vec<T::Default>> for IIterable<T>
+impl<T> From<Vec<T::Default>> for IIterable<T>
 where
     T: windows_core::RuntimeType,
     T::Default: Clone,
 {
-    type Error = windows_core::Error;
-    fn try_from(values: Vec<T::Default>) -> windows_core::Result<Self> {
-        // TODO: should provide a fallible try_into or more explicit allocator
-        Ok(windows_core::ComObject::new(StockIterable { values }).into_interface())
+    fn from(values: Vec<T::Default>) -> Self {
+        windows_core::ComObject::new(StockIterable { values }).into_interface()
     }
 }

--- a/crates/libs/windows/src/extensions/Foundation/Collections/MapView.rs
+++ b/crates/libs/windows/src/extensions/Foundation/Collections/MapView.rs
@@ -135,16 +135,14 @@ where
     }
 }
 
-impl<K, V> TryFrom<std::collections::BTreeMap<K::Default, V::Default>> for IMapView<K, V>
+impl<K, V> From<std::collections::BTreeMap<K::Default, V::Default>> for IMapView<K, V>
 where
     K: windows_core::RuntimeType,
     V: windows_core::RuntimeType,
     K::Default: Clone + Ord,
     V::Default: Clone,
 {
-    type Error = windows_core::Error;
-    fn try_from(map: std::collections::BTreeMap<K::Default, V::Default>) -> windows_core::Result<Self> {
-        // TODO: should provide a fallible try_into or more explicit allocator
-        Ok(StockMapView { map }.into())
+    fn from(map: std::collections::BTreeMap<K::Default, V::Default>) -> Self {
+        StockMapView { map }.into()
     }
 }

--- a/crates/libs/windows/src/extensions/Foundation/Collections/VectorView.rs
+++ b/crates/libs/windows/src/extensions/Foundation/Collections/VectorView.rs
@@ -105,14 +105,12 @@ where
     }
 }
 
-impl<T> TryFrom<Vec<T::Default>> for IVectorView<T>
+impl<T> From<Vec<T::Default>> for IVectorView<T>
 where
     T: windows_core::RuntimeType,
     T::Default: Clone + PartialEq,
 {
-    type Error = windows_core::Error;
-    fn try_from(values: Vec<T::Default>) -> windows_core::Result<Self> {
-        // TODO: should provide a fallible try_into or more explicit allocator
-        Ok(windows_core::ComObject::new(StockVectorView { values }).into_interface())
+    fn from(values: Vec<T::Default>) -> Self {
+        windows_core::ComObject::new(StockVectorView { values }).into_interface()
     }
 }

--- a/crates/tests/collections/tests/stock_iterable.rs
+++ b/crates/tests/collections/tests/stock_iterable.rs
@@ -6,7 +6,7 @@ use windows::{core::*, Foundation::Collections::*, Foundation::*, Win32::Foundat
 fn calendar() -> Result<()> {
     use windows::Globalization::*;
 
-    let languages = IIterable::try_from(vec![HSTRING::from("he-IL"), HSTRING::from("ja-JP")])?;
+    let languages = IIterable::from(vec![HSTRING::from("he-IL"), HSTRING::from("ja-JP")]);
     let calendar = Calendar::CreateCalendar(
         &languages,
         &CalendarIdentifiers::Hebrew()?,
@@ -23,7 +23,7 @@ fn calendar() -> Result<()> {
 
 #[test]
 fn primitive() -> Result<()> {
-    let able = IIterable::<i32>::try_from(vec![])?;
+    let able = IIterable::<i32>::from(vec![]);
     let iter = able.First()?;
 
     assert_eq!(iter.Current().unwrap_err().code(), E_BOUNDS);
@@ -37,7 +37,7 @@ fn primitive() -> Result<()> {
 
     assert_eq!(iter.GetMany(&mut [0; 5])?, 0);
 
-    let able = IIterable::<i32>::try_from(vec![1, 2, 3])?;
+    let able = IIterable::<i32>::from(vec![1, 2, 3]);
     let iter = able.First()?;
 
     assert_eq!(iter.Current()?, 1);
@@ -85,7 +85,7 @@ fn primitive() -> Result<()> {
 
 #[test]
 fn hstring() -> Result<()> {
-    let able = IIterable::<HSTRING>::try_from(vec![])?;
+    let able = IIterable::<HSTRING>::from(vec![]);
     let iter = able.First()?;
 
     assert_eq!(iter.Current().unwrap_err().code(), E_BOUNDS);
@@ -101,11 +101,11 @@ fn hstring() -> Result<()> {
     values.resize_with(5, Default::default);
     assert_eq!(iter.GetMany(&mut values)?, 0);
 
-    let able = IIterable::<HSTRING>::try_from(vec![
+    let able = IIterable::<HSTRING>::from(vec![
         HSTRING::from("one"),
         HSTRING::from("two"),
         HSTRING::from("three"),
-    ])?;
+    ]);
     let iter = able.First()?;
 
     assert_eq!(&iter.Current()?, h!("one"));
@@ -178,7 +178,7 @@ fn stringable(value: &str) -> IStringable {
 
 #[test]
 fn defaulted() -> Result<()> {
-    let able = IIterable::<IStringable>::try_from(vec![])?;
+    let able = IIterable::<IStringable>::from(vec![]);
     let iter = able.First()?;
 
     assert_eq!(iter.Current().unwrap_err().code(), E_BOUNDS);
@@ -194,11 +194,11 @@ fn defaulted() -> Result<()> {
     values.resize(5, None);
     assert_eq!(iter.GetMany(&mut values)?, 0);
 
-    let able = IIterable::<IStringable>::try_from(vec![
+    let able = IIterable::<IStringable>::from(vec![
         Some(stringable("one")),
         Some(stringable("two")),
         Some(stringable("three")),
-    ])?;
+    ]);
     let iter = able.First()?;
 
     assert_eq!(iter.Current()?.ToString()?, "one");

--- a/crates/tests/collections/tests/stock_map_view.rs
+++ b/crates/tests/collections/tests/stock_map_view.rs
@@ -5,7 +5,7 @@ use windows::{core::*, Foundation::Collections::*, Win32::Foundation::E_BOUNDS};
 
 #[test]
 fn primitive() -> Result<()> {
-    let m = IMapView::<i32, u64>::try_from(BTreeMap::from([]))?;
+    let m = IMapView::<i32, u64>::from(BTreeMap::from([]));
     assert_eq!(m.Lookup(0).unwrap_err().code(), E_BOUNDS);
     assert_eq!(m.Size()?, 0);
     assert_eq!(m.HasKey(0)?, false);
@@ -14,7 +14,7 @@ fn primitive() -> Result<()> {
     m.Split(&mut left, &mut right)?;
 
     let m = BTreeMap::from([(1, 10), (2, 20)]);
-    let m: IMapView<i32, u64> = m.try_into()?;
+    let m: IMapView<i32, u64> = m.into();
     assert_eq!(m.Lookup(1i32)?, 10u64);
     assert_eq!(m.Lookup(2)?, 20);
     assert_eq!(m.Size()?, 2);
@@ -29,7 +29,7 @@ fn primitive() -> Result<()> {
 
 #[test]
 fn primitive_iterator() -> Result<()> {
-    let able = IMapView::<i32, u64>::try_from(BTreeMap::from([]))?;
+    let able = IMapView::<i32, u64>::from(BTreeMap::from([]));
     let iter = able.First()?;
 
     assert_eq!(iter.Current().unwrap_err().code(), E_BOUNDS);
@@ -45,7 +45,7 @@ fn primitive_iterator() -> Result<()> {
     values.resize_with(5, Default::default);
     assert_eq!(iter.GetMany(&mut values)?, 0);
 
-    let able = IMapView::<i32, u64>::try_from(BTreeMap::from([(1, 10), (2, 20), (3, 30)]))?;
+    let able = IMapView::<i32, u64>::from(BTreeMap::from([(1, 10), (2, 20), (3, 30)]));
     let iter = able.First()?;
 
     assert_eq!(iter.Current()?.Key()?, 1i32);
@@ -112,7 +112,7 @@ where
 
 #[test]
 fn hstring() -> Result<()> {
-    let m = IMapView::<HSTRING, i32>::try_from(BTreeMap::new())?;
+    let m = IMapView::<HSTRING, i32>::from(BTreeMap::new());
     assert_eq!(m.Lookup(h!("missing")).unwrap_err().code(), E_BOUNDS);
     assert_eq!(m.Size()?, 0);
     assert_eq!(m.HasKey(h!("missing"))?, false);
@@ -120,7 +120,7 @@ fn hstring() -> Result<()> {
     let m = BTreeMap::from([("one".into(), 1), ("two".into(), 2)]);
     assert!(m.contains_key(h!("one")));
 
-    let m = IMapView::<HSTRING, i32>::try_from(m)?;
+    let m = IMapView::<HSTRING, i32>::from(m);
     assert_eq!(m.Lookup(h!("one"))?, 1);
     assert_eq!(m.Lookup(h!("two"))?, 2);
     assert_eq!(m.Size()?, 2);

--- a/crates/tests/collections/tests/stock_vector_view.rs
+++ b/crates/tests/collections/tests/stock_vector_view.rs
@@ -4,13 +4,13 @@ use windows::{core::*, Foundation::Collections::*, Win32::Foundation::E_BOUNDS};
 
 #[test]
 fn primitive() -> Result<()> {
-    let v = IVectorView::<i32>::try_from(vec![])?;
+    let v = IVectorView::<i32>::from(vec![]);
     assert_eq!(v.GetAt(0).unwrap_err().code(), E_BOUNDS);
     assert_eq!(v.Size()?, 0);
     assert_eq!(v.IndexOf(0, &mut 0)?, false);
     assert_eq!(v.GetMany(0, &mut [0; 5])?, 0);
 
-    let v = IVectorView::<i32>::try_from(vec![1, 2, 3])?;
+    let v = IVectorView::<i32>::from(vec![1, 2, 3]);
     assert_eq!(v.GetAt(0)?, 1);
     assert_eq!(v.GetAt(1)?, 2);
     assert_eq!(v.GetAt(2)?, 3);
@@ -45,7 +45,7 @@ fn primitive() -> Result<()> {
 
 #[test]
 fn primitive_iterator() -> Result<()> {
-    let able = IVectorView::<i32>::try_from(vec![])?;
+    let able = IVectorView::<i32>::from(vec![]);
     let iter = able.First()?;
 
     assert_eq!(iter.Current().unwrap_err().code(), E_BOUNDS);
@@ -59,7 +59,7 @@ fn primitive_iterator() -> Result<()> {
 
     assert_eq!(iter.GetMany(&mut [0; 5])?, 0);
 
-    let able = IVectorView::<i32>::try_from(vec![1, 2, 3])?;
+    let able = IVectorView::<i32>::from(vec![1, 2, 3]);
     let iter = able.First()?;
 
     assert_eq!(iter.Current()?, 1);


### PR DESCRIPTION
Following on from #3215, this similarly removes the unnecessary error handling around stock collection creation.