### PR TITLE
Add `Deref` implementation for `HSTRING`

### DIFF
--- a/crates/libs/result/src/error.rs
+++ b/crates/libs/result/src/error.rs
@@ -343,7 +343,7 @@ mod error_info {
                 }
             }
 
-            Some(String::from_utf16_lossy(wide_trim_end(message.as_wide())))
+            Some(String::from_utf16_lossy(wide_trim_end(&message)))
         }
 
         pub(crate) fn as_ptr(&self) -> *mut core::ffi::c_void {

--- a/crates/libs/strings/src/hstring.rs
+++ b/crates/libs/strings/src/hstring.rs
@@ -14,18 +14,6 @@ impl HSTRING {
         Self(core::ptr::null_mut())
     }
 
-    /// Returns a raw pointer to the `HSTRING` buffer.
-    ///
-    /// This string pointer is null-terminated so it will never be a null pointer.
-    pub fn as_ptr(&self) -> *const u16 {
-        if let Some(header) = self.as_header() {
-            header.data
-        } else {
-            const EMPTY: [u16; 1] = [0];
-            EMPTY.as_ptr()
-        }
-    }
-
     /// Create a `HSTRING` from a slice of 16 bit characters (wchars).
     pub fn from_wide(value: &[u16]) -> Self {
         unsafe { Self::from_wide_iter(value.iter().copied(), value.len()) }
@@ -77,7 +65,10 @@ impl Deref for HSTRING {
         if let Some(header) = self.as_header() {
             unsafe { core::slice::from_raw_parts(header.data, header.len as usize) }
         } else {
-            &[]
+            // This ensures that if `as_ptr` is called on the slice that the resulting pointer
+            // will still refer to a null-terminated string.
+            const EMPTY: [u16; 1] = [0];
+            &EMPTY[..0]
         }
     }
 }

--- a/crates/libs/strings/src/hstring.rs
+++ b/crates/libs/strings/src/hstring.rs
@@ -26,6 +26,18 @@ impl HSTRING {
         Self(core::ptr::null_mut())
     }
 
+    /// Returns a raw pointer to the `HSTRING` buffer.
+    ///
+    /// This string pointer is null-terminated so it will never be a null pointer.
+    pub fn as_ptr(&self) -> *const u16 {
+        if let Some(header) = self.as_header() {
+            header.data
+        } else {
+            const EMPTY: [u16; 1] = [0];
+            EMPTY.as_ptr()
+        }
+    }
+
     /// Create a `HSTRING` from a slice of 16 bit characters (wchars).
     pub fn from_wide(value: &[u16]) -> Self {
         unsafe { Self::from_wide_iter(value.iter().copied(), value.len()) }

--- a/crates/libs/strings/src/hstring.rs
+++ b/crates/libs/strings/src/hstring.rs
@@ -6,18 +6,6 @@ use core::ops::Deref;
 #[repr(transparent)]
 pub struct HSTRING(pub(crate) *mut HStringHeader);
 
-impl Deref for HSTRING {
-    type Target = [u16];
-
-    fn deref(&self) -> &[u16] {
-        if let Some(header) = self.as_header() {
-            unsafe { core::slice::from_raw_parts(header.data, header.len as usize) }
-        } else {
-            &[]
-        }
-    }
-}
-
 impl HSTRING {
     /// Create an empty `HSTRING`.
     ///
@@ -79,6 +67,18 @@ impl HSTRING {
 
     fn as_header(&self) -> Option<&HStringHeader> {
         unsafe { self.0.as_ref() }
+    }
+}
+
+impl Deref for HSTRING {
+    type Target = [u16];
+
+    fn deref(&self) -> &[u16] {
+        if let Some(header) = self.as_header() {
+            unsafe { core::slice::from_raw_parts(header.data, header.len as usize) }
+        } else {
+            &[]
+        }
     }
 }
 

--- a/crates/tests/misc/literals/tests/win.rs
+++ b/crates/tests/misc/literals/tests/win.rs
@@ -47,8 +47,6 @@ fn test() {
 fn into() {
     let a = h!("");
     assert!(a.is_empty());
-    assert!(!a.as_ptr().is_null());
-    assert!(a.as_wide().is_empty());
     let b = PCWSTR(a.as_ptr());
     // Even though an empty HSTRING is internally represented by a null pointer, the PCWSTR
     // will still be a non-null pointer to a null terminated empty string.
@@ -80,7 +78,7 @@ fn assert_hstring(left: &HSTRING, right: &[u16]) {
         unsafe { wcslen(PCWSTR::from_raw(left.as_ptr())) },
         right.len() - 1
     );
-    let left = unsafe { std::slice::from_raw_parts(left.as_wide().as_ptr(), right.len()) };
+    let left = unsafe { std::slice::from_raw_parts(left.as_ptr(), right.len()) };
     assert_eq!(left, right);
 }
 

--- a/crates/tests/misc/string_param/tests/pwstr.rs
+++ b/crates/tests/misc/string_param/tests/pwstr.rs
@@ -1,20 +1,4 @@
-use windows::{core::*, Win32::Foundation::*, Win32::UI::Shell::*};
-
-#[test]
-fn error() {
-    unsafe {
-        SetLastError(ERROR_BUSY_DRIVE);
-
-        let utf8 = "test\0".as_bytes();
-        let utf16 = HSTRING::from("test\0");
-        let utf16 = utf16.as_wide();
-        let len = 5;
-        assert_eq!(utf8.len(), len);
-        assert_eq!(utf16.len(), len);
-
-        assert_eq!(GetLastError(), ERROR_BUSY_DRIVE);
-    }
-}
+use windows::{core::*, Win32::UI::Shell::*};
 
 #[test]
 fn convert() {

--- a/crates/tests/misc/strings/tests/hstring.rs
+++ b/crates/tests/misc/strings/tests/hstring.rs
@@ -232,7 +232,7 @@ fn hstring_compat() -> Result<()> {
         let result = WindowsConcatString(&hey, &world)?;
         assert_eq!(result, "HeyWorld");
 
-        let result = WindowsCreateString(Some(&hey.as_wide()))?;
+        let result = WindowsCreateString(Some(&hey))?;
         assert_eq!(result, "Hey");
 
         let result = WindowsDuplicateString(&hey)?;
@@ -267,7 +267,7 @@ fn hstring_compat() -> Result<()> {
         let mut header: sys::HSTRING_HEADER = std::mem::zeroed();
         let mut stack_hstring: sys::HSTRING = std::mem::zeroed();
         let hresult = sys::WindowsCreateStringReference(
-            [87, 111, 114, 108, 100, 0].as_ptr(),
+            HSTRING::from("World").as_ptr(),
             5,
             &mut header,
             &mut stack_hstring,
@@ -289,6 +289,22 @@ fn hstring_compat() -> Result<()> {
         );
 
         Ok(())
+    }
+}
+
+#[test]
+fn deref_as_slice() {
+    let deref = HSTRING::from("0123456789");
+    assert!(!deref.is_empty());
+    assert_eq!(deref.len(), 10);
+    assert_eq!(HSTRING::from_wide(&deref[..=3]), "0123");
+    assert!(deref.ends_with(&deref[7..=9]));
+    assert_eq!(deref.get(5), Some(b'5' as u16).as_ref());
+    let ptr = PCWSTR(deref.as_ptr());
+    assert_eq!(deref.cmp(&deref), std::cmp::Ordering::Equal);
+
+    unsafe {
+        assert_eq!(*ptr.as_wide(), *deref);
     }
 }
 

--- a/crates/tests/misc/strings/tests/hstring.rs
+++ b/crates/tests/misc/strings/tests/hstring.rs
@@ -267,7 +267,7 @@ fn hstring_compat() -> Result<()> {
         let mut header: sys::HSTRING_HEADER = std::mem::zeroed();
         let mut stack_hstring: sys::HSTRING = std::mem::zeroed();
         let hresult = sys::WindowsCreateStringReference(
-            HSTRING::from("World").as_ptr(),
+            [87, 111, 114, 108, 100, 0].as_ptr(),
             5,
             &mut header,
             &mut stack_hstring,

--- a/crates/tests/misc/strings/tests/hstring.rs
+++ b/crates/tests/misc/strings/tests/hstring.rs
@@ -306,6 +306,19 @@ fn deref_as_slice() {
     unsafe {
         assert_eq!(*ptr.as_wide(), *deref);
     }
+
+    let empty = HSTRING::new();
+    assert!(empty.is_empty());
+    assert_eq!(empty.len(), 0);
+    assert_eq!(*empty, []);
+
+    unsafe {
+        assert_eq!(wcslen(empty.as_ptr()), 0);
+    }
+}
+
+extern "C" {
+    pub fn wcslen(s: *const u16) -> usize;
 }
 
 mod sys {

--- a/crates/tests/misc/strings/tests/hstring_builder.rs
+++ b/crates/tests/misc/strings/tests/hstring_builder.rs
@@ -4,7 +4,6 @@ use windows_strings::*;
 fn hstring() {
     let s = HSTRING::from("hello");
     assert_eq!(s.len(), 5);
-    assert_eq!(s.as_wide().len(), 5);
 }
 
 #[test]
@@ -36,7 +35,7 @@ fn hstring_builder() {
     b.copy_from_slice(&HELLO00);
     let h: HSTRING = b.into();
     assert_eq!(h.len(), 7);
-    assert_eq!(h.as_wide(), HELLO00);
+    assert_eq!(*h, HELLO00);
 
     // But trim_end can avoid that.
     let mut b = HStringBuilder::new(7);
@@ -44,7 +43,7 @@ fn hstring_builder() {
     b.trim_end();
     let h: HSTRING = b.into();
     assert_eq!(h.len(), 5);
-    assert_eq!(h.as_wide(), HELLO);
+    assert_eq!(*h, HELLO);
 
     // HStringBuilder will initialize memory to zero.
     let b = HStringBuilder::new(5);

--- a/crates/tests/misc/win32_arrays/tests/xmllite.rs
+++ b/crates/tests/misc/win32_arrays/tests/xmllite.rs
@@ -119,10 +119,7 @@ fn lite() -> Result<()> {
 
         writer.WriteStartElement(&HSTRING::from("html"))?;
         writer.WriteAttributeString(&HSTRING::from("no-value"), None)?;
-        writer.WriteAttributeString(
-            &HSTRING::from("with-value"),
-            Some(&HSTRING::from("value")),
-        )?;
+        writer.WriteAttributeString(&HSTRING::from("with-value"), Some(&HSTRING::from("value")))?;
         writer.WriteEndElement(&HSTRING::from("html"))?;
         writer.Flush()?;
 

--- a/crates/tests/misc/win32_arrays/tests/xmllite.rs
+++ b/crates/tests/misc/win32_arrays/tests/xmllite.rs
@@ -117,13 +117,13 @@ fn lite() -> Result<()> {
         let writer = writer.unwrap();
         writer.SetOutput(&stream)?;
 
-        writer.WriteStartElement(HSTRING::from("html").as_wide())?;
-        writer.WriteAttributeString(HSTRING::from("no-value").as_wide(), None)?;
+        writer.WriteStartElement(&HSTRING::from("html"))?;
+        writer.WriteAttributeString(&HSTRING::from("no-value"), None)?;
         writer.WriteAttributeString(
-            HSTRING::from("with-value").as_wide(),
-            Some(HSTRING::from("value").as_wide()),
+            &HSTRING::from("with-value"),
+            Some(&HSTRING::from("value")),
         )?;
-        writer.WriteEndElement(HSTRING::from("html").as_wide())?;
+        writer.WriteEndElement(&HSTRING::from("html"))?;
         writer.Flush()?;
 
         let mut pos = 0;


### PR DESCRIPTION
The `HSTRING` type represents a UTF-16 string that is modeled as a `[u16]` slice in Rust. This update replaces the `as_wide` method to retrieve the `HSTRING` as a slice with a `Deref` implementation. This makes it a lot easier to work with an `HSTRING` in Rust as conversion is implicit in many cases. 

The same is done for `BSTR` for consistency and code reduction. 

Fixes: https://github.com/rust-lang/rustup/pull/3896#issuecomment-2366820680