### PR TITLE
Update trim function in windows-registry

### DIFF
--- a/crates/libs/registry/src/value.rs
+++ b/crates/libs/registry/src/value.rs
@@ -142,9 +142,10 @@ impl<const N: usize> From<[u8; N]> for Value {
 }
 
 fn trim(mut wide: &[u16]) -> &[u16] {
-    while wide.last() == Some(&0) {
-        wide = &wide[..wide.len() - 1];
+    let index = wide.iter().position(|&x| x == 0u16);
+    if index.is_some() {
+        wide = &wide[..index.unwrap()];
     }
-
+    
     wide
 }


### PR DESCRIPTION
Original trim function is iterate from back to front to trim 0x0000, but I found in some registry value is not only have one 0x0000 in the end, but also in the middle. like below:
`HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\RecentDocs`
![image](https://github.com/user-attachments/assets/4fa8497f-1ca0-47db-b9ea-9352729151d6)
if use original trim function, I will get the string that is normal string plus unnormal string.
![image](https://github.com/user-attachments/assets/865bb96b-f36d-4f6f-b053-c20b92d98cee)
And if I use modified trim function, will work as expected.
![image](https://github.com/user-attachments/assets/4f569e9a-5144-425f-9f62-3113e51cb59a)
