### PR TITLE
Allow `noexcept` methods in a composable hierarchy

### DIFF
--- a/crates/libs/bindgen/src/rust/winrt_methods.rs
+++ b/crates/libs/bindgen/src/rust/winrt_methods.rs
@@ -148,10 +148,16 @@ pub fn writer(
         metadata::InterfaceKind::None
         | metadata::InterfaceKind::Base
         | metadata::InterfaceKind::Overridable => {
+            let unwrap = if noexcept {
+                quote! { .unwrap() }
+            } else {
+                quote! { ? }
+            };
+
             quote! {
                 #features
                 pub fn #name<#generics>(&self, #params) #return_type_tokens #where_clause {
-                    let this = &windows_core::Interface::cast::<#interface_name>(self)?;
+                    let this = &windows_core::Interface::cast::<#interface_name>(self)#unwrap;
                     unsafe {
                         #vcall
                     }

--- a/crates/tests/winrt/composable/src/bindings.rs
+++ b/crates/tests/winrt/composable/src/bindings.rs
@@ -172,15 +172,16 @@ windows_core::imp::interface_hierarchy!(
 );
 windows_core::imp::required_hierarchy!(ContainerVisual, Visual);
 impl ContainerVisual {
-    pub fn Children(&self) -> windows_core::Result<i32> {
+    pub fn Children(&self) -> i32 {
         let this = self;
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).Children)(
+            let hresult__ = (windows_core::Interface::vtable(this).Children)(
                 windows_core::Interface::as_raw(this),
                 &mut result__,
-            )
-            .map(|| result__)
+            );
+            debug_assert!(hresult__.0 == 0);
+            result__
         }
     }
     pub fn Compositor(&self) -> windows_core::Result<Compositor> {
@@ -218,26 +219,28 @@ windows_core::imp::interface_hierarchy!(
 );
 windows_core::imp::required_hierarchy!(SpriteVisual, ContainerVisual, Visual);
 impl SpriteVisual {
-    pub fn Children(&self) -> windows_core::Result<i32> {
-        let this = &windows_core::Interface::cast::<IContainerVisual>(self)?;
+    pub fn Children(&self) -> i32 {
+        let this = &windows_core::Interface::cast::<IContainerVisual>(self).unwrap();
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).Children)(
+            let hresult__ = (windows_core::Interface::vtable(this).Children)(
                 windows_core::Interface::as_raw(this),
                 &mut result__,
-            )
-            .map(|| result__)
+            );
+            debug_assert!(hresult__.0 == 0);
+            result__
         }
     }
-    pub fn Brush(&self) -> windows_core::Result<i32> {
+    pub fn Brush(&self) -> i32 {
         let this = self;
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).Brush)(
+            let hresult__ = (windows_core::Interface::vtable(this).Brush)(
                 windows_core::Interface::as_raw(this),
                 &mut result__,
-            )
-            .map(|| result__)
+            );
+            debug_assert!(hresult__.0 == 0);
+            result__
         }
     }
     pub fn Compositor(&self) -> windows_core::Result<Compositor> {
@@ -351,7 +354,7 @@ impl ICompositor_Vtbl {
     }
 }
 pub trait IContainerVisual_Impl: Sized + windows_core::IUnknownImpl {
-    fn Children(&self) -> windows_core::Result<i32>;
+    fn Children(&self) -> i32;
 }
 impl windows_core::RuntimeName for IContainerVisual {
     const NAME: &'static str = "test_composable.IContainerVisual";
@@ -364,13 +367,9 @@ impl IContainerVisual_Vtbl {
             result__: *mut i32,
         ) -> windows_core::HRESULT {
             let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-            match IContainerVisual_Impl::Children(this) {
-                Ok(ok__) => {
-                    result__.write(core::mem::transmute_copy(&ok__));
-                    windows_core::HRESULT(0)
-                }
-                Err(err) => err.into(),
-            }
+            let ok__ = IContainerVisual_Impl::Children(this);
+            result__.write(core::mem::transmute_copy(&ok__));
+            windows_core::HRESULT(0)
         }
         Self {
             base__: windows_core::IInspectable_Vtbl::new::<Identity, IContainerVisual, OFFSET>(),
@@ -398,7 +397,7 @@ impl IContainerVisualFactory_Vtbl {
     }
 }
 pub trait ISpriteVisual_Impl: Sized + windows_core::IUnknownImpl {
-    fn Brush(&self) -> windows_core::Result<i32>;
+    fn Brush(&self) -> i32;
 }
 impl windows_core::RuntimeName for ISpriteVisual {
     const NAME: &'static str = "test_composable.ISpriteVisual";
@@ -410,13 +409,9 @@ impl ISpriteVisual_Vtbl {
             result__: *mut i32,
         ) -> windows_core::HRESULT {
             let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-            match ISpriteVisual_Impl::Brush(this) {
-                Ok(ok__) => {
-                    result__.write(core::mem::transmute_copy(&ok__));
-                    windows_core::HRESULT(0)
-                }
-                Err(err) => err.into(),
-            }
+            let ok__ = ISpriteVisual_Impl::Brush(this);
+            result__.write(core::mem::transmute_copy(&ok__));
+            windows_core::HRESULT(0)
         }
         Self {
             base__: windows_core::IInspectable_Vtbl::new::<Identity, ISpriteVisual, OFFSET>(),

--- a/crates/tests/winrt/composable/src/lib.rs
+++ b/crates/tests/winrt/composable/src/lib.rs
@@ -51,8 +51,8 @@ impl ContainerVisual {
 }
 
 impl bindings::IContainerVisual_Impl for ContainerVisual_Impl {
-    fn Children(&self) -> Result<i32> {
-        Ok(self.children)
+    fn Children(&self) -> i32 {
+        self.children
     }
 }
 
@@ -75,14 +75,14 @@ impl SpriteVisual {
 }
 
 impl bindings::ISpriteVisual_Impl for SpriteVisual_Impl {
-    fn Brush(&self) -> Result<i32> {
-        Ok(self.brush)
+    fn Brush(&self) -> i32 {
+        self.brush
     }
 }
 
 impl bindings::IContainerVisual_Impl for SpriteVisual_Impl {
-    fn Children(&self) -> Result<i32> {
-        Ok(self.container.children)
+    fn Children(&self) -> i32 {
+        self.container.children
     }
 }
 

--- a/crates/tests/winrt/composable/src/metadata.idl
+++ b/crates/tests/winrt/composable/src/metadata.idl
@@ -20,11 +20,11 @@ namespace test_composable
 
     unsealed runtimeclass ContainerVisual : Visual
     {
-        Int32 Children {get;};
+        [noexcept] Int32 Children {get;};
     }
 
     runtimeclass SpriteVisual : ContainerVisual
     {
-        Int32 Brush {get;};
+        [noexcept] Int32 Brush {get;};
     }
 }

--- a/crates/tests/winrt/composable_client/src/bindings.rs
+++ b/crates/tests/winrt/composable_client/src/bindings.rs
@@ -172,15 +172,16 @@ windows_core::imp::interface_hierarchy!(
 );
 windows_core::imp::required_hierarchy!(ContainerVisual, Visual);
 impl ContainerVisual {
-    pub fn Children(&self) -> windows_core::Result<i32> {
+    pub fn Children(&self) -> i32 {
         let this = self;
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).Children)(
+            let hresult__ = (windows_core::Interface::vtable(this).Children)(
                 windows_core::Interface::as_raw(this),
                 &mut result__,
-            )
-            .map(|| result__)
+            );
+            debug_assert!(hresult__.0 == 0);
+            result__
         }
     }
     pub fn Compositor(&self) -> windows_core::Result<Compositor> {
@@ -218,26 +219,28 @@ windows_core::imp::interface_hierarchy!(
 );
 windows_core::imp::required_hierarchy!(SpriteVisual, ContainerVisual, Visual);
 impl SpriteVisual {
-    pub fn Children(&self) -> windows_core::Result<i32> {
-        let this = &windows_core::Interface::cast::<IContainerVisual>(self)?;
+    pub fn Children(&self) -> i32 {
+        let this = &windows_core::Interface::cast::<IContainerVisual>(self).unwrap();
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).Children)(
+            let hresult__ = (windows_core::Interface::vtable(this).Children)(
                 windows_core::Interface::as_raw(this),
                 &mut result__,
-            )
-            .map(|| result__)
+            );
+            debug_assert!(hresult__.0 == 0);
+            result__
         }
     }
-    pub fn Brush(&self) -> windows_core::Result<i32> {
+    pub fn Brush(&self) -> i32 {
         let this = self;
         unsafe {
             let mut result__ = core::mem::zeroed();
-            (windows_core::Interface::vtable(this).Brush)(
+            let hresult__ = (windows_core::Interface::vtable(this).Brush)(
                 windows_core::Interface::as_raw(this),
                 &mut result__,
-            )
-            .map(|| result__)
+            );
+            debug_assert!(hresult__.0 == 0);
+            result__
         }
     }
     pub fn Compositor(&self) -> windows_core::Result<Compositor> {

--- a/crates/tests/winrt/composable_client/src/lib.rs
+++ b/crates/tests/winrt/composable_client/src/lib.rs
@@ -16,12 +16,12 @@ fn test() -> Result<()> {
     let compositor = Compositor::new()?;
 
     let container = compositor.CreateContainerVisual(123)?;
-    assert_eq!(container.Children()?, 123);
+    assert_eq!(container.Children(), 123);
     assert_eq!(container.Compositor()?, compositor);
 
     let sprite = compositor.CreateSpriteVisual(456)?;
-    assert_eq!(sprite.Brush()?, 456);
-    assert_eq!(sprite.Children()?, 456 * 2);
+    assert_eq!(sprite.Brush(), 456);
+    assert_eq!(sprite.Children(), 456 * 2);
     assert_eq!(sprite.Compositor()?, compositor);
 
     Ok(())


### PR DESCRIPTION
This does mean that the base queries will panic on failure. In practice, these are guaranteed to succeed unless they're versioned which is pretty uncommon, and you can work around that by querying for the versioned interfaces directly. 

Fixes: #3257