### PR TITLE
Nightly Clippy warning about assumed lifetime

### DIFF
--- a/crates/libs/bindgen/src/rust/writer.rs
+++ b/crates/libs/bindgen/src/rust/writer.rs
@@ -374,7 +374,7 @@ impl Writer {
     pub fn generic_params<'b>(
         &'b self,
         params: &'b [metadata::SignatureParam],
-    ) -> impl Iterator<Item = (usize, &metadata::SignatureParam)> + 'b {
+    ) -> impl Iterator<Item = (usize, &'b metadata::SignatureParam)> + 'b {
         params
             .iter()
             .filter(move |param| param.is_convertible())


### PR DESCRIPTION
This deals with a new nightly Clippy warning first encountered in #3241