### PR TITLE
Use relative path for extension

### DIFF
--- a/crates/libs/bindgen/src/rust/extensions/mod.rs
+++ b/crates/libs/bindgen/src/rust/extensions/mod.rs
@@ -5,15 +5,12 @@ use super::*;
 /// This function generates an `include!(...)` that points into the `src/includes` directory for
 /// the `windows` and `windows-sys` crates. This makes it easy to inject code into WinMD namespaces.
 #[allow(dead_code)]
-fn include_ext(relative_path: &str) -> TokenStream {
+fn include_ext(namespace: &str, relative_path: &str) -> TokenStream {
+    let mut path = "../".repeat(namespace.split('.').count());
+    path.push_str("includes/");
+    path.push_str(relative_path);
     quote! {
-        core::include!(
-            core::concat!(
-                core::env!("CARGO_MANIFEST_DIR"),
-                "/src/includes/",
-                #relative_path
-            )
-        );
+        core::include!(#path);
     }
 }
 
@@ -21,7 +18,7 @@ fn include_ext(relative_path: &str) -> TokenStream {
 pub fn gen_mod(_writer: &Writer, namespace: &str) -> TokenStream {
     match namespace {
         "Windows.Win32.UI.WindowsAndMessaging" => {
-            include_ext("Win32/UI/WindowsAndMessaging/WindowLong.rs")
+            include_ext(namespace, "Win32/UI/WindowsAndMessaging/WindowLong.rs")
         }
 
         _ => quote!(),

--- a/crates/libs/sys/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -3757,4 +3757,4 @@ pub type SENDASYNCPROC = Option<unsafe extern "system" fn(param0: super::super::
 pub type TIMERPROC = Option<unsafe extern "system" fn(param0: super::super::Foundation::HWND, param1: u32, param2: usize, param3: u32)>;
 pub type WNDENUMPROC = Option<unsafe extern "system" fn(param0: super::super::Foundation::HWND, param1: super::super::Foundation::LPARAM) -> super::super::Foundation::BOOL>;
 pub type WNDPROC = Option<unsafe extern "system" fn(param0: super::super::Foundation::HWND, param1: u32, param2: super::super::Foundation::WPARAM, param3: super::super::Foundation::LPARAM) -> super::super::Foundation::LRESULT>;
-core::include!(core::concat!(core::env!("CARGO_MANIFEST_DIR"), "/src/includes/", "Win32/UI/WindowsAndMessaging/WindowLong.rs"));
+core::include!("../../../../includes/Win32/UI/WindowsAndMessaging/WindowLong.rs");

--- a/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -9456,4 +9456,4 @@ pub type SENDASYNCPROC = Option<unsafe extern "system" fn(param0: super::super::
 pub type TIMERPROC = Option<unsafe extern "system" fn(param0: super::super::Foundation::HWND, param1: u32, param2: usize, param3: u32)>;
 pub type WNDENUMPROC = Option<unsafe extern "system" fn(param0: super::super::Foundation::HWND, param1: super::super::Foundation::LPARAM) -> super::super::Foundation::BOOL>;
 pub type WNDPROC = Option<unsafe extern "system" fn(param0: super::super::Foundation::HWND, param1: u32, param2: super::super::Foundation::WPARAM, param3: super::super::Foundation::LPARAM) -> super::super::Foundation::LRESULT>;
-core::include!(core::concat!(core::env!("CARGO_MANIFEST_DIR"), "/src/includes/", "Win32/UI/WindowsAndMessaging/WindowLong.rs"));
+core::include!("../../../../includes/Win32/UI/WindowsAndMessaging/WindowLong.rs");


### PR DESCRIPTION
In the Firefox repository, we avoid vendoring windows-rs because it's big, and instead pull it some other way. Because cargo doesn't support this kind of setup, we have a fake windows-rs crate that uses the modules from where the real windows-rs is. This falls short when the WindowsAndMessaging feature is enabled because CARGO_MANIFEST_DIR doesn't point to the real windows-rs.
