### PR TITLE
Release 0.60.0

### DIFF
--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -27,7 +27,7 @@ path = "../result"
 default-features = false
 
 [dependencies.windows-strings]
-version = "0.1.0"
+version = "0.2.0"
 path = "../strings"
 default-features = false
 

--- a/crates/libs/registry/Cargo.toml
+++ b/crates/libs/registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Microsoft"]
 edition = "2021"
 rust-version = "1.60"
@@ -27,7 +27,7 @@ path = "../result"
 default-features = false
 
 [dependencies.windows-strings]
-version = "0.1.0"
+version = "0.2.0"
 path = "../strings"
 default-features = false
 

--- a/crates/libs/registry/readme.md
+++ b/crates/libs/registry/readme.md
@@ -10,7 +10,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-registry]
-version = "0.2"
+version = "0.3"
 ```
 
 Read and write registry keys and values as needed:

--- a/crates/libs/strings/Cargo.toml
+++ b/crates/libs/strings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Microsoft"]
 edition = "2021"
 rust-version = "1.60"

--- a/crates/libs/strings/readme.md
+++ b/crates/libs/strings/readme.md
@@ -10,7 +10,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-strings]
-version = "0.1"
+version = "0.2"
 ```
 
 Use the Windows string types as needed:


### PR DESCRIPTION
This release includes an update to the `windows-registry` and `windows-strings` crates, mainly to provide various improvements to registry support for `rustup`. 

https://github.com/rust-lang/rustup/pull/3896
