### PR TITLE
Exclude `web` on most workflows

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/debugger_visualizer.yml
+++ b/.github/workflows/debugger_visualizer.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/debugger_visualizer.yml
+++ b/.github/workflows/debugger_visualizer.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-bindgen.yml
+++ b/.github/workflows/msrv-windows-bindgen.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-bindgen.yml
+++ b/.github/workflows/msrv-windows-bindgen.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-core.yml
+++ b/.github/workflows/msrv-windows-core.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-core.yml
+++ b/.github/workflows/msrv-windows-core.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-metadata.yml
+++ b/.github/workflows/msrv-windows-metadata.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-metadata.yml
+++ b/.github/workflows/msrv-windows-metadata.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-registry.yml
+++ b/.github/workflows/msrv-windows-registry.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-registry.yml
+++ b/.github/workflows/msrv-windows-registry.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-result.yml
+++ b/.github/workflows/msrv-windows-result.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-result.yml
+++ b/.github/workflows/msrv-windows-result.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-strings.yml
+++ b/.github/workflows/msrv-windows-strings.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-strings.yml
+++ b/.github/workflows/msrv-windows-strings.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-sys.yml
+++ b/.github/workflows/msrv-windows-sys.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-sys.yml
+++ b/.github/workflows/msrv-windows-sys.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-version.yml
+++ b/.github/workflows/msrv-windows-version.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows-version.yml
+++ b/.github/workflows/msrv-windows-version.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows.yml
+++ b/.github/workflows/msrv-windows.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/msrv-windows.yml
+++ b/.github/workflows/msrv-windows.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/no-default-features.yml
+++ b/.github/workflows/no-default-features.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/no-default-features.yml
+++ b/.github/workflows/no-default-features.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/raw_dylib.yml
+++ b/.github/workflows/raw_dylib.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/raw_dylib.yml
+++ b/.github/workflows/raw_dylib.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/slim_errors.yml
+++ b/.github/workflows/slim_errors.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/slim_errors.yml
+++ b/.github/workflows/slim_errors.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
-      - '.web/**'
+      - 'web/**'
     branches:
       - master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - '.web/**'
     branches:
       - master
 

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -14,6 +14,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
     branches:
       - master
 
@@ -108,6 +109,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
     branches:
       - master
 
@@ -157,6 +159,7 @@ on:
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
     branches:
       - master
 


### PR DESCRIPTION
All those dependabot PRs don't need to run most of the workflows if they're just updating web hosting dependencies. 