### PR TITLE
Test `rust-lld`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,18 @@
 [build]
 rustflags = [
     "-D", "warnings",
-    "-C", "linker=rust-lld",
 
     # "--cfg", "windows_debugger_visualizer",
     # "--cfg", "windows_raw_dylib",
     # "--cfg", "windows_slim_errors",
     # "-C", "target-feature=+crt-static",
 ]
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"
+
+[target.i686-pc-windows-msvc]
+linker = "rust-lld"
+
+[target.aarch64-pc-windows-msvc]
+linker = "rust-lld"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 [build]
 rustflags = [
     "-D", "warnings",
+    "-C", "linker=rust-lld",
 
     # "--cfg", "windows_debugger_visualizer",
     # "--cfg", "windows_raw_dylib",


### PR DESCRIPTION
Tested locally, but CI can do a better job of testing the matrix of configurations. 

I'm not sure we should make this the default for workflows - so this is just an experiment for now. 