### PR TITLE
Use workspace dependencies where practical

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,16 @@ exclude = [
 rust_2018_idioms = { level = "warn", priority = -1 }
 missing_docs = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib, windows_debugger_visualizer, windows_slim_errors)'] }
+
+[workspace.dependencies]
+cppwinrt = { path = "crates/libs/cppwinrt" }
+windows = { path = "crates/libs/windows" }
+windows-bindgen = { path = "crates/libs/bindgen" }
+windows-core = { path = "crates/libs/core" }
+windows-metadata = { path = "crates/libs/metadata" }
+windows-registry = { path = "crates/libs/registry" }
+windows-result = { path = "crates/libs/result" }
+windows-strings = { path = "crates/libs/strings" }
+windows-sys = { path = "crates/libs/sys" }
+windows-targets = { path = "crates/libs/targets" }
+windows-version = { path = "crates/libs/version" }

--- a/crates/samples/components/json_validator/Cargo.toml
+++ b/crates/samples/components/json_validator/Cargo.toml
@@ -12,7 +12,7 @@ jsonschema = { version = "0.18", default-features = false }
 serde_json = {version = "1.0", default-features = false }
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Com",
 ]

--- a/crates/samples/components/json_validator_client/Cargo.toml
+++ b/crates/samples/components/json_validator_client/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 cc = "1.0"
 
 [dependencies.windows-targets]
-path = "../../../../crates/libs/targets"
+workspace = true
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825

--- a/crates/samples/components/json_validator_winrt/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt/Cargo.toml
@@ -13,14 +13,14 @@ jsonschema = { version = "0.18", default-features = false }
 serde_json = {version = "1.0", default-features = false }
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Win32_System_WinRT",
 ]
 
 [dependencies.windows-core]
-path = "../../../libs/core"
+workspace = true
 
 [build-dependencies.windows-bindgen]
-path = "../../../libs/bindgen"
+workspace = true

--- a/crates/samples/components/json_validator_winrt_client/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt_client/Cargo.toml
@@ -5,16 +5,16 @@ edition = "2021"
 publish = false
 
 [dev-dependencies.windows-core]
-path = "../../../libs/core"
+workspace = true
 
 [dev-dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_Foundation",
 ]
 
 [build-dependencies.windows-bindgen]
-path = "../../../libs/bindgen"
+workspace = true
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825

--- a/crates/samples/components/json_validator_winrt_client_cpp/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt_client_cpp/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 cc = "1.0"
 
 [build-dependencies.cppwinrt]
-path = "../../../../crates/libs/cppwinrt"
+workspace = true
 
 [dependencies.windows-targets]
-path = "../../../../crates/libs/targets"
+workspace = true
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825

--- a/crates/samples/windows-sys/counter/Cargo.toml
+++ b/crates/samples/windows-sys/counter/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows-sys]
-path = "../../../libs/sys"
+workspace = true
 features = [
     "Win32_System_Performance",
 ]

--- a/crates/samples/windows-sys/create_window/Cargo.toml
+++ b/crates/samples/windows-sys/create_window/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows-sys]
-path = "../../../libs/sys"
+workspace = true
 features = [
     "Win32_Graphics_Gdi",
     "Win32_System_LibraryLoader",

--- a/crates/samples/windows-sys/delay_load/Cargo.toml
+++ b/crates/samples/windows-sys/delay_load/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows-sys]
-path = "../../../libs/sys"
+workspace = true
 features = [
     "Win32_System_LibraryLoader",
 ]

--- a/crates/samples/windows-sys/enum_windows/Cargo.toml
+++ b/crates/samples/windows-sys/enum_windows/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows-sys]
-path = "../../../libs/sys"
+workspace = true
 features = [
     "Win32_UI_WindowsAndMessaging",
 ]

--- a/crates/samples/windows-sys/message_box/Cargo.toml
+++ b/crates/samples/windows-sys/message_box/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows-sys]
-path = "../../../libs/sys"
+workspace = true
 features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Shell",

--- a/crates/samples/windows-sys/privileges/Cargo.toml
+++ b/crates/samples/windows-sys/privileges/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows-sys]
-path = "../../../libs/sys"
+workspace = true
 features = [
     "Win32_Security",
     "Win32_System_Threading",

--- a/crates/samples/windows-sys/task_dialog/Cargo.toml
+++ b/crates/samples/windows-sys/task_dialog/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows-sys]
-path = "../../../libs/sys"
+workspace = true
 features = [
     "Win32_UI_Controls",
     "Win32_UI_WindowsAndMessaging",

--- a/crates/samples/windows-sys/thread_pool_work/Cargo.toml
+++ b/crates/samples/windows-sys/thread_pool_work/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows-sys]
-path = "../../../libs/sys"
+workspace = true
 features = [
     "Win32_System_Threading",
 ]

--- a/crates/samples/windows/bits/Cargo.toml
+++ b/crates/samples/windows/bits/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Win32_System_Com",
@@ -13,4 +13,4 @@ features = [
 ]
 
 [dependencies.windows-core]
-path = "../../../libs/core"
+workspace = true

--- a/crates/samples/windows/com_uri/Cargo.toml
+++ b/crates/samples/windows/com_uri/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Com",
 ]

--- a/crates/samples/windows/consent/Cargo.toml
+++ b/crates/samples/windows/consent/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Security_Credentials_UI",
     "Win32_System_WinRT",

--- a/crates/samples/windows/core_app/Cargo.toml
+++ b/crates/samples/windows/core_app/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "implement",
     "ApplicationModel_Core",
@@ -16,4 +16,4 @@ features = [
 ]
 
 [dependencies.windows-core]
-path = "../../../libs/core"
+workspace = true

--- a/crates/samples/windows/counter/Cargo.toml
+++ b/crates/samples/windows/counter/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Performance",
 ]

--- a/crates/samples/windows/create_window/Cargo.toml
+++ b/crates/samples/windows/create_window/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_Graphics_Gdi",
     "Win32_System_LibraryLoader",

--- a/crates/samples/windows/credentials/Cargo.toml
+++ b/crates/samples/windows/credentials/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_Security_Credentials"
 ]

--- a/crates/samples/windows/data_protection/Cargo.toml
+++ b/crates/samples/windows/data_protection/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Storage_Streams",
     "Security_Cryptography_DataProtection",

--- a/crates/samples/windows/dcomp/Cargo.toml
+++ b/crates/samples/windows/dcomp/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 rand = "0.8.5"
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Foundation_Numerics",
     "Win32_Graphics_Direct2D_Common",

--- a/crates/samples/windows/delay_load/Cargo.toml
+++ b/crates/samples/windows/delay_load/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_System_LibraryLoader",
 ]

--- a/crates/samples/windows/device_watcher/Cargo.toml
+++ b/crates/samples/windows/device_watcher/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Devices_Enumeration",
     "Foundation_Collections",

--- a/crates/samples/windows/direct2d/Cargo.toml
+++ b/crates/samples/windows/direct2d/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Foundation_Numerics",
     "Win32_System_Com",

--- a/crates/samples/windows/direct3d12/Cargo.toml
+++ b/crates/samples/windows/direct3d12/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 array-init = "2.0.0"
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_Graphics_Direct3D_Fxc",
     "Win32_Graphics_Direct3D12",

--- a/crates/samples/windows/enum_windows/Cargo.toml
+++ b/crates/samples/windows/enum_windows/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_UI_WindowsAndMessaging",
 ]

--- a/crates/samples/windows/file_dialogs/Cargo.toml
+++ b/crates/samples/windows/file_dialogs/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_UI_Shell_Common",
     "Win32_System_Com",

--- a/crates/samples/windows/kernel_event/Cargo.toml
+++ b/crates/samples/windows/kernel_event/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_Security",
     "Win32_System_Threading",

--- a/crates/samples/windows/memory_buffer/Cargo.toml
+++ b/crates/samples/windows/memory_buffer/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Foundation",
     "Win32_System_WinRT",

--- a/crates/samples/windows/message_box/Cargo.toml
+++ b/crates/samples/windows/message_box/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Shell",

--- a/crates/samples/windows/ocr/Cargo.toml
+++ b/crates/samples/windows/ocr/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Media_Ocr", 
     "Graphics_Imaging", 

--- a/crates/samples/windows/overlapped/Cargo.toml
+++ b/crates/samples/windows/overlapped/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_Security",
     "Win32_Storage_FileSystem",

--- a/crates/samples/windows/privileges/Cargo.toml
+++ b/crates/samples/windows/privileges/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_Security",
     "Win32_System_Threading",

--- a/crates/samples/windows/rss/Cargo.toml
+++ b/crates/samples/windows/rss/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Foundation_Collections",
     "Web_Syndication",

--- a/crates/samples/windows/shell/Cargo.toml
+++ b/crates/samples/windows/shell/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Com",
     "Win32_System_Ole",

--- a/crates/samples/windows/simple/Cargo.toml
+++ b/crates/samples/windows/simple/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "UI",
 ]

--- a/crates/samples/windows/spellchecker/Cargo.toml
+++ b/crates/samples/windows/spellchecker/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Com",
     "Win32_Globalization",

--- a/crates/samples/windows/task_dialog/Cargo.toml
+++ b/crates/samples/windows/task_dialog/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_UI_Controls",
     "Win32_UI_WindowsAndMessaging",

--- a/crates/samples/windows/thread_pool_work/Cargo.toml
+++ b/crates/samples/windows/thread_pool_work/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Threading",
 ]

--- a/crates/samples/windows/uiautomation/Cargo.toml
+++ b/crates/samples/windows/uiautomation/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Com",
     "Win32_UI_Accessibility",

--- a/crates/samples/windows/wmi/Cargo.toml
+++ b/crates/samples/windows/wmi/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Com",
     "Win32_System_Ole",

--- a/crates/samples/windows/xml/Cargo.toml
+++ b/crates/samples/windows/xml/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../../libs/windows"
+workspace = true
 features = [
     "Data_Xml_Dom",
 ]

--- a/crates/tests/agile/Cargo.toml
+++ b/crates/tests/agile/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation",
     "Win32_System_WinRT",

--- a/crates/tests/agile_reference/Cargo.toml
+++ b/crates/tests/agile_reference/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Media_Control",
     "Foundation_Collections"

--- a/crates/tests/alternate_success_code/Cargo.toml
+++ b/crates/tests/alternate_success_code/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Ole",
     "Win32_System_Com",

--- a/crates/tests/arch/Cargo.toml
+++ b/crates/tests/arch/Cargo.toml
@@ -9,13 +9,13 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Diagnostics_Debug",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_System_Diagnostics_Debug",
 ]

--- a/crates/tests/arch_feature/Cargo.toml
+++ b/crates/tests/arch_feature/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Diagnostics_Debug",
     "Win32_System_SystemServices",
@@ -18,7 +18,7 @@ features = [
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_System_Diagnostics_Debug",
     "Win32_System_SystemServices",

--- a/crates/tests/array/Cargo.toml
+++ b/crates/tests/array/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation",
     "Win32_Media_MediaFoundation",

--- a/crates/tests/async/Cargo.toml
+++ b/crates/tests/async/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Storage_Streams",

--- a/crates/tests/bcrypt/Cargo.toml
+++ b/crates/tests/bcrypt/Cargo.toml
@@ -9,13 +9,13 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Security_Cryptography",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_Security_Cryptography",
 ]

--- a/crates/tests/calling_convention/Cargo.toml
+++ b/crates/tests/calling_convention/Cargo.toml
@@ -12,14 +12,14 @@ doctest = false
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_raw_dylib)'] }
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Networking_Ldap",
     "Win32_System_SystemInformation",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_Networking_Ldap",
     "Win32_System_SystemInformation",

--- a/crates/tests/cfg_generic/Cargo.toml
+++ b/crates/tests/cfg_generic/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation_Collections",
     "Media_Playback",

--- a/crates/tests/class_hierarchy/Cargo.toml
+++ b/crates/tests/class_hierarchy/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation",
 ]

--- a/crates/tests/collections/Cargo.toml
+++ b/crates/tests/collections/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Foundation_Collections",
@@ -18,4 +18,4 @@ features = [
 ]
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true

--- a/crates/tests/component/Cargo.toml
+++ b/crates/tests/component/Cargo.toml
@@ -10,10 +10,10 @@ doc = false
 doctest = false
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Foundation",
@@ -21,4 +21,4 @@ features = [
 ]
 
 [build-dependencies.windows-bindgen]
-path = "../../libs/bindgen"
+workspace = true

--- a/crates/tests/component_client/Cargo.toml
+++ b/crates/tests/component_client/Cargo.toml
@@ -9,13 +9,13 @@ doc = false
 doctest = false
 
 [build-dependencies.windows-bindgen]
-path = "../../libs/bindgen"
+workspace = true
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Foundation",

--- a/crates/tests/const_fields/Cargo.toml
+++ b/crates/tests/const_fields/Cargo.toml
@@ -9,14 +9,14 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Storage_CloudFilters", 
     "Win32_System_CorrelationVector",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_Storage_CloudFilters", 
     "Win32_System_CorrelationVector",

--- a/crates/tests/const_params/Cargo.toml
+++ b/crates/tests/const_params/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_UI_Shell",
     "Win32_System_WinRT",
@@ -17,7 +17,7 @@ features = [
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_UI_Shell",
 ]

--- a/crates/tests/const_ptrs/Cargo.toml
+++ b/crates/tests/const_ptrs/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Com_StructuredStorage",
     "Win32_System_Variant",

--- a/crates/tests/constructors/Cargo.toml
+++ b/crates/tests/constructors/Cargo.toml
@@ -10,13 +10,13 @@ doc = false
 doctest = false
 
 [build-dependencies.windows-bindgen]
-path = "../../libs/bindgen"
+workspace = true
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Foundation",

--- a/crates/tests/constructors_client/Cargo.toml
+++ b/crates/tests/constructors_client/Cargo.toml
@@ -9,13 +9,13 @@ doc = false
 doctest = false
 
 [build-dependencies.windows-bindgen]
-path = "../../libs/bindgen"
+workspace = true
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Foundation",

--- a/crates/tests/core/Cargo.toml
+++ b/crates/tests/core/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Win32_System_WinRT",
@@ -19,10 +19,10 @@ features = [
 ]
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dependencies.windows-targets]
-path = "../../libs/targets"
+workspace = true
 
 [dev-dependencies]
 helpers = { package = "test_helpers", path = "../helpers" }

--- a/crates/tests/debug/Cargo.toml
+++ b/crates/tests/debug/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation",
 ]

--- a/crates/tests/debugger_visualizer/Cargo.toml
+++ b/crates/tests/debugger_visualizer/Cargo.toml
@@ -12,14 +12,14 @@ doctest = false
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(windows_debugger_visualizer)'] }
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Win32_System_Com",
 ]
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dev-dependencies]
 debugger_test = "0.1.0"

--- a/crates/tests/deprecated/Cargo.toml
+++ b/crates/tests/deprecated/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "deprecated",
     "ApplicationModel_Contacts",

--- a/crates/tests/dispatch/Cargo.toml
+++ b/crates/tests/dispatch/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Com",
     "Win32_System_Ole",

--- a/crates/tests/does_not_return/Cargo.toml
+++ b/crates/tests/does_not_return/Cargo.toml
@@ -9,13 +9,13 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Diagnostics_Debug",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_System_Diagnostics_Debug",
 ]

--- a/crates/tests/enums/Cargo.toml
+++ b/crates/tests/enums/Cargo.toml
@@ -9,14 +9,14 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Storage_Streams",
     "Win32_UI_WindowsAndMessaging",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_UI_WindowsAndMessaging",
 ]

--- a/crates/tests/error/Cargo.toml
+++ b/crates/tests/error/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Foundation",

--- a/crates/tests/event/Cargo.toml
+++ b/crates/tests/event/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation",
     "Win32_System_WinRT",

--- a/crates/tests/extensions/Cargo.toml
+++ b/crates/tests/extensions/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Security_Cryptography",   
     "Win32_NetworkManagement_IpHelper",

--- a/crates/tests/handles/Cargo.toml
+++ b/crates/tests/handles/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Graphics_Gdi",
     "Win32_System_Registry",
@@ -19,7 +19,7 @@ features = [
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_Graphics_Gdi",
 ]

--- a/crates/tests/helpers/Cargo.toml
+++ b/crates/tests/helpers/Cargo.toml
@@ -9,4 +9,4 @@ doc = false
 doctest = false
 
 [dependencies.windows-targets]
-path = "../../libs/targets"
+workspace = true

--- a/crates/tests/implement/Cargo.toml
+++ b/crates/tests/implement/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "ApplicationModel_Activation",
@@ -27,7 +27,7 @@ features = [
 ]
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dependencies]
 static_assertions = "1.1"

--- a/crates/tests/implement_core/Cargo.toml
+++ b/crates/tests/implement_core/Cargo.toml
@@ -8,7 +8,7 @@ doc = false
 doctest = false
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dependencies]
 static_assertions = "1.1"

--- a/crates/tests/interface/Cargo.toml
+++ b/crates/tests/interface/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Win32_Graphics_Direct3D",
@@ -21,4 +21,4 @@ features = [
 ]
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true

--- a/crates/tests/interface_core/Cargo.toml
+++ b/crates/tests/interface_core/Cargo.toml
@@ -9,4 +9,4 @@ doc = false
 doctest = false
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true

--- a/crates/tests/interop/Cargo.toml
+++ b/crates/tests/interop/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation_Collections",
     "Win32_System_Com",

--- a/crates/tests/lib/Cargo.toml
+++ b/crates/tests/lib/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Graphics_Direct3D_Fxc",
     "Win32_Graphics_Direct3D11",
@@ -19,7 +19,7 @@ features = [
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_Graphics_Gdi",
     "Win32_Security",
@@ -29,4 +29,4 @@ features = [
 ]
 
 [dependencies.windows-targets]
-path = "../../libs/targets"
+workspace = true

--- a/crates/tests/linux/Cargo.toml
+++ b/crates/tests/linux/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows-result]
-path = "../../libs/result"
+workspace = true
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true

--- a/crates/tests/literals/Cargo.toml
+++ b/crates/tests/literals/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true

--- a/crates/tests/match/Cargo.toml
+++ b/crates/tests/match/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation",
     "Win32_Foundation",

--- a/crates/tests/matrix3x2/Cargo.toml
+++ b/crates/tests/matrix3x2/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation_Numerics",
 ]

--- a/crates/tests/metadata/Cargo.toml
+++ b/crates/tests/metadata/Cargo.toml
@@ -9,17 +9,17 @@ doc = false
 doctest = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata" }
+windows-metadata = { workspace = true }
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Graphics_Gdi",
     "Win32_System_SystemServices",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_Graphics_Gdi",
     "Win32_System_SystemServices",

--- a/crates/tests/metadata/tests/attribute_enum.rs
+++ b/crates/tests/metadata/tests/attribute_enum.rs
@@ -1,4 +1,4 @@
-use metadata::*;
+use windows_metadata::*;
 
 #[test]
 fn attribute_enum() {

--- a/crates/tests/metadata/tests/fn_call_size.rs
+++ b/crates/tests/metadata/tests/fn_call_size.rs
@@ -1,4 +1,4 @@
-use metadata::*;
+use windows_metadata::*;
 
 #[test]
 fn size() {

--- a/crates/tests/metadata/tests/unused.rs
+++ b/crates/tests/metadata/tests/unused.rs
@@ -1,4 +1,4 @@
-use metadata::*;
+use windows_metadata::*;
 
 #[test]
 fn test() {

--- a/crates/tests/msrv/Cargo.toml
+++ b/crates/tests/msrv/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Globalization",
     "Win32_Graphics_Direct2D",

--- a/crates/tests/no_std/Cargo.toml
+++ b/crates/tests/no_std/Cargo.toml
@@ -28,8 +28,7 @@ path = "../../libs/sys"
 default-features = false
 
 [dependencies.windows-targets]
-path = "../../libs/targets"
-default-features = false
+workspace = true
 
 [dependencies.windows-version]
 path = "../../libs/version"

--- a/crates/tests/no_use/Cargo.toml
+++ b/crates/tests/no_use/Cargo.toml
@@ -9,11 +9,11 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Foundation",
 ]
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true

--- a/crates/tests/noexcept/Cargo.toml
+++ b/crates/tests/noexcept/Cargo.toml
@@ -9,13 +9,13 @@ doc = false
 doctest = false
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [build-dependencies.windows-bindgen]
-path = "../../libs/bindgen"
+workspace = true
 
 [build-dependencies]
 cc = "1.0"
 
 [build-dependencies.cppwinrt]
-path = "../../libs/cppwinrt"
+workspace = true

--- a/crates/tests/not_dll/Cargo.toml
+++ b/crates/tests/not_dll/Cargo.toml
@@ -9,14 +9,14 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Graphics_Printing",
     "Win32_Graphics_Gdi",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_Graphics_Printing",
     "Win32_Graphics_Gdi",

--- a/crates/tests/query_signature/Cargo.toml
+++ b/crates/tests/query_signature/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Diagnostics_Debug_Extensions",
 ]

--- a/crates/tests/readme/Cargo.toml
+++ b/crates/tests/readme/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Data_Xml_Dom",
     "Win32_Security",
@@ -14,7 +14,7 @@ features = [
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_Security",
     "Win32_System_Threading",
@@ -22,22 +22,22 @@ features = [
 ]
 
 [dependencies.windows-targets]
-path = "../../libs/targets"
+workspace = true
 
 [dependencies.windows-metadata]
-path = "../../libs/metadata"
+workspace = true
 
 [dev-dependencies.windows-result]
-path = "../../libs/result"
+workspace = true
 
 [dev-dependencies.windows-registry]
-path = "../../libs/registry"
+workspace = true
 
 [dev-dependencies.windows-version]
-path = "../../libs/version"
+workspace = true
 
 [dev-dependencies.windows-strings]
-path = "../../libs/strings"
+workspace = true
 
 [dev-dependencies.cppwinrt]
-path = "../../libs/cppwinrt"
+workspace = true

--- a/crates/tests/registry/Cargo.toml
+++ b/crates/tests/registry/Cargo.toml
@@ -9,18 +9,18 @@ doc = false
 doctest = false
 
 [dependencies.windows-registry]
-path = "../../libs/registry"
+workspace = true
 
 [dependencies.windows-result]
-path = "../../libs/result"
+workspace = true
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = ["Win32_System_Registry"]
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = ["Win32_System_Registry"]
 
 [dependencies.windows-strings]
-path = "../../libs/strings"
+workspace = true

--- a/crates/tests/registry_default/Cargo.toml
+++ b/crates/tests/registry_default/Cargo.toml
@@ -9,4 +9,4 @@ doc = false
 doctest = false
 
 [dependencies.windows-registry]
-path = "../../libs/registry"
+workspace = true

--- a/crates/tests/reserved/Cargo.toml
+++ b/crates/tests/reserved/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Registry",
     "Win32_UI_WindowsAndMessaging",
@@ -17,7 +17,7 @@ features = [
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_System_Registry",
     "Win32_UI_WindowsAndMessaging",

--- a/crates/tests/resources/Cargo.toml
+++ b/crates/tests/resources/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_UI_Controls",
     "Win32_UI_WindowsAndMessaging",
@@ -17,7 +17,7 @@ features = [
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_UI_Controls",
     "Win32_UI_WindowsAndMessaging",

--- a/crates/tests/result/Cargo.toml
+++ b/crates/tests/result/Cargo.toml
@@ -9,10 +9,10 @@ doc = false
 doctest = false
 
 [dependencies.windows-result]
-path = "../../libs/result"
+workspace = true
 
 [dependencies.windows-targets]
-path = "../../libs/targets"
+workspace = true
 
 [dependencies]
 helpers = { package = "test_helpers", path = "../helpers" }

--- a/crates/tests/return_handle/Cargo.toml
+++ b/crates/tests/return_handle/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_System_Threading",
     "Win32_Security",

--- a/crates/tests/return_struct/Cargo.toml
+++ b/crates/tests/return_struct/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Graphics_Direct2D_Common"
 ]

--- a/crates/tests/riddle/Cargo.toml
+++ b/crates/tests/riddle/Cargo.toml
@@ -9,13 +9,13 @@ doc = false
 doctest = false
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dependencies.windows-metadata]
-path = "../../libs/metadata"
+workspace = true
 
 [dependencies.tool_lib]
 path = "../../tools/lib"
 
 [dependencies.windows-bindgen]
-path = "../../libs/bindgen"
+workspace = true

--- a/crates/tests/standalone/Cargo.toml
+++ b/crates/tests/standalone/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dependencies.windows-targets]
-path = "../../libs/targets"
+workspace = true

--- a/crates/tests/string_param/Cargo.toml
+++ b/crates/tests/string_param/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_UI_Shell",
 ]

--- a/crates/tests/strings/Cargo.toml
+++ b/crates/tests/strings/Cargo.toml
@@ -9,13 +9,13 @@ doc = false
 doctest = false
 
 [dependencies.windows-strings]
-path = "../../libs/strings"
+workspace = true
 
 [dependencies.windows-targets]
-path = "../../libs/targets"
+workspace = true
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_System_WinRT",

--- a/crates/tests/structs/Cargo.toml
+++ b/crates/tests/structs/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "implement",
     "Storage_Search",

--- a/crates/tests/sys/Cargo.toml
+++ b/crates/tests/sys/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_Graphics_Gdi",
     "Win32_Security",

--- a/crates/tests/targets/Cargo.toml
+++ b/crates/tests/targets/Cargo.toml
@@ -9,14 +9,14 @@ doc = false
 doctest = false
 
 [dependencies.windows-targets]
-path = "../../libs/targets"
+workspace = true
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [ "Win32_Security_Authentication_Identity" ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [ "Win32_Security_Authentication_Identity" ]
 
 [dependencies.tool_lib]

--- a/crates/tests/unions/Cargo.toml
+++ b/crates/tests/unions/Cargo.toml
@@ -9,14 +9,14 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Graphics_Direct3D12",
     "Win32_System_IO",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_System_IO",
 ]

--- a/crates/tests/variant/Cargo.toml
+++ b/crates/tests/variant/Cargo.toml
@@ -9,10 +9,10 @@ doc = false
 doctest = false
 
 [dependencies.windows-core]
-path = "../../libs/core"
+workspace = true
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation",
     "Win32_System_Com_Events",

--- a/crates/tests/wdk/Cargo.toml
+++ b/crates/tests/wdk/Cargo.toml
@@ -9,14 +9,14 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Wdk_System_SystemServices",
     "Wdk_System_OfflineRegistry",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Wdk_System_SystemServices",
     "Wdk_System_OfflineRegistry",

--- a/crates/tests/weak/Cargo.toml
+++ b/crates/tests/weak/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Foundation",
 ]

--- a/crates/tests/weak_ref/Cargo.toml
+++ b/crates/tests/weak_ref/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_System_WinRT",
 ]

--- a/crates/tests/win32/Cargo.toml
+++ b/crates/tests/win32/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Gaming",
     "Win32_Graphics_Direct2D",

--- a/crates/tests/win32_arrays/Cargo.toml
+++ b/crates/tests/win32_arrays/Cargo.toml
@@ -9,7 +9,7 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Gdi",

--- a/crates/tests/window_long/Cargo.toml
+++ b/crates/tests/window_long/Cargo.toml
@@ -9,13 +9,13 @@ doc = false
 doctest = false
 
 [dependencies.windows]
-path = "../../libs/windows"
+workspace = true
 features = [
     "Win32_UI_WindowsAndMessaging",
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+workspace = true
 features = [
     "Win32_UI_WindowsAndMessaging",
 ]

--- a/crates/tools/bindings/Cargo.toml
+++ b/crates/tools/bindings/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-windows-bindgen = { path = "../../libs/bindgen" }
+windows-bindgen = { workspace = true }

--- a/crates/tools/lib/Cargo.toml
+++ b/crates/tools/lib/Cargo.toml
@@ -6,4 +6,4 @@ publish = false
 
 [dependencies]
 regex = "1.7"
-metadata = { package = "windows-metadata", path = "../../libs/metadata" }
+windows-metadata = { workspace = true }

--- a/crates/tools/lib/src/lib.rs
+++ b/crates/tools/lib/src/lib.rs
@@ -1,6 +1,7 @@
 use regex::Regex;
 use std::collections::BTreeMap;
 use std::path::Path;
+use windows_metadata as metadata;
 
 pub enum CallingConvention {
     Stdcall(usize),

--- a/crates/tools/standalone/Cargo.toml
+++ b/crates/tools/standalone/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-windows-bindgen = { path = "../../libs/bindgen" }
+windows-bindgen = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
This reduces the need for relative paths and makes workspace/repo organization more manageable.

Unfortunately, it doesn't appear to be compatible with `default-features` so some still need relative paths. 