### PR TITLE
Update workflows to ignore paths on pull request

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,6 +2,9 @@ name: clippy
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -2,6 +2,9 @@ name: cross
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/debugger_visualizer.yml
+++ b/.github/workflows/debugger_visualizer.yml
@@ -2,6 +2,9 @@ name: debugger_visualizer
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,6 +2,9 @@ name: docs
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -2,6 +2,9 @@ name: fmt
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -2,6 +2,9 @@ name: gen
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -2,6 +2,9 @@ name: lib
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,9 @@ name: linux
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/msrv-windows-bindgen.yml
+++ b/.github/workflows/msrv-windows-bindgen.yml
@@ -2,6 +2,9 @@ name: windows-bindgen
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/msrv-windows-core.yml
+++ b/.github/workflows/msrv-windows-core.yml
@@ -2,6 +2,9 @@ name: windows-core
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/msrv-windows-metadata.yml
+++ b/.github/workflows/msrv-windows-metadata.yml
@@ -2,6 +2,9 @@ name: windows-metadata
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/msrv-windows-registry.yml
+++ b/.github/workflows/msrv-windows-registry.yml
@@ -2,6 +2,9 @@ name: windows-registry
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/msrv-windows-result.yml
+++ b/.github/workflows/msrv-windows-result.yml
@@ -2,6 +2,9 @@ name: windows-result
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/msrv-windows-strings.yml
+++ b/.github/workflows/msrv-windows-strings.yml
@@ -2,6 +2,9 @@ name: windows-strings
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/msrv-windows-sys.yml
+++ b/.github/workflows/msrv-windows-sys.yml
@@ -2,6 +2,9 @@ name: windows-sys
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/msrv-windows-version.yml
+++ b/.github/workflows/msrv-windows-version.yml
@@ -2,6 +2,9 @@ name: windows-version
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/msrv-windows.yml
+++ b/.github/workflows/msrv-windows.yml
@@ -2,6 +2,9 @@ name: windows
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/no-default-features.yml
+++ b/.github/workflows/no-default-features.yml
@@ -2,6 +2,9 @@ name: no-default-features
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -2,6 +2,9 @@ name: no_std
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/raw-dylib.yml
+++ b/.github/workflows/raw-dylib.yml
@@ -2,6 +2,9 @@ name: raw-dylib
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/slim_errors.yml
+++ b/.github/workflows/slim_errors.yml
@@ -2,6 +2,9 @@ name: slim_errors
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -11,6 +11,8 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -13,6 +13,9 @@ fn test_yml(name: &str, raw_dylib: bool) {
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
@@ -122,6 +125,9 @@ fn clippy_yml() {
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
@@ -172,6 +178,9 @@ fn no_default_features_yml() {
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - 'web/**'
   push:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'


### PR DESCRIPTION
Updates all our workflows to ignore the same paths across both push and pull request.

Fixes: #3300 ([example](https://github.com/riverar/windows-rs/pull/3))