### PR TITLE
Address Rust nightly compiler warnings

### DIFF
--- a/crates/libs/sys/src/lib.rs
+++ b/crates/libs/sys/src/lib.rs
@@ -6,8 +6,10 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![no_std]
 #![doc(html_no_source)]
-#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, missing_docs, improper_ctypes, clippy::all)]
+#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, missing_docs, clippy::all)]
 #![cfg_attr(not(feature = "docs"), doc(hidden))]
+// TODO: workaround for https://github.com/rust-lang/rust/issues/130757
+#![allow(improper_ctypes)]
 
 #[allow(unused_extern_crates)]
 extern crate self as windows_sys;

--- a/crates/libs/sys/src/lib.rs
+++ b/crates/libs/sys/src/lib.rs
@@ -6,7 +6,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![no_std]
 #![doc(html_no_source)]
-#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, missing_docs, clippy::all)]
+#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, missing_docs, improper_ctypes, clippy::all)]
 #![cfg_attr(not(feature = "docs"), doc(hidden))]
 
 #[allow(unused_extern_crates)]

--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -8,7 +8,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![cfg(windows)]
 #![doc(html_no_source)]
-#![allow(non_snake_case, clashing_extern_declarations, non_upper_case_globals, non_camel_case_types, missing_docs, dead_code, clippy::all)]
+#![allow(non_snake_case, clashing_extern_declarations, non_upper_case_globals, non_camel_case_types, missing_docs, dead_code, improper_ctypes, clippy::all)]
 #![cfg_attr(not(feature = "docs"), doc(hidden))]
 #![cfg_attr(all(not(feature = "std")), no_std)]
 

--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -8,9 +8,11 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![cfg(windows)]
 #![doc(html_no_source)]
-#![allow(non_snake_case, clashing_extern_declarations, non_upper_case_globals, non_camel_case_types, missing_docs, dead_code, improper_ctypes, clippy::all)]
+#![allow(non_snake_case, clashing_extern_declarations, non_upper_case_globals, non_camel_case_types, missing_docs, dead_code, clippy::all)]
 #![cfg_attr(not(feature = "docs"), doc(hidden))]
 #![cfg_attr(all(not(feature = "std")), no_std)]
+// TODO: workaround for https://github.com/rust-lang/rust/issues/130757
+#![allow(improper_ctypes)]
 
 #[allow(unused_extern_crates)]
 extern crate self as windows;

--- a/crates/tests/misc/implement/tests/identity.rs
+++ b/crates/tests/misc/implement/tests/identity.rs
@@ -1,26 +1,23 @@
 #![allow(non_snake_case)]
 
+use std::sync::atomic::*;
 use windows::{core::*, Foundation::*};
 
-static mut COUNTER: isize = 0;
+static COUNTER: AtomicIsize = AtomicIsize::new(0);
 
 #[implement(IStringable, IClosable)]
 struct Test(String);
 
 impl Test {
     fn new(value: &str) -> Self {
-        unsafe {
-            COUNTER += 1;
-        }
+        COUNTER.fetch_add(1, Ordering::Relaxed);
         Self(value.to_string())
     }
 }
 
 impl Drop for Test {
     fn drop(&mut self) {
-        unsafe {
-            COUNTER -= 1;
-        }
+        COUNTER.fetch_sub(1, Ordering::Release);
     }
 }
 
@@ -38,48 +35,47 @@ impl IClosable_Impl for Test_Impl {
 
 #[test]
 fn identity() -> Result<()> {
-    unsafe {
-        assert_eq!(COUNTER, 0);
-        {
-            let a: IStringable = Test::new("test").into();
-            assert!(a.ToString()? == "test");
+    assert_eq!(COUNTER.load(Ordering::Acquire), 0);
+    {
+        let a: IStringable = Test::new("test").into();
+        assert_eq!(COUNTER.load(Ordering::Acquire), 1);
+        assert!(a.ToString()? == "test");
 
-            let b: IClosable = a.cast()?;
-            b.Close()?;
+        let b: IClosable = a.cast()?;
+        b.Close()?;
 
-            let c: IUnknown = b.cast()?;
+        let c: IUnknown = b.cast()?;
 
-            let d: IInspectable = c.cast()?;
+        let d: IInspectable = c.cast()?;
 
-            assert!(a == d.cast()?);
-        }
-        {
-            let a: IUnknown = Test::new("test").into();
-            let b: IClosable = a.cast()?;
-            let c: IStringable = b.cast()?;
-            assert!(c.ToString()? == "test");
-        }
-        {
-            let a: IInspectable = Test::new("test").into();
-            let b: IStringable = a.cast()?;
-            assert!(b.ToString()? == "test");
-        }
-        {
-            let a: IInspectable = Test::new("test").into();
-            assert_eq!(a.GetRuntimeClassName()?, "Windows.Foundation.IStringable");
-
-            let b: IStringable = a.cast()?;
-            let c: &IInspectable = &b.cast()?;
-            assert_eq!(c.GetRuntimeClassName()?, "Windows.Foundation.IStringable");
-
-            let d: IClosable = a.cast()?;
-            let e: &IInspectable = (&d).into();
-            assert_eq!(e.GetRuntimeClassName()?, "Windows.Foundation.IClosable");
-
-            let f: IInspectable = e.cast()?;
-            assert_eq!(f.GetRuntimeClassName()?, "Windows.Foundation.IStringable");
-        }
-        assert_eq!(COUNTER, 0);
-        Ok(())
+        assert!(a == d.cast()?);
     }
+    {
+        let a: IUnknown = Test::new("test").into();
+        let b: IClosable = a.cast()?;
+        let c: IStringable = b.cast()?;
+        assert!(c.ToString()? == "test");
+    }
+    {
+        let a: IInspectable = Test::new("test").into();
+        let b: IStringable = a.cast()?;
+        assert!(b.ToString()? == "test");
+    }
+    {
+        let a: IInspectable = Test::new("test").into();
+        assert_eq!(a.GetRuntimeClassName()?, "Windows.Foundation.IStringable");
+
+        let b: IStringable = a.cast()?;
+        let c: &IInspectable = &b.cast()?;
+        assert_eq!(c.GetRuntimeClassName()?, "Windows.Foundation.IStringable");
+
+        let d: IClosable = a.cast()?;
+        let e: &IInspectable = (&d).into();
+        assert_eq!(e.GetRuntimeClassName()?, "Windows.Foundation.IClosable");
+
+        let f: IInspectable = e.cast()?;
+        assert_eq!(f.GetRuntimeClassName()?, "Windows.Foundation.IStringable");
+    }
+    assert_eq!(COUNTER.load(Ordering::Acquire), 0);
+    Ok(())
 }


### PR DESCRIPTION
Nightly Rust just started lighting up the `improper_ctypes` warning a "type is infinitely recursive" but it seems to be a false positive. 

You can see examples in the build failure here:

https://github.com/microsoft/windows-rs/actions/runs/10997420809/job/30532908394?pr=3291

And here:

https://github.com/microsoft/windows-rs/actions/runs/10997420795/job/30532923854?pr=3291
