### PR TITLE
Improve interop testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 /target
 *.lock
 *.winmd
-**/src/winrt

--- a/crates/samples/components/json_validator_winrt_client_cpp/build.rs
+++ b/crates/samples/components/json_validator_winrt_client_cpp/build.rs
@@ -6,12 +6,14 @@ fn main() {
     println!("cargo:rerun-if-changed=src/client.cpp");
     println!("cargo:rustc-link-lib=windows.0.52.0");
 
+    let include = std::env::var("OUT_DIR").unwrap();
+
     cppwinrt::cppwinrt([
         "-in",
         "../json_validator_winrt/sample.winmd",
         &format!("{}\\System32\\WinMetadata", env!("windir")),
         "-out",
-        "src",
+        &include,
     ])
     .unwrap();
 
@@ -20,5 +22,6 @@ fn main() {
         .std("c++20")
         .flag("/EHsc")
         .file("src/client.cpp")
+        .include(include)
         .compile("client");
 }

--- a/crates/tests/misc/noexcept/build.rs
+++ b/crates/tests/misc/noexcept/build.rs
@@ -41,12 +41,14 @@ fn main() {
         panic!("{error}");
     }
 
+    let include = std::env::var("OUT_DIR").unwrap();
+
     cppwinrt::cppwinrt([
         "-in",
         "test.winmd",
         &format!("{}\\System32\\WinMetadata", env!("windir")),
         "-out",
-        "src",
+        &include,
     ])
     .unwrap();
 
@@ -55,5 +57,6 @@ fn main() {
         .std("c++20")
         .flag("/EHsc")
         .file("src/interop.cpp")
+        .include(include)
         .compile("interop");
 }

--- a/crates/tests/winrt/constructors_client/Cargo.toml
+++ b/crates/tests/winrt/constructors_client/Cargo.toml
@@ -26,3 +26,9 @@ features = [
 # Cargo doesn't understand cdylib targets. https://github.com/rust-lang/cargo/issues/7825
 [dependencies.test_constructors]
 path = "../constructors"
+
+[build-dependencies]
+cc = "1.0"
+
+[build-dependencies.cppwinrt]
+workspace = true

--- a/crates/tests/winrt/constructors_client/build.rs
+++ b/crates/tests/winrt/constructors_client/build.rs
@@ -1,4 +1,6 @@
 fn main() {
+    println!("cargo:rerun-if-changed=src/interop.cpp");
+
     windows_bindgen::bindgen([
         "--in",
         "../constructors/metadata.winmd",
@@ -10,4 +12,20 @@ fn main() {
         "no-bindgen-comment",
     ])
     .unwrap();
+
+    cppwinrt::cppwinrt([
+        "-in",
+        "../constructors/metadata.winmd",
+        &format!("{}\\System32\\WinMetadata", env!("windir")),
+        "-out",
+        "src",
+    ])
+    .unwrap();
+
+    cc::Build::new()
+        .cpp(true)
+        .std("c++20")
+        .flag("/EHsc")
+        .file("src/interop.cpp")
+        .compile("interop");
 }

--- a/crates/tests/winrt/constructors_client/build.rs
+++ b/crates/tests/winrt/constructors_client/build.rs
@@ -13,12 +13,14 @@ fn main() {
     ])
     .unwrap();
 
+    let include = std::env::var("OUT_DIR").unwrap();
+
     cppwinrt::cppwinrt([
         "-in",
         "../constructors/metadata.winmd",
         &format!("{}\\System32\\WinMetadata", env!("windir")),
         "-out",
-        "src",
+        &include,
     ])
     .unwrap();
 
@@ -27,5 +29,6 @@ fn main() {
         .std("c++20")
         .flag("/EHsc")
         .file("src/interop.cpp")
+        .include(include)
         .compile("interop");
 }

--- a/crates/tests/winrt/constructors_client/build.rs
+++ b/crates/tests/winrt/constructors_client/build.rs
@@ -1,4 +1,8 @@
 fn main() {
+    if !cfg!(target_env = "msvc") {
+        return;
+    }
+
     println!("cargo:rerun-if-changed=src/interop.cpp");
 
     windows_bindgen::bindgen([

--- a/crates/tests/winrt/constructors_client/src/interop.cpp
+++ b/crates/tests/winrt/constructors_client/src/interop.cpp
@@ -1,0 +1,34 @@
+#include <windows.h>
+#include "winrt/test_constructors.h"
+
+using namespace winrt;
+using namespace test_constructors;
+
+void test()
+{
+    Activatable activatable;
+    assert(activatable.Property() == 0);
+
+    Activatable activatable2(123);
+    assert(activatable2.Property() == 123);
+
+    Composable composable;
+    assert(composable.Property() == 0);
+
+    Composable composable2(456);
+    assert(composable2.Property() == 456);
+}
+
+extern "C"
+{
+    HRESULT __stdcall interop() noexcept
+    try
+    {
+        test();
+        return S_OK;
+    }
+    catch (...)
+    {
+        return to_hresult();
+    }
+}

--- a/crates/tests/winrt/constructors_client/src/interop.cpp
+++ b/crates/tests/winrt/constructors_client/src/interop.cpp
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <assert.h>
 #include "winrt/test_constructors.h"
 
 using namespace winrt;

--- a/crates/tests/winrt/constructors_client/src/lib.rs
+++ b/crates/tests/winrt/constructors_client/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(target_env = "msvc")]
 #![cfg(test)]
 
 mod bindings;

--- a/crates/tests/winrt/constructors_client/src/lib.rs
+++ b/crates/tests/winrt/constructors_client/src/lib.rs
@@ -4,8 +4,14 @@ mod bindings;
 use bindings::*;
 use windows::core::*;
 
+extern "system" {
+    fn interop() -> HRESULT;
+}
+
 #[test]
 fn test() -> Result<()> {
+    unsafe { interop().ok()? };
+
     let activatable = Activatable::new()?;
     assert_eq!(activatable.Property()?, 0);
 


### PR DESCRIPTION
Interop testing primarily involves using the [cppwinrt](https://crates.io/crates/cppwinrt) crate. This ensures that the Rust implementation is implemented correctly using [C++/WinRT](https://github.com/microsoft/cppwinrt) as a reference. 

* Move generated headers to `OUT_DIR` and thus simplifies `.gitignore` handling.
* Add interop testing for activatable and composable constructor tests.
