### PR TITLE
Make registry key/value iterators lazy

### DIFF
--- a/crates/libs/registry/src/bindings.rs
+++ b/crates/libs/registry/src/bindings.rs
@@ -20,7 +20,9 @@ windows_targets::link!("kernel32.dll" "system" fn HeapAlloc(hheap : HANDLE, dwfl
 windows_targets::link!("kernel32.dll" "system" fn HeapFree(hheap : HANDLE, dwflags : HEAP_FLAGS, lpmem : *const core::ffi::c_void) -> BOOL);
 pub type BOOL = i32;
 pub const ERROR_INVALID_DATA: WIN32_ERROR = 13u32;
+pub const ERROR_MORE_DATA: WIN32_ERROR = 234u32;
 pub const ERROR_NO_MORE_ITEMS: WIN32_ERROR = 259u32;
+pub const ERROR_SUCCESS: WIN32_ERROR = 0u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct FILETIME {

--- a/crates/libs/registry/src/key_iterator.rs
+++ b/crates/libs/registry/src/key_iterator.rs
@@ -3,37 +3,25 @@ use super::*;
 /// An iterator of registry key names.
 pub struct KeyIterator<'a> {
     key: &'a Key,
-    range: core::ops::Range<usize>,
+    idx: u32,
     name: Vec<u16>,
 }
 
 impl<'a> KeyIterator<'a> {
     pub(crate) fn new(key: &'a Key) -> Result<Self> {
-        let mut count = 0;
-        let mut max_len = 0;
+        let info = get_key_info(key)?;
 
-        let result = unsafe {
-            RegQueryInfoKeyW(
-                key.0,
-                null_mut(),
-                null_mut(),
-                null_mut(),
-                &mut count,
-                &mut max_len,
-                null_mut(),
-                null_mut(),
-                null_mut(),
-                null_mut(),
-                null_mut(),
-                null_mut(),
-            )
-        };
-
-        win32_error(result).map(|_| Self {
+        Ok(Self {
             key,
-            range: 0..count as usize,
-            name: vec![0; max_len as usize + 1],
+            idx: 0,
+            name: vec![0; (info.subkey_name_max + 1) as usize],
         })
+    }
+
+    fn resize(&mut self) -> Result<()> {
+        let info = get_key_info(self.key)?;
+        self.name.resize((info.subkey_name_max + 1) as usize, 0);
+        Ok(())
     }
 }
 
@@ -41,28 +29,33 @@ impl<'a> Iterator for KeyIterator<'a> {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().and_then(|index| {
-            let mut len = self.name.len() as u32;
+        let mut len = self.name.len() as u32;
+        let result = unsafe {
+            RegEnumKeyExW(
+                self.key.0,
+                self.idx,
+                self.name.as_mut_ptr(),
+                &mut len,
+                null_mut(),
+                null_mut(),
+                null_mut(),
+                null_mut(),
+            )
+        };
 
-            let result = unsafe {
-                RegEnumKeyExW(
-                    self.key.0,
-                    index as u32,
-                    self.name.as_mut_ptr(),
-                    &mut len,
-                    null(),
-                    null_mut(),
-                    null_mut(),
-                    null_mut(),
-                )
-            };
-
-            if result != 0 {
-                debug_assert_eq!(result, ERROR_NO_MORE_ITEMS);
-                None
-            } else {
-                Some(String::from_utf16_lossy(&self.name[0..len as usize]))
+        if result == ERROR_MORE_DATA {
+            if self.resize().is_err() {
+                return None;
             }
-        })
+            return self.next();
+        }
+
+        if result != 0 {
+            debug_assert_eq!(result, ERROR_NO_MORE_ITEMS);
+            return None;
+        }
+
+        self.idx += 1;
+        Some(String::from_utf16_lossy(&self.name[0..len as usize]))
     }
 }

--- a/crates/libs/registry/src/key_iterator.rs
+++ b/crates/libs/registry/src/key_iterator.rs
@@ -50,7 +50,7 @@ impl<'a> Iterator for KeyIterator<'a> {
             return self.next();
         }
 
-        if result != 0 {
+        if result != ERROR_SUCCESS {
             debug_assert_eq!(result, ERROR_NO_MORE_ITEMS);
             return None;
         }

--- a/crates/libs/registry/src/value_iterator.rs
+++ b/crates/libs/registry/src/value_iterator.rs
@@ -3,42 +3,28 @@ use super::*;
 /// An iterator of registry values.
 pub struct ValueIterator<'a> {
     key: &'a Key,
-    range: core::ops::Range<usize>,
+    idx: u32,
     name: Vec<u16>,
     data: Data,
 }
 
 impl<'a> ValueIterator<'a> {
     pub(crate) fn new(key: &'a Key) -> Result<Self> {
-        let mut count = 0;
-        let mut name_max_len = 0;
-        let mut value_max_len = 0;
-
-        let result = unsafe {
-            RegQueryInfoKeyW(
-                key.0,
-                null_mut(),
-                null_mut(),
-                null_mut(),
-                null_mut(),
-                null_mut(),
-                null_mut(),
-                &mut count,
-                &mut name_max_len,
-                &mut value_max_len,
-                null_mut(),
-                null_mut(),
-            )
-        };
-
-        win32_error(result)?;
+        let info = get_key_info(key)?;
 
         Ok(Self {
             key,
-            range: 0..count as usize,
-            name: vec![0; name_max_len as usize + 1],
-            data: Data::new(value_max_len as usize),
+            idx: 0,
+            name: vec![0; (info.value_name_max + 1) as usize],
+            data: Data::new(info.value_data_max as usize),
         })
+    }
+
+    fn resize(&mut self) -> Result<()> {
+        let info = get_key_info(self.key)?;
+        self.name.resize((info.value_name_max + 1) as usize, 0);
+        self.data = Data::new(info.value_data_max as usize);
+        Ok(())
     }
 }
 
@@ -46,37 +32,43 @@ impl<'a> Iterator for ValueIterator<'a> {
     type Item = (String, Value);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.range.next().and_then(|index| {
-            let mut ty = 0;
-            let mut name_len = self.name.len() as u32;
-            let mut data_len = self.data.len() as u32;
+        let mut ty = 0;
+        let mut name_len = self.name.len() as u32;
+        let mut data_len = self.data.len() as u32;
 
-            let result = unsafe {
-                RegEnumValueW(
-                    self.key.0,
-                    index as u32,
-                    self.name.as_mut_ptr(),
-                    &mut name_len,
-                    core::ptr::null(),
-                    &mut ty,
-                    self.data.as_mut_ptr(),
-                    &mut data_len,
-                )
-            };
+        let result = unsafe {
+            RegEnumValueW(
+                self.key.0,
+                self.idx,
+                self.name.as_mut_ptr(),
+                &mut name_len,
+                core::ptr::null(),
+                &mut ty,
+                self.data.as_mut_ptr(),
+                &mut data_len,
+            )
+        };
 
-            if result != 0 {
-                debug_assert_eq!(result, ERROR_NO_MORE_ITEMS);
-                None
-            } else {
-                let name = String::from_utf16_lossy(&self.name[0..name_len as usize]);
-                Some((
-                    name,
-                    Value {
-                        data: Data::from_slice(&self.data[0..data_len as usize]),
-                        ty: ty.into(),
-                    },
-                ))
+        if result == ERROR_MORE_DATA {
+            if self.resize().is_err() {
+                return None;
             }
-        })
+            return self.next();
+        }
+
+        if result != ERROR_SUCCESS {
+            debug_assert_eq!(result, ERROR_NO_MORE_ITEMS);
+            return None;
+        }
+
+        self.idx += 1;
+        let name = String::from_utf16_lossy(&self.name[0..name_len as usize]);
+        Some((
+            name,
+            Value {
+                data: Data::from_slice(&self.data[0..data_len as usize]),
+                ty: ty.into(),
+            },
+        ))
     }
 }

--- a/crates/tests/misc/registry/tests/keys.rs
+++ b/crates/tests/misc/registry/tests/keys.rs
@@ -14,6 +14,17 @@ fn keys() -> Result<()> {
     let names: Vec<String> = key.keys()?.collect();
     assert_eq!(names, ["one", "three", "two"]);
 
+    let mut names = Vec::<String>::new();
+    let iterator = key.keys()?;
+    for name in iterator {
+        if name == "one" {
+            key.remove_tree("three")?;
+            key.create("seventy")?;
+        }
+        names.push(name.clone());
+    }
+    assert_eq!(names, ["one", "seventy", "two"]);
+
     let err = key.open("missing").unwrap_err();
     assert_eq!(err.code(), HRESULT(0x80070002u32 as i32)); // HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
     assert_eq!(err.message(), "The system cannot find the file specified.");

--- a/crates/tests/misc/registry/tests/values.rs
+++ b/crates/tests/misc/registry/tests/values.rs
@@ -22,5 +22,23 @@ fn values() -> Result<()> {
         ]
     );
 
+    let mut names = Vec::<(String, Value)>::new();
+    let iterator = key.values()?;
+    for (name, value) in iterator {
+        if name == "string" {
+            key.set_string("string-two", "hello world two")?;
+        }
+        names.push((name, value));
+    }
+    assert_eq!(
+        names,
+        [
+            ("u32".to_string(), Value::from(123u32)),
+            ("u64".to_string(), Value::from(456u64)),
+            ("string".to_string(), Value::from("hello world")),
+            ("string-two".to_string(), Value::from("hello world two")),
+        ]
+    );
+
     Ok(())
 }

--- a/crates/tools/bindings/src/registry.txt
+++ b/crates/tools/bindings/src/registry.txt
@@ -3,7 +3,9 @@
 
 --filter
     Windows.Win32.Foundation.ERROR_INVALID_DATA
+    Windows.Win32.Foundation.ERROR_MORE_DATA
     Windows.Win32.Foundation.ERROR_NO_MORE_ITEMS
+    Windows.Win32.Foundation.ERROR_SUCCESS
     Windows.Win32.System.Memory.GetProcessHeap
     Windows.Win32.System.Memory.HeapAlloc
     Windows.Win32.System.Memory.HeapFree


### PR DESCRIPTION
This change updates the key and value iterators to support "forward-lazy" iteration, where the underlying key may change during the iteration process. Previously, the iterators assumed a static state for the registry key but this could lead to panic if keys were modified externally during iteration. The updated iterators now account for potential changes, at the expense of some additional registry queries and/or heap activity.