### PR TITLE
Address Rust nightly compiler warnings

### DIFF
--- a/crates/libs/bindgen/src/tokens/runtime.rs
+++ b/crates/libs/bindgen/src/tokens/runtime.rs
@@ -80,7 +80,7 @@ pub mod ext {
         fn quote_into_iter(&'q self) -> (Self::Iter, HasIter);
     }
 
-    impl<'q, 'a, T: RepAsIteratorExt<'q> + ?Sized> RepAsIteratorExt<'q> for &'a T {
+    impl<'q, T: RepAsIteratorExt<'q> + ?Sized> RepAsIteratorExt<'q> for &T {
         type Iter = T::Iter;
 
         fn quote_into_iter(&'q self) -> (Self::Iter, HasIter) {
@@ -88,7 +88,7 @@ pub mod ext {
         }
     }
 
-    impl<'q, 'a, T: RepAsIteratorExt<'q> + ?Sized> RepAsIteratorExt<'q> for &'a mut T {
+    impl<'q, T: RepAsIteratorExt<'q> + ?Sized> RepAsIteratorExt<'q> for &mut T {
         type Iter = T::Iter;
 
         fn quote_into_iter(&'q self) -> (Self::Iter, HasIter) {

--- a/crates/libs/bindgen/src/tokens/to_tokens.rs
+++ b/crates/libs/bindgen/src/tokens/to_tokens.rs
@@ -32,19 +32,19 @@ pub trait ToTokens {
     }
 }
 
-impl<'a, T: ?Sized + ToTokens> ToTokens for &'a T {
+impl<T: ?Sized + ToTokens> ToTokens for &T {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         (**self).to_tokens(tokens);
     }
 }
 
-impl<'a, T: ?Sized + ToTokens> ToTokens for &'a mut T {
+impl<T: ?Sized + ToTokens> ToTokens for &mut T {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         (**self).to_tokens(tokens);
     }
 }
 
-impl<'a, T: ?Sized + ToOwned + ToTokens> ToTokens for Cow<'a, T> {
+impl<T: ?Sized + ToOwned + ToTokens> ToTokens for Cow<'_, T> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         (**self).to_tokens(tokens);
     }

--- a/crates/libs/core/src/interface.rs
+++ b/crates/libs/core/src/interface.rs
@@ -272,21 +272,21 @@ pub unsafe fn from_raw_borrowed<T: Interface>(raw: &*mut c_void) -> Option<&T> {
 #[repr(transparent)]
 pub struct InterfaceRef<'a, I>(NonNull<c_void>, PhantomData<&'a I>);
 
-impl<'a, I> Copy for InterfaceRef<'a, I> {}
+impl<I> Copy for InterfaceRef<'_, I> {}
 
-impl<'a, I> Clone for InterfaceRef<'a, I> {
+impl<I> Clone for InterfaceRef<'_, I> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, I: core::fmt::Debug + Interface> core::fmt::Debug for InterfaceRef<'a, I> {
+impl<I: core::fmt::Debug + Interface> core::fmt::Debug for InterfaceRef<'_, I> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         <I as core::fmt::Debug>::fmt(&**self, f)
     }
 }
 
-impl<'a, I: Interface> InterfaceRef<'a, I> {
+impl<I: Interface> InterfaceRef<'_, I> {
     /// Creates an `InterfaceRef` from a raw pointer. _This is extremely dangerous, since there
     /// is no lifetime tracking at all!_
     ///
@@ -325,7 +325,7 @@ impl<'a, 'i: 'a, I: Interface> From<&'i I> for InterfaceRef<'a, I> {
     }
 }
 
-impl<'a, I: Interface> core::ops::Deref for InterfaceRef<'a, I> {
+impl<I: Interface> core::ops::Deref for InterfaceRef<'_, I> {
     type Target = I;
 
     #[inline(always)]

--- a/crates/libs/core/src/out_ref.rs
+++ b/crates/libs/core/src/out_ref.rs
@@ -6,7 +6,7 @@ use super::*;
 #[repr(transparent)]
 pub struct OutRef<'a, T: Type<T>>(*mut T::Abi, core::marker::PhantomData<&'a T>);
 
-impl<'a, T: Type<T>> OutRef<'a, T> {
+impl<T: Type<T>> OutRef<'_, T> {
     /// Returns `true` if the argument is null.
     pub fn is_null(&self) -> bool {
         self.0.is_null()

--- a/crates/libs/core/src/ref.rs
+++ b/crates/libs/core/src/ref.rs
@@ -7,7 +7,7 @@ use core::mem::transmute;
 #[repr(transparent)]
 pub struct Ref<'a, T: Type<T>>(T::Abi, PhantomData<&'a T>);
 
-impl<'a, T: Type<T, Default = Option<T>, Abi = *mut c_void>> Ref<'a, T> {
+impl<T: Type<T, Default = Option<T>, Abi = *mut c_void>> Ref<'_, T> {
     /// Converts the argument to a [Result<&T>] reference.
     pub fn ok(&self) -> Result<&T> {
         if self.0.is_null() {
@@ -18,7 +18,7 @@ impl<'a, T: Type<T, Default = Option<T>, Abi = *mut c_void>> Ref<'a, T> {
     }
 }
 
-impl<'a, T: Type<T>> core::ops::Deref for Ref<'a, T> {
+impl<T: Type<T>> core::ops::Deref for Ref<'_, T> {
     type Target = T::Default;
     fn deref(&self) -> &Self::Target {
         unsafe { transmute(&self.0) }

--- a/crates/libs/core/src/scoped_interface.rs
+++ b/crates/libs/core/src/scoped_interface.rs
@@ -15,7 +15,7 @@ pub struct ScopedInterface<'a, T: Interface> {
     lifetime: PhantomData<&'a T>,
 }
 
-impl<'a, T: Interface> ScopedInterface<'a, T> {
+impl<T: Interface> ScopedInterface<'_, T> {
     pub fn new(interface: T) -> Self {
         Self {
             interface,
@@ -24,7 +24,7 @@ impl<'a, T: Interface> ScopedInterface<'a, T> {
     }
 }
 
-impl<'a, T: Interface> core::ops::Deref for ScopedInterface<'a, T> {
+impl<T: Interface> core::ops::Deref for ScopedInterface<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -32,7 +32,7 @@ impl<'a, T: Interface> core::ops::Deref for ScopedInterface<'a, T> {
     }
 }
 
-impl<'a, T: Interface> Drop for ScopedInterface<'a, T> {
+impl<T: Interface> Drop for ScopedInterface<'_, T> {
     fn drop(&mut self) {
         unsafe {
             let _ = Box::from_raw(self.interface.as_raw() as *const _ as *mut ScopedHeap);

--- a/crates/libs/registry/src/key_iterator.rs
+++ b/crates/libs/registry/src/key_iterator.rs
@@ -37,7 +37,7 @@ impl<'a> KeyIterator<'a> {
     }
 }
 
-impl<'a> Iterator for KeyIterator<'a> {
+impl Iterator for KeyIterator<'_> {
     type Item = String;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/libs/registry/src/value_iterator.rs
+++ b/crates/libs/registry/src/value_iterator.rs
@@ -42,7 +42,7 @@ impl<'a> ValueIterator<'a> {
     }
 }
 
-impl<'a> Iterator for ValueIterator<'a> {
+impl Iterator for ValueIterator<'_> {
     type Item = (String, Value);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/libs/strings/src/bstr.rs
+++ b/crates/libs/strings/src/bstr.rs
@@ -93,7 +93,7 @@ impl From<&String> for BSTR {
     }
 }
 
-impl<'a> TryFrom<&'a BSTR> for String {
+impl TryFrom<&BSTR> for String {
     type Error = alloc::string::FromUtf16Error;
 
     fn try_from(value: &BSTR) -> core::result::Result<Self, Self::Error> {

--- a/crates/libs/strings/src/hstring.rs
+++ b/crates/libs/strings/src/hstring.rs
@@ -357,7 +357,7 @@ impl PartialEq<&HSTRING> for std::ffi::OsString {
     }
 }
 
-impl<'a> TryFrom<&'a HSTRING> for String {
+impl TryFrom<&HSTRING> for String {
     type Error = alloc::string::FromUtf16Error;
 
     fn try_from(hstring: &HSTRING) -> core::result::Result<Self, Self::Error> {
@@ -374,7 +374,7 @@ impl TryFrom<HSTRING> for String {
 }
 
 #[cfg(feature = "std")]
-impl<'a> From<&'a HSTRING> for std::ffi::OsString {
+impl From<&HSTRING> for std::ffi::OsString {
     fn from(hstring: &HSTRING) -> Self {
         hstring.to_os_string()
     }

--- a/crates/tests/misc/array/tests/primitive.rs
+++ b/crates/tests/misc/array/tests/primitive.rs
@@ -18,7 +18,7 @@ fn array() {
     assert_eq!(a[1], 2);
     assert_eq!(a[2], 3);
 
-    let result = a.as_slice().iter().fold(0, |acc, x| acc + x);
+    let result = a.as_slice().iter().sum::<i32>();
     assert_eq!(result, 6);
 
     let a = Array::<i32>::from_slice(&[4, 5, 6]);

--- a/crates/tests/misc/bcrypt/tests/sys.rs
+++ b/crates/tests/misc/bcrypt/tests/sys.rs
@@ -70,8 +70,7 @@ fn test() {
         let block_len = u32::from_le_bytes(block_len) as usize;
 
         let send_message = "I ❤️ Rust";
-        let mut send_buffer =
-            vec![0; block_len * send_message.len().div_ceil(block_len)];
+        let mut send_buffer = vec![0; block_len * send_message.len().div_ceil(block_len)];
         send_buffer[..send_message.len()].copy_from_slice(send_message.as_bytes());
 
         let mut encrypted_len = 0;

--- a/crates/tests/misc/bcrypt/tests/sys.rs
+++ b/crates/tests/misc/bcrypt/tests/sys.rs
@@ -71,7 +71,7 @@ fn test() {
 
         let send_message = "I ❤️ Rust";
         let mut send_buffer =
-            vec![0; block_len * ((send_message.len() + (block_len - 1)) / block_len)];
+            vec![0; block_len * send_message.len().div_ceil(block_len)];
         send_buffer[..send_message.len()].copy_from_slice(send_message.as_bytes());
 
         let mut encrypted_len = 0;

--- a/crates/tests/misc/bcrypt/tests/win.rs
+++ b/crates/tests/misc/bcrypt/tests/win.rs
@@ -42,7 +42,7 @@ fn test() -> Result<()> {
 
         let send_message = "I ❤️ Rust";
         let mut send_buffer =
-            vec![0; block_len * ((send_message.len() + (block_len - 1)) / block_len)];
+            vec![0; block_len * send_message.len().div_ceil(block_len)];
         send_buffer[..send_message.len()].copy_from_slice(send_message.as_bytes());
 
         let mut encrypted_len = 0;

--- a/crates/tests/misc/bcrypt/tests/win.rs
+++ b/crates/tests/misc/bcrypt/tests/win.rs
@@ -41,8 +41,7 @@ fn test() -> Result<()> {
         let block_len = u32::from_le_bytes(block_len) as usize;
 
         let send_message = "I ❤️ Rust";
-        let mut send_buffer =
-            vec![0; block_len * send_message.len().div_ceil(block_len)];
+        let mut send_buffer = vec![0; block_len * send_message.len().div_ceil(block_len)];
         send_buffer[..send_message.len()].copy_from_slice(send_message.as_bytes());
 
         let mut encrypted_len = 0;

--- a/crates/tests/misc/calling_convention/tests/sys.rs
+++ b/crates/tests/misc/calling_convention/tests/sys.rs
@@ -19,7 +19,7 @@ fn variadic() {
     unsafe {
         let mut buffer = vec![0u8; 1024];
         let len = wsprintfA(buffer.as_mut_ptr(), s!("test-%d-%d!"), 123u32, 456u32);
-        let result = std::str::from_utf8_unchecked(&std::slice::from_raw_parts(
+        let result = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
             buffer.as_ptr(),
             len as usize,
         ));

--- a/crates/tests/misc/class_hierarchy/tests/tests.rs
+++ b/crates/tests/misc/class_hierarchy/tests/tests.rs
@@ -30,9 +30,9 @@ fn call_interface(b: &IMemoryBuffer) -> Result<()> {
 }
 
 fn as_class<P: Param<MemoryBuffer>>(b: P) -> Result<()> {
-    unsafe { call_class(&b.param().borrow().as_ref().unwrap()) }
+    unsafe { call_class(b.param().borrow().as_ref().unwrap()) }
 }
 
 fn as_interface<P: Param<IMemoryBuffer>>(b: P) -> Result<()> {
-    unsafe { call_interface(&b.param().borrow().as_ref().unwrap()) }
+    unsafe { call_interface(b.param().borrow().as_ref().unwrap()) }
 }

--- a/crates/tests/misc/error/tests/test.rs
+++ b/crates/tests/misc/error/tests/test.rs
@@ -7,10 +7,10 @@ fn hresult() -> Result<()> {
     let error: Error = E_INVALIDARG.into();
 
     assert_eq!(error.code(), E_INVALIDARG);
-    assert_eq!(E_INVALIDARG.is_ok(), false);
-    assert_eq!(E_INVALIDARG.is_err(), true);
-    assert_eq!(S_OK.is_ok(), true);
-    assert_eq!(S_OK.is_err(), false);
+    assert!(!E_INVALIDARG.is_ok());
+    assert!(E_INVALIDARG.is_err());
+    assert!(S_OK.is_ok());
+    assert!(!S_OK.is_err());
 
     assert_eq!(format!("{S_OK:?}"), "HRESULT(0x00000000)");
     assert_eq!(format!("{E_INVALIDARG:?}"), "HRESULT(0x80070057)");
@@ -27,10 +27,10 @@ fn win32_error() -> Result<()> {
 
     assert_eq!(error.code(), hresult);
     assert_eq!(WIN32_ERROR::from_error(&error), Some(ERROR_BAD_ARGUMENTS));
-    assert_eq!(ERROR_BAD_ARGUMENTS.is_ok(), false);
-    assert_eq!(ERROR_BAD_ARGUMENTS.is_err(), true);
-    assert_eq!(ERROR_SUCCESS.is_ok(), true);
-    assert_eq!(ERROR_SUCCESS.is_err(), false);
+    assert!(!ERROR_BAD_ARGUMENTS.is_ok());
+    assert!(ERROR_BAD_ARGUMENTS.is_err());
+    assert!(ERROR_SUCCESS.is_ok());
+    assert!(!ERROR_SUCCESS.is_err());
 
     assert_eq!(format!("{ERROR_SUCCESS:?}"), "WIN32_ERROR(0)");
     assert_eq!(format!("{ERROR_BAD_ARGUMENTS:?}"), "WIN32_ERROR(160)");
@@ -47,10 +47,10 @@ fn ntstatus() -> Result<()> {
 
     assert_eq!(error.code(), hresult);
     assert_eq!(error.message(), "The object was not found.");
-    assert_eq!(STATUS_NOT_FOUND.is_ok(), false);
-    assert_eq!(STATUS_NOT_FOUND.is_err(), true);
-    assert_eq!(STATUS_SUCCESS.is_ok(), true);
-    assert_eq!(STATUS_SUCCESS.is_err(), false);
+    assert!(!STATUS_NOT_FOUND.is_ok());
+    assert!(STATUS_NOT_FOUND.is_err());
+    assert!(STATUS_SUCCESS.is_ok());
+    assert!(!STATUS_SUCCESS.is_err());
 
     assert_eq!(format!("{STATUS_SUCCESS:?}"), "NTSTATUS(0)");
     assert_eq!(format!("{STATUS_NOT_FOUND:?}"), "NTSTATUS(-1073741275)");

--- a/crates/tests/misc/extensions/tests/bool32.rs
+++ b/crates/tests/misc/extensions/tests/bool32.rs
@@ -7,17 +7,17 @@ fn test() {
 
     let status = BOOL(1);
     assert_eq!(status.0, 1);
-    assert_eq!(status.as_bool(), true);
-    assert_eq!(status.ok().is_ok(), true);
+    assert!(status.as_bool());
+    assert!(status.ok().is_ok());
 
     unsafe {
         SetLastError(ERROR_ACCESS_DENIED);
     }
     let status = BOOL(0);
     assert_eq!(status.0, 0);
-    assert_eq!(status.as_bool(), false);
+    assert!(!status.as_bool());
     let result = status.ok();
-    assert_eq!(result.is_ok(), false);
+    assert!(!result.is_ok());
     let error = result.unwrap_err();
     assert_eq!(error.code(), E_ACCESSDENIED);
 }

--- a/crates/tests/misc/extensions/tests/boolean.rs
+++ b/crates/tests/misc/extensions/tests/boolean.rs
@@ -7,17 +7,17 @@ fn test() {
 
     let status = BOOLEAN(1);
     assert_eq!(status.0, 1);
-    assert_eq!(status.as_bool(), true);
-    assert_eq!(status.ok().is_ok(), true);
+    assert!(status.as_bool());
+    assert!(status.ok().is_ok());
 
     unsafe {
         SetLastError(ERROR_ACCESS_DENIED);
     }
     let status = BOOLEAN(0);
     assert_eq!(status.0, 0);
-    assert_eq!(status.as_bool(), false);
+    assert!(!status.as_bool());
     let result = status.ok();
-    assert_eq!(result.is_ok(), false);
+    assert!(!result.is_ok());
     let error = result.unwrap_err();
     assert_eq!(error.code(), E_ACCESSDENIED);
 }

--- a/crates/tests/misc/extensions/tests/ntstatus.rs
+++ b/crates/tests/misc/extensions/tests/ntstatus.rs
@@ -4,15 +4,15 @@ use windows::{core::*, Win32::Foundation::*, Win32::Security::Cryptography::*};
 fn test() -> Result<()> {
     let status = NTSTATUS::default();
     assert_eq!(status.0, 0);
-    assert_eq!(status.is_ok(), true);
-    assert_eq!(status.is_err(), false);
-    assert_eq!(status.ok().is_ok(), true);
+    assert!(status.is_ok());
+    assert!(!status.is_err());
+    assert!(status.ok().is_ok());
 
     let status = STATUS_NOT_FOUND;
     assert_eq!(status.0, -1073741275);
-    assert_eq!(status.is_ok(), false);
-    assert_eq!(status.is_err(), true);
-    assert_eq!(status.ok().is_ok(), false);
+    assert!(!status.is_ok());
+    assert!(status.is_err());
+    assert!(!status.ok().is_ok());
 
     let error = status.ok().unwrap_err();
     assert_eq!(error.code(), HRESULT(-805305819));
@@ -64,9 +64,9 @@ fn is_valid(status: NTSTATUS) -> Result<bool> {
 
 #[test]
 fn test_verify() -> Result<()> {
-    assert_eq!(is_valid(STATUS_SUCCESS)?, true);
-    assert_eq!(is_valid(STATUS_INVALID_SIGNATURE)?, false);
-    assert_eq!(is_valid(STATUS_NOT_FOUND).is_err(), true);
+    assert!(is_valid(STATUS_SUCCESS)?);
+    assert!(!(is_valid(STATUS_INVALID_SIGNATURE)?));
+    assert!(is_valid(STATUS_NOT_FOUND).is_err());
 
     Ok(())
 }

--- a/crates/tests/misc/extensions/tests/variant_bool.rs
+++ b/crates/tests/misc/extensions/tests/variant_bool.rs
@@ -7,17 +7,17 @@ fn test() {
 
     let status = VARIANT_TRUE;
     assert_eq!(status.0, -1);
-    assert_eq!(status.as_bool(), true);
-    assert_eq!(status.ok().is_ok(), true);
+    assert!(status.as_bool());
+    assert!(status.ok().is_ok());
 
     unsafe {
         SetLastError(ERROR_ACCESS_DENIED);
     }
     let status = VARIANT_FALSE;
     assert_eq!(status.0, 0);
-    assert_eq!(status.as_bool(), false);
+    assert!(!status.as_bool());
     let result = status.ok();
-    assert_eq!(result.is_ok(), false);
+    assert!(!result.is_ok());
     let error = result.unwrap_err();
     assert_eq!(error.code(), E_ACCESSDENIED);
 }

--- a/crates/tests/misc/handles/tests/legacy.rs
+++ b/crates/tests/misc/handles/tests/legacy.rs
@@ -5,7 +5,7 @@ use windows::Win32::System::Registry::*;
 #[test]
 fn handle() {
     let handle = HANDLE(0 as _);
-    let _clone = handle.clone();
+    let _clone = handle;
     let _copy: HANDLE = handle;
     assert!(HANDLE::default() == HANDLE(0 as _));
     assert!(HANDLE(0 as _).is_invalid());
@@ -24,7 +24,7 @@ fn boolean() {
 #[test]
 fn pstr() {
     let handle = PSTR(core::ptr::null_mut());
-    let _clone = handle.clone();
+    let _clone = handle;
     let _copy: PSTR = handle;
     assert!(handle.is_null());
 }
@@ -32,7 +32,7 @@ fn pstr() {
 #[test]
 fn pwstr() {
     let handle = PWSTR::null();
-    let _clone = handle.clone();
+    let _clone = handle;
     let _copy: PWSTR = handle;
     assert!(handle.is_null());
 }

--- a/crates/tests/misc/handles/tests/win.rs
+++ b/crates/tests/misc/handles/tests/win.rs
@@ -13,7 +13,7 @@ fn handle() {
     let copy = handle;
     assert!(copy == handle);
 
-    let clone = handle.clone();
+    let clone = handle;
     assert!(clone == handle);
 
     let default = HANDLE::default();
@@ -31,7 +31,7 @@ fn psid() {
     let copy = handle;
     assert!(copy == handle);
 
-    let clone = handle.clone();
+    let clone = handle;
     assert!(clone == handle);
 
     let default = PSID::default();

--- a/crates/tests/misc/implement/tests/generic_default.rs
+++ b/crates/tests/misc/implement/tests/generic_default.rs
@@ -63,11 +63,11 @@ fn test_implement() -> Result<()> {
     assert_eq!(3, v.Size()?);
 
     let mut index = 0;
-    assert_eq!(true, v.IndexOf(20, &mut index)?);
+    assert!(v.IndexOf(20, &mut index)?);
     assert_eq!(1, index);
-    assert_eq!(true, v.IndexOf(30, &mut index)?);
+    assert!(v.IndexOf(30, &mut index)?);
     assert_eq!(2, index);
-    assert_eq!(false, v.IndexOf(123, &mut index)?);
+    assert!(!(v.IndexOf(123, &mut index)?));
 
     let v: IVectorView<HSTRING> = Thing(vec!["10".into(), "20".into(), "30".into()]).into();
     assert_eq!("10", v.GetAt(0)?);
@@ -76,11 +76,11 @@ fn test_implement() -> Result<()> {
     assert_eq!(3, v.Size()?);
 
     let mut index = 0;
-    assert_eq!(true, v.IndexOf(&HSTRING::from("20"), &mut index)?);
+    assert!(v.IndexOf(&HSTRING::from("20"), &mut index)?);
     assert_eq!(1, index);
-    assert_eq!(true, v.IndexOf(&HSTRING::from("30"), &mut index)?);
+    assert!(v.IndexOf(&HSTRING::from("30"), &mut index)?);
     assert_eq!(2, index);
-    assert_eq!(false, v.IndexOf(&HSTRING::from("123"), &mut index)?);
+    assert!(!(v.IndexOf(&HSTRING::from("123"), &mut index)?));
 
     let url1: HSTRING = "http://one/".into();
     let url2: HSTRING = "http://two/".into();

--- a/crates/tests/misc/implement/tests/generic_primitive.rs
+++ b/crates/tests/misc/implement/tests/generic_primitive.rs
@@ -41,7 +41,7 @@ fn test_implement() -> Result<()> {
     assert_eq!(012, v.GetAt(012)?);
     assert_eq!(123, v.Size()?);
     let mut index = 0;
-    assert_eq!(true, v.IndexOf(456, &mut index)?);
+    assert!(v.IndexOf(456, &mut index)?);
     assert_eq!(456, index);
 
     Ok(())

--- a/crates/tests/misc/implement/tests/into_impl.rs
+++ b/crates/tests/misc/implement/tests/into_impl.rs
@@ -94,34 +94,34 @@ fn test_explicit() -> Result<()> {
     let it1 = iterable.First()?;
 
     assert_eq!(it1.Current()?, 10);
-    assert_eq!(it1.HasCurrent()?, true);
-    assert_eq!(it1.MoveNext()?, true);
+    assert!(it1.HasCurrent()?);
+    assert!(it1.MoveNext()?);
 
     assert_eq!(it1.Current()?, 20);
-    assert_eq!(it1.HasCurrent()?, true);
-    assert_eq!(it1.MoveNext()?, true);
+    assert!(it1.HasCurrent()?);
+    assert!(it1.MoveNext()?);
 
     assert_eq!(it1.Current()?, 30);
-    assert_eq!(it1.HasCurrent()?, true);
-    assert_eq!(it1.MoveNext()?, false);
+    assert!(it1.HasCurrent()?);
+    assert!(!(it1.MoveNext()?));
 
-    assert_eq!(it1.Current().is_err(), true);
-    assert_eq!(it1.HasCurrent()?, false);
-    assert_eq!(it1.MoveNext()?, false);
+    assert!(it1.Current().is_err());
+    assert!(!(it1.HasCurrent()?));
+    assert!(!(it1.MoveNext()?));
 
     // The following just validates that iterators are independent and stable.
 
     let it2 = iterable.First()?;
 
     assert_eq!(it2.Current()?, 10);
-    assert_eq!(it2.HasCurrent()?, true);
-    assert_eq!(it1.Current().is_err(), true);
-    assert_eq!(it1.HasCurrent()?, false);
+    assert!(it2.HasCurrent()?);
+    assert!(it1.Current().is_err());
+    assert!(!(it1.HasCurrent()?));
 
     assert_eq!(it2.Current()?, 10);
-    assert_eq!(it2.HasCurrent()?, true);
-    assert_eq!(it1.Current().is_err(), true);
-    assert_eq!(it1.HasCurrent()?, false);
+    assert!(it2.HasCurrent()?);
+    assert!(it1.Current().is_err());
+    assert!(!(it1.HasCurrent()?));
 
     Ok(())
 }

--- a/crates/tests/misc/implement/tests/vector.rs
+++ b/crates/tests/misc/implement/tests/vector.rs
@@ -94,7 +94,7 @@ where
         } else {
             let len = writer.len();
             writer.try_reserve(len + 1).map_err(|_| err_memory())?;
-            writer.insert(index as usize, value.clone());
+            writer.insert(index, value.clone());
             Ok(())
         }
     }
@@ -202,24 +202,23 @@ fn Size() -> Result<()> {
 fn IndexOf() -> Result<()> {
     let v: IVector<i32> = Vector::new(vec![123, 456]).into();
     let mut index = 0;
-    assert_eq!(v.IndexOf(123, &mut index)?, true);
+    assert!(v.IndexOf(123, &mut index)?);
     assert_eq!(index, 0);
-    assert_eq!(v.IndexOf(456, &mut index)?, true);
+    assert!(v.IndexOf(456, &mut index)?);
     assert_eq!(index, 1);
-    assert_eq!(v.IndexOf(789, &mut index)?, false);
+    assert!(!(v.IndexOf(789, &mut index)?));
 
     let uri = Uri::CreateUri(&HSTRING::from("http://test/"))?;
     let v: IVector<IStringable> = Vector::new(vec![Some(uri.cast()?), None]).into();
-    assert_eq!(v.IndexOf(&uri.cast::<IStringable>()?, &mut index)?, true);
+    assert!(v.IndexOf(&uri.cast::<IStringable>()?, &mut index)?);
     assert_eq!(index, 0);
-    assert_eq!(v.IndexOf(None, &mut index)?, true);
+    assert!(v.IndexOf(None, &mut index)?);
     assert_eq!(index, 1);
-    assert_eq!(
-        v.IndexOf(
+    assert!(
+        !(v.IndexOf(
             &Uri::CreateUri(&HSTRING::from("http://test/"))?.cast::<IStringable>()?,
             &mut index
-        )?,
-        false
+        )?)
     );
 
     Ok(())
@@ -248,11 +247,11 @@ fn test() -> Result<()> {
     ); // TODO: needs to have `1<Int32>
 
     let mut index = 0;
-    assert_eq!(true, v.IndexOf(20, &mut index)?);
+    assert!(v.IndexOf(20, &mut index)?);
     assert_eq!(1, index);
-    assert_eq!(true, v.IndexOf(30, &mut index)?);
+    assert!(v.IndexOf(30, &mut index)?);
     assert_eq!(2, index);
-    assert_eq!(false, v.IndexOf(123, &mut index)?);
+    assert!(!(v.IndexOf(123, &mut index)?));
 
     let v: IVectorView<HSTRING> = Vector::new(vec!["10".into(), "20".into(), "30".into()]).into();
     assert_eq!("10", v.GetAt(0)?);
@@ -261,11 +260,11 @@ fn test() -> Result<()> {
     assert_eq!(3, v.Size()?);
 
     let mut index = 0;
-    assert_eq!(true, v.IndexOf(&HSTRING::from("20"), &mut index)?);
+    assert!(v.IndexOf(&HSTRING::from("20"), &mut index)?);
     assert_eq!(1, index);
-    assert_eq!(true, v.IndexOf(&HSTRING::from("30"), &mut index)?);
+    assert!(v.IndexOf(&HSTRING::from("30"), &mut index)?);
     assert_eq!(2, index);
-    assert_eq!(false, v.IndexOf(&HSTRING::from("123"), &mut index)?);
+    assert!(!(v.IndexOf(&HSTRING::from("123"), &mut index)?));
 
     let v: IVectorView<IStringable> = Vector::new(vec![
         Some(Uri::CreateUri(&HSTRING::from("http://one/"))?.cast()?),

--- a/crates/tests/misc/sys/tests/simple.rs
+++ b/crates/tests/misc/sys/tests/simple.rs
@@ -27,7 +27,7 @@ fn types() {
 
     // Handles
     let _: HANDLE = core::ptr::null_mut();
-    let _: PSTR = b"hello\0".as_ptr() as _;
+    let _: PSTR = c"hello".as_ptr() as _;
 }
 
 #[test]

--- a/crates/tests/misc/variant/tests/tests.rs
+++ b/crates/tests/misc/variant/tests/tests.rs
@@ -19,9 +19,9 @@ fn test_variant() -> Result<()> {
     let v = VARIANT::from(true);
     assert!(!v.is_empty());
     assert_eq!(v.vt(), VT_BOOL);
-    assert_eq!(bool::try_from(&v)?, true);
+    assert!(bool::try_from(&v)?);
     let v = VARIANT::from(false);
-    assert_eq!(bool::try_from(&v)?, false);
+    assert!(!(bool::try_from(&v)?));
     assert_eq!(VARIANT::from(true), VARIANT::from(true));
     assert_eq!(VARIANT::from(false), VARIANT::from(false));
     assert_ne!(VARIANT::from(true), VARIANT::from(false));
@@ -145,9 +145,9 @@ fn test_propvariant() -> Result<()> {
     let v = PROPVARIANT::from(true);
     assert!(!v.is_empty());
     assert_eq!(v.vt(), VT_BOOL);
-    assert_eq!(bool::try_from(&v)?, true);
+    assert!(bool::try_from(&v)?);
     let v = PROPVARIANT::from(false);
-    assert_eq!(bool::try_from(&v)?, false);
+    assert!(!(bool::try_from(&v)?));
     assert_eq!(PROPVARIANT::from(true), PROPVARIANT::from(true));
     assert_eq!(PROPVARIANT::from(false), PROPVARIANT::from(false));
     assert_ne!(PROPVARIANT::from(true), PROPVARIANT::from(false));

--- a/crates/tests/misc/win32/tests/win32.rs
+++ b/crates/tests/misc/win32/tests/win32.rs
@@ -49,7 +49,7 @@ fn rect() {
     assert!(rect.right == 3);
     assert!(rect.bottom == 4);
 
-    let clone = rect.clone();
+    let clone = rect;
 
     assert!(
         clone
@@ -142,7 +142,7 @@ fn bool_as_error() {
 fn com() -> windows::core::Result<()> {
     unsafe {
         let stream = CreateStreamOnHGlobal(None, true)?;
-        let values = vec![1u8, 2u8, 3u8, 4u8];
+        let values = [1u8, 2u8, 3u8, 4u8];
 
         let mut copied = 0;
         stream
@@ -237,7 +237,7 @@ fn callback() {
         assert!(BOOL(789) == a.unwrap()(HWND(123 as _), s!("hello a"), HANDLE(456 as _)));
 
         let a: PROPENUMPROCW = Some(callback_w);
-        assert!(BOOL(789) == a.unwrap()(HWND(123 as _), w!("hello w").into(), HANDLE(456 as _)));
+        assert!(BOOL(789) == a.unwrap()(HWND(123 as _), w!("hello w"), HANDLE(456 as _)));
     }
 }
 

--- a/crates/tests/winrt/collections/tests/stock_map_view.rs
+++ b/crates/tests/winrt/collections/tests/stock_map_view.rs
@@ -8,7 +8,7 @@ fn primitive() -> Result<()> {
     let m = IMapView::<i32, u64>::from(BTreeMap::from([]));
     assert_eq!(m.Lookup(0).unwrap_err().code(), E_BOUNDS);
     assert_eq!(m.Size()?, 0);
-    assert_eq!(m.HasKey(0)?, false);
+    assert!(!(m.HasKey(0)?));
     let mut left = None;
     let mut right = None;
     m.Split(&mut left, &mut right)?;
@@ -18,7 +18,7 @@ fn primitive() -> Result<()> {
     assert_eq!(m.Lookup(1i32)?, 10u64);
     assert_eq!(m.Lookup(2)?, 20);
     assert_eq!(m.Size()?, 2);
-    assert_eq!(m.HasKey(2)?, true);
+    assert!(m.HasKey(2)?);
 
     let able: IIterable<IKeyValuePair<i32, u64>> = m.cast()?;
     let m2: IMapView<i32, u64> = able.cast()?;
@@ -115,7 +115,7 @@ fn hstring() -> Result<()> {
     let m = IMapView::<HSTRING, i32>::from(BTreeMap::new());
     assert_eq!(m.Lookup(h!("missing")).unwrap_err().code(), E_BOUNDS);
     assert_eq!(m.Size()?, 0);
-    assert_eq!(m.HasKey(h!("missing"))?, false);
+    assert!(!(m.HasKey(h!("missing"))?));
 
     let m = BTreeMap::from([("one".into(), 1), ("two".into(), 2)]);
     assert!(m.contains_key(h!("one")));
@@ -124,8 +124,8 @@ fn hstring() -> Result<()> {
     assert_eq!(m.Lookup(h!("one"))?, 1);
     assert_eq!(m.Lookup(h!("two"))?, 2);
     assert_eq!(m.Size()?, 2);
-    assert_eq!(m.HasKey(h!("one"))?, true);
-    assert_eq!(m.HasKey(h!("three"))?, false);
+    assert!(m.HasKey(h!("one"))?);
+    assert!(!(m.HasKey(h!("three"))?));
 
     let able: IIterable<IKeyValuePair<HSTRING, i32>> = m.cast()?;
     let m2: IMapView<HSTRING, i32> = able.cast()?;

--- a/crates/tests/winrt/collections/tests/stock_vector_view.rs
+++ b/crates/tests/winrt/collections/tests/stock_vector_view.rs
@@ -7,7 +7,7 @@ fn primitive() -> Result<()> {
     let v = IVectorView::<i32>::from(vec![]);
     assert_eq!(v.GetAt(0).unwrap_err().code(), E_BOUNDS);
     assert_eq!(v.Size()?, 0);
-    assert_eq!(v.IndexOf(0, &mut 0)?, false);
+    assert!(!(v.IndexOf(0, &mut 0)?));
     assert_eq!(v.GetMany(0, &mut [0; 5])?, 0);
 
     let v = IVectorView::<i32>::from(vec![1, 2, 3]);
@@ -16,12 +16,12 @@ fn primitive() -> Result<()> {
     assert_eq!(v.GetAt(2)?, 3);
     assert_eq!(v.Size()?, 3);
     let mut index = 0;
-    assert_eq!(v.IndexOf(0, &mut index)?, false);
-    assert_eq!(v.IndexOf(1, &mut index)?, true);
+    assert!(!(v.IndexOf(0, &mut index)?));
+    assert!(v.IndexOf(1, &mut index)?);
     assert_eq!(index, 0);
-    assert_eq!(v.IndexOf(2, &mut index)?, true);
+    assert!(v.IndexOf(2, &mut index)?);
     assert_eq!(index, 1);
-    assert_eq!(v.IndexOf(3, &mut index)?, true);
+    assert!(v.IndexOf(3, &mut index)?);
     assert_eq!(index, 2);
 
     let mut values = [0; 5];


### PR DESCRIPTION
Spotted in the #3310 build.

Looks like Clippy is covering a lot more test code by default now. 