### PR TITLE
Avoid deriving `Eq` for structs containing floating point type parameters

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -221,6 +221,8 @@ jobs:
         run:  cargo clippy -p test_query_signature
       - name: Clippy test_readme
         run:  cargo clippy -p test_readme
+      - name: Clippy test_reference_float
+        run:  cargo clippy -p test_reference_float
       - name: Clippy test_registry
         run:  cargo clippy -p test_registry
       - name: Clippy test_registry_default

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,16 +247,18 @@ jobs:
         run:  cargo test -p test_query_signature --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_readme
         run:  cargo test -p test_readme --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test test_reference_float
+        run:  cargo test -p test_reference_float --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_registry
         run:  cargo test -p test_registry --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_registry_default
         run:  cargo test -p test_registry_default --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_reserved
         run:  cargo test -p test_reserved --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test test_resources
-        run:  cargo test -p test_resources --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Clean
         run:  cargo clean
+      - name: Test test_resources
+        run:  cargo test -p test_resources --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_result
         run:  cargo test -p test_result --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_return_handle

--- a/crates/libs/bindgen/src/metadata.rs
+++ b/crates/libs/bindgen/src/metadata.rs
@@ -551,7 +551,9 @@ pub fn type_has_float(ty: &Type) -> bool {
     match ty {
         Type::F32 | Type::F64 => true,
         Type::Win32Array(ty, _) => type_has_float(ty),
-        Type::TypeDef(def, _) => type_def_has_float(*def),
+        Type::TypeDef(def, generics) => {
+            type_def_has_float(*def) || generics.iter().any(type_has_float)
+        }
         _ => false,
     }
 }

--- a/crates/tests/winrt/reference_float/Cargo.toml
+++ b/crates/tests/winrt/reference_float/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "test_reference_float"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doc = false
+doctest = false
+
+[build-dependencies.windows-bindgen]
+workspace = true
+
+[dependencies.windows-core]
+workspace = true
+
+[dependencies.windows]
+workspace = true
+features = [
+    "implement",
+    "Foundation",
+]

--- a/crates/tests/winrt/reference_float/build.rs
+++ b/crates/tests/winrt/reference_float/build.rs
@@ -1,0 +1,33 @@
+fn main() {
+    let mut command = std::process::Command::new("midlrt.exe");
+    command.args([
+        "/winrt",
+        "/nomidl",
+        "/h",
+        "nul",
+        "/metadata_dir",
+        "../../../libs/bindgen/default",
+        "/reference",
+        "../../../libs/bindgen/default/Windows.winmd",
+        "/winmd",
+        "metadata.winmd",
+        "src/metadata.idl",
+    ]);
+
+    if !command.status().unwrap().success() {
+        panic!("Failed to run midlrt");
+    }
+
+    windows_bindgen::bindgen([
+        "--in",
+        "metadata.winmd",
+        "--out",
+        "src/bindings.rs",
+        "--filter",
+        "test_reference_float",
+        "--config",
+        "implement",
+        "no-bindgen-comment",
+    ])
+    .unwrap();
+}

--- a/crates/tests/winrt/reference_float/src/bindings.rs
+++ b/crates/tests/winrt/reference_float/src/bindings.rs
@@ -8,33 +8,15 @@
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct RefWithFloat {
-    pub ReferenceFloat: Option<windows::Foundation::IReference<f32>>,
-    pub ReferenceWithFloat: Option<windows::Foundation::IReference<WithFloat>>,
+    pub Value: Option<windows::Foundation::IReference<f32>>,
 }
 impl windows_core::TypeKind for RefWithFloat {
     type TypeKind = windows_core::CloneType;
 }
 impl windows_core::RuntimeType for RefWithFloat {
-    const SIGNATURE :windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::from_slice ( b"struct(test_reference_float.RefWithFloat;pinterface({61c17706-2d65-11e0-9ae8-d48564015472};f4);pinterface({61c17706-2d65-11e0-9ae8-d48564015472};struct(test_reference_float.WithFloat;f4)))" ) ;
+    const SIGNATURE :windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::from_slice ( b"struct(test_reference_float.RefWithFloat;pinterface({61c17706-2d65-11e0-9ae8-d48564015472};f4))" ) ;
 }
 impl Default for RefWithFloat {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct WithFloat {
-    pub Value: f32,
-}
-impl windows_core::TypeKind for WithFloat {
-    type TypeKind = windows_core::CopyType;
-}
-impl windows_core::RuntimeType for WithFloat {
-    const SIGNATURE: windows_core::imp::ConstBuffer =
-        windows_core::imp::ConstBuffer::from_slice(b"struct(test_reference_float.WithFloat;f4)");
-}
-impl Default for WithFloat {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/tests/winrt/reference_float/src/bindings.rs
+++ b/crates/tests/winrt/reference_float/src/bindings.rs
@@ -1,0 +1,41 @@
+#![allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    dead_code,
+    clippy::all
+)]
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RefWithFloat {
+    pub ReferenceFloat: Option<windows::Foundation::IReference<f32>>,
+    pub ReferenceWithFloat: Option<windows::Foundation::IReference<WithFloat>>,
+}
+impl windows_core::TypeKind for RefWithFloat {
+    type TypeKind = windows_core::CloneType;
+}
+impl windows_core::RuntimeType for RefWithFloat {
+    const SIGNATURE :windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::from_slice ( b"struct(test_reference_float.RefWithFloat;pinterface({61c17706-2d65-11e0-9ae8-d48564015472};f4);pinterface({61c17706-2d65-11e0-9ae8-d48564015472};struct(test_reference_float.WithFloat;f4)))" ) ;
+}
+impl Default for RefWithFloat {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct WithFloat {
+    pub Value: f32,
+}
+impl windows_core::TypeKind for WithFloat {
+    type TypeKind = windows_core::CopyType;
+}
+impl windows_core::RuntimeType for WithFloat {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::from_slice(b"struct(test_reference_float.WithFloat;f4)");
+}
+impl Default for WithFloat {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}

--- a/crates/tests/winrt/reference_float/src/lib.rs
+++ b/crates/tests/winrt/reference_float/src/lib.rs
@@ -1,0 +1,14 @@
+mod bindings;
+use bindings::*;
+use windows::{core::*, Foundation::*};
+
+#[test]
+fn test() -> Result<()> {
+    let mut container = RefWithFloat::default();
+    container.ReferenceFloat = Some(PropertyValue::CreateSingle(1.23)?.cast()?);
+
+    // TODO: https://github.com/microsoft/windows-rs/issues/292 is needed to provide a stock implementation
+    // of `IReference` for arbitrary types in order to test `container.ReferenceWithFloat`.
+
+    Ok(())
+}

--- a/crates/tests/winrt/reference_float/src/lib.rs
+++ b/crates/tests/winrt/reference_float/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg(test)]
+
 mod bindings;
 use bindings::*;
 use windows::{core::*, Foundation::*};

--- a/crates/tests/winrt/reference_float/src/lib.rs
+++ b/crates/tests/winrt/reference_float/src/lib.rs
@@ -6,6 +6,7 @@ use windows::{core::*, Foundation::*};
 fn test() -> Result<()> {
     let mut container = RefWithFloat::default();
     container.Value = Some(PropertyValue::CreateSingle(1.23)?.cast()?);
+    assert_eq!(container.Value.unwrap().Value()?, 1.23);
 
     Ok(())
 }

--- a/crates/tests/winrt/reference_float/src/lib.rs
+++ b/crates/tests/winrt/reference_float/src/lib.rs
@@ -5,10 +5,7 @@ use windows::{core::*, Foundation::*};
 #[test]
 fn test() -> Result<()> {
     let mut container = RefWithFloat::default();
-    container.ReferenceFloat = Some(PropertyValue::CreateSingle(1.23)?.cast()?);
-
-    // TODO: https://github.com/microsoft/windows-rs/issues/292 is needed to provide a stock implementation
-    // of `IReference` for arbitrary types in order to test `container.ReferenceWithFloat`.
+    container.Value = Some(PropertyValue::CreateSingle(1.23)?.cast()?);
 
     Ok(())
 }

--- a/crates/tests/winrt/reference_float/src/metadata.idl
+++ b/crates/tests/winrt/reference_float/src/metadata.idl
@@ -3,14 +3,8 @@
 
 namespace test_reference_float
 {
-    struct WithFloat
-    {
-        Single Value;
-    };
-
     struct RefWithFloat
     {
-        Windows.Foundation.IReference<Single> ReferenceFloat; 
-        Windows.Foundation.IReference<WithFloat> ReferenceWithFloat; 
+        Windows.Foundation.IReference<Single> Value; 
     };
 }

--- a/crates/tests/winrt/reference_float/src/metadata.idl
+++ b/crates/tests/winrt/reference_float/src/metadata.idl
@@ -1,0 +1,16 @@
+// This tests that windows-bindgen avoids deriving `Eq` for types with floating point fields.
+// https://github.com/microsoft/windows-rs/issues/3220
+
+namespace test_reference_float
+{
+    struct WithFloat
+    {
+        Single Value;
+    };
+
+    struct RefWithFloat
+    {
+        Windows.Foundation.IReference<Single> ReferenceFloat; 
+        Windows.Foundation.IReference<WithFloat> ReferenceWithFloat; 
+    };
+}


### PR DESCRIPTION
Previously such structs were only detected when the field, or some nested type, contained a floating-point type. This update extends that to generic types. 

Fixes: #3220
