### PR TITLE
Final `riddle` update

### DIFF
--- a/crates/tools/riddle/Cargo.toml
+++ b/crates/tools/riddle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riddle"
-version = "0.58.0"
+version = "0.58.1"
 authors = ["Microsoft"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/tools/riddle/readme.md
+++ b/crates/tools/riddle/readme.md
@@ -1,5 +1,7 @@
 ## Generate Rust bindings for Windows
 
+Update: the `riddle` tool is no longer being updated. You can continue to use the [windows-bindgen](https://crates.io/crates/windows-bindgen) library crate directly.
+
 The [riddle](https://crates.io/crates/riddle) tool automatically generates Rust bindings from Windows metadata.
 
 * [Getting started](https://kennykerr.ca/rust-getting-started/)


### PR DESCRIPTION
Updates the `riddle` crate registry to indicate that this tool is no longer being updated. 