### PR TITLE
Implement `ExactSizeIterator` for registry keys and values

### DIFF
--- a/crates/libs/registry/src/key_iterator.rs
+++ b/crates/libs/registry/src/key_iterator.rs
@@ -66,3 +66,9 @@ impl<'a> Iterator for KeyIterator<'a> {
         })
     }
 }
+
+impl<'a> ExactSizeIterator for KeyIterator<'a> {
+    fn len(&self) -> usize {
+        self.range.len()
+    }
+}

--- a/crates/libs/registry/src/value_iterator.rs
+++ b/crates/libs/registry/src/value_iterator.rs
@@ -80,3 +80,9 @@ impl<'a> Iterator for ValueIterator<'a> {
         })
     }
 }
+
+impl<'a> ExactSizeIterator for ValueIterator<'a> {
+    fn len(&self) -> usize {
+        self.range.len()
+    }
+}

--- a/crates/tests/registry/tests/keys.rs
+++ b/crates/tests/registry/tests/keys.rs
@@ -14,6 +14,10 @@ fn keys() -> Result<()> {
     let names: Vec<String> = key.keys()?.collect();
     assert_eq!(names, ["one", "three", "two"]);
 
+    // The "keys" iterator implements `ExactSizeIterator`.
+    let iter = key.keys()?;
+    assert_eq!(iter.len(), 3);
+
     let err = key.open("missing").unwrap_err();
     assert_eq!(err.code(), HRESULT(0x80070002u32 as i32)); // HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
     assert_eq!(err.message(), "The system cannot find the file specified.");

--- a/crates/tests/registry/tests/values.rs
+++ b/crates/tests/registry/tests/values.rs
@@ -22,5 +22,9 @@ fn values() -> Result<()> {
         ]
     );
 
+    // The "values" iterator implements `ExactSizeIterator`.
+    let iter = key.values()?;
+    assert_eq!(iter.len(), 3);
+
     Ok(())
 }


### PR DESCRIPTION
This allows the caller to query how many keys and values there are without iterating and offers allocator optimization for `Iterator::collect()`.