### PR TITLE
Fix nested struct sort order 

### DIFF
--- a/crates/libs/bindgen/src/rust/standalone.rs
+++ b/crates/libs/bindgen/src/rust/standalone.rs
@@ -241,7 +241,7 @@ fn type_collect_standalone_nested(
     td: metadata::TypeDef,
     set: &mut std::collections::BTreeSet<metadata::Type>,
 ) {
-    for nested in td.reader().nested_types(td) {
+    for (_, nested) in td.reader().nested_types(td) {
         type_collect_standalone_nested(writer, nested, set);
 
         for field in nested.fields() {

--- a/crates/libs/bindgen/src/rust/structs.rs
+++ b/crates/libs/bindgen/src/rust/structs.rs
@@ -109,7 +109,7 @@ fn gen_struct_with_name(
         });
     }
 
-    for (index, nested_type) in writer.reader.nested_types(def).enumerate() {
+    for (index, nested_type) in writer.reader.nested_types(def) {
         let nested_name = format!("{struct_name}_{index}");
         tokens.combine(&gen_struct_with_name(
             writer,

--- a/crates/libs/bindgen/src/rust/writer.rs
+++ b/crates/libs/bindgen/src/rust/writer.rs
@@ -535,7 +535,7 @@ impl Writer {
     }
     fn scoped_name(&self, def: metadata::TypeDef) -> String {
         if let Some(enclosing_type) = def.enclosing_type() {
-            for (index, nested_type) in self.reader.nested_types(enclosing_type).enumerate() {
+            for (index, nested_type) in self.reader.nested_types(enclosing_type) {
                 if nested_type.name() == def.name() {
                     return format!("{}_{index}", &self.scoped_name(enclosing_type));
                 }

--- a/crates/libs/sys/src/Windows/Wdk/Foundation/mod.rs
+++ b/crates/libs/sys/src/Windows/Wdk/Foundation/mod.rs
@@ -504,50 +504,50 @@ pub struct IO_STACK_LOCATION {
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
 pub union IO_STACK_LOCATION_0 {
-    pub Create: IO_STACK_LOCATION_0_2,
+    pub Create: IO_STACK_LOCATION_0_0,
     pub CreatePipe: IO_STACK_LOCATION_0_1,
-    pub CreateMailslot: IO_STACK_LOCATION_0_0,
-    pub Read: IO_STACK_LOCATION_0_25,
-    pub Write: IO_STACK_LOCATION_0_38,
-    pub QueryDirectory: IO_STACK_LOCATION_0_16,
-    pub NotifyDirectory: IO_STACK_LOCATION_0_10,
-    pub NotifyDirectoryEx: IO_STACK_LOCATION_0_9,
-    pub QueryFile: IO_STACK_LOCATION_0_18,
-    pub SetFile: IO_STACK_LOCATION_0_28,
-    pub QueryEa: IO_STACK_LOCATION_0_17,
-    pub SetEa: IO_STACK_LOCATION_0_27,
-    pub QueryVolume: IO_STACK_LOCATION_0_23,
-    pub SetVolume: IO_STACK_LOCATION_0_32,
-    pub FileSystemControl: IO_STACK_LOCATION_0_5,
-    pub LockControl: IO_STACK_LOCATION_0_7,
-    pub DeviceIoControl: IO_STACK_LOCATION_0_4,
-    pub QuerySecurity: IO_STACK_LOCATION_0_22,
-    pub SetSecurity: IO_STACK_LOCATION_0_31,
-    pub MountVolume: IO_STACK_LOCATION_0_8,
-    pub VerifyVolume: IO_STACK_LOCATION_0_35,
-    pub Scsi: IO_STACK_LOCATION_0_26,
-    pub QueryQuota: IO_STACK_LOCATION_0_21,
-    pub SetQuota: IO_STACK_LOCATION_0_30,
-    pub QueryDeviceRelations: IO_STACK_LOCATION_0_14,
-    pub QueryInterface: IO_STACK_LOCATION_0_20,
-    pub DeviceCapabilities: IO_STACK_LOCATION_0_3,
-    pub FilterResourceRequirements: IO_STACK_LOCATION_0_6,
-    pub ReadWriteConfig: IO_STACK_LOCATION_0_24,
+    pub CreateMailslot: IO_STACK_LOCATION_0_2,
+    pub Read: IO_STACK_LOCATION_0_3,
+    pub Write: IO_STACK_LOCATION_0_4,
+    pub QueryDirectory: IO_STACK_LOCATION_0_5,
+    pub NotifyDirectory: IO_STACK_LOCATION_0_6,
+    pub NotifyDirectoryEx: IO_STACK_LOCATION_0_7,
+    pub QueryFile: IO_STACK_LOCATION_0_8,
+    pub SetFile: IO_STACK_LOCATION_0_9,
+    pub QueryEa: IO_STACK_LOCATION_0_10,
+    pub SetEa: IO_STACK_LOCATION_0_11,
+    pub QueryVolume: IO_STACK_LOCATION_0_12,
+    pub SetVolume: IO_STACK_LOCATION_0_13,
+    pub FileSystemControl: IO_STACK_LOCATION_0_14,
+    pub LockControl: IO_STACK_LOCATION_0_15,
+    pub DeviceIoControl: IO_STACK_LOCATION_0_16,
+    pub QuerySecurity: IO_STACK_LOCATION_0_17,
+    pub SetSecurity: IO_STACK_LOCATION_0_18,
+    pub MountVolume: IO_STACK_LOCATION_0_19,
+    pub VerifyVolume: IO_STACK_LOCATION_0_20,
+    pub Scsi: IO_STACK_LOCATION_0_21,
+    pub QueryQuota: IO_STACK_LOCATION_0_22,
+    pub SetQuota: IO_STACK_LOCATION_0_23,
+    pub QueryDeviceRelations: IO_STACK_LOCATION_0_24,
+    pub QueryInterface: IO_STACK_LOCATION_0_25,
+    pub DeviceCapabilities: IO_STACK_LOCATION_0_26,
+    pub FilterResourceRequirements: IO_STACK_LOCATION_0_27,
+    pub ReadWriteConfig: IO_STACK_LOCATION_0_28,
     pub SetLock: IO_STACK_LOCATION_0_29,
-    pub QueryId: IO_STACK_LOCATION_0_19,
-    pub QueryDeviceText: IO_STACK_LOCATION_0_15,
-    pub UsageNotification: IO_STACK_LOCATION_0_34,
-    pub WaitWake: IO_STACK_LOCATION_0_37,
-    pub PowerSequence: IO_STACK_LOCATION_0_12,
-    pub Power: IO_STACK_LOCATION_0_13,
-    pub StartDevice: IO_STACK_LOCATION_0_33,
-    pub WMI: IO_STACK_LOCATION_0_36,
-    pub Others: IO_STACK_LOCATION_0_11,
+    pub QueryId: IO_STACK_LOCATION_0_30,
+    pub QueryDeviceText: IO_STACK_LOCATION_0_31,
+    pub UsageNotification: IO_STACK_LOCATION_0_32,
+    pub WaitWake: IO_STACK_LOCATION_0_33,
+    pub PowerSequence: IO_STACK_LOCATION_0_34,
+    pub Power: IO_STACK_LOCATION_0_35,
+    pub StartDevice: IO_STACK_LOCATION_0_36,
+    pub WMI: IO_STACK_LOCATION_0_37,
+    pub Others: IO_STACK_LOCATION_0_38,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_0 {
+pub struct IO_STACK_LOCATION_0_2 {
     pub SecurityContext: *mut IO_SECURITY_CONTEXT,
     pub Options: u32,
     pub Reserved: u16,
@@ -567,7 +567,7 @@ pub struct IO_STACK_LOCATION_0_1 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_2 {
+pub struct IO_STACK_LOCATION_0_0 {
     pub SecurityContext: *mut IO_SECURITY_CONTEXT,
     pub Options: u32,
     pub FileAttributes: u16,
@@ -577,13 +577,13 @@ pub struct IO_STACK_LOCATION_0_2 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_3 {
+pub struct IO_STACK_LOCATION_0_26 {
     pub Capabilities: *mut super::System::SystemServices::DEVICE_CAPABILITIES,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_4 {
+pub struct IO_STACK_LOCATION_0_16 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub IoControlCode: u32,
@@ -592,7 +592,7 @@ pub struct IO_STACK_LOCATION_0_4 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_5 {
+pub struct IO_STACK_LOCATION_0_14 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub FsControlCode: u32,
@@ -601,13 +601,13 @@ pub struct IO_STACK_LOCATION_0_5 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_6 {
+pub struct IO_STACK_LOCATION_0_27 {
     pub IoResourceRequirementList: *mut super::System::SystemServices::IO_RESOURCE_REQUIREMENTS_LIST,
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_7 {
+pub struct IO_STACK_LOCATION_0_15 {
     pub Length: *mut i64,
     pub Key: u32,
     pub ByteOffset: i64,
@@ -615,14 +615,14 @@ pub struct IO_STACK_LOCATION_0_7 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_8 {
+pub struct IO_STACK_LOCATION_0_19 {
     pub Vpb: *mut VPB,
     pub DeviceObject: *mut DEVICE_OBJECT,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_9 {
+pub struct IO_STACK_LOCATION_0_7 {
     pub Length: u32,
     pub CompletionFilter: u32,
     pub DirectoryNotifyInformationClass: super::System::SystemServices::DIRECTORY_NOTIFY_INFORMATION_CLASS,
@@ -630,14 +630,14 @@ pub struct IO_STACK_LOCATION_0_9 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_10 {
+pub struct IO_STACK_LOCATION_0_6 {
     pub Length: u32,
     pub CompletionFilter: u32,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_11 {
+pub struct IO_STACK_LOCATION_0_38 {
     pub Argument1: *mut core::ffi::c_void,
     pub Argument2: *mut core::ffi::c_void,
     pub Argument3: *mut core::ffi::c_void,
@@ -646,14 +646,14 @@ pub struct IO_STACK_LOCATION_0_11 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_12 {
+pub struct IO_STACK_LOCATION_0_34 {
     pub PowerSequence: *mut super::System::SystemServices::POWER_SEQUENCE,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_13 {
-    pub Anonymous: IO_STACK_LOCATION_0_13_0,
+pub struct IO_STACK_LOCATION_0_35 {
+    pub Anonymous: IO_STACK_LOCATION_0_35_0,
     pub Type: super::System::SystemServices::POWER_STATE_TYPE,
     pub State: super::System::SystemServices::POWER_STATE,
     pub ShutdownType: super::super::Win32::System::Power::POWER_ACTION,
@@ -661,27 +661,27 @@ pub struct IO_STACK_LOCATION_0_13 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union IO_STACK_LOCATION_0_13_0 {
+pub union IO_STACK_LOCATION_0_35_0 {
     pub SystemContext: u32,
     pub SystemPowerStateContext: super::System::SystemServices::SYSTEM_POWER_STATE_CONTEXT,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_14 {
+pub struct IO_STACK_LOCATION_0_24 {
     pub Type: super::System::SystemServices::DEVICE_RELATION_TYPE,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_15 {
+pub struct IO_STACK_LOCATION_0_31 {
     pub DeviceTextType: super::System::SystemServices::DEVICE_TEXT_TYPE,
     pub LocaleId: u32,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_16 {
+pub struct IO_STACK_LOCATION_0_5 {
     pub Length: u32,
     pub FileName: *mut super::super::Win32::Foundation::UNICODE_STRING,
     pub FileInformationClass: super::Storage::FileSystem::FILE_INFORMATION_CLASS,
@@ -690,7 +690,7 @@ pub struct IO_STACK_LOCATION_0_16 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_17 {
+pub struct IO_STACK_LOCATION_0_10 {
     pub Length: u32,
     pub EaList: *mut core::ffi::c_void,
     pub EaListLength: u32,
@@ -699,20 +699,20 @@ pub struct IO_STACK_LOCATION_0_17 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_18 {
+pub struct IO_STACK_LOCATION_0_8 {
     pub Length: u32,
     pub FileInformationClass: super::Storage::FileSystem::FILE_INFORMATION_CLASS,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_19 {
+pub struct IO_STACK_LOCATION_0_30 {
     pub IdType: super::System::SystemServices::BUS_QUERY_ID_TYPE,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_20 {
+pub struct IO_STACK_LOCATION_0_25 {
     pub InterfaceType: *const windows_sys::core::GUID,
     pub Size: u16,
     pub Version: u16,
@@ -722,7 +722,7 @@ pub struct IO_STACK_LOCATION_0_20 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_21 {
+pub struct IO_STACK_LOCATION_0_22 {
     pub Length: u32,
     pub StartSid: super::super::Win32::Security::PSID,
     pub SidList: *mut super::Storage::FileSystem::FILE_GET_QUOTA_INFORMATION,
@@ -731,21 +731,21 @@ pub struct IO_STACK_LOCATION_0_21 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_22 {
+pub struct IO_STACK_LOCATION_0_17 {
     pub SecurityInformation: u32,
     pub Length: u32,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_23 {
+pub struct IO_STACK_LOCATION_0_12 {
     pub Length: u32,
     pub FsInformationClass: super::Storage::FileSystem::FS_INFORMATION_CLASS,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_24 {
+pub struct IO_STACK_LOCATION_0_28 {
     pub WhichSpace: u32,
     pub Buffer: *mut core::ffi::c_void,
     pub Offset: u32,
@@ -754,7 +754,7 @@ pub struct IO_STACK_LOCATION_0_24 {
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_25 {
+pub struct IO_STACK_LOCATION_0_3 {
     pub Length: u32,
     pub Key: u32,
     pub ByteOffset: i64,
@@ -762,36 +762,36 @@ pub struct IO_STACK_LOCATION_0_25 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_26 {
+pub struct IO_STACK_LOCATION_0_21 {
     pub Srb: *mut _SCSI_REQUEST_BLOCK,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_27 {
+pub struct IO_STACK_LOCATION_0_11 {
     pub Length: u32,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_28 {
+pub struct IO_STACK_LOCATION_0_9 {
     pub Length: u32,
     pub FileInformationClass: super::Storage::FileSystem::FILE_INFORMATION_CLASS,
     pub FileObject: *mut FILE_OBJECT,
-    pub Anonymous: IO_STACK_LOCATION_0_28_0,
+    pub Anonymous: IO_STACK_LOCATION_0_9_0,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union IO_STACK_LOCATION_0_28_0 {
-    pub Anonymous: IO_STACK_LOCATION_0_28_0_0,
+pub union IO_STACK_LOCATION_0_9_0 {
+    pub Anonymous: IO_STACK_LOCATION_0_9_0_0,
     pub ClusterCount: u32,
     pub DeleteHandle: super::super::Win32::Foundation::HANDLE,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_28_0_0 {
+pub struct IO_STACK_LOCATION_0_9_0_0 {
     pub ReplaceIfExists: super::super::Win32::Foundation::BOOLEAN,
     pub AdvanceOnly: super::super::Win32::Foundation::BOOLEAN,
 }
@@ -804,34 +804,34 @@ pub struct IO_STACK_LOCATION_0_29 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_30 {
+pub struct IO_STACK_LOCATION_0_23 {
     pub Length: u32,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_31 {
+pub struct IO_STACK_LOCATION_0_18 {
     pub SecurityInformation: u32,
     pub SecurityDescriptor: super::super::Win32::Security::PSECURITY_DESCRIPTOR,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_32 {
+pub struct IO_STACK_LOCATION_0_13 {
     pub Length: u32,
     pub FsInformationClass: super::Storage::FileSystem::FS_INFORMATION_CLASS,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_33 {
+pub struct IO_STACK_LOCATION_0_36 {
     pub AllocatedResources: *mut super::System::SystemServices::CM_RESOURCE_LIST,
     pub AllocatedResourcesTranslated: *mut super::System::SystemServices::CM_RESOURCE_LIST,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_34 {
+pub struct IO_STACK_LOCATION_0_32 {
     pub InPath: super::super::Win32::Foundation::BOOLEAN,
     pub Reserved: [super::super::Win32::Foundation::BOOLEAN; 3],
     pub Type: super::System::SystemServices::DEVICE_USAGE_NOTIFICATION_TYPE,
@@ -839,14 +839,14 @@ pub struct IO_STACK_LOCATION_0_34 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_35 {
+pub struct IO_STACK_LOCATION_0_20 {
     pub Vpb: *mut VPB,
     pub DeviceObject: *mut DEVICE_OBJECT,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_36 {
+pub struct IO_STACK_LOCATION_0_37 {
     pub ProviderId: usize,
     pub DataPath: *mut core::ffi::c_void,
     pub BufferSize: u32,
@@ -855,13 +855,13 @@ pub struct IO_STACK_LOCATION_0_36 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_37 {
+pub struct IO_STACK_LOCATION_0_33 {
     pub PowerState: super::super::Win32::System::Power::SYSTEM_POWER_STATE,
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_38 {
+pub struct IO_STACK_LOCATION_0_4 {
     pub Length: u32,
     pub Key: u32,
     pub ByteOffset: i64,
@@ -874,7 +874,7 @@ pub struct IRP {
     pub Size: u16,
     pub MdlAddress: *mut MDL,
     pub Flags: u32,
-    pub AssociatedIrp: IRP_1,
+    pub AssociatedIrp: IRP_0,
     pub ThreadListEntry: super::super::Win32::System::Kernel::LIST_ENTRY,
     pub IoStatus: super::super::Win32::System::IO::IO_STATUS_BLOCK,
     pub RequestorMode: i8,
@@ -885,7 +885,7 @@ pub struct IRP {
     pub CancelIrql: u8,
     pub ApcEnvironment: i8,
     pub AllocationFlags: u8,
-    pub Anonymous: IRP_0,
+    pub Anonymous: IRP_1,
     pub UserEvent: *mut KEVENT,
     pub Overlay: IRP_2,
     pub CancelRoutine: DRIVER_CANCEL,
@@ -895,14 +895,14 @@ pub struct IRP {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union IRP_0 {
+pub union IRP_1 {
     pub UserIosb: *mut super::super::Win32::System::IO::IO_STATUS_BLOCK,
     pub IoRingContext: *mut core::ffi::c_void,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union IRP_1 {
+pub union IRP_0 {
     pub MasterIrp: *mut IRP,
     pub IrpCount: i32,
     pub SystemBuffer: *mut core::ffi::c_void,

--- a/crates/libs/sys/src/Windows/Wdk/Graphics/Direct3D/mod.rs
+++ b/crates/libs/sys/src/Windows/Wdk/Graphics/Direct3D/mod.rs
@@ -2254,9 +2254,9 @@ pub struct D3DDDI_ALLOCATIONINFO2 {
     pub pPrivateDriverData: *mut core::ffi::c_void,
     pub PrivateDriverDataSize: u32,
     pub VidPnSourceId: u32,
-    pub Flags: D3DDDI_ALLOCATIONINFO2_2,
+    pub Flags: D3DDDI_ALLOCATIONINFO2_1,
     pub GpuVirtualAddress: u64,
-    pub Anonymous2: D3DDDI_ALLOCATIONINFO2_1,
+    pub Anonymous2: D3DDDI_ALLOCATIONINFO2_2,
     pub Reserved: [usize; 5],
 }
 #[repr(C)]
@@ -2267,19 +2267,19 @@ pub union D3DDDI_ALLOCATIONINFO2_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union D3DDDI_ALLOCATIONINFO2_1 {
+pub union D3DDDI_ALLOCATIONINFO2_2 {
     pub Priority: u32,
     pub Unused: usize,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union D3DDDI_ALLOCATIONINFO2_2 {
-    pub Anonymous: D3DDDI_ALLOCATIONINFO2_2_0,
+pub union D3DDDI_ALLOCATIONINFO2_1 {
+    pub Anonymous: D3DDDI_ALLOCATIONINFO2_1_0,
     pub Value: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_ALLOCATIONINFO2_2_0 {
+pub struct D3DDDI_ALLOCATIONINFO2_1_0 {
     pub _bitfield: u32,
 }
 #[repr(C)]
@@ -2725,13 +2725,13 @@ pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_SYNCHRONIZATIONOBJECTINFO_0 {
-    pub SynchronizationMutex: D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2,
+    pub SynchronizationMutex: D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0,
     pub Semaphore: D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_1,
-    pub Reserved: D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0,
+    pub Reserved: D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
     pub Reserved: [u32; 16],
 }
 #[repr(C)]
@@ -2742,7 +2742,7 @@ pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
     pub InitialState: super::super::super::Win32::Foundation::BOOL,
 }
 #[repr(C)]
@@ -2756,27 +2756,27 @@ pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0 {
-    pub SynchronizationMutex: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6,
-    pub Semaphore: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5,
-    pub Fence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1,
-    pub CPUNotification: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0,
-    pub MonitoredFence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2,
-    pub PeriodicMonitoredFence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3,
-    pub Reserved: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4,
+    pub SynchronizationMutex: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0,
+    pub Semaphore: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1,
+    pub Fence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2,
+    pub CPUNotification: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3,
+    pub MonitoredFence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4,
+    pub PeriodicMonitoredFence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5,
+    pub Reserved: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3 {
     pub Event: super::super::super::Win32::Foundation::HANDLE,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
     pub FenceValue: u64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4 {
     pub InitialFenceValue: u64,
     pub FenceValueCPUVirtualAddress: *mut core::ffi::c_void,
     pub FenceValueGPUVirtualAddress: u64,
@@ -2785,7 +2785,7 @@ pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5 {
     pub hAdapter: u32,
     pub VidPnTargetId: u32,
     pub Time: u64,
@@ -2796,18 +2796,18 @@ pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6 {
     pub Reserved: [u64; 8],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1 {
     pub MaxCount: u32,
     pub InitialCount: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
     pub InitialState: super::super::super::Win32::Foundation::BOOL,
 }
 #[repr(C)]
@@ -2889,14 +2889,14 @@ pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0 {
-    pub Map: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2,
+    pub Map: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0,
     pub MapProtect: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_1,
-    pub Unmap: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3,
-    pub Copy: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0,
+    pub Unmap: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2,
+    pub Copy: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
+pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
     pub SourceAddress: u64,
     pub SizeInBytes: u64,
     pub DestAddress: u64,
@@ -2914,7 +2914,7 @@ pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
+pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
     pub BaseAddress: u64,
     pub SizeInBytes: u64,
     pub hAllocation: u32,
@@ -2923,7 +2923,7 @@ pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
+pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
     pub BaseAddress: u64,
     pub SizeInBytes: u64,
     pub Protection: D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE,
@@ -7345,25 +7345,25 @@ pub struct D3DKMT_VIDMM_ESCAPE {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_VIDMM_ESCAPE_0 {
-    pub SetFault: D3DKMT_VIDMM_ESCAPE_0_9,
-    pub Evict: D3DKMT_VIDMM_ESCAPE_0_4,
-    pub EvictByNtHandle: D3DKMT_VIDMM_ESCAPE_0_3,
-    pub GetVads: D3DKMT_VIDMM_ESCAPE_0_6,
-    pub SetBudget: D3DKMT_VIDMM_ESCAPE_0_8,
-    pub SuspendProcess: D3DKMT_VIDMM_ESCAPE_0_11,
-    pub ResumeProcess: D3DKMT_VIDMM_ESCAPE_0_7,
-    pub GetBudget: D3DKMT_VIDMM_ESCAPE_0_5,
-    pub SetTrimIntervals: D3DKMT_VIDMM_ESCAPE_0_10,
+    pub SetFault: D3DKMT_VIDMM_ESCAPE_0_0,
+    pub Evict: D3DKMT_VIDMM_ESCAPE_0_1,
+    pub EvictByNtHandle: D3DKMT_VIDMM_ESCAPE_0_2,
+    pub GetVads: D3DKMT_VIDMM_ESCAPE_0_3,
+    pub SetBudget: D3DKMT_VIDMM_ESCAPE_0_4,
+    pub SuspendProcess: D3DKMT_VIDMM_ESCAPE_0_5,
+    pub ResumeProcess: D3DKMT_VIDMM_ESCAPE_0_6,
+    pub GetBudget: D3DKMT_VIDMM_ESCAPE_0_7,
+    pub SetTrimIntervals: D3DKMT_VIDMM_ESCAPE_0_8,
     pub EvictByCriteria: D3DKMT_EVICTION_CRITERIA,
-    pub Wake: D3DKMT_VIDMM_ESCAPE_0_13,
-    pub Defrag: D3DKMT_VIDMM_ESCAPE_0_0,
-    pub DelayExecution: D3DKMT_VIDMM_ESCAPE_0_1,
+    pub Wake: D3DKMT_VIDMM_ESCAPE_0_9,
+    pub Defrag: D3DKMT_VIDMM_ESCAPE_0_10,
+    pub DelayExecution: D3DKMT_VIDMM_ESCAPE_0_11,
     pub VerifyIntegrity: D3DKMT_VIDMM_ESCAPE_0_12,
-    pub DelayedEvictionConfig: D3DKMT_VIDMM_ESCAPE_0_2,
+    pub DelayedEvictionConfig: D3DKMT_VIDMM_ESCAPE_0_13,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_0 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_10 {
     pub Operation: D3DKMT_DEFRAG_ESCAPE_OPERATION,
     pub SegmentId: u32,
     pub TotalCommitted: u64,
@@ -7373,7 +7373,7 @@ pub struct D3DKMT_VIDMM_ESCAPE_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_1 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_11 {
     pub hPagingQueue: u32,
     pub PhysicalAdapterIndex: u32,
     pub Milliseconds: u32,
@@ -7381,37 +7381,37 @@ pub struct D3DKMT_VIDMM_ESCAPE_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_2 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_13 {
     pub TimerValue: i64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_3 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_2 {
     pub NtHandle: u64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_4 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_1 {
     pub ResourceHandle: u32,
     pub AllocationHandle: u32,
     pub hProcess: super::super::super::Win32::Foundation::HANDLE,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_5 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_7 {
     pub NumBytesToTrim: u64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_6 {
-    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_6_0,
+pub struct D3DKMT_VIDMM_ESCAPE_0_3 {
+    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_3_0,
     pub Command: D3DKMT_VAD_ESCAPE_COMMAND,
     pub Status: super::super::super::Win32::Foundation::NTSTATUS,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union D3DKMT_VIDMM_ESCAPE_0_6_0 {
-    pub GetNumVads: D3DKMT_VIDMM_ESCAPE_0_6_0_0,
+pub union D3DKMT_VIDMM_ESCAPE_0_3_0 {
+    pub GetNumVads: D3DKMT_VIDMM_ESCAPE_0_3_0_0,
     pub GetVad: D3DKMT_VAD_DESC,
     pub GetVadRange: D3DKMT_VA_RANGE_DESC,
     pub GetGpuMmuCaps: D3DKMT_GET_GPUMMU_CAPS,
@@ -7420,46 +7420,46 @@ pub union D3DKMT_VIDMM_ESCAPE_0_6_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_6_0_0 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_3_0_0 {
     pub NumVads: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_7 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_6 {
     pub hProcess: super::super::super::Win32::Foundation::HANDLE,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_8 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_4 {
     pub LocalMemoryBudget: u64,
     pub SystemMemoryBudget: u64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_9 {
-    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_9_0,
+pub struct D3DKMT_VIDMM_ESCAPE_0_0 {
+    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_0_0,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union D3DKMT_VIDMM_ESCAPE_0_9_0 {
-    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_9_0_0,
+pub union D3DKMT_VIDMM_ESCAPE_0_0_0 {
+    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_0_0_0,
     pub Value: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_9_0_0 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_0_0_0 {
     pub _bitfield: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_10 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_8 {
     pub MinTrimInterval: u32,
     pub MaxTrimInterval: u32,
     pub IdleTrimInterval: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_11 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_5 {
     pub hProcess: super::super::super::Win32::Foundation::HANDLE,
     pub bAllowWakeOnSubmission: super::super::super::Win32::Foundation::BOOL,
 }
@@ -7470,7 +7470,7 @@ pub struct D3DKMT_VIDMM_ESCAPE_0_12 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_13 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_9 {
     pub bFlush: super::super::super::Win32::Foundation::BOOL,
 }
 #[repr(C)]

--- a/crates/libs/sys/src/Windows/Wdk/NetworkManagement/Ndis/mod.rs
+++ b/crates/libs/sys/src/Windows/Wdk/NetworkManagement/Ndis/mod.rs
@@ -2867,14 +2867,9 @@ pub struct NDIS_INTERRUPT_MODERATION_PARAMETERS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_IPSEC_OFFLOAD_V1 {
-    pub Supported: NDIS_IPSEC_OFFLOAD_V1_2,
-    pub IPv4AH: NDIS_IPSEC_OFFLOAD_V1_0,
-    pub IPv4ESP: NDIS_IPSEC_OFFLOAD_V1_1,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NDIS_IPSEC_OFFLOAD_V1_0 {
-    pub _bitfield: u32,
+    pub Supported: NDIS_IPSEC_OFFLOAD_V1_0,
+    pub IPv4AH: NDIS_IPSEC_OFFLOAD_V1_1,
+    pub IPv4ESP: NDIS_IPSEC_OFFLOAD_V1_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2884,6 +2879,11 @@ pub struct NDIS_IPSEC_OFFLOAD_V1_1 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_IPSEC_OFFLOAD_V1_2 {
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NDIS_IPSEC_OFFLOAD_V1_0 {
     pub Encapsulation: u32,
     pub AhEspCombined: u32,
     pub TransportTunnelCombined: u32,
@@ -3258,16 +3258,10 @@ pub struct NDIS_TCP_CONNECTION_OFFLOAD {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD {
-    pub IPv4Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_1,
-    pub IPv4Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_0,
-    pub IPv6Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_3,
-    pub IPv6Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_2,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    pub Encapsulation: u32,
-    pub _bitfield: u32,
+    pub IPv4Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_0,
+    pub IPv4Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_1,
+    pub IPv6Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv6Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3277,7 +3271,7 @@ pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     pub Encapsulation: u32,
     pub _bitfield: u32,
 }
@@ -3289,24 +3283,30 @@ pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
+pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+    pub Encapsulation: u32,
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
 pub struct NDIS_TCP_IP_CHECKSUM_PACKET_INFO {
     pub Anonymous: NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0 {
-    pub Transmit: NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1,
-    pub Receive: NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0,
+    pub Transmit: NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0,
+    pub Receive: NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1,
     pub Value: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
+pub struct NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1 {
     pub _bitfield: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1 {
+pub struct NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
     pub _bitfield: u32,
 }
 #[repr(C)]
@@ -3500,13 +3500,13 @@ pub struct NDIS_WMI_EVENT_HEADER {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_WMI_IPSEC_OFFLOAD_V1 {
-    pub Supported: NDIS_WMI_IPSEC_OFFLOAD_V1_2,
-    pub IPv4AH: NDIS_WMI_IPSEC_OFFLOAD_V1_0,
-    pub IPv4ESP: NDIS_WMI_IPSEC_OFFLOAD_V1_1,
+    pub Supported: NDIS_WMI_IPSEC_OFFLOAD_V1_0,
+    pub IPv4AH: NDIS_WMI_IPSEC_OFFLOAD_V1_1,
+    pub IPv4ESP: NDIS_WMI_IPSEC_OFFLOAD_V1_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
+pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
     pub Md5: u32,
     pub Sha_1: u32,
     pub Transport: u32,
@@ -3516,7 +3516,7 @@ pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
+pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
     pub Des: u32,
     pub Reserved: u32,
     pub TripleDes: u32,
@@ -3528,7 +3528,7 @@ pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     pub Encapsulation: u32,
     pub AhEspCombined: u32,
     pub TransportTunnelCombined: u32,
@@ -3590,20 +3590,10 @@ pub struct NDIS_WMI_TCP_CONNECTION_OFFLOAD {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
-    pub IPv4Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1,
-    pub IPv4Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0,
-    pub IPv6Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3,
-    pub IPv6Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    pub Encapsulation: u32,
-    pub IpOptionsSupported: u32,
-    pub TcpOptionsSupported: u32,
-    pub TcpChecksum: u32,
-    pub UdpChecksum: u32,
-    pub IpChecksum: u32,
+    pub IPv4Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0,
+    pub IPv4Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1,
+    pub IPv6Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv6Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3617,7 +3607,17 @@ pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
+    pub Encapsulation: u32,
+    pub IpOptionsSupported: u32,
+    pub TcpOptionsSupported: u32,
+    pub TcpChecksum: u32,
+    pub UdpChecksum: u32,
+    pub IpChecksum: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
     pub Encapsulation: u32,
     pub IpExtensionHeadersSupported: u32,
     pub TcpOptionsSupported: u32,
@@ -3626,7 +3626,7 @@ pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
+pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
     pub Encapsulation: u32,
     pub IpExtensionHeadersSupported: u32,
     pub TcpOptionsSupported: u32,

--- a/crates/libs/sys/src/Windows/Wdk/Storage/FileSystem/Minifilters/mod.rs
+++ b/crates/libs/sys/src/Windows/Wdk/Storage/FileSystem/Minifilters/mod.rs
@@ -668,51 +668,51 @@ pub struct FLT_OPERATION_REGISTRATION {
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
 pub union FLT_PARAMETERS {
-    pub Create: FLT_PARAMETERS_4,
-    pub CreatePipe: FLT_PARAMETERS_3,
+    pub Create: FLT_PARAMETERS_0,
+    pub CreatePipe: FLT_PARAMETERS_1,
     pub CreateMailslot: FLT_PARAMETERS_2,
-    pub Read: FLT_PARAMETERS_24,
-    pub Write: FLT_PARAMETERS_32,
-    pub QueryFileInformation: FLT_PARAMETERS_19,
-    pub SetFileInformation: FLT_PARAMETERS_27,
-    pub QueryEa: FLT_PARAMETERS_18,
-    pub SetEa: FLT_PARAMETERS_26,
-    pub QueryVolumeInformation: FLT_PARAMETERS_23,
-    pub SetVolumeInformation: FLT_PARAMETERS_30,
-    pub DirectoryControl: FLT_PARAMETERS_6,
-    pub FileSystemControl: FLT_PARAMETERS_8,
-    pub DeviceIoControl: FLT_PARAMETERS_5,
-    pub LockControl: FLT_PARAMETERS_9,
-    pub QuerySecurity: FLT_PARAMETERS_22,
-    pub SetSecurity: FLT_PARAMETERS_29,
-    pub WMI: FLT_PARAMETERS_31,
-    pub QueryQuota: FLT_PARAMETERS_21,
-    pub SetQuota: FLT_PARAMETERS_28,
-    pub Pnp: FLT_PARAMETERS_16,
-    pub AcquireForSectionSynchronization: FLT_PARAMETERS_1,
-    pub AcquireForModifiedPageWriter: FLT_PARAMETERS_0,
-    pub ReleaseForModifiedPageWriter: FLT_PARAMETERS_25,
-    pub QueryOpen: FLT_PARAMETERS_20,
-    pub FastIoCheckIfPossible: FLT_PARAMETERS_7,
-    pub NetworkQueryOpen: FLT_PARAMETERS_14,
-    pub MdlRead: FLT_PARAMETERS_11,
-    pub MdlReadComplete: FLT_PARAMETERS_10,
-    pub PrepareMdlWrite: FLT_PARAMETERS_17,
-    pub MdlWriteComplete: FLT_PARAMETERS_12,
-    pub MountVolume: FLT_PARAMETERS_13,
-    pub Others: FLT_PARAMETERS_15,
+    pub Read: FLT_PARAMETERS_3,
+    pub Write: FLT_PARAMETERS_4,
+    pub QueryFileInformation: FLT_PARAMETERS_5,
+    pub SetFileInformation: FLT_PARAMETERS_6,
+    pub QueryEa: FLT_PARAMETERS_7,
+    pub SetEa: FLT_PARAMETERS_8,
+    pub QueryVolumeInformation: FLT_PARAMETERS_9,
+    pub SetVolumeInformation: FLT_PARAMETERS_10,
+    pub DirectoryControl: FLT_PARAMETERS_11,
+    pub FileSystemControl: FLT_PARAMETERS_12,
+    pub DeviceIoControl: FLT_PARAMETERS_13,
+    pub LockControl: FLT_PARAMETERS_14,
+    pub QuerySecurity: FLT_PARAMETERS_15,
+    pub SetSecurity: FLT_PARAMETERS_16,
+    pub WMI: FLT_PARAMETERS_17,
+    pub QueryQuota: FLT_PARAMETERS_18,
+    pub SetQuota: FLT_PARAMETERS_19,
+    pub Pnp: FLT_PARAMETERS_20,
+    pub AcquireForSectionSynchronization: FLT_PARAMETERS_21,
+    pub AcquireForModifiedPageWriter: FLT_PARAMETERS_22,
+    pub ReleaseForModifiedPageWriter: FLT_PARAMETERS_23,
+    pub QueryOpen: FLT_PARAMETERS_24,
+    pub FastIoCheckIfPossible: FLT_PARAMETERS_25,
+    pub NetworkQueryOpen: FLT_PARAMETERS_26,
+    pub MdlRead: FLT_PARAMETERS_27,
+    pub MdlReadComplete: FLT_PARAMETERS_28,
+    pub PrepareMdlWrite: FLT_PARAMETERS_29,
+    pub MdlWriteComplete: FLT_PARAMETERS_30,
+    pub MountVolume: FLT_PARAMETERS_31,
+    pub Others: FLT_PARAMETERS_32,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_0 {
+pub struct FLT_PARAMETERS_22 {
     pub EndingOffset: *mut i64,
     pub ResourceToRelease: *mut *mut super::super::super::Foundation::ERESOURCE,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_1 {
+pub struct FLT_PARAMETERS_21 {
     pub SyncType: super::FS_FILTER_SECTION_SYNC_TYPE,
     pub PageProtection: u32,
     pub OutputInformation: *mut super::FS_FILTER_SECTION_SYNC_OUTPUT,
@@ -732,7 +732,7 @@ pub struct FLT_PARAMETERS_2 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_3 {
+pub struct FLT_PARAMETERS_1 {
     pub SecurityContext: *mut super::super::super::Foundation::IO_SECURITY_CONTEXT,
     pub Options: u32,
     pub Reserved: u16,
@@ -742,7 +742,7 @@ pub struct FLT_PARAMETERS_3 {
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_4 {
+pub struct FLT_PARAMETERS_0 {
     pub SecurityContext: *mut super::super::super::Foundation::IO_SECURITY_CONTEXT,
     pub Options: u32,
     pub FileAttributes: u16,
@@ -754,17 +754,17 @@ pub struct FLT_PARAMETERS_4 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union FLT_PARAMETERS_5 {
-    pub Common: FLT_PARAMETERS_5_1,
-    pub Neither: FLT_PARAMETERS_5_4,
-    pub Buffered: FLT_PARAMETERS_5_0,
-    pub Direct: FLT_PARAMETERS_5_2,
-    pub FastIo: FLT_PARAMETERS_5_3,
+pub union FLT_PARAMETERS_13 {
+    pub Common: FLT_PARAMETERS_13_0,
+    pub Neither: FLT_PARAMETERS_13_1,
+    pub Buffered: FLT_PARAMETERS_13_2,
+    pub Direct: FLT_PARAMETERS_13_3,
+    pub FastIo: FLT_PARAMETERS_13_4,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_5_0 {
+pub struct FLT_PARAMETERS_13_2 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub IoControlCode: u32,
@@ -773,7 +773,7 @@ pub struct FLT_PARAMETERS_5_0 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_5_1 {
+pub struct FLT_PARAMETERS_13_0 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub IoControlCode: u32,
@@ -781,7 +781,7 @@ pub struct FLT_PARAMETERS_5_1 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_5_2 {
+pub struct FLT_PARAMETERS_13_3 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub IoControlCode: u32,
@@ -792,7 +792,7 @@ pub struct FLT_PARAMETERS_5_2 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_5_3 {
+pub struct FLT_PARAMETERS_13_4 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub IoControlCode: u32,
@@ -802,7 +802,7 @@ pub struct FLT_PARAMETERS_5_3 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_5_4 {
+pub struct FLT_PARAMETERS_13_1 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub IoControlCode: u32,
@@ -813,15 +813,15 @@ pub struct FLT_PARAMETERS_5_4 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union FLT_PARAMETERS_6 {
-    pub QueryDirectory: FLT_PARAMETERS_6_2,
-    pub NotifyDirectory: FLT_PARAMETERS_6_1,
-    pub NotifyDirectoryEx: FLT_PARAMETERS_6_0,
+pub union FLT_PARAMETERS_11 {
+    pub QueryDirectory: FLT_PARAMETERS_11_0,
+    pub NotifyDirectory: FLT_PARAMETERS_11_1,
+    pub NotifyDirectoryEx: FLT_PARAMETERS_11_2,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_6_0 {
+pub struct FLT_PARAMETERS_11_2 {
     pub Length: u32,
     pub CompletionFilter: u32,
     pub DirectoryNotifyInformationClass: super::super::super::System::SystemServices::DIRECTORY_NOTIFY_INFORMATION_CLASS,
@@ -832,7 +832,7 @@ pub struct FLT_PARAMETERS_6_0 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_6_1 {
+pub struct FLT_PARAMETERS_11_1 {
     pub Length: u32,
     pub CompletionFilter: u32,
     pub Spare1: u32,
@@ -843,7 +843,7 @@ pub struct FLT_PARAMETERS_6_1 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_6_2 {
+pub struct FLT_PARAMETERS_11_0 {
     pub Length: u32,
     pub FileName: *mut super::super::super::super::Win32::Foundation::UNICODE_STRING,
     pub FileInformationClass: super::FILE_INFORMATION_CLASS,
@@ -854,7 +854,7 @@ pub struct FLT_PARAMETERS_6_2 {
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_7 {
+pub struct FLT_PARAMETERS_25 {
     pub FileOffset: i64,
     pub Length: u32,
     pub LockKey: u32,
@@ -863,17 +863,17 @@ pub struct FLT_PARAMETERS_7 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union FLT_PARAMETERS_8 {
-    pub VerifyVolume: FLT_PARAMETERS_8_4,
-    pub Common: FLT_PARAMETERS_8_1,
-    pub Neither: FLT_PARAMETERS_8_3,
-    pub Buffered: FLT_PARAMETERS_8_0,
-    pub Direct: FLT_PARAMETERS_8_2,
+pub union FLT_PARAMETERS_12 {
+    pub VerifyVolume: FLT_PARAMETERS_12_0,
+    pub Common: FLT_PARAMETERS_12_1,
+    pub Neither: FLT_PARAMETERS_12_2,
+    pub Buffered: FLT_PARAMETERS_12_3,
+    pub Direct: FLT_PARAMETERS_12_4,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_8_0 {
+pub struct FLT_PARAMETERS_12_3 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub FsControlCode: u32,
@@ -882,7 +882,7 @@ pub struct FLT_PARAMETERS_8_0 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_8_1 {
+pub struct FLT_PARAMETERS_12_1 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub FsControlCode: u32,
@@ -890,7 +890,7 @@ pub struct FLT_PARAMETERS_8_1 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_8_2 {
+pub struct FLT_PARAMETERS_12_4 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub FsControlCode: u32,
@@ -901,7 +901,7 @@ pub struct FLT_PARAMETERS_8_2 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_8_3 {
+pub struct FLT_PARAMETERS_12_2 {
     pub OutputBufferLength: u32,
     pub InputBufferLength: u32,
     pub FsControlCode: u32,
@@ -912,14 +912,14 @@ pub struct FLT_PARAMETERS_8_3 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_8_4 {
+pub struct FLT_PARAMETERS_12_0 {
     pub Vpb: *mut super::super::super::Foundation::VPB,
     pub DeviceObject: *mut super::super::super::Foundation::DEVICE_OBJECT,
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_9 {
+pub struct FLT_PARAMETERS_14 {
     pub Length: *mut i64,
     pub Key: u32,
     pub ByteOffset: i64,
@@ -930,13 +930,13 @@ pub struct FLT_PARAMETERS_9 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_10 {
+pub struct FLT_PARAMETERS_28 {
     pub MdlChain: *mut super::super::super::Foundation::MDL,
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_11 {
+pub struct FLT_PARAMETERS_27 {
     pub FileOffset: i64,
     pub Length: u32,
     pub Key: u32,
@@ -945,27 +945,27 @@ pub struct FLT_PARAMETERS_11 {
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_12 {
+pub struct FLT_PARAMETERS_30 {
     pub FileOffset: i64,
     pub MdlChain: *mut super::super::super::Foundation::MDL,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_13 {
+pub struct FLT_PARAMETERS_31 {
     pub DeviceType: u32,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_14 {
+pub struct FLT_PARAMETERS_26 {
     pub Irp: *mut super::super::super::Foundation::IRP,
     pub NetworkInformation: *mut super::FILE_NETWORK_OPEN_INFORMATION,
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_15 {
+pub struct FLT_PARAMETERS_32 {
     pub Argument1: *mut core::ffi::c_void,
     pub Argument2: *mut core::ffi::c_void,
     pub Argument3: *mut core::ffi::c_void,
@@ -976,53 +976,53 @@ pub struct FLT_PARAMETERS_15 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union FLT_PARAMETERS_16 {
-    pub StartDevice: FLT_PARAMETERS_16_8,
-    pub QueryDeviceRelations: FLT_PARAMETERS_16_2,
-    pub QueryInterface: FLT_PARAMETERS_16_5,
-    pub DeviceCapabilities: FLT_PARAMETERS_16_0,
-    pub FilterResourceRequirements: FLT_PARAMETERS_16_1,
-    pub ReadWriteConfig: FLT_PARAMETERS_16_6,
-    pub SetLock: FLT_PARAMETERS_16_7,
-    pub QueryId: FLT_PARAMETERS_16_4,
-    pub QueryDeviceText: FLT_PARAMETERS_16_3,
-    pub UsageNotification: FLT_PARAMETERS_16_9,
+pub union FLT_PARAMETERS_20 {
+    pub StartDevice: FLT_PARAMETERS_20_0,
+    pub QueryDeviceRelations: FLT_PARAMETERS_20_1,
+    pub QueryInterface: FLT_PARAMETERS_20_2,
+    pub DeviceCapabilities: FLT_PARAMETERS_20_3,
+    pub FilterResourceRequirements: FLT_PARAMETERS_20_4,
+    pub ReadWriteConfig: FLT_PARAMETERS_20_5,
+    pub SetLock: FLT_PARAMETERS_20_6,
+    pub QueryId: FLT_PARAMETERS_20_7,
+    pub QueryDeviceText: FLT_PARAMETERS_20_8,
+    pub UsageNotification: FLT_PARAMETERS_20_9,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_16_0 {
+pub struct FLT_PARAMETERS_20_3 {
     pub Capabilities: *mut super::super::super::System::SystemServices::DEVICE_CAPABILITIES,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_16_1 {
+pub struct FLT_PARAMETERS_20_4 {
     pub IoResourceRequirementList: *mut super::super::super::System::SystemServices::IO_RESOURCE_REQUIREMENTS_LIST,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_16_2 {
+pub struct FLT_PARAMETERS_20_1 {
     pub Type: super::super::super::System::SystemServices::DEVICE_RELATION_TYPE,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_16_3 {
+pub struct FLT_PARAMETERS_20_8 {
     pub DeviceTextType: super::super::super::System::SystemServices::DEVICE_TEXT_TYPE,
     pub LocaleId: u32,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_16_4 {
+pub struct FLT_PARAMETERS_20_7 {
     pub IdType: super::super::super::System::SystemServices::BUS_QUERY_ID_TYPE,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_16_5 {
+pub struct FLT_PARAMETERS_20_2 {
     pub InterfaceType: *const windows_sys::core::GUID,
     pub Size: u16,
     pub Version: u16,
@@ -1032,7 +1032,7 @@ pub struct FLT_PARAMETERS_16_5 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_16_6 {
+pub struct FLT_PARAMETERS_20_5 {
     pub WhichSpace: u32,
     pub Buffer: *mut core::ffi::c_void,
     pub Offset: u32,
@@ -1041,20 +1041,20 @@ pub struct FLT_PARAMETERS_16_6 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_16_7 {
+pub struct FLT_PARAMETERS_20_6 {
     pub Lock: super::super::super::super::Win32::Foundation::BOOLEAN,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_16_8 {
+pub struct FLT_PARAMETERS_20_0 {
     pub AllocatedResources: *mut super::super::super::System::SystemServices::CM_RESOURCE_LIST,
     pub AllocatedResourcesTranslated: *mut super::super::super::System::SystemServices::CM_RESOURCE_LIST,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_16_9 {
+pub struct FLT_PARAMETERS_20_9 {
     pub InPath: super::super::super::super::Win32::Foundation::BOOLEAN,
     pub Reserved: [super::super::super::super::Win32::Foundation::BOOLEAN; 3],
     pub Type: super::super::super::System::SystemServices::DEVICE_USAGE_NOTIFICATION_TYPE,
@@ -1062,7 +1062,7 @@ pub struct FLT_PARAMETERS_16_9 {
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_17 {
+pub struct FLT_PARAMETERS_29 {
     pub FileOffset: i64,
     pub Length: u32,
     pub Key: u32,
@@ -1071,7 +1071,7 @@ pub struct FLT_PARAMETERS_17 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_18 {
+pub struct FLT_PARAMETERS_7 {
     pub Length: u32,
     pub EaList: *mut core::ffi::c_void,
     pub EaListLength: u32,
@@ -1082,7 +1082,7 @@ pub struct FLT_PARAMETERS_18 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_19 {
+pub struct FLT_PARAMETERS_5 {
     pub Length: u32,
     pub FileInformationClass: super::FILE_INFORMATION_CLASS,
     pub InfoBuffer: *mut core::ffi::c_void,
@@ -1090,7 +1090,7 @@ pub struct FLT_PARAMETERS_19 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_20 {
+pub struct FLT_PARAMETERS_24 {
     pub Irp: *mut super::super::super::Foundation::IRP,
     pub FileInformation: *mut core::ffi::c_void,
     pub Length: *mut u32,
@@ -1099,7 +1099,7 @@ pub struct FLT_PARAMETERS_20 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_21 {
+pub struct FLT_PARAMETERS_18 {
     pub Length: u32,
     pub StartSid: super::super::super::super::Win32::Security::PSID,
     pub SidList: *mut super::FILE_GET_QUOTA_INFORMATION,
@@ -1110,7 +1110,7 @@ pub struct FLT_PARAMETERS_21 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_22 {
+pub struct FLT_PARAMETERS_15 {
     pub SecurityInformation: u32,
     pub Length: u32,
     pub SecurityBuffer: *mut core::ffi::c_void,
@@ -1119,7 +1119,7 @@ pub struct FLT_PARAMETERS_22 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_23 {
+pub struct FLT_PARAMETERS_9 {
     pub Length: u32,
     pub FsInformationClass: super::FS_INFORMATION_CLASS,
     pub VolumeBuffer: *mut core::ffi::c_void,
@@ -1127,7 +1127,7 @@ pub struct FLT_PARAMETERS_23 {
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_24 {
+pub struct FLT_PARAMETERS_3 {
     pub Length: u32,
     pub Key: u32,
     pub ByteOffset: i64,
@@ -1137,13 +1137,13 @@ pub struct FLT_PARAMETERS_24 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_25 {
+pub struct FLT_PARAMETERS_23 {
     pub ResourceToRelease: *mut super::super::super::Foundation::ERESOURCE,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_26 {
+pub struct FLT_PARAMETERS_8 {
     pub Length: u32,
     pub EaBuffer: *mut core::ffi::c_void,
     pub MdlAddress: *mut super::super::super::Foundation::MDL,
@@ -1151,32 +1151,32 @@ pub struct FLT_PARAMETERS_26 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_27 {
+pub struct FLT_PARAMETERS_6 {
     pub Length: u32,
     pub FileInformationClass: super::FILE_INFORMATION_CLASS,
     pub ParentOfTarget: *mut super::super::super::Foundation::FILE_OBJECT,
-    pub Anonymous: FLT_PARAMETERS_27_0,
+    pub Anonymous: FLT_PARAMETERS_6_0,
     pub InfoBuffer: *mut core::ffi::c_void,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union FLT_PARAMETERS_27_0 {
-    pub Anonymous: FLT_PARAMETERS_27_0_0,
+pub union FLT_PARAMETERS_6_0 {
+    pub Anonymous: FLT_PARAMETERS_6_0_0,
     pub ClusterCount: u32,
     pub DeleteHandle: super::super::super::super::Win32::Foundation::HANDLE,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_27_0_0 {
+pub struct FLT_PARAMETERS_6_0_0 {
     pub ReplaceIfExists: super::super::super::super::Win32::Foundation::BOOLEAN,
     pub AdvanceOnly: super::super::super::super::Win32::Foundation::BOOLEAN,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_28 {
+pub struct FLT_PARAMETERS_19 {
     pub Length: u32,
     pub QuotaBuffer: *mut core::ffi::c_void,
     pub MdlAddress: *mut super::super::super::Foundation::MDL,
@@ -1184,14 +1184,14 @@ pub struct FLT_PARAMETERS_28 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_29 {
+pub struct FLT_PARAMETERS_16 {
     pub SecurityInformation: u32,
     pub SecurityDescriptor: super::super::super::super::Win32::Security::PSECURITY_DESCRIPTOR,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_30 {
+pub struct FLT_PARAMETERS_10 {
     pub Length: u32,
     pub FsInformationClass: super::FS_INFORMATION_CLASS,
     pub VolumeBuffer: *mut core::ffi::c_void,
@@ -1199,7 +1199,7 @@ pub struct FLT_PARAMETERS_30 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_31 {
+pub struct FLT_PARAMETERS_17 {
     pub ProviderId: usize,
     pub DataPath: *mut core::ffi::c_void,
     pub BufferSize: u32,
@@ -1208,7 +1208,7 @@ pub struct FLT_PARAMETERS_31 {
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_32 {
+pub struct FLT_PARAMETERS_4 {
     pub Length: u32,
     pub Key: u32,
     pub ByteOffset: i64,
@@ -1280,25 +1280,25 @@ pub struct FLT_TAG_DATA_BUFFER {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FLT_TAG_DATA_BUFFER_0 {
-    pub SymbolicLinkReparseBuffer: FLT_TAG_DATA_BUFFER_0_3,
-    pub MountPointReparseBuffer: FLT_TAG_DATA_BUFFER_0_2,
-    pub GenericReparseBuffer: FLT_TAG_DATA_BUFFER_0_1,
-    pub GenericGUIDReparseBuffer: FLT_TAG_DATA_BUFFER_0_0,
+    pub SymbolicLinkReparseBuffer: FLT_TAG_DATA_BUFFER_0_0,
+    pub MountPointReparseBuffer: FLT_TAG_DATA_BUFFER_0_1,
+    pub GenericReparseBuffer: FLT_TAG_DATA_BUFFER_0_2,
+    pub GenericGUIDReparseBuffer: FLT_TAG_DATA_BUFFER_0_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FLT_TAG_DATA_BUFFER_0_0 {
+pub struct FLT_TAG_DATA_BUFFER_0_3 {
     pub TagGuid: windows_sys::core::GUID,
     pub DataBuffer: [u8; 1],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FLT_TAG_DATA_BUFFER_0_1 {
+pub struct FLT_TAG_DATA_BUFFER_0_2 {
     pub DataBuffer: [u8; 1],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FLT_TAG_DATA_BUFFER_0_2 {
+pub struct FLT_TAG_DATA_BUFFER_0_1 {
     pub SubstituteNameOffset: u16,
     pub SubstituteNameLength: u16,
     pub PrintNameOffset: u16,
@@ -1307,7 +1307,7 @@ pub struct FLT_TAG_DATA_BUFFER_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FLT_TAG_DATA_BUFFER_0_3 {
+pub struct FLT_TAG_DATA_BUFFER_0_0 {
     pub SubstituteNameOffset: u16,
     pub SubstituteNameLength: u16,
     pub PrintNameOffset: u16,

--- a/crates/libs/sys/src/Windows/Wdk/Storage/FileSystem/mod.rs
+++ b/crates/libs/sys/src/Windows/Wdk/Storage/FileSystem/mod.rs
@@ -3233,10 +3233,10 @@ pub struct FS_FILTER_CALLBACK_DATA {
 #[derive(Clone, Copy)]
 pub union FS_FILTER_PARAMETERS {
     pub AcquireForModifiedPageWriter: FS_FILTER_PARAMETERS_0,
-    pub ReleaseForModifiedPageWriter: FS_FILTER_PARAMETERS_4,
-    pub AcquireForSectionSynchronization: FS_FILTER_PARAMETERS_1,
+    pub ReleaseForModifiedPageWriter: FS_FILTER_PARAMETERS_1,
+    pub AcquireForSectionSynchronization: FS_FILTER_PARAMETERS_2,
     pub QueryOpen: FS_FILTER_PARAMETERS_3,
-    pub Others: FS_FILTER_PARAMETERS_2,
+    pub Others: FS_FILTER_PARAMETERS_4,
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -3248,7 +3248,7 @@ pub struct FS_FILTER_PARAMETERS_0 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FS_FILTER_PARAMETERS_1 {
+pub struct FS_FILTER_PARAMETERS_2 {
     pub SyncType: FS_FILTER_SECTION_SYNC_TYPE,
     pub PageProtection: u32,
     pub OutputInformation: *mut FS_FILTER_SECTION_SYNC_OUTPUT,
@@ -3258,7 +3258,7 @@ pub struct FS_FILTER_PARAMETERS_1 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FS_FILTER_PARAMETERS_2 {
+pub struct FS_FILTER_PARAMETERS_4 {
     pub Argument1: *mut core::ffi::c_void,
     pub Argument2: *mut core::ffi::c_void,
     pub Argument3: *mut core::ffi::c_void,
@@ -3278,7 +3278,7 @@ pub struct FS_FILTER_PARAMETERS_3 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FS_FILTER_PARAMETERS_4 {
+pub struct FS_FILTER_PARAMETERS_1 {
     pub ResourceToRelease: *mut super::super::Foundation::ERESOURCE,
 }
 #[repr(C)]
@@ -3965,13 +3965,13 @@ pub struct REPARSE_DATA_BUFFER {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union REPARSE_DATA_BUFFER_0 {
-    pub SymbolicLinkReparseBuffer: REPARSE_DATA_BUFFER_0_2,
+    pub SymbolicLinkReparseBuffer: REPARSE_DATA_BUFFER_0_0,
     pub MountPointReparseBuffer: REPARSE_DATA_BUFFER_0_1,
-    pub GenericReparseBuffer: REPARSE_DATA_BUFFER_0_0,
+    pub GenericReparseBuffer: REPARSE_DATA_BUFFER_0_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct REPARSE_DATA_BUFFER_0_0 {
+pub struct REPARSE_DATA_BUFFER_0_2 {
     pub DataBuffer: [u8; 1],
 }
 #[repr(C)]
@@ -3985,7 +3985,7 @@ pub struct REPARSE_DATA_BUFFER_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct REPARSE_DATA_BUFFER_0_2 {
+pub struct REPARSE_DATA_BUFFER_0_0 {
     pub SubstituteNameOffset: u16,
     pub SubstituteNameLength: u16,
     pub PrintNameOffset: u16,

--- a/crates/libs/sys/src/Windows/Wdk/System/SystemServices/mod.rs
+++ b/crates/libs/sys/src/Windows/Wdk/System/SystemServices/mod.rs
@@ -5048,31 +5048,31 @@ pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CM_PARTIAL_RESOURCE_DESCRIPTOR_0 {
-    pub Generic: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6,
-    pub Port: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13,
-    pub Interrupt: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7,
-    pub MessageInterrupt: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12,
-    pub Memory: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11,
+    pub Generic: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0,
+    pub Port: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1,
+    pub Interrupt: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2,
+    pub MessageInterrupt: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3,
+    pub Memory: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4,
     pub Dma: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_5,
-    pub DmaV3: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4,
-    pub DevicePrivate: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2,
-    pub BusNumber: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0,
-    pub DeviceSpecificData: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3,
-    pub Memory40: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8,
-    pub Memory48: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9,
-    pub Memory64: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10,
-    pub Connection: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1,
+    pub DmaV3: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6,
+    pub DevicePrivate: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7,
+    pub BusNumber: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8,
+    pub DeviceSpecificData: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9,
+    pub Memory40: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10,
+    pub Memory48: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11,
+    pub Memory64: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12,
+    pub Connection: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
     pub Start: u32,
     pub Length: u32,
     pub Reserved: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13 {
     pub Class: u8,
     pub Type: u8,
     pub Reserved1: u8,
@@ -5082,19 +5082,19 @@ pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
     pub Data: [u32; 3],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
     pub DataSize: u32,
     pub Reserved1: u32,
     pub Reserved2: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6 {
     pub Channel: u32,
     pub RequestLine: u32,
     pub TransferWidth: u8,
@@ -5111,55 +5111,55 @@ pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_5 {
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
     pub Start: i64,
     pub Length: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2 {
     pub Level: u32,
     pub Vector: u32,
     pub Affinity: usize,
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10 {
     pub Start: i64,
     pub Length40: u32,
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11 {
     pub Start: i64,
     pub Length48: u32,
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12 {
     pub Start: i64,
     pub Length64: u32,
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
     pub Start: i64,
     pub Length: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12 {
-    pub Anonymous: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0,
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
+    pub Anonymous: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0 {
-    pub Raw: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_0,
-    pub Translated: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_1,
+pub union CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0 {
+    pub Raw: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_0,
+    pub Translated: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_0 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_0 {
     pub Reserved: u16,
     pub MessageCount: u16,
     pub Vector: u32,
@@ -5167,14 +5167,14 @@ pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_1 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_1 {
     pub Level: u32,
     pub Vector: u32,
     pub Affinity: usize,
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
     pub Start: i64,
     pub Length: u32,
 }
@@ -5488,18 +5488,18 @@ pub struct DEVICE_BUS_SPECIFIC_RESET_INFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVICE_BUS_SPECIFIC_RESET_TYPE {
-    pub Pci: DEVICE_BUS_SPECIFIC_RESET_TYPE_1,
-    pub Acpi: DEVICE_BUS_SPECIFIC_RESET_TYPE_0,
+    pub Pci: DEVICE_BUS_SPECIFIC_RESET_TYPE_0,
+    pub Acpi: DEVICE_BUS_SPECIFIC_RESET_TYPE_1,
     pub AsULONGLONG: u64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
+pub struct DEVICE_BUS_SPECIFIC_RESET_TYPE_1 {
     pub _bitfield: u64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct DEVICE_BUS_SPECIFIC_RESET_TYPE_1 {
+pub struct DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
     pub _bitfield: u64,
 }
 #[repr(C)]
@@ -5604,17 +5604,17 @@ pub struct DISK_SIGNATURE {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISK_SIGNATURE_0 {
-    pub Mbr: DISK_SIGNATURE_0_1,
-    pub Gpt: DISK_SIGNATURE_0_0,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct DISK_SIGNATURE_0_0 {
-    pub DiskId: windows_sys::core::GUID,
+    pub Mbr: DISK_SIGNATURE_0_0,
+    pub Gpt: DISK_SIGNATURE_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DISK_SIGNATURE_0_1 {
+    pub DiskId: windows_sys::core::GUID,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct DISK_SIGNATURE_0_0 {
     pub Signature: u32,
     pub CheckSum: u32,
 }
@@ -6518,21 +6518,21 @@ pub struct IOMMU_MAP_PHYSICAL_ADDRESS {
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
 pub union IOMMU_MAP_PHYSICAL_ADDRESS_0 {
-    pub Mdl: IOMMU_MAP_PHYSICAL_ADDRESS_0_1,
-    pub ContiguousRange: IOMMU_MAP_PHYSICAL_ADDRESS_0_0,
+    pub Mdl: IOMMU_MAP_PHYSICAL_ADDRESS_0_0,
+    pub ContiguousRange: IOMMU_MAP_PHYSICAL_ADDRESS_0_1,
     pub PfnArray: IOMMU_MAP_PHYSICAL_ADDRESS_0_2,
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
-pub struct IOMMU_MAP_PHYSICAL_ADDRESS_0_0 {
+pub struct IOMMU_MAP_PHYSICAL_ADDRESS_0_1 {
     pub Base: i64,
     pub Size: usize,
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
-pub struct IOMMU_MAP_PHYSICAL_ADDRESS_0_1 {
+pub struct IOMMU_MAP_PHYSICAL_ADDRESS_0_0 {
     pub Mdl: *mut super::super::Foundation::MDL,
 }
 #[repr(C)]
@@ -6809,23 +6809,23 @@ pub struct IO_RESOURCE_DESCRIPTOR {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IO_RESOURCE_DESCRIPTOR_0 {
-    pub Port: IO_RESOURCE_DESCRIPTOR_0_12,
-    pub Memory: IO_RESOURCE_DESCRIPTOR_0_11,
-    pub Interrupt: IO_RESOURCE_DESCRIPTOR_0_7,
-    pub Dma: IO_RESOURCE_DESCRIPTOR_0_5,
+    pub Port: IO_RESOURCE_DESCRIPTOR_0_0,
+    pub Memory: IO_RESOURCE_DESCRIPTOR_0_1,
+    pub Interrupt: IO_RESOURCE_DESCRIPTOR_0_2,
+    pub Dma: IO_RESOURCE_DESCRIPTOR_0_3,
     pub DmaV3: IO_RESOURCE_DESCRIPTOR_0_4,
-    pub Generic: IO_RESOURCE_DESCRIPTOR_0_6,
-    pub DevicePrivate: IO_RESOURCE_DESCRIPTOR_0_3,
-    pub BusNumber: IO_RESOURCE_DESCRIPTOR_0_0,
-    pub ConfigData: IO_RESOURCE_DESCRIPTOR_0_1,
-    pub Memory40: IO_RESOURCE_DESCRIPTOR_0_8,
-    pub Memory48: IO_RESOURCE_DESCRIPTOR_0_9,
-    pub Memory64: IO_RESOURCE_DESCRIPTOR_0_10,
-    pub Connection: IO_RESOURCE_DESCRIPTOR_0_2,
+    pub Generic: IO_RESOURCE_DESCRIPTOR_0_5,
+    pub DevicePrivate: IO_RESOURCE_DESCRIPTOR_0_6,
+    pub BusNumber: IO_RESOURCE_DESCRIPTOR_0_7,
+    pub ConfigData: IO_RESOURCE_DESCRIPTOR_0_8,
+    pub Memory40: IO_RESOURCE_DESCRIPTOR_0_9,
+    pub Memory48: IO_RESOURCE_DESCRIPTOR_0_10,
+    pub Memory64: IO_RESOURCE_DESCRIPTOR_0_11,
+    pub Connection: IO_RESOURCE_DESCRIPTOR_0_12,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_0 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_7 {
     pub Length: u32,
     pub MinBusNumber: u32,
     pub MaxBusNumber: u32,
@@ -6833,14 +6833,14 @@ pub struct IO_RESOURCE_DESCRIPTOR_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_1 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_8 {
     pub Priority: u32,
     pub Reserved1: u32,
     pub Reserved2: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_2 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_12 {
     pub Class: u8,
     pub Type: u8,
     pub Reserved1: u8,
@@ -6850,7 +6850,7 @@ pub struct IO_RESOURCE_DESCRIPTOR_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_3 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_6 {
     pub Data: [u32; 3],
 }
 #[repr(C)]
@@ -6863,13 +6863,13 @@ pub struct IO_RESOURCE_DESCRIPTOR_0_4 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_5 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_3 {
     pub MinimumChannel: u32,
     pub MaximumChannel: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_6 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_5 {
     pub Length: u32,
     pub Alignment: u32,
     pub MinimumAddress: i64,
@@ -6877,7 +6877,7 @@ pub struct IO_RESOURCE_DESCRIPTOR_0_6 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_7 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_2 {
     pub MinimumVector: u32,
     pub MaximumVector: u32,
     pub AffinityPolicy: IRQ_DEVICE_POLICY,
@@ -6886,7 +6886,7 @@ pub struct IO_RESOURCE_DESCRIPTOR_0_7 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_8 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_9 {
     pub Length40: u32,
     pub Alignment40: u32,
     pub MinimumAddress: i64,
@@ -6894,7 +6894,7 @@ pub struct IO_RESOURCE_DESCRIPTOR_0_8 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_9 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_10 {
     pub Length48: u32,
     pub Alignment48: u32,
     pub MinimumAddress: i64,
@@ -6902,7 +6902,7 @@ pub struct IO_RESOURCE_DESCRIPTOR_0_9 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_10 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_11 {
     pub Length64: u32,
     pub Alignment64: u32,
     pub MinimumAddress: i64,
@@ -6910,7 +6910,7 @@ pub struct IO_RESOURCE_DESCRIPTOR_0_10 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_11 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_1 {
     pub Length: u32,
     pub Alignment: u32,
     pub MinimumAddress: i64,
@@ -6918,7 +6918,7 @@ pub struct IO_RESOURCE_DESCRIPTOR_0_11 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_12 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_0 {
     pub Length: u32,
     pub Alignment: u32,
     pub MinimumAddress: i64,
@@ -7861,27 +7861,16 @@ pub struct PCIBUSDATA {
 #[derive(Clone, Copy)]
 pub struct PCIX_BRIDGE_CAPABILITY {
     pub Header: PCI_CAPABILITIES_HEADER,
-    pub SecondaryStatus: PCIX_BRIDGE_CAPABILITY_2,
-    pub BridgeStatus: PCIX_BRIDGE_CAPABILITY_0,
+    pub SecondaryStatus: PCIX_BRIDGE_CAPABILITY_0,
+    pub BridgeStatus: PCIX_BRIDGE_CAPABILITY_1,
     pub UpstreamSplitTransactionCapacity: u16,
     pub UpstreamSplitTransactionLimit: u16,
     pub DownstreamSplitTransactionCapacity: u16,
     pub DownstreamSplitTransactionLimit: u16,
-    pub EccControlStatus: PCIX_BRIDGE_CAPABILITY_1,
+    pub EccControlStatus: PCIX_BRIDGE_CAPABILITY_2,
     pub EccFirstAddress: u32,
     pub EccSecondAddress: u32,
     pub EccAttribute: u32,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub union PCIX_BRIDGE_CAPABILITY_0 {
-    pub Anonymous: PCIX_BRIDGE_CAPABILITY_0_0,
-    pub AsULONG: u32,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct PCIX_BRIDGE_CAPABILITY_0_0 {
-    pub _bitfield: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7898,11 +7887,22 @@ pub struct PCIX_BRIDGE_CAPABILITY_1_0 {
 #[derive(Clone, Copy)]
 pub union PCIX_BRIDGE_CAPABILITY_2 {
     pub Anonymous: PCIX_BRIDGE_CAPABILITY_2_0,
-    pub AsUSHORT: u16,
+    pub AsULONG: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PCIX_BRIDGE_CAPABILITY_2_0 {
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union PCIX_BRIDGE_CAPABILITY_0 {
+    pub Anonymous: PCIX_BRIDGE_CAPABILITY_0_0,
+    pub AsUSHORT: u16,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct PCIX_BRIDGE_CAPABILITY_0_0 {
     pub _bitfield: u16,
 }
 #[repr(C)]
@@ -7957,17 +7957,17 @@ pub struct PCI_AGP_APERTURE_PAGE_SIZE {
 pub struct PCI_AGP_CAPABILITY {
     pub Header: PCI_CAPABILITIES_HEADER,
     pub _bitfield: u16,
-    pub AGPStatus: PCI_AGP_CAPABILITY_1,
-    pub AGPCommand: PCI_AGP_CAPABILITY_0,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct PCI_AGP_CAPABILITY_0 {
-    pub _bitfield: u32,
+    pub AGPStatus: PCI_AGP_CAPABILITY_0,
+    pub AGPCommand: PCI_AGP_CAPABILITY_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PCI_AGP_CAPABILITY_1 {
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct PCI_AGP_CAPABILITY_0 {
     pub _bitfield: u32,
 }
 #[repr(C)]
@@ -9507,14 +9507,14 @@ pub struct PCI_PMCSR_BSE {
 #[derive(Clone, Copy)]
 pub struct PCI_PM_CAPABILITY {
     pub Header: PCI_CAPABILITIES_HEADER,
-    pub PMC: PCI_PM_CAPABILITY_2,
+    pub PMC: PCI_PM_CAPABILITY_0,
     pub PMCSR: PCI_PM_CAPABILITY_1,
-    pub PMCSR_BSE: PCI_PM_CAPABILITY_0,
+    pub PMCSR_BSE: PCI_PM_CAPABILITY_2,
     pub Data: u8,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union PCI_PM_CAPABILITY_0 {
+pub union PCI_PM_CAPABILITY_2 {
     pub BridgeSupport: PCI_PMCSR_BSE,
     pub AsUCHAR: u8,
 }
@@ -9526,7 +9526,7 @@ pub union PCI_PM_CAPABILITY_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union PCI_PM_CAPABILITY_2 {
+pub union PCI_PM_CAPABILITY_0 {
     pub Capabilities: PCI_PMC,
     pub AsUSHORT: u16,
 }
@@ -10135,18 +10135,18 @@ pub struct PROCESS_DEVICEMAP_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROCESS_DEVICEMAP_INFORMATION_0 {
-    pub Set: PROCESS_DEVICEMAP_INFORMATION_0_1,
-    pub Query: PROCESS_DEVICEMAP_INFORMATION_0_0,
+    pub Set: PROCESS_DEVICEMAP_INFORMATION_0_0,
+    pub Query: PROCESS_DEVICEMAP_INFORMATION_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PROCESS_DEVICEMAP_INFORMATION_0_0 {
+pub struct PROCESS_DEVICEMAP_INFORMATION_0_1 {
     pub DriveMap: u32,
     pub DriveType: [u8; 32],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PROCESS_DEVICEMAP_INFORMATION_0_1 {
+pub struct PROCESS_DEVICEMAP_INFORMATION_0_0 {
     pub DirectoryHandle: super::super::super::Win32::Foundation::HANDLE,
 }
 #[repr(C)]
@@ -10158,18 +10158,18 @@ pub struct PROCESS_DEVICEMAP_INFORMATION_EX {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROCESS_DEVICEMAP_INFORMATION_EX_0 {
-    pub Set: PROCESS_DEVICEMAP_INFORMATION_EX_0_1,
-    pub Query: PROCESS_DEVICEMAP_INFORMATION_EX_0_0,
+    pub Set: PROCESS_DEVICEMAP_INFORMATION_EX_0_0,
+    pub Query: PROCESS_DEVICEMAP_INFORMATION_EX_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
+pub struct PROCESS_DEVICEMAP_INFORMATION_EX_0_1 {
     pub DriveMap: u32,
     pub DriveType: [u8; 32],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PROCESS_DEVICEMAP_INFORMATION_EX_0_1 {
+pub struct PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
     pub DirectoryHandle: super::super::super::Win32::Foundation::HANDLE,
 }
 #[repr(C)]
@@ -12914,8 +12914,8 @@ pub struct WHEA_XPF_TLB_CHECK_0 {
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct XPF_RECOVERY_INFO {
-    pub FailureReason: XPF_RECOVERY_INFO_1,
-    pub Action: XPF_RECOVERY_INFO_0,
+    pub FailureReason: XPF_RECOVERY_INFO_0,
+    pub Action: XPF_RECOVERY_INFO_1,
     pub ActionRequired: super::super::super::Win32::Foundation::BOOLEAN,
     pub RecoverySucceeded: super::super::super::Win32::Foundation::BOOLEAN,
     pub RecoveryKernel: super::super::super::Win32::Foundation::BOOLEAN,
@@ -12926,12 +12926,12 @@ pub struct XPF_RECOVERY_INFO {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct XPF_RECOVERY_INFO_0 {
+pub struct XPF_RECOVERY_INFO_1 {
     pub _bitfield: u32,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct XPF_RECOVERY_INFO_1 {
+pub struct XPF_RECOVERY_INFO_0 {
     pub _bitfield: u32,
 }
 #[repr(C)]

--- a/crates/libs/sys/src/Windows/Win32/Devices/BiometricFramework/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Devices/BiometricFramework/mod.rs
@@ -247,38 +247,38 @@ pub struct WINBIO_ASYNC_RESULT {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINBIO_ASYNC_RESULT_0 {
-    pub Verify: WINBIO_ASYNC_RESULT_0_20,
-    pub Identify: WINBIO_ASYNC_RESULT_0_15,
-    pub EnrollBegin: WINBIO_ASYNC_RESULT_0_3,
-    pub EnrollCapture: WINBIO_ASYNC_RESULT_0_4,
-    pub EnrollCommit: WINBIO_ASYNC_RESULT_0_5,
-    pub EnumEnrollments: WINBIO_ASYNC_RESULT_0_9,
-    pub CaptureSample: WINBIO_ASYNC_RESULT_0_0,
-    pub DeleteTemplate: WINBIO_ASYNC_RESULT_0_2,
-    pub GetProperty: WINBIO_ASYNC_RESULT_0_12,
-    pub SetProperty: WINBIO_ASYNC_RESULT_0_18,
-    pub GetEvent: WINBIO_ASYNC_RESULT_0_11,
-    pub ControlUnit: WINBIO_ASYNC_RESULT_0_1,
-    pub EnumServiceProviders: WINBIO_ASYNC_RESULT_0_10,
-    pub EnumBiometricUnits: WINBIO_ASYNC_RESULT_0_7,
-    pub EnumDatabases: WINBIO_ASYNC_RESULT_0_8,
-    pub VerifyAndReleaseTicket: WINBIO_ASYNC_RESULT_0_19,
-    pub IdentifyAndReleaseTicket: WINBIO_ASYNC_RESULT_0_14,
-    pub EnrollSelect: WINBIO_ASYNC_RESULT_0_6,
-    pub MonitorPresence: WINBIO_ASYNC_RESULT_0_16,
-    pub GetProtectionPolicy: WINBIO_ASYNC_RESULT_0_13,
-    pub NotifyUnitStatusChange: WINBIO_ASYNC_RESULT_0_17,
+    pub Verify: WINBIO_ASYNC_RESULT_0_0,
+    pub Identify: WINBIO_ASYNC_RESULT_0_1,
+    pub EnrollBegin: WINBIO_ASYNC_RESULT_0_2,
+    pub EnrollCapture: WINBIO_ASYNC_RESULT_0_3,
+    pub EnrollCommit: WINBIO_ASYNC_RESULT_0_4,
+    pub EnumEnrollments: WINBIO_ASYNC_RESULT_0_5,
+    pub CaptureSample: WINBIO_ASYNC_RESULT_0_6,
+    pub DeleteTemplate: WINBIO_ASYNC_RESULT_0_7,
+    pub GetProperty: WINBIO_ASYNC_RESULT_0_8,
+    pub SetProperty: WINBIO_ASYNC_RESULT_0_9,
+    pub GetEvent: WINBIO_ASYNC_RESULT_0_10,
+    pub ControlUnit: WINBIO_ASYNC_RESULT_0_11,
+    pub EnumServiceProviders: WINBIO_ASYNC_RESULT_0_12,
+    pub EnumBiometricUnits: WINBIO_ASYNC_RESULT_0_13,
+    pub EnumDatabases: WINBIO_ASYNC_RESULT_0_14,
+    pub VerifyAndReleaseTicket: WINBIO_ASYNC_RESULT_0_15,
+    pub IdentifyAndReleaseTicket: WINBIO_ASYNC_RESULT_0_16,
+    pub EnrollSelect: WINBIO_ASYNC_RESULT_0_17,
+    pub MonitorPresence: WINBIO_ASYNC_RESULT_0_18,
+    pub GetProtectionPolicy: WINBIO_ASYNC_RESULT_0_19,
+    pub NotifyUnitStatusChange: WINBIO_ASYNC_RESULT_0_20,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_0 {
+pub struct WINBIO_ASYNC_RESULT_0_6 {
     pub Sample: *mut WINBIO_BIR,
     pub SampleSize: usize,
     pub RejectDetail: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_1 {
+pub struct WINBIO_ASYNC_RESULT_0_11 {
     pub Component: WINBIO_COMPONENT,
     pub ControlCode: u32,
     pub OperationStatus: u32,
@@ -290,107 +290,64 @@ pub struct WINBIO_ASYNC_RESULT_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_2 {
+pub struct WINBIO_ASYNC_RESULT_0_7 {
     pub Identity: WINBIO_IDENTITY,
+    pub SubFactor: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_2 {
     pub SubFactor: u8,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WINBIO_ASYNC_RESULT_0_3 {
-    pub SubFactor: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_4 {
     pub RejectDetail: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_5 {
+pub struct WINBIO_ASYNC_RESULT_0_4 {
     pub Identity: WINBIO_IDENTITY,
     pub IsNewTemplate: super::super::Foundation::BOOLEAN,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_6 {
+pub struct WINBIO_ASYNC_RESULT_0_17 {
     pub SelectorValue: u64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_7 {
+pub struct WINBIO_ASYNC_RESULT_0_13 {
     pub UnitCount: usize,
     pub UnitSchemaArray: *mut WINBIO_UNIT_SCHEMA,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_8 {
+pub struct WINBIO_ASYNC_RESULT_0_14 {
     pub StorageCount: usize,
     pub StorageSchemaArray: *mut WINBIO_STORAGE_SCHEMA,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_9 {
+pub struct WINBIO_ASYNC_RESULT_0_5 {
     pub Identity: WINBIO_IDENTITY,
     pub SubFactorCount: usize,
     pub SubFactorArray: *mut u8,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_10 {
+pub struct WINBIO_ASYNC_RESULT_0_12 {
     pub BspCount: usize,
     pub BspSchemaArray: *mut WINBIO_BSP_SCHEMA,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_11 {
+pub struct WINBIO_ASYNC_RESULT_0_10 {
     pub Event: WINBIO_EVENT,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_12 {
-    pub PropertyType: u32,
-    pub PropertyId: u32,
-    pub Identity: WINBIO_IDENTITY,
-    pub SubFactor: u8,
-    pub PropertyBufferSize: usize,
-    pub PropertyBuffer: *mut core::ffi::c_void,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_13 {
-    pub Identity: WINBIO_IDENTITY,
-    pub Policy: WINBIO_PROTECTION_POLICY,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_14 {
-    pub Identity: WINBIO_IDENTITY,
-    pub SubFactor: u8,
-    pub RejectDetail: u32,
-    pub Ticket: u64,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_15 {
-    pub Identity: WINBIO_IDENTITY,
-    pub SubFactor: u8,
-    pub RejectDetail: u32,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_16 {
-    pub ChangeType: u32,
-    pub PresenceCount: usize,
-    pub PresenceArray: *mut WINBIO_PRESENCE,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_17 {
-    pub ExtendedStatus: WINBIO_EXTENDED_UNIT_STATUS,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_18 {
+pub struct WINBIO_ASYNC_RESULT_0_8 {
     pub PropertyType: u32,
     pub PropertyId: u32,
     pub Identity: WINBIO_IDENTITY,
@@ -401,13 +358,56 @@ pub struct WINBIO_ASYNC_RESULT_0_18 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WINBIO_ASYNC_RESULT_0_19 {
+    pub Identity: WINBIO_IDENTITY,
+    pub Policy: WINBIO_PROTECTION_POLICY,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_16 {
+    pub Identity: WINBIO_IDENTITY,
+    pub SubFactor: u8,
+    pub RejectDetail: u32,
+    pub Ticket: u64,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_1 {
+    pub Identity: WINBIO_IDENTITY,
+    pub SubFactor: u8,
+    pub RejectDetail: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_18 {
+    pub ChangeType: u32,
+    pub PresenceCount: usize,
+    pub PresenceArray: *mut WINBIO_PRESENCE,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_20 {
+    pub ExtendedStatus: WINBIO_EXTENDED_UNIT_STATUS,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_9 {
+    pub PropertyType: u32,
+    pub PropertyId: u32,
+    pub Identity: WINBIO_IDENTITY,
+    pub SubFactor: u8,
+    pub PropertyBufferSize: usize,
+    pub PropertyBuffer: *mut core::ffi::c_void,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_15 {
     pub Match: super::super::Foundation::BOOLEAN,
     pub RejectDetail: u32,
     pub Ticket: u64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_20 {
+pub struct WINBIO_ASYNC_RESULT_0_0 {
     pub Match: super::super::Foundation::BOOLEAN,
     pub RejectDetail: u32,
 }
@@ -602,13 +602,13 @@ pub struct WINBIO_EVENT {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINBIO_EVENT_0 {
-    pub Unclaimed: WINBIO_EVENT_0_2,
+    pub Unclaimed: WINBIO_EVENT_0_0,
     pub UnclaimedIdentify: WINBIO_EVENT_0_1,
-    pub Error: WINBIO_EVENT_0_0,
+    pub Error: WINBIO_EVENT_0_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_EVENT_0_0 {
+pub struct WINBIO_EVENT_0_2 {
     pub ErrorCode: windows_sys::core::HRESULT,
 }
 #[repr(C)]
@@ -621,7 +621,7 @@ pub struct WINBIO_EVENT_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_EVENT_0_2 {
+pub struct WINBIO_EVENT_0_0 {
     pub UnitId: u32,
     pub RejectDetail: u32,
 }

--- a/crates/libs/sys/src/Windows/Win32/Devices/Bluetooth/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Devices/Bluetooth/mod.rs
@@ -1183,9 +1183,9 @@ pub struct BTH_LE_GATT_DESCRIPTOR_VALUE {
 #[derive(Clone, Copy)]
 pub union BTH_LE_GATT_DESCRIPTOR_VALUE_0 {
     pub CharacteristicExtendedProperties: BTH_LE_GATT_DESCRIPTOR_VALUE_0_0,
-    pub ClientCharacteristicConfiguration: BTH_LE_GATT_DESCRIPTOR_VALUE_0_2,
-    pub ServerCharacteristicConfiguration: BTH_LE_GATT_DESCRIPTOR_VALUE_0_3,
-    pub CharacteristicFormat: BTH_LE_GATT_DESCRIPTOR_VALUE_0_1,
+    pub ClientCharacteristicConfiguration: BTH_LE_GATT_DESCRIPTOR_VALUE_0_1,
+    pub ServerCharacteristicConfiguration: BTH_LE_GATT_DESCRIPTOR_VALUE_0_2,
+    pub CharacteristicFormat: BTH_LE_GATT_DESCRIPTOR_VALUE_0_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1195,7 +1195,7 @@ pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
+pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
     pub Format: u8,
     pub Exponent: u8,
     pub Unit: BTH_LE_UUID,
@@ -1204,13 +1204,13 @@ pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_2 {
+pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
     pub IsSubscribeToNotification: super::super::Foundation::BOOLEAN,
     pub IsSubscribeToIndication: super::super::Foundation::BOOLEAN,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
+pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_2 {
     pub IsBroadcast: super::super::Foundation::BOOLEAN,
 }
 #[repr(C)]
@@ -1337,20 +1337,14 @@ pub union SDP_ELEMENT_DATA_0 {
     pub uuid128: windows_sys::core::GUID,
     pub uuid32: u32,
     pub uuid16: u16,
-    pub string: SDP_ELEMENT_DATA_0_2,
-    pub url: SDP_ELEMENT_DATA_0_3,
-    pub sequence: SDP_ELEMENT_DATA_0_1,
-    pub alternative: SDP_ELEMENT_DATA_0_0,
+    pub string: SDP_ELEMENT_DATA_0_0,
+    pub url: SDP_ELEMENT_DATA_0_1,
+    pub sequence: SDP_ELEMENT_DATA_0_2,
+    pub alternative: SDP_ELEMENT_DATA_0_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct SDP_ELEMENT_DATA_0_0 {
-    pub value: *mut u8,
-    pub length: u32,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct SDP_ELEMENT_DATA_0_1 {
+pub struct SDP_ELEMENT_DATA_0_3 {
     pub value: *mut u8,
     pub length: u32,
 }
@@ -1362,7 +1356,13 @@ pub struct SDP_ELEMENT_DATA_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct SDP_ELEMENT_DATA_0_3 {
+pub struct SDP_ELEMENT_DATA_0_0 {
+    pub value: *mut u8,
+    pub length: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SDP_ELEMENT_DATA_0_1 {
     pub value: *mut u8,
     pub length: u32,
 }

--- a/crates/libs/sys/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
@@ -2441,13 +2441,13 @@ pub struct CM_NOTIFY_EVENT_DATA {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CM_NOTIFY_EVENT_DATA_0 {
-    pub DeviceInterface: CM_NOTIFY_EVENT_DATA_0_2,
-    pub DeviceHandle: CM_NOTIFY_EVENT_DATA_0_0,
-    pub DeviceInstance: CM_NOTIFY_EVENT_DATA_0_1,
+    pub DeviceInterface: CM_NOTIFY_EVENT_DATA_0_0,
+    pub DeviceHandle: CM_NOTIFY_EVENT_DATA_0_1,
+    pub DeviceInstance: CM_NOTIFY_EVENT_DATA_0_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_NOTIFY_EVENT_DATA_0_0 {
+pub struct CM_NOTIFY_EVENT_DATA_0_1 {
     pub EventGuid: windows_sys::core::GUID,
     pub NameOffset: i32,
     pub DataSize: u32,
@@ -2455,12 +2455,12 @@ pub struct CM_NOTIFY_EVENT_DATA_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_NOTIFY_EVENT_DATA_0_1 {
+pub struct CM_NOTIFY_EVENT_DATA_0_2 {
     pub InstanceId: [u16; 1],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CM_NOTIFY_EVENT_DATA_0_2 {
+pub struct CM_NOTIFY_EVENT_DATA_0_0 {
     pub ClassGuid: windows_sys::core::GUID,
     pub SymbolicLink: [u16; 1],
 }
@@ -2476,23 +2476,23 @@ pub struct CM_NOTIFY_FILTER {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CM_NOTIFY_FILTER_0 {
-    pub DeviceInterface: CM_NOTIFY_FILTER_0_2,
-    pub DeviceHandle: CM_NOTIFY_FILTER_0_0,
-    pub DeviceInstance: CM_NOTIFY_FILTER_0_1,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct CM_NOTIFY_FILTER_0_0 {
-    pub hTarget: super::super::Foundation::HANDLE,
+    pub DeviceInterface: CM_NOTIFY_FILTER_0_0,
+    pub DeviceHandle: CM_NOTIFY_FILTER_0_1,
+    pub DeviceInstance: CM_NOTIFY_FILTER_0_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CM_NOTIFY_FILTER_0_1 {
-    pub InstanceId: [u16; 200],
+    pub hTarget: super::super::Foundation::HANDLE,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CM_NOTIFY_FILTER_0_2 {
+    pub InstanceId: [u16; 200],
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CM_NOTIFY_FILTER_0_0 {
     pub ClassGuid: windows_sys::core::GUID,
 }
 #[repr(C)]

--- a/crates/libs/sys/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -3304,12 +3304,12 @@ pub struct HIDP_BUTTON_CAPS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HIDP_BUTTON_CAPS_0 {
-    pub Range: HIDP_BUTTON_CAPS_0_1,
-    pub NotRange: HIDP_BUTTON_CAPS_0_0,
+    pub Range: HIDP_BUTTON_CAPS_0_0,
+    pub NotRange: HIDP_BUTTON_CAPS_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct HIDP_BUTTON_CAPS_0_0 {
+pub struct HIDP_BUTTON_CAPS_0_1 {
     pub Usage: u16,
     pub Reserved1: u16,
     pub StringIndex: u16,
@@ -3321,7 +3321,7 @@ pub struct HIDP_BUTTON_CAPS_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct HIDP_BUTTON_CAPS_0_1 {
+pub struct HIDP_BUTTON_CAPS_0_0 {
     pub UsageMin: u16,
     pub UsageMax: u16,
     pub StringMin: u16,
@@ -3437,12 +3437,12 @@ pub struct HIDP_VALUE_CAPS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HIDP_VALUE_CAPS_0 {
-    pub Range: HIDP_VALUE_CAPS_0_1,
-    pub NotRange: HIDP_VALUE_CAPS_0_0,
+    pub Range: HIDP_VALUE_CAPS_0_0,
+    pub NotRange: HIDP_VALUE_CAPS_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct HIDP_VALUE_CAPS_0_0 {
+pub struct HIDP_VALUE_CAPS_0_1 {
     pub Usage: u16,
     pub Reserved1: u16,
     pub StringIndex: u16,
@@ -3454,7 +3454,7 @@ pub struct HIDP_VALUE_CAPS_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct HIDP_VALUE_CAPS_0_1 {
+pub struct HIDP_VALUE_CAPS_0_0 {
     pub UsageMin: u16,
     pub UsageMax: u16,
     pub StringMin: u16,

--- a/crates/libs/sys/src/Windows/Win32/Devices/Tapi/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Devices/Tapi/mod.rs
@@ -2621,31 +2621,31 @@ pub struct LINEPROXYREQUEST {
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
 pub union LINEPROXYREQUEST_0 {
-    pub SetAgentGroup: LINEPROXYREQUEST_0_14,
-    pub SetAgentState: LINEPROXYREQUEST_0_18,
-    pub SetAgentActivity: LINEPROXYREQUEST_0_13,
-    pub GetAgentCaps: LINEPROXYREQUEST_0_4,
-    pub GetAgentStatus: LINEPROXYREQUEST_0_9,
-    pub AgentSpecific: LINEPROXYREQUEST_0_0,
-    pub GetAgentActivityList: LINEPROXYREQUEST_0_3,
-    pub GetAgentGroupList: LINEPROXYREQUEST_0_5,
-    pub CreateAgent: LINEPROXYREQUEST_0_2,
-    pub SetAgentStateEx: LINEPROXYREQUEST_0_17,
-    pub SetAgentMeasurementPeriod: LINEPROXYREQUEST_0_15,
-    pub GetAgentInfo: LINEPROXYREQUEST_0_6,
-    pub CreateAgentSession: LINEPROXYREQUEST_0_1,
-    pub GetAgentSessionList: LINEPROXYREQUEST_0_8,
-    pub GetAgentSessionInfo: LINEPROXYREQUEST_0_7,
-    pub SetAgentSessionState: LINEPROXYREQUEST_0_16,
-    pub GetQueueList: LINEPROXYREQUEST_0_12,
-    pub SetQueueMeasurementPeriod: LINEPROXYREQUEST_0_19,
-    pub GetQueueInfo: LINEPROXYREQUEST_0_11,
-    pub GetGroupList: LINEPROXYREQUEST_0_10,
+    pub SetAgentGroup: LINEPROXYREQUEST_0_0,
+    pub SetAgentState: LINEPROXYREQUEST_0_1,
+    pub SetAgentActivity: LINEPROXYREQUEST_0_2,
+    pub GetAgentCaps: LINEPROXYREQUEST_0_3,
+    pub GetAgentStatus: LINEPROXYREQUEST_0_4,
+    pub AgentSpecific: LINEPROXYREQUEST_0_5,
+    pub GetAgentActivityList: LINEPROXYREQUEST_0_6,
+    pub GetAgentGroupList: LINEPROXYREQUEST_0_7,
+    pub CreateAgent: LINEPROXYREQUEST_0_8,
+    pub SetAgentStateEx: LINEPROXYREQUEST_0_9,
+    pub SetAgentMeasurementPeriod: LINEPROXYREQUEST_0_10,
+    pub GetAgentInfo: LINEPROXYREQUEST_0_11,
+    pub CreateAgentSession: LINEPROXYREQUEST_0_12,
+    pub GetAgentSessionList: LINEPROXYREQUEST_0_13,
+    pub GetAgentSessionInfo: LINEPROXYREQUEST_0_14,
+    pub SetAgentSessionState: LINEPROXYREQUEST_0_15,
+    pub GetQueueList: LINEPROXYREQUEST_0_16,
+    pub SetQueueMeasurementPeriod: LINEPROXYREQUEST_0_17,
+    pub GetQueueInfo: LINEPROXYREQUEST_0_18,
+    pub GetGroupList: LINEPROXYREQUEST_0_19,
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_0 {
+pub struct LINEPROXYREQUEST_0_5 {
     pub dwAddressID: u32,
     pub dwAgentExtensionIDIndex: u32,
     pub dwSize: u32,
@@ -2654,7 +2654,7 @@ pub struct LINEPROXYREQUEST_0_0 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_1 {
+pub struct LINEPROXYREQUEST_0_12 {
     pub hAgentSession: u32,
     pub dwAgentPINSize: u32,
     pub dwAgentPINOffset: u32,
@@ -2665,7 +2665,7 @@ pub struct LINEPROXYREQUEST_0_1 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_2 {
+pub struct LINEPROXYREQUEST_0_8 {
     pub hAgent: u32,
     pub dwAgentIDSize: u32,
     pub dwAgentIDOffset: u32,
@@ -2675,97 +2675,97 @@ pub struct LINEPROXYREQUEST_0_2 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_3 {
+pub struct LINEPROXYREQUEST_0_6 {
     pub dwAddressID: u32,
     pub ActivityList: LINEAGENTACTIVITYLIST,
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_4 {
+pub struct LINEPROXYREQUEST_0_3 {
     pub dwAddressID: u32,
     pub AgentCaps: LINEAGENTCAPS,
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_5 {
-    pub dwAddressID: u32,
-    pub GroupList: LINEAGENTGROUPLIST,
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_6 {
-    pub hAgent: u32,
-    pub AgentInfo: LINEAGENTINFO,
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
 pub struct LINEPROXYREQUEST_0_7 {
-    pub hAgentSession: u32,
-    pub SessionInfo: LINEAGENTSESSIONINFO,
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_8 {
-    pub hAgent: u32,
-    pub SessionList: LINEAGENTSESSIONLIST,
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_9 {
     pub dwAddressID: u32,
-    pub AgentStatus: LINEAGENTSTATUS,
-}
-#[repr(C)]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_10 {
     pub GroupList: LINEAGENTGROUPLIST,
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
 pub struct LINEPROXYREQUEST_0_11 {
+    pub hAgent: u32,
+    pub AgentInfo: LINEAGENTINFO,
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_14 {
+    pub hAgentSession: u32,
+    pub SessionInfo: LINEAGENTSESSIONINFO,
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_13 {
+    pub hAgent: u32,
+    pub SessionList: LINEAGENTSESSIONLIST,
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_4 {
+    pub dwAddressID: u32,
+    pub AgentStatus: LINEAGENTSTATUS,
+}
+#[repr(C)]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_19 {
+    pub GroupList: LINEAGENTGROUPLIST,
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_18 {
     pub dwQueueID: u32,
     pub QueueInfo: LINEQUEUEINFO,
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_12 {
+pub struct LINEPROXYREQUEST_0_16 {
     pub GroupID: windows_sys::core::GUID,
     pub QueueList: LINEQUEUELIST,
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_13 {
+pub struct LINEPROXYREQUEST_0_2 {
     pub dwAddressID: u32,
     pub dwActivityID: u32,
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_14 {
+pub struct LINEPROXYREQUEST_0_0 {
     pub dwAddressID: u32,
     pub GroupList: LINEAGENTGROUPLIST,
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_15 {
+pub struct LINEPROXYREQUEST_0_10 {
     pub hAgent: u32,
     pub dwMeasurementPeriod: u32,
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_16 {
+pub struct LINEPROXYREQUEST_0_15 {
     pub hAgentSession: u32,
     pub dwAgentSessionState: u32,
     pub dwNextAgentSessionState: u32,
@@ -2773,7 +2773,7 @@ pub struct LINEPROXYREQUEST_0_16 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_17 {
+pub struct LINEPROXYREQUEST_0_9 {
     pub hAgent: u32,
     pub dwAgentState: u32,
     pub dwNextAgentState: u32,
@@ -2781,7 +2781,7 @@ pub struct LINEPROXYREQUEST_0_17 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_18 {
+pub struct LINEPROXYREQUEST_0_1 {
     pub dwAddressID: u32,
     pub dwAgentState: u32,
     pub dwNextAgentState: u32,
@@ -2789,7 +2789,7 @@ pub struct LINEPROXYREQUEST_0_18 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_19 {
+pub struct LINEPROXYREQUEST_0_17 {
     pub dwQueueID: u32,
     pub dwMeasurementPeriod: u32,
 }
@@ -2929,13 +2929,13 @@ pub struct MSP_EVENT_INFO {
 #[derive(Clone, Copy)]
 pub union MSP_EVENT_INFO_0 {
     pub MSP_ADDRESS_EVENT_INFO: MSP_EVENT_INFO_0_0,
-    pub MSP_CALL_EVENT_INFO: MSP_EVENT_INFO_0_2,
-    pub MSP_TSP_DATA: MSP_EVENT_INFO_0_6,
-    pub MSP_PRIVATE_EVENT_INFO: MSP_EVENT_INFO_0_4,
-    pub MSP_FILE_TERMINAL_EVENT_INFO: MSP_EVENT_INFO_0_3,
-    pub MSP_ASR_TERMINAL_EVENT_INFO: MSP_EVENT_INFO_0_1,
-    pub MSP_TTS_TERMINAL_EVENT_INFO: MSP_EVENT_INFO_0_7,
-    pub MSP_TONE_TERMINAL_EVENT_INFO: MSP_EVENT_INFO_0_5,
+    pub MSP_CALL_EVENT_INFO: MSP_EVENT_INFO_0_1,
+    pub MSP_TSP_DATA: MSP_EVENT_INFO_0_2,
+    pub MSP_PRIVATE_EVENT_INFO: MSP_EVENT_INFO_0_3,
+    pub MSP_FILE_TERMINAL_EVENT_INFO: MSP_EVENT_INFO_0_4,
+    pub MSP_ASR_TERMINAL_EVENT_INFO: MSP_EVENT_INFO_0_5,
+    pub MSP_TTS_TERMINAL_EVENT_INFO: MSP_EVENT_INFO_0_6,
+    pub MSP_TONE_TERMINAL_EVENT_INFO: MSP_EVENT_INFO_0_7,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2945,13 +2945,13 @@ pub struct MSP_EVENT_INFO_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MSP_EVENT_INFO_0_1 {
+pub struct MSP_EVENT_INFO_0_5 {
     pub pASRTerminal: *mut core::ffi::c_void,
     pub hrErrorCode: windows_sys::core::HRESULT,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MSP_EVENT_INFO_0_2 {
+pub struct MSP_EVENT_INFO_0_1 {
     pub Type: MSP_CALL_EVENT,
     pub Cause: MSP_CALL_EVENT_CAUSE,
     pub pStream: *mut core::ffi::c_void,
@@ -2960,7 +2960,7 @@ pub struct MSP_EVENT_INFO_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MSP_EVENT_INFO_0_3 {
+pub struct MSP_EVENT_INFO_0_4 {
     pub pParentFileTerminal: *mut core::ffi::c_void,
     pub pFileTrack: *mut core::ffi::c_void,
     pub TerminalMediaState: TERMINAL_MEDIA_STATE,
@@ -2969,25 +2969,25 @@ pub struct MSP_EVENT_INFO_0_3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MSP_EVENT_INFO_0_4 {
+pub struct MSP_EVENT_INFO_0_3 {
     pub pEvent: *mut core::ffi::c_void,
     pub lEventCode: i32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MSP_EVENT_INFO_0_5 {
+pub struct MSP_EVENT_INFO_0_7 {
     pub pToneTerminal: *mut core::ffi::c_void,
     pub hrErrorCode: windows_sys::core::HRESULT,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MSP_EVENT_INFO_0_6 {
+pub struct MSP_EVENT_INFO_0_2 {
     pub dwBufferSize: u32,
     pub pBuffer: [u8; 1],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MSP_EVENT_INFO_0_7 {
+pub struct MSP_EVENT_INFO_0_6 {
     pub pTTSTerminal: *mut core::ffi::c_void,
     pub hrErrorCode: windows_sys::core::HRESULT,
 }

--- a/crates/libs/sys/src/Windows/Win32/Devices/Usb/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Devices/Usb/mod.rs
@@ -1456,21 +1456,9 @@ pub struct USB_CYCLE_PORT_PARAMS {
 pub struct USB_DEFAULT_PIPE_SETUP_PACKET {
     pub bmRequestType: BM_REQUEST_TYPE,
     pub bRequest: u8,
-    pub wValue: USB_DEFAULT_PIPE_SETUP_PACKET_1,
-    pub wIndex: USB_DEFAULT_PIPE_SETUP_PACKET_0,
+    pub wValue: USB_DEFAULT_PIPE_SETUP_PACKET_0,
+    pub wIndex: USB_DEFAULT_PIPE_SETUP_PACKET_1,
     pub wLength: u16,
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub union USB_DEFAULT_PIPE_SETUP_PACKET_0 {
-    pub Anonymous: USB_DEFAULT_PIPE_SETUP_PACKET_0_0,
-    pub W: u16,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
-    pub LowByte: u8,
-    pub HiByte: u8,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1481,6 +1469,18 @@ pub union USB_DEFAULT_PIPE_SETUP_PACKET_1 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct USB_DEFAULT_PIPE_SETUP_PACKET_1_0 {
+    pub LowByte: u8,
+    pub HiByte: u8,
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub union USB_DEFAULT_PIPE_SETUP_PACKET_0 {
+    pub Anonymous: USB_DEFAULT_PIPE_SETUP_PACKET_0_0,
+    pub W: u16,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
     pub LowByte: u8,
     pub HiByte: u8,
 }
@@ -1509,27 +1509,27 @@ pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {
     pub iAddtionalInfoURL: u8,
     pub bNumberOfAlternateModes: u8,
     pub bPreferredAlternateMode: u8,
-    pub VconnPower: USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1,
+    pub VconnPower: USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0,
     pub bmConfigured: [u8; 32],
     pub bReserved: u32,
-    pub AlternateMode: [USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0; 1],
+    pub AlternateMode: [USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1; 1],
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
+pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
     pub wSVID: u16,
     pub bAlternateMode: u8,
     pub iAlternateModeSetting: u8,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub union USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
+pub union USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
     pub AsUshort: u16,
-    pub Anonymous: USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0,
+    pub Anonymous: USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0_0,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0 {
+pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0_0 {
     pub _bitfield: u16,
 }
 #[repr(C)]

--- a/crates/libs/sys/src/Windows/Win32/Media/KernelStreaming/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Media/KernelStreaming/mod.rs
@@ -2437,8 +2437,8 @@ pub struct KSCAMERA_PROFILE_INFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSCAMERA_PROFILE_MEDIAINFO {
-    pub Resolution: KSCAMERA_PROFILE_MEDIAINFO_1,
-    pub MaxFrameRate: KSCAMERA_PROFILE_MEDIAINFO_0,
+    pub Resolution: KSCAMERA_PROFILE_MEDIAINFO_0,
+    pub MaxFrameRate: KSCAMERA_PROFILE_MEDIAINFO_1,
     pub Flags: u64,
     pub Data0: u32,
     pub Data1: u32,
@@ -2447,13 +2447,13 @@ pub struct KSCAMERA_PROFILE_MEDIAINFO {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct KSCAMERA_PROFILE_MEDIAINFO_0 {
+pub struct KSCAMERA_PROFILE_MEDIAINFO_1 {
     pub Numerator: u32,
     pub Denominator: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct KSCAMERA_PROFILE_MEDIAINFO_1 {
+pub struct KSCAMERA_PROFILE_MEDIAINFO_0 {
     pub X: u32,
     pub Y: u32,
 }
@@ -2813,25 +2813,25 @@ pub struct KSEVENTDATA {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSEVENTDATA_0 {
-    pub EventHandle: KSEVENTDATA_0_1,
-    pub SemaphoreHandle: KSEVENTDATA_0_2,
-    pub Alignment: KSEVENTDATA_0_0,
+    pub EventHandle: KSEVENTDATA_0_0,
+    pub SemaphoreHandle: KSEVENTDATA_0_1,
+    pub Alignment: KSEVENTDATA_0_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct KSEVENTDATA_0_0 {
+pub struct KSEVENTDATA_0_2 {
     pub Unused: *mut core::ffi::c_void,
     pub Alignment: [isize; 2],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct KSEVENTDATA_0_1 {
+pub struct KSEVENTDATA_0_0 {
     pub Event: super::super::Foundation::HANDLE,
     pub Reserved: [usize; 2],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct KSEVENTDATA_0_2 {
+pub struct KSEVENTDATA_0_1 {
     pub Semaphore: super::super::Foundation::HANDLE,
     pub Reserved: u32,
     pub Adjustment: i32,
@@ -3456,20 +3456,20 @@ pub union KSPROPERTY_EXTXPORT_NODE_S_0 {
     pub LoadMedium: u32,
     pub MediumInfo: MEDIUM_INFO,
     pub XPrtState: TRANSPORT_STATE,
-    pub Timecode: KSPROPERTY_EXTXPORT_NODE_S_0_1,
+    pub Timecode: KSPROPERTY_EXTXPORT_NODE_S_0_0,
     pub dwTimecode: u32,
     pub dwAbsTrackNumber: u32,
-    pub RawAVC: KSPROPERTY_EXTXPORT_NODE_S_0_0,
+    pub RawAVC: KSPROPERTY_EXTXPORT_NODE_S_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct KSPROPERTY_EXTXPORT_NODE_S_0_0 {
+pub struct KSPROPERTY_EXTXPORT_NODE_S_0_1 {
     pub PayloadSize: u32,
     pub Payload: [u8; 512],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct KSPROPERTY_EXTXPORT_NODE_S_0_1 {
+pub struct KSPROPERTY_EXTXPORT_NODE_S_0_0 {
     pub frame: u8,
     pub second: u8,
     pub minute: u8,
@@ -3489,20 +3489,20 @@ pub union KSPROPERTY_EXTXPORT_S_0 {
     pub LoadMedium: u32,
     pub MediumInfo: MEDIUM_INFO,
     pub XPrtState: TRANSPORT_STATE,
-    pub Timecode: KSPROPERTY_EXTXPORT_S_0_1,
+    pub Timecode: KSPROPERTY_EXTXPORT_S_0_0,
     pub dwTimecode: u32,
     pub dwAbsTrackNumber: u32,
-    pub RawAVC: KSPROPERTY_EXTXPORT_S_0_0,
+    pub RawAVC: KSPROPERTY_EXTXPORT_S_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct KSPROPERTY_EXTXPORT_S_0_0 {
+pub struct KSPROPERTY_EXTXPORT_S_0_1 {
     pub PayloadSize: u32,
     pub Payload: [u8; 512],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct KSPROPERTY_EXTXPORT_S_0_1 {
+pub struct KSPROPERTY_EXTXPORT_S_0_0 {
     pub frame: u8,
     pub second: u8,
     pub minute: u8,

--- a/crates/libs/sys/src/Windows/Win32/Media/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Media/mod.rs
@@ -136,17 +136,17 @@ pub union MMTIME_0 {
     pub sample: u32,
     pub cb: u32,
     pub ticks: u32,
-    pub smpte: MMTIME_0_1,
-    pub midi: MMTIME_0_0,
+    pub smpte: MMTIME_0_0,
+    pub midi: MMTIME_0_1,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct MMTIME_0_0 {
+pub struct MMTIME_0_1 {
     pub songptrpos: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MMTIME_0_1 {
+pub struct MMTIME_0_0 {
     pub hour: u8,
     pub min: u8,
     pub sec: u8,

--- a/crates/libs/sys/src/Windows/Win32/NetworkManagement/Dns/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/NetworkManagement/Dns/mod.rs
@@ -916,14 +916,14 @@ pub struct DNS_RECORDA {
     pub pName: windows_sys::core::PSTR,
     pub wType: u16,
     pub wDataLength: u16,
-    pub Flags: DNS_RECORDA_1,
+    pub Flags: DNS_RECORDA_0,
     pub dwTtl: u32,
     pub dwReserved: u32,
-    pub Data: DNS_RECORDA_0,
+    pub Data: DNS_RECORDA_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORDA_0 {
+pub union DNS_RECORDA_1 {
     pub A: DNS_A_DATA,
     pub SOA: DNS_SOA_DATAA,
     pub Soa: DNS_SOA_DATAA,
@@ -1013,7 +1013,7 @@ pub union DNS_RECORDA_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORDA_1 {
+pub union DNS_RECORDA_0 {
     pub DW: u32,
     pub S: DNS_RECORD_FLAGS,
 }
@@ -1024,14 +1024,14 @@ pub struct DNS_RECORDW {
     pub pName: windows_sys::core::PWSTR,
     pub wType: u16,
     pub wDataLength: u16,
-    pub Flags: DNS_RECORDW_1,
+    pub Flags: DNS_RECORDW_0,
     pub dwTtl: u32,
     pub dwReserved: u32,
-    pub Data: DNS_RECORDW_0,
+    pub Data: DNS_RECORDW_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORDW_0 {
+pub union DNS_RECORDW_1 {
     pub A: DNS_A_DATA,
     pub SOA: DNS_SOA_DATAW,
     pub Soa: DNS_SOA_DATAW,
@@ -1121,7 +1121,7 @@ pub union DNS_RECORDW_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORDW_1 {
+pub union DNS_RECORDW_0 {
     pub DW: u32,
     pub S: DNS_RECORD_FLAGS,
 }
@@ -1137,21 +1137,21 @@ pub struct DNS_RECORD_OPTW {
     pub pName: windows_sys::core::PWSTR,
     pub wType: u16,
     pub wDataLength: u16,
-    pub Flags: DNS_RECORD_OPTW_1,
+    pub Flags: DNS_RECORD_OPTW_0,
     pub ExtHeader: DNS_HEADER_EXT,
     pub wPayloadSize: u16,
     pub wReserved: u16,
-    pub Data: DNS_RECORD_OPTW_0,
+    pub Data: DNS_RECORD_OPTW_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORD_OPTW_0 {
+pub union DNS_RECORD_OPTW_1 {
     pub OPT: DNS_OPT_DATA,
     pub Opt: DNS_OPT_DATA,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORD_OPTW_1 {
+pub union DNS_RECORD_OPTW_0 {
     pub DW: u32,
     pub S: DNS_RECORD_FLAGS,
 }
@@ -1537,21 +1537,21 @@ pub struct _DnsRecordOptA {
     pub pName: windows_sys::core::PSTR,
     pub wType: u16,
     pub wDataLength: u16,
-    pub Flags: _DnsRecordOptA_1,
+    pub Flags: _DnsRecordOptA_0,
     pub ExtHeader: DNS_HEADER_EXT,
     pub wPayloadSize: u16,
     pub wReserved: u16,
-    pub Data: _DnsRecordOptA_0,
+    pub Data: _DnsRecordOptA_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union _DnsRecordOptA_0 {
+pub union _DnsRecordOptA_1 {
     pub OPT: DNS_OPT_DATA,
     pub Opt: DNS_OPT_DATA,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union _DnsRecordOptA_1 {
+pub union _DnsRecordOptA_0 {
     pub DW: u32,
     pub S: DNS_RECORD_FLAGS,
 }

--- a/crates/libs/sys/src/Windows/Win32/NetworkManagement/Ndis/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/NetworkManagement/Ndis/mod.rs
@@ -2519,14 +2519,9 @@ pub struct NDIS_INTERRUPT_MODERATION_PARAMETERS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_IPSEC_OFFLOAD_V1 {
-    pub Supported: NDIS_IPSEC_OFFLOAD_V1_2,
-    pub IPv4AH: NDIS_IPSEC_OFFLOAD_V1_0,
-    pub IPv4ESP: NDIS_IPSEC_OFFLOAD_V1_1,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NDIS_IPSEC_OFFLOAD_V1_0 {
-    pub _bitfield: u32,
+    pub Supported: NDIS_IPSEC_OFFLOAD_V1_0,
+    pub IPv4AH: NDIS_IPSEC_OFFLOAD_V1_1,
+    pub IPv4ESP: NDIS_IPSEC_OFFLOAD_V1_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2536,6 +2531,11 @@ pub struct NDIS_IPSEC_OFFLOAD_V1_1 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_IPSEC_OFFLOAD_V1_2 {
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NDIS_IPSEC_OFFLOAD_V1_0 {
     pub Encapsulation: u32,
     pub AhEspCombined: u32,
     pub TransportTunnelCombined: u32,
@@ -2815,16 +2815,10 @@ pub struct NDIS_TCP_CONNECTION_OFFLOAD {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD {
-    pub IPv4Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_1,
-    pub IPv4Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_0,
-    pub IPv6Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_3,
-    pub IPv6Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_2,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    pub Encapsulation: u32,
-    pub _bitfield: u32,
+    pub IPv4Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_0,
+    pub IPv4Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_1,
+    pub IPv6Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv6Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2834,13 +2828,19 @@ pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     pub Encapsulation: u32,
     pub _bitfield: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
+    pub Encapsulation: u32,
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
     pub Encapsulation: u32,
     pub _bitfield: u32,
 }
@@ -2981,13 +2981,13 @@ pub struct NDIS_WMI_EVENT_HEADER {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_WMI_IPSEC_OFFLOAD_V1 {
-    pub Supported: NDIS_WMI_IPSEC_OFFLOAD_V1_2,
-    pub IPv4AH: NDIS_WMI_IPSEC_OFFLOAD_V1_0,
-    pub IPv4ESP: NDIS_WMI_IPSEC_OFFLOAD_V1_1,
+    pub Supported: NDIS_WMI_IPSEC_OFFLOAD_V1_0,
+    pub IPv4AH: NDIS_WMI_IPSEC_OFFLOAD_V1_1,
+    pub IPv4ESP: NDIS_WMI_IPSEC_OFFLOAD_V1_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
+pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
     pub Md5: u32,
     pub Sha_1: u32,
     pub Transport: u32,
@@ -2997,7 +2997,7 @@ pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
+pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
     pub Des: u32,
     pub Reserved: u32,
     pub TripleDes: u32,
@@ -3009,7 +3009,7 @@ pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     pub Encapsulation: u32,
     pub AhEspCombined: u32,
     pub TransportTunnelCombined: u32,
@@ -3069,20 +3069,10 @@ pub struct NDIS_WMI_TCP_CONNECTION_OFFLOAD {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
-    pub IPv4Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1,
-    pub IPv4Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0,
-    pub IPv6Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3,
-    pub IPv6Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    pub Encapsulation: u32,
-    pub IpOptionsSupported: u32,
-    pub TcpOptionsSupported: u32,
-    pub TcpChecksum: u32,
-    pub UdpChecksum: u32,
-    pub IpChecksum: u32,
+    pub IPv4Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0,
+    pub IPv4Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1,
+    pub IPv6Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv6Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3096,7 +3086,17 @@ pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
+    pub Encapsulation: u32,
+    pub IpOptionsSupported: u32,
+    pub TcpOptionsSupported: u32,
+    pub TcpChecksum: u32,
+    pub UdpChecksum: u32,
+    pub IpChecksum: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
     pub Encapsulation: u32,
     pub IpExtensionHeadersSupported: u32,
     pub TcpOptionsSupported: u32,
@@ -3105,7 +3105,7 @@ pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
+pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
     pub Encapsulation: u32,
     pub IpExtensionHeadersSupported: u32,
     pub TcpOptionsSupported: u32,

--- a/crates/libs/sys/src/Windows/Win32/NetworkManagement/QoS/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/NetworkManagement/QoS/mod.rs
@@ -876,20 +876,20 @@ pub struct IP_PATTERN {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IP_PATTERN_0 {
-    pub S_un_ports: IP_PATTERN_0_1,
-    pub S_un_icmp: IP_PATTERN_0_0,
+    pub S_un_ports: IP_PATTERN_0_0,
+    pub S_un_icmp: IP_PATTERN_0_1,
     pub S_Spi: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IP_PATTERN_0_0 {
+pub struct IP_PATTERN_0_1 {
     pub s_type: u8,
     pub s_code: u8,
     pub filler: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IP_PATTERN_0_1 {
+pub struct IP_PATTERN_0_0 {
     pub s_srcport: u16,
     pub s_dstport: u16,
 }

--- a/crates/libs/sys/src/Windows/Win32/Networking/HttpServer/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Networking/HttpServer/mod.rs
@@ -522,21 +522,21 @@ pub struct HTTP_DATA_CHUNK {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HTTP_DATA_CHUNK_0 {
-    pub FromMemory: HTTP_DATA_CHUNK_0_3,
-    pub FromFileHandle: HTTP_DATA_CHUNK_0_0,
+    pub FromMemory: HTTP_DATA_CHUNK_0_0,
+    pub FromFileHandle: HTTP_DATA_CHUNK_0_1,
     pub FromFragmentCache: HTTP_DATA_CHUNK_0_2,
-    pub FromFragmentCacheEx: HTTP_DATA_CHUNK_0_1,
+    pub FromFragmentCacheEx: HTTP_DATA_CHUNK_0_3,
     pub Trailers: HTTP_DATA_CHUNK_0_4,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct HTTP_DATA_CHUNK_0_0 {
+pub struct HTTP_DATA_CHUNK_0_1 {
     pub ByteRange: HTTP_BYTE_RANGE,
     pub FileHandle: super::super::Foundation::HANDLE,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct HTTP_DATA_CHUNK_0_1 {
+pub struct HTTP_DATA_CHUNK_0_3 {
     pub ByteRange: HTTP_BYTE_RANGE,
     pub pFragmentName: windows_sys::core::PCWSTR,
 }
@@ -548,7 +548,7 @@ pub struct HTTP_DATA_CHUNK_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct HTTP_DATA_CHUNK_0_3 {
+pub struct HTTP_DATA_CHUNK_0_0 {
     pub pBuffer: *mut core::ffi::c_void,
     pub BufferLength: u32,
 }

--- a/crates/libs/sys/src/Windows/Win32/Networking/WebSocket/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Networking/WebSocket/mod.rs
@@ -54,19 +54,19 @@ pub type WEB_SOCKET_PROPERTY_TYPE = i32;
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WEB_SOCKET_BUFFER {
-    pub Data: WEB_SOCKET_BUFFER_1,
-    pub CloseStatus: WEB_SOCKET_BUFFER_0,
+    pub Data: WEB_SOCKET_BUFFER_0,
+    pub CloseStatus: WEB_SOCKET_BUFFER_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WEB_SOCKET_BUFFER_0 {
+pub struct WEB_SOCKET_BUFFER_1 {
     pub pbReason: *mut u8,
     pub ulReasonLength: u32,
     pub usStatus: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WEB_SOCKET_BUFFER_1 {
+pub struct WEB_SOCKET_BUFFER_0 {
     pub pbBuffer: *mut u8,
     pub ulBufferLength: u32,
 }

--- a/crates/libs/sys/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -3206,26 +3206,26 @@ pub struct NETRESOURCE2W {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NLA_BLOB {
-    pub header: NLA_BLOB_1,
-    pub data: NLA_BLOB_0,
+    pub header: NLA_BLOB_0,
+    pub data: NLA_BLOB_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union NLA_BLOB_0 {
+pub union NLA_BLOB_1 {
     pub rawData: [i8; 1],
-    pub interfaceData: NLA_BLOB_0_2,
-    pub locationData: NLA_BLOB_0_3,
-    pub connectivity: NLA_BLOB_0_1,
-    pub ICS: NLA_BLOB_0_0,
+    pub interfaceData: NLA_BLOB_1_0,
+    pub locationData: NLA_BLOB_1_1,
+    pub connectivity: NLA_BLOB_1_2,
+    pub ICS: NLA_BLOB_1_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NLA_BLOB_0_0 {
-    pub remote: NLA_BLOB_0_0_0,
+pub struct NLA_BLOB_1_3 {
+    pub remote: NLA_BLOB_1_3_0,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NLA_BLOB_0_0_0 {
+pub struct NLA_BLOB_1_3_0 {
     pub speed: u32,
     pub r#type: u32,
     pub state: u32,
@@ -3234,25 +3234,25 @@ pub struct NLA_BLOB_0_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NLA_BLOB_0_1 {
+pub struct NLA_BLOB_1_2 {
     pub r#type: NLA_CONNECTIVITY_TYPE,
     pub internet: NLA_INTERNET,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NLA_BLOB_0_2 {
+pub struct NLA_BLOB_1_0 {
     pub dwType: u32,
     pub dwSpeed: u32,
     pub adapterName: [i8; 1],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NLA_BLOB_0_3 {
+pub struct NLA_BLOB_1_1 {
     pub information: [i8; 1],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NLA_BLOB_1 {
+pub struct NLA_BLOB_0 {
     pub r#type: NLA_BLOB_DATA_TYPE,
     pub dwSize: u32,
     pub nextOffset: u32,
@@ -4228,15 +4228,15 @@ pub struct WSACOMPLETION {
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy)]
 pub union WSACOMPLETION_0 {
-    pub WindowMessage: WSACOMPLETION_0_3,
+    pub WindowMessage: WSACOMPLETION_0_0,
     pub Event: WSACOMPLETION_0_1,
-    pub Apc: WSACOMPLETION_0_0,
-    pub Port: WSACOMPLETION_0_2,
+    pub Apc: WSACOMPLETION_0_2,
+    pub Port: WSACOMPLETION_0_3,
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy)]
-pub struct WSACOMPLETION_0_0 {
+pub struct WSACOMPLETION_0_2 {
     pub lpOverlapped: *mut super::super::System::IO::OVERLAPPED,
     pub lpfnCompletionProc: LPWSAOVERLAPPED_COMPLETION_ROUTINE,
 }
@@ -4249,7 +4249,7 @@ pub struct WSACOMPLETION_0_1 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy)]
-pub struct WSACOMPLETION_0_2 {
+pub struct WSACOMPLETION_0_3 {
     pub lpOverlapped: *mut super::super::System::IO::OVERLAPPED,
     pub hPort: super::super::Foundation::HANDLE,
     pub Key: usize,
@@ -4257,7 +4257,7 @@ pub struct WSACOMPLETION_0_2 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy)]
-pub struct WSACOMPLETION_0_3 {
+pub struct WSACOMPLETION_0_0 {
     pub hWnd: super::super::Foundation::HWND,
     pub uMsg: u32,
     pub context: super::super::Foundation::WPARAM,

--- a/crates/libs/sys/src/Windows/Win32/Storage/Cabinets/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/Cabinets/mod.rs
@@ -126,8 +126,8 @@ pub struct FDIDECRYPT {
 #[derive(Clone, Copy)]
 pub union FDIDECRYPT_0 {
     pub cabinet: FDIDECRYPT_0_0,
-    pub folder: FDIDECRYPT_0_2,
-    pub decrypt: FDIDECRYPT_0_1,
+    pub folder: FDIDECRYPT_0_1,
+    pub decrypt: FDIDECRYPT_0_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -139,7 +139,7 @@ pub struct FDIDECRYPT_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FDIDECRYPT_0_1 {
+pub struct FDIDECRYPT_0_2 {
     pub pDataReserve: *mut core::ffi::c_void,
     pub cbDataReserve: u16,
     pub pbData: *mut core::ffi::c_void,
@@ -149,7 +149,7 @@ pub struct FDIDECRYPT_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FDIDECRYPT_0_2 {
+pub struct FDIDECRYPT_0_1 {
     pub pFolderReserve: *mut core::ffi::c_void,
     pub cbFolderReserve: u16,
     pub iFolder: u16,

--- a/crates/libs/sys/src/Windows/Win32/Storage/CloudFilters/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/CloudFilters/mod.rs
@@ -316,17 +316,17 @@ pub struct CF_CALLBACK_PARAMETERS {
 #[derive(Clone, Copy)]
 pub union CF_CALLBACK_PARAMETERS_0 {
     pub Cancel: CF_CALLBACK_PARAMETERS_0_0,
-    pub FetchData: CF_CALLBACK_PARAMETERS_0_6,
-    pub ValidateData: CF_CALLBACK_PARAMETERS_0_11,
-    pub FetchPlaceholders: CF_CALLBACK_PARAMETERS_0_7,
-    pub OpenCompletion: CF_CALLBACK_PARAMETERS_0_8,
-    pub CloseCompletion: CF_CALLBACK_PARAMETERS_0_1,
-    pub Dehydrate: CF_CALLBACK_PARAMETERS_0_3,
-    pub DehydrateCompletion: CF_CALLBACK_PARAMETERS_0_2,
-    pub Delete: CF_CALLBACK_PARAMETERS_0_5,
-    pub DeleteCompletion: CF_CALLBACK_PARAMETERS_0_4,
+    pub FetchData: CF_CALLBACK_PARAMETERS_0_1,
+    pub ValidateData: CF_CALLBACK_PARAMETERS_0_2,
+    pub FetchPlaceholders: CF_CALLBACK_PARAMETERS_0_3,
+    pub OpenCompletion: CF_CALLBACK_PARAMETERS_0_4,
+    pub CloseCompletion: CF_CALLBACK_PARAMETERS_0_5,
+    pub Dehydrate: CF_CALLBACK_PARAMETERS_0_6,
+    pub DehydrateCompletion: CF_CALLBACK_PARAMETERS_0_7,
+    pub Delete: CF_CALLBACK_PARAMETERS_0_8,
+    pub DeleteCompletion: CF_CALLBACK_PARAMETERS_0_9,
     pub Rename: CF_CALLBACK_PARAMETERS_0_10,
-    pub RenameCompletion: CF_CALLBACK_PARAMETERS_0_9,
+    pub RenameCompletion: CF_CALLBACK_PARAMETERS_0_11,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -347,34 +347,34 @@ pub struct CF_CALLBACK_PARAMETERS_0_0_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CF_CALLBACK_PARAMETERS_0_1 {
+pub struct CF_CALLBACK_PARAMETERS_0_5 {
     pub Flags: CF_CALLBACK_CLOSE_COMPLETION_FLAGS,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CF_CALLBACK_PARAMETERS_0_2 {
+pub struct CF_CALLBACK_PARAMETERS_0_7 {
     pub Flags: CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS,
     pub Reason: CF_CALLBACK_DEHYDRATION_REASON,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CF_CALLBACK_PARAMETERS_0_3 {
+pub struct CF_CALLBACK_PARAMETERS_0_6 {
     pub Flags: CF_CALLBACK_DEHYDRATE_FLAGS,
     pub Reason: CF_CALLBACK_DEHYDRATION_REASON,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CF_CALLBACK_PARAMETERS_0_4 {
+pub struct CF_CALLBACK_PARAMETERS_0_9 {
     pub Flags: CF_CALLBACK_DELETE_COMPLETION_FLAGS,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CF_CALLBACK_PARAMETERS_0_5 {
+pub struct CF_CALLBACK_PARAMETERS_0_8 {
     pub Flags: CF_CALLBACK_DELETE_FLAGS,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CF_CALLBACK_PARAMETERS_0_6 {
+pub struct CF_CALLBACK_PARAMETERS_0_1 {
     pub Flags: CF_CALLBACK_FETCH_DATA_FLAGS,
     pub RequiredFileOffset: i64,
     pub RequiredLength: i64,
@@ -385,18 +385,18 @@ pub struct CF_CALLBACK_PARAMETERS_0_6 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CF_CALLBACK_PARAMETERS_0_7 {
+pub struct CF_CALLBACK_PARAMETERS_0_3 {
     pub Flags: CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS,
     pub Pattern: windows_sys::core::PCWSTR,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CF_CALLBACK_PARAMETERS_0_8 {
+pub struct CF_CALLBACK_PARAMETERS_0_4 {
     pub Flags: CF_CALLBACK_OPEN_COMPLETION_FLAGS,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CF_CALLBACK_PARAMETERS_0_9 {
+pub struct CF_CALLBACK_PARAMETERS_0_11 {
     pub Flags: CF_CALLBACK_RENAME_COMPLETION_FLAGS,
     pub SourcePath: windows_sys::core::PCWSTR,
 }
@@ -408,7 +408,7 @@ pub struct CF_CALLBACK_PARAMETERS_0_10 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CF_CALLBACK_PARAMETERS_0_11 {
+pub struct CF_CALLBACK_PARAMETERS_0_2 {
     pub Flags: CF_CALLBACK_VALIDATE_DATA_FLAGS,
     pub RequiredFileOffset: i64,
     pub RequiredLength: i64,
@@ -463,19 +463,19 @@ pub struct CF_OPERATION_PARAMETERS {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
 pub union CF_OPERATION_PARAMETERS_0 {
-    pub TransferData: CF_OPERATION_PARAMETERS_0_6,
-    pub RetrieveData: CF_OPERATION_PARAMETERS_0_5,
-    pub AckData: CF_OPERATION_PARAMETERS_0_0,
-    pub RestartHydration: CF_OPERATION_PARAMETERS_0_4,
-    pub TransferPlaceholders: CF_OPERATION_PARAMETERS_0_7,
-    pub AckDehydrate: CF_OPERATION_PARAMETERS_0_1,
-    pub AckRename: CF_OPERATION_PARAMETERS_0_3,
-    pub AckDelete: CF_OPERATION_PARAMETERS_0_2,
+    pub TransferData: CF_OPERATION_PARAMETERS_0_0,
+    pub RetrieveData: CF_OPERATION_PARAMETERS_0_1,
+    pub AckData: CF_OPERATION_PARAMETERS_0_2,
+    pub RestartHydration: CF_OPERATION_PARAMETERS_0_3,
+    pub TransferPlaceholders: CF_OPERATION_PARAMETERS_0_4,
+    pub AckDehydrate: CF_OPERATION_PARAMETERS_0_5,
+    pub AckRename: CF_OPERATION_PARAMETERS_0_6,
+    pub AckDelete: CF_OPERATION_PARAMETERS_0_7,
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
-pub struct CF_OPERATION_PARAMETERS_0_0 {
+pub struct CF_OPERATION_PARAMETERS_0_2 {
     pub Flags: CF_OPERATION_ACK_DATA_FLAGS,
     pub CompletionStatus: super::super::Foundation::NTSTATUS,
     pub Offset: i64,
@@ -484,7 +484,7 @@ pub struct CF_OPERATION_PARAMETERS_0_0 {
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
-pub struct CF_OPERATION_PARAMETERS_0_1 {
+pub struct CF_OPERATION_PARAMETERS_0_5 {
     pub Flags: CF_OPERATION_ACK_DEHYDRATE_FLAGS,
     pub CompletionStatus: super::super::Foundation::NTSTATUS,
     pub FileIdentity: *const core::ffi::c_void,
@@ -493,21 +493,21 @@ pub struct CF_OPERATION_PARAMETERS_0_1 {
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
-pub struct CF_OPERATION_PARAMETERS_0_2 {
+pub struct CF_OPERATION_PARAMETERS_0_7 {
     pub Flags: CF_OPERATION_ACK_DELETE_FLAGS,
     pub CompletionStatus: super::super::Foundation::NTSTATUS,
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
-pub struct CF_OPERATION_PARAMETERS_0_3 {
+pub struct CF_OPERATION_PARAMETERS_0_6 {
     pub Flags: CF_OPERATION_ACK_RENAME_FLAGS,
     pub CompletionStatus: super::super::Foundation::NTSTATUS,
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
-pub struct CF_OPERATION_PARAMETERS_0_4 {
+pub struct CF_OPERATION_PARAMETERS_0_3 {
     pub Flags: CF_OPERATION_RESTART_HYDRATION_FLAGS,
     pub FsMetadata: *const CF_FS_METADATA,
     pub FileIdentity: *const core::ffi::c_void,
@@ -516,7 +516,7 @@ pub struct CF_OPERATION_PARAMETERS_0_4 {
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
-pub struct CF_OPERATION_PARAMETERS_0_5 {
+pub struct CF_OPERATION_PARAMETERS_0_1 {
     pub Flags: CF_OPERATION_RETRIEVE_DATA_FLAGS,
     pub Buffer: *mut core::ffi::c_void,
     pub Offset: i64,
@@ -526,7 +526,7 @@ pub struct CF_OPERATION_PARAMETERS_0_5 {
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
-pub struct CF_OPERATION_PARAMETERS_0_6 {
+pub struct CF_OPERATION_PARAMETERS_0_0 {
     pub Flags: CF_OPERATION_TRANSFER_DATA_FLAGS,
     pub CompletionStatus: super::super::Foundation::NTSTATUS,
     pub Buffer: *const core::ffi::c_void,
@@ -536,7 +536,7 @@ pub struct CF_OPERATION_PARAMETERS_0_6 {
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
-pub struct CF_OPERATION_PARAMETERS_0_7 {
+pub struct CF_OPERATION_PARAMETERS_0_4 {
     pub Flags: CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS,
     pub CompletionStatus: super::super::Foundation::NTSTATUS,
     pub PlaceholderTotalCount: i64,

--- a/crates/libs/sys/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -1591,52 +1591,52 @@ pub struct CLFS_MGMT_POLICY {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CLFS_MGMT_POLICY_0 {
-    pub MaximumSize: CLFS_MGMT_POLICY_0_4,
-    pub MinimumSize: CLFS_MGMT_POLICY_0_5,
-    pub NewContainerSize: CLFS_MGMT_POLICY_0_8,
-    pub GrowthRate: CLFS_MGMT_POLICY_0_2,
-    pub LogTail: CLFS_MGMT_POLICY_0_3,
-    pub AutoShrink: CLFS_MGMT_POLICY_0_1,
-    pub AutoGrow: CLFS_MGMT_POLICY_0_0,
+    pub MaximumSize: CLFS_MGMT_POLICY_0_0,
+    pub MinimumSize: CLFS_MGMT_POLICY_0_1,
+    pub NewContainerSize: CLFS_MGMT_POLICY_0_2,
+    pub GrowthRate: CLFS_MGMT_POLICY_0_3,
+    pub LogTail: CLFS_MGMT_POLICY_0_4,
+    pub AutoShrink: CLFS_MGMT_POLICY_0_5,
+    pub AutoGrow: CLFS_MGMT_POLICY_0_6,
     pub NewContainerPrefix: CLFS_MGMT_POLICY_0_7,
-    pub NewContainerSuffix: CLFS_MGMT_POLICY_0_9,
-    pub NewContainerExtension: CLFS_MGMT_POLICY_0_6,
+    pub NewContainerSuffix: CLFS_MGMT_POLICY_0_8,
+    pub NewContainerExtension: CLFS_MGMT_POLICY_0_9,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CLFS_MGMT_POLICY_0_0 {
+pub struct CLFS_MGMT_POLICY_0_6 {
     pub Enabled: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CLFS_MGMT_POLICY_0_1 {
+pub struct CLFS_MGMT_POLICY_0_5 {
     pub Percentage: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CLFS_MGMT_POLICY_0_2 {
+pub struct CLFS_MGMT_POLICY_0_3 {
     pub AbsoluteGrowthInContainers: u32,
     pub RelativeGrowthPercentage: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CLFS_MGMT_POLICY_0_3 {
+pub struct CLFS_MGMT_POLICY_0_4 {
     pub MinimumAvailablePercentage: u32,
     pub MinimumAvailableContainers: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CLFS_MGMT_POLICY_0_4 {
+pub struct CLFS_MGMT_POLICY_0_0 {
     pub Containers: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CLFS_MGMT_POLICY_0_5 {
+pub struct CLFS_MGMT_POLICY_0_1 {
     pub Containers: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CLFS_MGMT_POLICY_0_6 {
+pub struct CLFS_MGMT_POLICY_0_9 {
     pub ExtensionLengthInBytes: u16,
     pub ExtensionString: [u16; 1],
 }
@@ -1648,12 +1648,12 @@ pub struct CLFS_MGMT_POLICY_0_7 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CLFS_MGMT_POLICY_0_8 {
+pub struct CLFS_MGMT_POLICY_0_2 {
     pub SizeInBytes: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CLFS_MGMT_POLICY_0_9 {
+pub struct CLFS_MGMT_POLICY_0_8 {
     pub NextContainerSuffix: u64,
 }
 #[repr(C)]
@@ -1805,16 +1805,16 @@ pub struct COPYFILE2_MESSAGE {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union COPYFILE2_MESSAGE_0 {
-    pub ChunkStarted: COPYFILE2_MESSAGE_0_1,
-    pub ChunkFinished: COPYFILE2_MESSAGE_0_0,
-    pub StreamStarted: COPYFILE2_MESSAGE_0_5,
-    pub StreamFinished: COPYFILE2_MESSAGE_0_4,
-    pub PollContinue: COPYFILE2_MESSAGE_0_3,
-    pub Error: COPYFILE2_MESSAGE_0_2,
+    pub ChunkStarted: COPYFILE2_MESSAGE_0_0,
+    pub ChunkFinished: COPYFILE2_MESSAGE_0_1,
+    pub StreamStarted: COPYFILE2_MESSAGE_0_2,
+    pub StreamFinished: COPYFILE2_MESSAGE_0_3,
+    pub PollContinue: COPYFILE2_MESSAGE_0_4,
+    pub Error: COPYFILE2_MESSAGE_0_5,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct COPYFILE2_MESSAGE_0_0 {
+pub struct COPYFILE2_MESSAGE_0_1 {
     pub dwStreamNumber: u32,
     pub dwFlags: u32,
     pub hSourceFile: super::super::Foundation::HANDLE,
@@ -1828,7 +1828,7 @@ pub struct COPYFILE2_MESSAGE_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct COPYFILE2_MESSAGE_0_1 {
+pub struct COPYFILE2_MESSAGE_0_0 {
     pub dwStreamNumber: u32,
     pub dwReserved: u32,
     pub hSourceFile: super::super::Foundation::HANDLE,
@@ -1840,7 +1840,7 @@ pub struct COPYFILE2_MESSAGE_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct COPYFILE2_MESSAGE_0_2 {
+pub struct COPYFILE2_MESSAGE_0_5 {
     pub CopyPhase: COPYFILE2_COPY_PHASE,
     pub dwStreamNumber: u32,
     pub hrFailure: windows_sys::core::HRESULT,
@@ -1853,12 +1853,12 @@ pub struct COPYFILE2_MESSAGE_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct COPYFILE2_MESSAGE_0_3 {
+pub struct COPYFILE2_MESSAGE_0_4 {
     pub dwReserved: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct COPYFILE2_MESSAGE_0_4 {
+pub struct COPYFILE2_MESSAGE_0_3 {
     pub dwStreamNumber: u32,
     pub dwReserved: u32,
     pub hSourceFile: super::super::Foundation::HANDLE,
@@ -1870,7 +1870,7 @@ pub struct COPYFILE2_MESSAGE_0_4 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct COPYFILE2_MESSAGE_0_5 {
+pub struct COPYFILE2_MESSAGE_0_2 {
     pub dwStreamNumber: u32,
     pub dwReserved: u32,
     pub hSourceFile: super::super::Foundation::HANDLE,

--- a/crates/libs/sys/src/Windows/Win32/Storage/InstallableFileSystems/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/InstallableFileSystems/mod.rs
@@ -168,18 +168,18 @@ pub struct FILTER_AGGREGATE_BASIC_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILTER_AGGREGATE_BASIC_INFORMATION_0 {
-    pub MiniFilter: FILTER_AGGREGATE_BASIC_INFORMATION_0_1,
-    pub LegacyFilter: FILTER_AGGREGATE_BASIC_INFORMATION_0_0,
+    pub MiniFilter: FILTER_AGGREGATE_BASIC_INFORMATION_0_0,
+    pub LegacyFilter: FILTER_AGGREGATE_BASIC_INFORMATION_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
+pub struct FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
     pub FilterNameLength: u16,
     pub FilterNameBufferOffset: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
+pub struct FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
     pub FrameID: u32,
     pub NumberOfInstances: u32,
     pub FilterNameLength: u16,
@@ -197,12 +197,12 @@ pub struct FILTER_AGGREGATE_STANDARD_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
-    pub MiniFilter: FILTER_AGGREGATE_STANDARD_INFORMATION_0_1,
-    pub LegacyFilter: FILTER_AGGREGATE_STANDARD_INFORMATION_0_0,
+    pub MiniFilter: FILTER_AGGREGATE_STANDARD_INFORMATION_0_0,
+    pub LegacyFilter: FILTER_AGGREGATE_STANDARD_INFORMATION_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
+pub struct FILTER_AGGREGATE_STANDARD_INFORMATION_0_1 {
     pub Flags: u32,
     pub FilterNameLength: u16,
     pub FilterNameBufferOffset: u16,
@@ -211,7 +211,7 @@ pub struct FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct FILTER_AGGREGATE_STANDARD_INFORMATION_0_1 {
+pub struct FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
     pub Flags: u32,
     pub FrameID: u32,
     pub NumberOfInstances: u32,
@@ -269,12 +269,12 @@ pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
-    pub MiniFilter: INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1,
-    pub LegacyFilter: INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0,
+    pub MiniFilter: INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0,
+    pub LegacyFilter: INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
+pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
     pub Flags: u32,
     pub AltitudeLength: u16,
     pub AltitudeBufferOffset: u16,
@@ -286,7 +286,7 @@ pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
+pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
     pub Flags: u32,
     pub FrameID: u32,
     pub VolumeFileSystemType: FLT_FILESYSTEM_TYPE,

--- a/crates/libs/sys/src/Windows/Win32/Storage/Nvme/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/Nvme/mod.rs
@@ -1603,35 +1603,35 @@ pub struct NVME_COMMAND {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_COMMAND_0 {
-    pub GENERAL: NVME_COMMAND_0_9,
-    pub IDENTIFY: NVME_COMMAND_0_12,
-    pub ABORT: NVME_COMMAND_0_0,
-    pub GETFEATURES: NVME_COMMAND_0_10,
-    pub SETFEATURES: NVME_COMMAND_0_21,
-    pub GETLOGPAGE: NVME_COMMAND_0_11,
-    pub CREATEIOCQ: NVME_COMMAND_0_1,
-    pub CREATEIOSQ: NVME_COMMAND_0_2,
-    pub DATASETMANAGEMENT: NVME_COMMAND_0_3,
-    pub SECURITYSEND: NVME_COMMAND_0_20,
-    pub SECURITYRECEIVE: NVME_COMMAND_0_19,
-    pub FIRMWAREDOWNLOAD: NVME_COMMAND_0_7,
-    pub FIRMWAREACTIVATE: NVME_COMMAND_0_6,
-    pub FORMATNVM: NVME_COMMAND_0_8,
-    pub DIRECTIVERECEIVE: NVME_COMMAND_0_4,
-    pub DIRECTIVESEND: NVME_COMMAND_0_5,
-    pub SANITIZE: NVME_COMMAND_0_18,
-    pub READWRITE: NVME_COMMAND_0_13,
-    pub RESERVATIONACQUIRE: NVME_COMMAND_0_14,
-    pub RESERVATIONREGISTER: NVME_COMMAND_0_15,
-    pub RESERVATIONRELEASE: NVME_COMMAND_0_16,
-    pub RESERVATIONREPORT: NVME_COMMAND_0_17,
-    pub ZONEMANAGEMENTSEND: NVME_COMMAND_0_24,
+    pub GENERAL: NVME_COMMAND_0_0,
+    pub IDENTIFY: NVME_COMMAND_0_1,
+    pub ABORT: NVME_COMMAND_0_2,
+    pub GETFEATURES: NVME_COMMAND_0_3,
+    pub SETFEATURES: NVME_COMMAND_0_4,
+    pub GETLOGPAGE: NVME_COMMAND_0_5,
+    pub CREATEIOCQ: NVME_COMMAND_0_6,
+    pub CREATEIOSQ: NVME_COMMAND_0_7,
+    pub DATASETMANAGEMENT: NVME_COMMAND_0_8,
+    pub SECURITYSEND: NVME_COMMAND_0_9,
+    pub SECURITYRECEIVE: NVME_COMMAND_0_10,
+    pub FIRMWAREDOWNLOAD: NVME_COMMAND_0_11,
+    pub FIRMWAREACTIVATE: NVME_COMMAND_0_12,
+    pub FORMATNVM: NVME_COMMAND_0_13,
+    pub DIRECTIVERECEIVE: NVME_COMMAND_0_14,
+    pub DIRECTIVESEND: NVME_COMMAND_0_15,
+    pub SANITIZE: NVME_COMMAND_0_16,
+    pub READWRITE: NVME_COMMAND_0_17,
+    pub RESERVATIONACQUIRE: NVME_COMMAND_0_18,
+    pub RESERVATIONREGISTER: NVME_COMMAND_0_19,
+    pub RESERVATIONRELEASE: NVME_COMMAND_0_20,
+    pub RESERVATIONREPORT: NVME_COMMAND_0_21,
+    pub ZONEMANAGEMENTSEND: NVME_COMMAND_0_22,
     pub ZONEMANAGEMENTRECEIVE: NVME_COMMAND_0_23,
-    pub ZONEAPPEND: NVME_COMMAND_0_22,
+    pub ZONEAPPEND: NVME_COMMAND_0_24,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_0 {
+pub struct NVME_COMMAND_0_2 {
     pub CDW10: NVME_CDW10_ABORT,
     pub CDW11: u32,
     pub CDW12: u32,
@@ -1641,7 +1641,7 @@ pub struct NVME_COMMAND_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_1 {
+pub struct NVME_COMMAND_0_6 {
     pub CDW10: NVME_CDW10_CREATE_IO_QUEUE,
     pub CDW11: NVME_CDW11_CREATE_IO_CQ,
     pub CDW12: u32,
@@ -1651,7 +1651,7 @@ pub struct NVME_COMMAND_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_2 {
+pub struct NVME_COMMAND_0_7 {
     pub CDW10: NVME_CDW10_CREATE_IO_QUEUE,
     pub CDW11: NVME_CDW11_CREATE_IO_SQ,
     pub CDW12: u32,
@@ -1661,7 +1661,7 @@ pub struct NVME_COMMAND_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_3 {
+pub struct NVME_COMMAND_0_8 {
     pub CDW10: NVME_CDW10_DATASET_MANAGEMENT,
     pub CDW11: NVME_CDW11_DATASET_MANAGEMENT,
     pub CDW12: u32,
@@ -1671,7 +1671,7 @@ pub struct NVME_COMMAND_0_3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_4 {
+pub struct NVME_COMMAND_0_14 {
     pub CDW10: NVME_CDW10_DIRECTIVE_RECEIVE,
     pub CDW11: NVME_CDW11_DIRECTIVE_RECEIVE,
     pub CDW12: NVME_CDW12_DIRECTIVE_RECEIVE,
@@ -1681,7 +1681,7 @@ pub struct NVME_COMMAND_0_4 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_5 {
+pub struct NVME_COMMAND_0_15 {
     pub CDW10: NVME_CDW10_DIRECTIVE_SEND,
     pub CDW11: NVME_CDW11_DIRECTIVE_SEND,
     pub CDW12: NVME_CDW12_DIRECTIVE_SEND,
@@ -1691,7 +1691,7 @@ pub struct NVME_COMMAND_0_5 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_6 {
+pub struct NVME_COMMAND_0_12 {
     pub CDW10: NVME_CDW10_FIRMWARE_ACTIVATE,
     pub CDW11: u32,
     pub CDW12: u32,
@@ -1701,7 +1701,7 @@ pub struct NVME_COMMAND_0_6 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_7 {
+pub struct NVME_COMMAND_0_11 {
     pub CDW10: NVME_CDW10_FIRMWARE_DOWNLOAD,
     pub CDW11: NVME_CDW11_FIRMWARE_DOWNLOAD,
     pub CDW12: u32,
@@ -1711,7 +1711,7 @@ pub struct NVME_COMMAND_0_7 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_8 {
+pub struct NVME_COMMAND_0_13 {
     pub CDW10: NVME_CDW10_FORMAT_NVM,
     pub CDW11: u32,
     pub CDW12: u32,
@@ -1721,7 +1721,7 @@ pub struct NVME_COMMAND_0_8 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_9 {
+pub struct NVME_COMMAND_0_0 {
     pub CDW10: u32,
     pub CDW11: u32,
     pub CDW12: u32,
@@ -1731,7 +1731,7 @@ pub struct NVME_COMMAND_0_9 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_10 {
+pub struct NVME_COMMAND_0_3 {
     pub CDW10: NVME_CDW10_GET_FEATURES,
     pub CDW11: NVME_CDW11_FEATURES,
     pub CDW12: u32,
@@ -1741,8 +1741,8 @@ pub struct NVME_COMMAND_0_10 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_11 {
-    pub Anonymous: NVME_COMMAND_0_11_0,
+pub struct NVME_COMMAND_0_5 {
+    pub Anonymous: NVME_COMMAND_0_5_0,
     pub CDW11: NVME_CDW11_GET_LOG_PAGE,
     pub CDW12: NVME_CDW12_GET_LOG_PAGE,
     pub CDW13: NVME_CDW13_GET_LOG_PAGE,
@@ -1751,13 +1751,13 @@ pub struct NVME_COMMAND_0_11 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union NVME_COMMAND_0_11_0 {
+pub union NVME_COMMAND_0_5_0 {
     pub CDW10: NVME_CDW10_GET_LOG_PAGE,
     pub CDW10_V13: NVME_CDW10_GET_LOG_PAGE_V13,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_12 {
+pub struct NVME_COMMAND_0_1 {
     pub CDW10: NVME_CDW10_IDENTIFY,
     pub CDW11: NVME_CDW11_IDENTIFY,
     pub CDW12: u32,
@@ -1767,7 +1767,7 @@ pub struct NVME_COMMAND_0_12 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_13 {
+pub struct NVME_COMMAND_0_17 {
     pub LBALOW: u32,
     pub LBAHIGH: u32,
     pub CDW12: NVME_CDW12_READ_WRITE,
@@ -1777,7 +1777,7 @@ pub struct NVME_COMMAND_0_13 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_14 {
+pub struct NVME_COMMAND_0_18 {
     pub CDW10: NVME_CDW10_RESERVATION_ACQUIRE,
     pub CDW11: u32,
     pub CDW12: u32,
@@ -1787,7 +1787,7 @@ pub struct NVME_COMMAND_0_14 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_15 {
+pub struct NVME_COMMAND_0_19 {
     pub CDW10: NVME_CDW10_RESERVATION_REGISTER,
     pub CDW11: u32,
     pub CDW12: u32,
@@ -1797,7 +1797,7 @@ pub struct NVME_COMMAND_0_15 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_16 {
+pub struct NVME_COMMAND_0_20 {
     pub CDW10: NVME_CDW10_RESERVATION_RELEASE,
     pub CDW11: u32,
     pub CDW12: u32,
@@ -1807,7 +1807,7 @@ pub struct NVME_COMMAND_0_16 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_17 {
+pub struct NVME_COMMAND_0_21 {
     pub CDW10: NVME_CDW10_RESERVATION_REPORT,
     pub CDW11: NVME_CDW11_RESERVATION_REPORT,
     pub CDW12: u32,
@@ -1817,7 +1817,7 @@ pub struct NVME_COMMAND_0_17 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_18 {
+pub struct NVME_COMMAND_0_16 {
     pub CDW10: NVME_CDW10_SANITIZE,
     pub CDW11: NVME_CDW11_SANITIZE,
     pub CDW12: u32,
@@ -1827,7 +1827,7 @@ pub struct NVME_COMMAND_0_18 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_19 {
+pub struct NVME_COMMAND_0_10 {
     pub CDW10: NVME_CDW10_SECURITY_SEND_RECEIVE,
     pub CDW11: NVME_CDW11_SECURITY_RECEIVE,
     pub CDW12: u32,
@@ -1837,7 +1837,7 @@ pub struct NVME_COMMAND_0_19 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_20 {
+pub struct NVME_COMMAND_0_9 {
     pub CDW10: NVME_CDW10_SECURITY_SEND_RECEIVE,
     pub CDW11: NVME_CDW11_SECURITY_SEND,
     pub CDW12: u32,
@@ -1847,7 +1847,7 @@ pub struct NVME_COMMAND_0_20 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_21 {
+pub struct NVME_COMMAND_0_4 {
     pub CDW10: NVME_CDW10_SET_FEATURES,
     pub CDW11: NVME_CDW11_FEATURES,
     pub CDW12: NVME_CDW12_FEATURES,
@@ -1857,7 +1857,7 @@ pub struct NVME_COMMAND_0_21 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_22 {
+pub struct NVME_COMMAND_0_24 {
     pub CDW1011: NVME_CDW10_ZONE_APPEND,
     pub CDW12: NVME_CDW12_ZONE_APPEND,
     pub CDW13: u32,
@@ -1875,7 +1875,7 @@ pub struct NVME_COMMAND_0_23 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_24 {
+pub struct NVME_COMMAND_0_22 {
     pub CDW1011: NVME_CDW10_ZONE_MANAGEMENT_SEND,
     pub CDW12: u32,
     pub CDW13: NVME_CDW13_ZONE_MANAGEMENT_SEND,
@@ -2076,34 +2076,39 @@ pub struct NVME_CONTROLLER_STATUS_0 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_DEVICE_SELF_TEST_LOG {
-    pub CurrentOperation: NVME_DEVICE_SELF_TEST_LOG_1,
-    pub CurrentCompletion: NVME_DEVICE_SELF_TEST_LOG_0,
+    pub CurrentOperation: NVME_DEVICE_SELF_TEST_LOG_0,
+    pub CurrentCompletion: NVME_DEVICE_SELF_TEST_LOG_1,
     pub Reserved: [u8; 2],
     pub ResultData: [NVME_DEVICE_SELF_TEST_RESULT_DATA; 20],
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_DEVICE_SELF_TEST_LOG_0 {
-    pub _bitfield: u8,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_DEVICE_SELF_TEST_LOG_1 {
     pub _bitfield: u8,
 }
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_DEVICE_SELF_TEST_LOG_0 {
+    pub _bitfield: u8,
+}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_DEVICE_SELF_TEST_RESULT_DATA {
-    pub Status: NVME_DEVICE_SELF_TEST_RESULT_DATA_1,
+    pub Status: NVME_DEVICE_SELF_TEST_RESULT_DATA_0,
     pub SegmentNumber: u8,
-    pub ValidDiagnostics: NVME_DEVICE_SELF_TEST_RESULT_DATA_2,
+    pub ValidDiagnostics: NVME_DEVICE_SELF_TEST_RESULT_DATA_1,
     pub Reserved: u8,
     pub POH: u64,
     pub NSID: u32,
     pub FailingLBA: u64,
-    pub StatusCodeType: NVME_DEVICE_SELF_TEST_RESULT_DATA_0,
+    pub StatusCodeType: NVME_DEVICE_SELF_TEST_RESULT_DATA_2,
     pub StatusCode: u8,
     pub VendorSpecific: u16,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
+    pub _bitfield: u8,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2113,11 +2118,6 @@ pub struct NVME_DEVICE_SELF_TEST_RESULT_DATA_0 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_DEVICE_SELF_TEST_RESULT_DATA_1 {
-    pub _bitfield: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
     pub _bitfield: u8,
 }
 #[repr(C)]
@@ -2300,15 +2300,15 @@ pub struct NVME_IDENTIFY_CONTROLLER_DATA {
     pub FR: [u8; 8],
     pub RAB: u8,
     pub IEEE: [u8; 3],
-    pub CMIC: NVME_IDENTIFY_CONTROLLER_DATA_3,
+    pub CMIC: NVME_IDENTIFY_CONTROLLER_DATA_0,
     pub MDTS: u8,
     pub CNTLID: u16,
     pub VER: u32,
     pub RTD3R: u32,
     pub RTD3E: u32,
-    pub OAES: NVME_IDENTIFY_CONTROLLER_DATA_14,
-    pub CTRATT: NVME_IDENTIFY_CONTROLLER_DATA_5,
-    pub RRLS: NVME_IDENTIFY_CONTROLLER_DATA_17,
+    pub OAES: NVME_IDENTIFY_CONTROLLER_DATA_1,
+    pub CTRATT: NVME_IDENTIFY_CONTROLLER_DATA_2,
+    pub RRLS: NVME_IDENTIFY_CONTROLLER_DATA_3,
     pub Reserved0: [u8; 9],
     pub CNTRLTYPE: u8,
     pub FGUID: [u8; 16],
@@ -2317,15 +2317,15 @@ pub struct NVME_IDENTIFY_CONTROLLER_DATA {
     pub CRDT3: u16,
     pub Reserved0_1: [u8; 106],
     pub ReservedForManagement: [u8; 16],
-    pub OACS: NVME_IDENTIFY_CONTROLLER_DATA_13,
+    pub OACS: NVME_IDENTIFY_CONTROLLER_DATA_4,
     pub ACL: u8,
     pub AERL: u8,
-    pub FRMW: NVME_IDENTIFY_CONTROLLER_DATA_7,
-    pub LPA: NVME_IDENTIFY_CONTROLLER_DATA_10,
+    pub FRMW: NVME_IDENTIFY_CONTROLLER_DATA_5,
+    pub LPA: NVME_IDENTIFY_CONTROLLER_DATA_6,
     pub ELPE: u8,
     pub NPSS: u8,
-    pub AVSCC: NVME_IDENTIFY_CONTROLLER_DATA_2,
-    pub APSTA: NVME_IDENTIFY_CONTROLLER_DATA_1,
+    pub AVSCC: NVME_IDENTIFY_CONTROLLER_DATA_7,
+    pub APSTA: NVME_IDENTIFY_CONTROLLER_DATA_8,
     pub WCTEMP: u16,
     pub CCTEMP: u16,
     pub MTFA: u16,
@@ -2333,40 +2333,40 @@ pub struct NVME_IDENTIFY_CONTROLLER_DATA {
     pub HMMIN: u32,
     pub TNVMCAP: [u8; 16],
     pub UNVMCAP: [u8; 16],
-    pub RPMBS: NVME_IDENTIFY_CONTROLLER_DATA_16,
+    pub RPMBS: NVME_IDENTIFY_CONTROLLER_DATA_9,
     pub EDSTT: u16,
     pub DSTO: u8,
     pub FWUG: u8,
     pub KAS: u16,
-    pub HCTMA: NVME_IDENTIFY_CONTROLLER_DATA_9,
+    pub HCTMA: NVME_IDENTIFY_CONTROLLER_DATA_10,
     pub MNTMT: u16,
     pub MXTMT: u16,
-    pub SANICAP: NVME_IDENTIFY_CONTROLLER_DATA_18,
+    pub SANICAP: NVME_IDENTIFY_CONTROLLER_DATA_11,
     pub HMMINDS: u32,
     pub HMMAXD: u16,
     pub NSETIDMAX: u16,
     pub ENDGIDMAX: u16,
     pub ANATT: u8,
-    pub ANACAP: NVME_IDENTIFY_CONTROLLER_DATA_0,
+    pub ANACAP: NVME_IDENTIFY_CONTROLLER_DATA_12,
     pub ANAGRPMAX: u32,
     pub NANAGRPID: u32,
     pub PELS: u32,
     pub Reserved1: [u8; 156],
-    pub SQES: NVME_IDENTIFY_CONTROLLER_DATA_20,
-    pub CQES: NVME_IDENTIFY_CONTROLLER_DATA_4,
+    pub SQES: NVME_IDENTIFY_CONTROLLER_DATA_13,
+    pub CQES: NVME_IDENTIFY_CONTROLLER_DATA_14,
     pub MAXCMD: u16,
     pub NN: u32,
     pub ONCS: NVME_IDENTIFY_CONTROLLER_DATA_15,
-    pub FUSES: NVME_IDENTIFY_CONTROLLER_DATA_8,
-    pub FNA: NVME_IDENTIFY_CONTROLLER_DATA_6,
-    pub VWC: NVME_IDENTIFY_CONTROLLER_DATA_21,
+    pub FUSES: NVME_IDENTIFY_CONTROLLER_DATA_16,
+    pub FNA: NVME_IDENTIFY_CONTROLLER_DATA_17,
+    pub VWC: NVME_IDENTIFY_CONTROLLER_DATA_18,
     pub AWUN: u16,
     pub AWUPF: u16,
-    pub NVSCC: NVME_IDENTIFY_CONTROLLER_DATA_11,
-    pub NWPC: NVME_IDENTIFY_CONTROLLER_DATA_12,
+    pub NVSCC: NVME_IDENTIFY_CONTROLLER_DATA_19,
+    pub NWPC: NVME_IDENTIFY_CONTROLLER_DATA_20,
     pub ACWU: u16,
     pub Reserved4: [u8; 2],
-    pub SGLS: NVME_IDENTIFY_CONTROLLER_DATA_19,
+    pub SGLS: NVME_IDENTIFY_CONTROLLER_DATA_21,
     pub MNAN: u32,
     pub Reserved6: [u8; 224],
     pub SUBNQN: [u8; 256],
@@ -2377,37 +2377,12 @@ pub struct NVME_IDENTIFY_CONTROLLER_DATA {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_0 {
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_12 {
     pub _bitfield: u8,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_1 {
-    pub _bitfield: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_2 {
-    pub _bitfield: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_3 {
-    pub _bitfield: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_4 {
-    pub _bitfield: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_5 {
-    pub _bitfield: u32,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_6 {
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_8 {
     pub _bitfield: u8,
 }
 #[repr(C)]
@@ -2417,37 +2392,62 @@ pub struct NVME_IDENTIFY_CONTROLLER_DATA_7 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_8 {
-    pub _bitfield: u16,
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_0 {
+    pub _bitfield: u8,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_9 {
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_14 {
+    pub _bitfield: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_2 {
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_17 {
+    pub _bitfield: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_5 {
+    pub _bitfield: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_16 {
     pub _bitfield: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_10 {
-    pub _bitfield: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_11 {
-    pub _bitfield: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_12 {
-    pub _bitfield: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_13 {
     pub _bitfield: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_14 {
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_6 {
+    pub _bitfield: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_19 {
+    pub _bitfield: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_20 {
+    pub _bitfield: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_4 {
+    pub _bitfield: u16,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_1 {
     pub _bitfield: u32,
 }
 #[repr(C)]
@@ -2457,32 +2457,32 @@ pub struct NVME_IDENTIFY_CONTROLLER_DATA_15 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_16 {
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_9 {
     pub _bitfield: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_17 {
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_3 {
     pub _bitfield: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_18 {
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_11 {
     pub _bitfield: u32,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_19 {
-    pub _bitfield: u32,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_20 {
-    pub _bitfield: u8,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_21 {
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_13 {
+    pub _bitfield: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_18 {
     pub _bitfield: u8,
 }
 #[repr(C)]
@@ -2496,16 +2496,16 @@ pub struct NVME_IDENTIFY_NAMESPACE_DATA {
     pub NSZE: u64,
     pub NCAP: u64,
     pub NUSE: u64,
-    pub NSFEAT: NVME_IDENTIFY_NAMESPACE_DATA_8,
+    pub NSFEAT: NVME_IDENTIFY_NAMESPACE_DATA_0,
     pub NLBAF: u8,
-    pub FLBAS: NVME_IDENTIFY_NAMESPACE_DATA_3,
-    pub MC: NVME_IDENTIFY_NAMESPACE_DATA_5,
-    pub DPC: NVME_IDENTIFY_NAMESPACE_DATA_1,
-    pub DPS: NVME_IDENTIFY_NAMESPACE_DATA_2,
-    pub NMIC: NVME_IDENTIFY_NAMESPACE_DATA_6,
+    pub FLBAS: NVME_IDENTIFY_NAMESPACE_DATA_1,
+    pub MC: NVME_IDENTIFY_NAMESPACE_DATA_2,
+    pub DPC: NVME_IDENTIFY_NAMESPACE_DATA_3,
+    pub DPS: NVME_IDENTIFY_NAMESPACE_DATA_4,
+    pub NMIC: NVME_IDENTIFY_NAMESPACE_DATA_5,
     pub RESCAP: NVM_RESERVATION_CAPABILITIES,
-    pub FPI: NVME_IDENTIFY_NAMESPACE_DATA_4,
-    pub DLFEAT: NVME_IDENTIFY_NAMESPACE_DATA_0,
+    pub FPI: NVME_IDENTIFY_NAMESPACE_DATA_6,
+    pub DLFEAT: NVME_IDENTIFY_NAMESPACE_DATA_7,
     pub NAWUN: u16,
     pub NAWUPF: u16,
     pub NACWU: u16,
@@ -2525,7 +2525,7 @@ pub struct NVME_IDENTIFY_NAMESPACE_DATA {
     pub Reserved2: [u8; 11],
     pub ANAGRPID: u32,
     pub Reserved3: [u8; 3],
-    pub NSATTR: NVME_IDENTIFY_NAMESPACE_DATA_7,
+    pub NSATTR: NVME_IDENTIFY_NAMESPACE_DATA_8,
     pub NVMSETID: u16,
     pub ENDGID: u16,
     pub NGUID: [u8; 16],
@@ -2536,17 +2536,7 @@ pub struct NVME_IDENTIFY_NAMESPACE_DATA {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_NAMESPACE_DATA_0 {
-    pub _bitfield: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_NAMESPACE_DATA_1 {
-    pub _bitfield: u8,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_NAMESPACE_DATA_2 {
+pub struct NVME_IDENTIFY_NAMESPACE_DATA_7 {
     pub _bitfield: u8,
 }
 #[repr(C)]
@@ -2561,7 +2551,7 @@ pub struct NVME_IDENTIFY_NAMESPACE_DATA_4 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_NAMESPACE_DATA_5 {
+pub struct NVME_IDENTIFY_NAMESPACE_DATA_1 {
     pub _bitfield: u8,
 }
 #[repr(C)]
@@ -2571,12 +2561,22 @@ pub struct NVME_IDENTIFY_NAMESPACE_DATA_6 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_NAMESPACE_DATA_7 {
+pub struct NVME_IDENTIFY_NAMESPACE_DATA_2 {
+    pub _bitfield: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_NAMESPACE_DATA_5 {
     pub _bitfield: u8,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_IDENTIFY_NAMESPACE_DATA_8 {
+    pub _bitfield: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_IDENTIFY_NAMESPACE_DATA_0 {
     pub _bitfield: u8,
 }
 #[repr(C)]
@@ -2601,8 +2601,8 @@ pub struct NVME_IDENTIFY_NVM_SPECIFIC_CONTROLLER_IO_COMMAND_SET {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET {
-    pub ZOC: NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1,
-    pub OZCS: NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0,
+    pub ZOC: NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0,
+    pub OZCS: NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1,
     pub MAR: u32,
     pub MOR: u32,
     pub RRL: u32,
@@ -2614,12 +2614,12 @@ pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0 {
+pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1 {
     pub _bitfield: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1 {
+pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0 {
     pub _bitfield: u16,
 }
 #[repr(C)]
@@ -2680,18 +2680,40 @@ pub struct NVME_NVM_SUBSYSTEM_RESET {
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG {
     pub PciePorts: u16,
-    pub OobMgmtSupport: NVME_OCP_DEVICE_CAPABILITIES_LOG_2,
-    pub WriteZeroesCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_5,
-    pub SanitizeCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_3,
-    pub DatasetMgmtCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_0,
+    pub OobMgmtSupport: NVME_OCP_DEVICE_CAPABILITIES_LOG_0,
+    pub WriteZeroesCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_1,
+    pub SanitizeCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_2,
+    pub DatasetMgmtCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_3,
     pub WriteUncorrectableCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_4,
-    pub FusedCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_1,
+    pub FusedCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_5,
     pub MinimumValidDSSDPowerState: u16,
     pub Reserved0: u8,
     pub DssdDescriptors: [DSSD_POWER_STATE_DESCRIPTOR; 127],
     pub Reserved1: [u8; 3934],
     pub LogPageVersionNumber: u16,
     pub LogPageGUID: windows_sys::core::GUID,
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_3 {
+    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_3_0,
+    pub AsUshort: u16,
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_3_0 {
+    pub _bitfield: u16,
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_5 {
+    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0,
+    pub AsUshort: u16,
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
+    pub _bitfield: u16,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2702,17 +2724,6 @@ pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_0 {
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0 {
-    pub _bitfield: u16,
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_1 {
-    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0,
-    pub AsUshort: u16,
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
     pub _bitfield: u16,
 }
 #[repr(C, packed(1))]
@@ -2728,17 +2739,6 @@ pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_3 {
-    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_3_0,
-    pub AsUshort: u16,
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_3_0 {
-    pub _bitfield: u16,
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
 pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_4 {
     pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_4_0,
     pub AsUshort: u16,
@@ -2750,13 +2750,13 @@ pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_4_0 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_5 {
-    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0,
+pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_1 {
+    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0,
     pub AsUshort: u16,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
+pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
     pub _bitfield: u16,
 }
 #[repr(C, packed(1))]
@@ -2845,16 +2845,16 @@ pub struct NVME_OCP_DEVICE_LATENCY_MONITOR_LOG_0_0 {
 pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3 {
     pub MediaUnitsWritten: [u8; 16],
     pub MediaUnitsRead: [u8; 16],
-    pub BadUserNANDBlockCount: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1,
-    pub BadSystemNANDBlockCount: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0,
+    pub BadUserNANDBlockCount: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0,
+    pub BadSystemNANDBlockCount: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1,
     pub XORRecoveryCount: u64,
     pub UnrecoverableReadErrorCount: u64,
     pub SoftECCErrorCount: u64,
     pub EndToEndCorrectionCounts: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_2,
     pub PercentageSystemDataUsed: u8,
     pub RefreshCount: [u8; 7],
-    pub UserDataEraseCounts: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4,
-    pub ThermalThrottling: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3,
+    pub UserDataEraseCounts: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3,
+    pub ThermalThrottling: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4,
     pub DSSDSpecVersion: [u8; 6],
     pub PCIeCorrectableErrorCount: u64,
     pub IncompleteShutdownCount: u32,
@@ -2877,13 +2877,13 @@ pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0 {
+pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1 {
     pub RawCount: [u8; 6],
     pub Normalized: [u8; 2],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1 {
+pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0 {
     pub RawCount: [u8; 6],
     pub Normalized: [u8; 2],
 }
@@ -2895,13 +2895,13 @@ pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
+pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4 {
     pub EventCount: u8,
     pub Status: u8,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4 {
+pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
     pub MaximumCount: u32,
     pub MinimumCount: u32,
 }
@@ -3266,16 +3266,16 @@ pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG {
 pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2 {
     pub MediaUnitsWritten: [u8; 16],
     pub MediaUnitsRead: [u8; 16],
-    pub BadUserNANDBlockCount: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1,
-    pub BadSystemNANDBlockCount: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0,
+    pub BadUserNANDBlockCount: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0,
+    pub BadSystemNANDBlockCount: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1,
     pub XORRecoveryCount: u64,
     pub UnrecoverableReadErrorCount: u64,
     pub SoftECCErrorCount: u64,
     pub EndToEndCorrectionCounts: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_2,
     pub PercentageSystemDataUsed: u8,
     pub RefreshCount: [u8; 7],
-    pub UserDataEraseCounts: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4,
-    pub ThermalThrottling: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3,
+    pub UserDataEraseCounts: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3,
+    pub ThermalThrottling: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4,
     pub Reserved0: [u8; 6],
     pub PCIeCorrectableErrorCount: u64,
     pub IncompleteShutdownCount: u32,
@@ -3295,13 +3295,13 @@ pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0 {
+pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1 {
     pub RawCount: [u8; 6],
     pub Normalized: [u8; 2],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1 {
+pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0 {
     pub RawCount: [u8; 6],
     pub Normalized: [u8; 2],
 }
@@ -3313,13 +3313,13 @@ pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
+pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4 {
     pub EventCount: u8,
     pub Status: u8,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4 {
+pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
     pub MaximumCount: u32,
     pub MinimumCount: u32,
 }

--- a/crates/libs/sys/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
@@ -116,17 +116,17 @@ pub struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
-    pub Notification: PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1,
-    pub Enumeration: PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
-    pub DirEntryBufferHandle: PRJ_DIR_ENTRY_BUFFER_HANDLE,
+    pub Notification: PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0,
+    pub Enumeration: PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
+    pub DirEntryBufferHandle: PRJ_DIR_ENTRY_BUFFER_HANDLE,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
     pub NotificationMask: PRJ_NOTIFY_TYPES,
 }
 pub type PRJ_DIR_ENTRY_BUFFER_HANDLE = *mut core::ffi::c_void;
@@ -168,13 +168,13 @@ pub struct PRJ_NOTIFICATION_MAPPING {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PRJ_NOTIFICATION_PARAMETERS {
-    pub PostCreate: PRJ_NOTIFICATION_PARAMETERS_2,
+    pub PostCreate: PRJ_NOTIFICATION_PARAMETERS_0,
     pub FileRenamed: PRJ_NOTIFICATION_PARAMETERS_1,
-    pub FileDeletedOnHandleClose: PRJ_NOTIFICATION_PARAMETERS_0,
+    pub FileDeletedOnHandleClose: PRJ_NOTIFICATION_PARAMETERS_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PRJ_NOTIFICATION_PARAMETERS_0 {
+pub struct PRJ_NOTIFICATION_PARAMETERS_2 {
     pub IsFileModified: super::super::Foundation::BOOLEAN,
 }
 #[repr(C)]
@@ -184,7 +184,7 @@ pub struct PRJ_NOTIFICATION_PARAMETERS_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PRJ_NOTIFICATION_PARAMETERS_2 {
+pub struct PRJ_NOTIFICATION_PARAMETERS_0 {
     pub NotificationMask: PRJ_NOTIFY_TYPES,
 }
 #[repr(C)]

--- a/crates/libs/sys/src/Windows/Win32/Storage/Vhd/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/Vhd/mod.rs
@@ -428,7 +428,7 @@ pub struct GET_VIRTUAL_DISK_INFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union GET_VIRTUAL_DISK_INFO_0 {
-    pub Size: GET_VIRTUAL_DISK_INFO_0_3,
+    pub Size: GET_VIRTUAL_DISK_INFO_0_0,
     pub Identifier: windows_sys::core::GUID,
     pub ParentLocation: GET_VIRTUAL_DISK_INFO_0_1,
     pub ParentIdentifier: windows_sys::core::GUID,
@@ -442,11 +442,11 @@ pub union GET_VIRTUAL_DISK_INFO_0 {
     pub SmallestSafeVirtualSize: u64,
     pub FragmentationPercentage: u32,
     pub VirtualDiskId: windows_sys::core::GUID,
-    pub ChangeTrackingState: GET_VIRTUAL_DISK_INFO_0_0,
+    pub ChangeTrackingState: GET_VIRTUAL_DISK_INFO_0_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct GET_VIRTUAL_DISK_INFO_0_0 {
+pub struct GET_VIRTUAL_DISK_INFO_0_3 {
     pub Enabled: super::super::Foundation::BOOL,
     pub NewerChanges: super::super::Foundation::BOOL,
     pub MostRecentId: [u16; 1],
@@ -466,7 +466,7 @@ pub struct GET_VIRTUAL_DISK_INFO_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct GET_VIRTUAL_DISK_INFO_0_3 {
+pub struct GET_VIRTUAL_DISK_INFO_0_0 {
     pub VirtualSize: u64,
     pub PhysicalSize: u64,
     pub BlockSize: u32,
@@ -639,21 +639,21 @@ pub struct SET_VIRTUAL_DISK_INFO {
 pub union SET_VIRTUAL_DISK_INFO_0 {
     pub ParentFilePath: windows_sys::core::PCWSTR,
     pub UniqueIdentifier: windows_sys::core::GUID,
-    pub ParentPathWithDepthInfo: SET_VIRTUAL_DISK_INFO_0_1,
+    pub ParentPathWithDepthInfo: SET_VIRTUAL_DISK_INFO_0_0,
     pub VhdPhysicalSectorSize: u32,
     pub VirtualDiskId: windows_sys::core::GUID,
     pub ChangeTrackingEnabled: super::super::Foundation::BOOL,
-    pub ParentLocator: SET_VIRTUAL_DISK_INFO_0_0,
+    pub ParentLocator: SET_VIRTUAL_DISK_INFO_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct SET_VIRTUAL_DISK_INFO_0_0 {
+pub struct SET_VIRTUAL_DISK_INFO_0_1 {
     pub LinkageId: windows_sys::core::GUID,
     pub ParentFilePath: windows_sys::core::PCWSTR,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct SET_VIRTUAL_DISK_INFO_0_1 {
+pub struct SET_VIRTUAL_DISK_INFO_0_0 {
     pub ChildDepth: u32,
     pub ParentFilePath: windows_sys::core::PCWSTR,
 }

--- a/crates/libs/sys/src/Windows/Win32/Storage/Xps/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/Xps/mod.rs
@@ -330,19 +330,19 @@ pub struct XPS_COLOR {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union XPS_COLOR_0 {
-    pub sRGB: XPS_COLOR_0_1,
-    pub scRGB: XPS_COLOR_0_2,
-    pub context: XPS_COLOR_0_0,
+    pub sRGB: XPS_COLOR_0_0,
+    pub scRGB: XPS_COLOR_0_1,
+    pub context: XPS_COLOR_0_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct XPS_COLOR_0_0 {
+pub struct XPS_COLOR_0_2 {
     pub channelCount: u8,
     pub channels: [f32; 9],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct XPS_COLOR_0_1 {
+pub struct XPS_COLOR_0_0 {
     pub alpha: u8,
     pub red: u8,
     pub green: u8,
@@ -350,7 +350,7 @@ pub struct XPS_COLOR_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct XPS_COLOR_0_2 {
+pub struct XPS_COLOR_0_1 {
     pub alpha: f32,
     pub red: f32,
     pub green: f32,

--- a/crates/libs/sys/src/Windows/Win32/System/Diagnostics/Debug/Extensions/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Diagnostics/Debug/Extensions/mod.rs
@@ -2609,8 +2609,8 @@ pub union DEBUG_VALUE_0 {
     pub VI64: [u64; 2],
     pub VF32: [f32; 4],
     pub VF64: [f64; 2],
-    pub I64Parts32: DEBUG_VALUE_0_2,
-    pub F128Parts64: DEBUG_VALUE_0_1,
+    pub I64Parts32: DEBUG_VALUE_0_1,
+    pub F128Parts64: DEBUG_VALUE_0_2,
     pub RawBytes: [u8; 24],
 }
 #[repr(C)]
@@ -2621,13 +2621,13 @@ pub struct DEBUG_VALUE_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct DEBUG_VALUE_0_1 {
+pub struct DEBUG_VALUE_0_2 {
     pub LowPart: u64,
     pub HighPart: i64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct DEBUG_VALUE_0_2 {
+pub struct DEBUG_VALUE_0_1 {
     pub LowPart: u32,
     pub HighPart: u32,
 }
@@ -3400,17 +3400,17 @@ pub struct ScriptDebugEventInformation {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ScriptDebugEventInformation_0 {
-    pub ExceptionInformation: ScriptDebugEventInformation_0_1,
-    pub BreakpointInformation: ScriptDebugEventInformation_0_0,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct ScriptDebugEventInformation_0_0 {
-    pub BreakpointId: u64,
+    pub ExceptionInformation: ScriptDebugEventInformation_0_0,
+    pub BreakpointInformation: ScriptDebugEventInformation_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ScriptDebugEventInformation_0_1 {
+    pub BreakpointId: u64,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ScriptDebugEventInformation_0_0 {
     pub IsUncaught: u8,
 }
 #[repr(C)]

--- a/crates/libs/sys/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
@@ -2439,17 +2439,17 @@ pub struct CONTEXT {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CPU_INFORMATION {
-    pub X86CpuInfo: CPU_INFORMATION_1,
-    pub OtherCpuInfo: CPU_INFORMATION_0,
+    pub X86CpuInfo: CPU_INFORMATION_0,
+    pub OtherCpuInfo: CPU_INFORMATION_1,
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub struct CPU_INFORMATION_0 {
+pub struct CPU_INFORMATION_1 {
     pub ProcessorFeatures: [u64; 2],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct CPU_INFORMATION_1 {
+pub struct CPU_INFORMATION_0 {
     pub VendorId: [u32; 3],
     pub VersionInformation: u32,
     pub FeatureInformation: u32,
@@ -3617,17 +3617,17 @@ pub struct LDT_ENTRY {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union LDT_ENTRY_0 {
-    pub Bytes: LDT_ENTRY_0_1,
-    pub Bits: LDT_ENTRY_0_0,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct LDT_ENTRY_0_0 {
-    pub _bitfield: u32,
+    pub Bytes: LDT_ENTRY_0_0,
+    pub Bits: LDT_ENTRY_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct LDT_ENTRY_0_1 {
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct LDT_ENTRY_0_0 {
     pub BaseMid: u8,
     pub Flags1: u8,
     pub Flags2: u8,
@@ -5083,18 +5083,18 @@ pub struct WHEA_NOTIFICATION_DESCRIPTOR {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHEA_NOTIFICATION_DESCRIPTOR_0 {
-    pub Polled: WHEA_NOTIFICATION_DESCRIPTOR_0_4,
+    pub Polled: WHEA_NOTIFICATION_DESCRIPTOR_0_0,
     pub Interrupt: WHEA_NOTIFICATION_DESCRIPTOR_0_1,
     pub LocalInterrupt: WHEA_NOTIFICATION_DESCRIPTOR_0_2,
-    pub Sci: WHEA_NOTIFICATION_DESCRIPTOR_0_5,
-    pub Nmi: WHEA_NOTIFICATION_DESCRIPTOR_0_3,
-    pub Sea: WHEA_NOTIFICATION_DESCRIPTOR_0_6,
-    pub Sei: WHEA_NOTIFICATION_DESCRIPTOR_0_7,
-    pub Gsiv: WHEA_NOTIFICATION_DESCRIPTOR_0_0,
+    pub Sci: WHEA_NOTIFICATION_DESCRIPTOR_0_3,
+    pub Nmi: WHEA_NOTIFICATION_DESCRIPTOR_0_4,
+    pub Sea: WHEA_NOTIFICATION_DESCRIPTOR_0_5,
+    pub Sei: WHEA_NOTIFICATION_DESCRIPTOR_0_6,
+    pub Gsiv: WHEA_NOTIFICATION_DESCRIPTOR_0_7,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
+pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
     pub PollInterval: u32,
     pub Vector: u32,
     pub SwitchToPollingThreshold: u32,
@@ -5124,7 +5124,7 @@ pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_2 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
+pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
     pub PollInterval: u32,
     pub Vector: u32,
     pub SwitchToPollingThreshold: u32,
@@ -5134,8 +5134,18 @@ pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
+pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
     pub PollInterval: u32,
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
+    pub PollInterval: u32,
+    pub Vector: u32,
+    pub SwitchToPollingThreshold: u32,
+    pub SwitchToPollingWindow: u32,
+    pub ErrorThreshold: u32,
+    pub ErrorThresholdWindow: u32,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5150,16 +5160,6 @@ pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_5 {
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_6 {
-    pub PollInterval: u32,
-    pub Vector: u32,
-    pub SwitchToPollingThreshold: u32,
-    pub SwitchToPollingWindow: u32,
-    pub ErrorThreshold: u32,
-    pub ErrorThresholdWindow: u32,
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
     pub PollInterval: u32,
     pub Vector: u32,
     pub SwitchToPollingThreshold: u32,
@@ -5292,17 +5292,17 @@ pub struct WOW64_LDT_ENTRY {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WOW64_LDT_ENTRY_0 {
-    pub Bytes: WOW64_LDT_ENTRY_0_1,
-    pub Bits: WOW64_LDT_ENTRY_0_0,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WOW64_LDT_ENTRY_0_0 {
-    pub _bitfield: u32,
+    pub Bytes: WOW64_LDT_ENTRY_0_0,
+    pub Bits: WOW64_LDT_ENTRY_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WOW64_LDT_ENTRY_0_1 {
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WOW64_LDT_ENTRY_0_0 {
     pub BaseMid: u8,
     pub Flags1: u8,
     pub Flags2: u8,

--- a/crates/libs/sys/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -1234,27 +1234,27 @@ pub struct EVENT_PROPERTY_INFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_PROPERTY_INFO_0 {
-    pub nonStructType: EVENT_PROPERTY_INFO_0_1,
-    pub structType: EVENT_PROPERTY_INFO_0_2,
-    pub customSchemaType: EVENT_PROPERTY_INFO_0_0,
+    pub nonStructType: EVENT_PROPERTY_INFO_0_0,
+    pub structType: EVENT_PROPERTY_INFO_0_1,
+    pub customSchemaType: EVENT_PROPERTY_INFO_0_2,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct EVENT_PROPERTY_INFO_0_0 {
+pub struct EVENT_PROPERTY_INFO_0_2 {
     pub InType: u16,
     pub OutType: u16,
     pub CustomSchemaOffset: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct EVENT_PROPERTY_INFO_0_1 {
+pub struct EVENT_PROPERTY_INFO_0_0 {
     pub InType: u16,
     pub OutType: u16,
     pub MapNameOffset: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct EVENT_PROPERTY_INFO_0_2 {
+pub struct EVENT_PROPERTY_INFO_0_1 {
     pub StructStartIndex: u16,
     pub NumOfStructMembers: u16,
     pub padding: u32,

--- a/crates/libs/sys/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
@@ -120,22 +120,22 @@ pub struct PSS_HANDLE_ENTRY {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PSS_HANDLE_ENTRY_0 {
-    pub Process: PSS_HANDLE_ENTRY_0_2,
-    pub Thread: PSS_HANDLE_ENTRY_0_5,
-    pub Mutant: PSS_HANDLE_ENTRY_0_1,
-    pub Event: PSS_HANDLE_ENTRY_0_0,
-    pub Section: PSS_HANDLE_ENTRY_0_3,
-    pub Semaphore: PSS_HANDLE_ENTRY_0_4,
+    pub Process: PSS_HANDLE_ENTRY_0_0,
+    pub Thread: PSS_HANDLE_ENTRY_0_1,
+    pub Mutant: PSS_HANDLE_ENTRY_0_2,
+    pub Event: PSS_HANDLE_ENTRY_0_3,
+    pub Section: PSS_HANDLE_ENTRY_0_4,
+    pub Semaphore: PSS_HANDLE_ENTRY_0_5,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PSS_HANDLE_ENTRY_0_0 {
+pub struct PSS_HANDLE_ENTRY_0_3 {
     pub ManualReset: super::super::super::Foundation::BOOL,
     pub Signaled: super::super::super::Foundation::BOOL,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PSS_HANDLE_ENTRY_0_1 {
+pub struct PSS_HANDLE_ENTRY_0_2 {
     pub CurrentCount: i32,
     pub Abandoned: super::super::super::Foundation::BOOL,
     pub OwnerProcessId: u32,
@@ -143,7 +143,7 @@ pub struct PSS_HANDLE_ENTRY_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PSS_HANDLE_ENTRY_0_2 {
+pub struct PSS_HANDLE_ENTRY_0_0 {
     pub ExitStatus: u32,
     pub PebBaseAddress: *mut core::ffi::c_void,
     pub AffinityMask: usize,
@@ -154,20 +154,20 @@ pub struct PSS_HANDLE_ENTRY_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PSS_HANDLE_ENTRY_0_3 {
+pub struct PSS_HANDLE_ENTRY_0_4 {
     pub BaseAddress: *mut core::ffi::c_void,
     pub AllocationAttributes: u32,
     pub MaximumSize: i64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PSS_HANDLE_ENTRY_0_4 {
+pub struct PSS_HANDLE_ENTRY_0_5 {
     pub CurrentCount: i32,
     pub MaximumCount: i32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PSS_HANDLE_ENTRY_0_5 {
+pub struct PSS_HANDLE_ENTRY_0_1 {
     pub ExitStatus: u32,
     pub TebBaseAddress: *mut core::ffi::c_void,
     pub ProcessId: u32,

--- a/crates/libs/sys/src/Windows/Win32/System/Hypervisor/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Hypervisor/mod.rs
@@ -928,55 +928,55 @@ pub struct VIRTUAL_PROCESSOR_REGISTER_0 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIRTUAL_PROCESSOR_REGISTER_1 {
-    pub Segment: VIRTUAL_PROCESSOR_REGISTER_1_1,
-    pub Table: VIRTUAL_PROCESSOR_REGISTER_1_2,
-    pub FpControlStatus: VIRTUAL_PROCESSOR_REGISTER_1_0,
+    pub Segment: VIRTUAL_PROCESSOR_REGISTER_1_0,
+    pub Table: VIRTUAL_PROCESSOR_REGISTER_1_1,
+    pub FpControlStatus: VIRTUAL_PROCESSOR_REGISTER_1_2,
     pub XmmControlStatus: VIRTUAL_PROCESSOR_REGISTER_1_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct VIRTUAL_PROCESSOR_REGISTER_1_0 {
+pub struct VIRTUAL_PROCESSOR_REGISTER_1_2 {
     pub FpControl: u16,
     pub FpStatus: u16,
     pub FpTag: u8,
     pub Reserved: u8,
     pub LastFpOp: u16,
-    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_0_0,
+    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_2_0,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
+pub union VIRTUAL_PROCESSOR_REGISTER_1_2_0 {
     pub LastFpRip: u64,
-    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_0_0_0,
+    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_2_0_0,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {
+pub struct VIRTUAL_PROCESSOR_REGISTER_1_2_0_0 {
     pub LastFpEip: u32,
     pub LastFpCs: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct VIRTUAL_PROCESSOR_REGISTER_1_1 {
+pub struct VIRTUAL_PROCESSOR_REGISTER_1_0 {
     pub Base: u64,
     pub Limit: u32,
     pub Selector: u16,
-    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_1_0,
+    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_0_0,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union VIRTUAL_PROCESSOR_REGISTER_1_1_0 {
+pub union VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
     pub Attributes: u16,
-    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_1_0_0,
+    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_0_0_0,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct VIRTUAL_PROCESSOR_REGISTER_1_1_0_0 {
+pub struct VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {
     pub _bitfield: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct VIRTUAL_PROCESSOR_REGISTER_1_2 {
+pub struct VIRTUAL_PROCESSOR_REGISTER_1_1 {
     pub Limit: u16,
     pub Base: u64,
 }

--- a/crates/libs/sys/src/Windows/Win32/System/Ioctl/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Ioctl/mod.rs
@@ -2154,18 +2154,18 @@ pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
-    pub ExternalStack: DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1,
-    pub AtaPort: DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0,
+    pub ExternalStack: DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0,
+    pub AtaPort: DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1,
     pub StorPort: DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
+pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
     pub dwAtaPortSpecific: u32,
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
+pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
     pub dwReserved: u32,
 }
 #[repr(C, packed(1))]
@@ -2610,18 +2610,18 @@ pub struct DISK_CACHE_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISK_CACHE_INFORMATION_0 {
-    pub ScalarPrefetch: DISK_CACHE_INFORMATION_0_1,
-    pub BlockPrefetch: DISK_CACHE_INFORMATION_0_0,
+    pub ScalarPrefetch: DISK_CACHE_INFORMATION_0_0,
+    pub BlockPrefetch: DISK_CACHE_INFORMATION_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct DISK_CACHE_INFORMATION_0_0 {
+pub struct DISK_CACHE_INFORMATION_0_1 {
     pub Minimum: u16,
     pub Maximum: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct DISK_CACHE_INFORMATION_0_1 {
+pub struct DISK_CACHE_INFORMATION_0_0 {
     pub Minimum: u16,
     pub Maximum: u16,
     pub MaximumBlocks: u16,
@@ -2732,17 +2732,17 @@ pub struct DISK_PARTITION_INFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISK_PARTITION_INFO_0 {
-    pub Mbr: DISK_PARTITION_INFO_0_1,
-    pub Gpt: DISK_PARTITION_INFO_0_0,
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct DISK_PARTITION_INFO_0_0 {
-    pub DiskId: windows_sys::core::GUID,
+    pub Mbr: DISK_PARTITION_INFO_0_0,
+    pub Gpt: DISK_PARTITION_INFO_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DISK_PARTITION_INFO_0_1 {
+    pub DiskId: windows_sys::core::GUID,
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct DISK_PARTITION_INFO_0_0 {
     pub Signature: u32,
     pub CheckSum: u32,
 }
@@ -3627,13 +3627,13 @@ pub struct NTFS_STATISTICS {
     pub MftReadBytes: u32,
     pub MftWrites: u32,
     pub MftWriteBytes: u32,
-    pub MftWritesUserLevel: NTFS_STATISTICS_4,
+    pub MftWritesUserLevel: NTFS_STATISTICS_0,
     pub MftWritesFlushForLogFileFull: u16,
     pub MftWritesLazyWriter: u16,
     pub MftWritesUserRequest: u16,
     pub Mft2Writes: u32,
     pub Mft2WriteBytes: u32,
-    pub Mft2WritesUserLevel: NTFS_STATISTICS_2,
+    pub Mft2WritesUserLevel: NTFS_STATISTICS_1,
     pub Mft2WritesFlushForLogFileFull: u16,
     pub Mft2WritesLazyWriter: u16,
     pub Mft2WritesUserRequest: u16,
@@ -3648,7 +3648,7 @@ pub struct NTFS_STATISTICS {
     pub BitmapWritesFlushForLogFileFull: u16,
     pub BitmapWritesLazyWriter: u16,
     pub BitmapWritesUserRequest: u16,
-    pub BitmapWritesUserLevel: NTFS_STATISTICS_1,
+    pub BitmapWritesUserLevel: NTFS_STATISTICS_2,
     pub MftBitmapReads: u32,
     pub MftBitmapReadBytes: u32,
     pub MftBitmapWrites: u32,
@@ -3665,12 +3665,12 @@ pub struct NTFS_STATISTICS {
     pub LogFileReadBytes: u32,
     pub LogFileWrites: u32,
     pub LogFileWriteBytes: u32,
-    pub Allocate: NTFS_STATISTICS_0,
+    pub Allocate: NTFS_STATISTICS_4,
     pub DiskResourcesExhausted: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NTFS_STATISTICS_0 {
+pub struct NTFS_STATISTICS_4 {
     pub Calls: u32,
     pub Clusters: u32,
     pub Hints: u32,
@@ -3684,14 +3684,14 @@ pub struct NTFS_STATISTICS_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NTFS_STATISTICS_1 {
+pub struct NTFS_STATISTICS_2 {
     pub Write: u16,
     pub Create: u16,
     pub SetInfo: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NTFS_STATISTICS_2 {
+pub struct NTFS_STATISTICS_1 {
     pub Write: u16,
     pub Create: u16,
     pub SetInfo: u16,
@@ -3707,7 +3707,7 @@ pub struct NTFS_STATISTICS_3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NTFS_STATISTICS_4 {
+pub struct NTFS_STATISTICS_0 {
     pub Write: u16,
     pub Create: u16,
     pub SetInfo: u16,
@@ -3722,13 +3722,13 @@ pub struct NTFS_STATISTICS_EX {
     pub MftReadBytes: u64,
     pub MftWrites: u64,
     pub MftWriteBytes: u64,
-    pub MftWritesUserLevel: NTFS_STATISTICS_EX_4,
+    pub MftWritesUserLevel: NTFS_STATISTICS_EX_0,
     pub MftWritesFlushForLogFileFull: u32,
     pub MftWritesLazyWriter: u32,
     pub MftWritesUserRequest: u32,
     pub Mft2Writes: u64,
     pub Mft2WriteBytes: u64,
-    pub Mft2WritesUserLevel: NTFS_STATISTICS_EX_2,
+    pub Mft2WritesUserLevel: NTFS_STATISTICS_EX_1,
     pub Mft2WritesFlushForLogFileFull: u32,
     pub Mft2WritesLazyWriter: u32,
     pub Mft2WritesUserRequest: u32,
@@ -3743,7 +3743,7 @@ pub struct NTFS_STATISTICS_EX {
     pub BitmapWritesFlushForLogFileFull: u32,
     pub BitmapWritesLazyWriter: u32,
     pub BitmapWritesUserRequest: u32,
-    pub BitmapWritesUserLevel: NTFS_STATISTICS_EX_1,
+    pub BitmapWritesUserLevel: NTFS_STATISTICS_EX_2,
     pub MftBitmapReads: u64,
     pub MftBitmapReadBytes: u64,
     pub MftBitmapWrites: u64,
@@ -3760,7 +3760,7 @@ pub struct NTFS_STATISTICS_EX {
     pub LogFileReadBytes: u64,
     pub LogFileWrites: u64,
     pub LogFileWriteBytes: u64,
-    pub Allocate: NTFS_STATISTICS_EX_0,
+    pub Allocate: NTFS_STATISTICS_EX_4,
     pub DiskResourcesExhausted: u32,
     pub VolumeTrimCount: u64,
     pub VolumeTrimTime: u64,
@@ -3776,7 +3776,7 @@ pub struct NTFS_STATISTICS_EX {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NTFS_STATISTICS_EX_0 {
+pub struct NTFS_STATISTICS_EX_4 {
     pub Calls: u32,
     pub RunsReturned: u32,
     pub Hints: u32,
@@ -3790,7 +3790,7 @@ pub struct NTFS_STATISTICS_EX_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NTFS_STATISTICS_EX_1 {
+pub struct NTFS_STATISTICS_EX_2 {
     pub Write: u32,
     pub Create: u32,
     pub SetInfo: u32,
@@ -3798,7 +3798,7 @@ pub struct NTFS_STATISTICS_EX_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NTFS_STATISTICS_EX_2 {
+pub struct NTFS_STATISTICS_EX_1 {
     pub Write: u32,
     pub Create: u32,
     pub SetInfo: u32,
@@ -3814,7 +3814,7 @@ pub struct NTFS_STATISTICS_EX_3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NTFS_STATISTICS_EX_4 {
+pub struct NTFS_STATISTICS_EX_0 {
     pub Write: u32,
     pub Create: u32,
     pub SetInfo: u32,
@@ -5298,20 +5298,20 @@ pub struct STORAGE_OPERATIONAL_REASON {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_OPERATIONAL_REASON_0 {
-    pub ScsiSenseKey: STORAGE_OPERATIONAL_REASON_0_1,
-    pub NVDIMM_N: STORAGE_OPERATIONAL_REASON_0_0,
+    pub ScsiSenseKey: STORAGE_OPERATIONAL_REASON_0_0,
+    pub NVDIMM_N: STORAGE_OPERATIONAL_REASON_0_1,
     pub AsUlong: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct STORAGE_OPERATIONAL_REASON_0_0 {
+pub struct STORAGE_OPERATIONAL_REASON_0_1 {
     pub CriticalHealth: u8,
     pub ModuleHealth: [u8; 2],
     pub ErrorThresholdStatus: u8,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct STORAGE_OPERATIONAL_REASON_0_1 {
+pub struct STORAGE_OPERATIONAL_REASON_0_0 {
     pub SenseKey: u8,
     pub ASC: u8,
     pub ASCQ: u8,
@@ -5669,18 +5669,18 @@ pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
-    pub SequentialRequiredZone: STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1,
-    pub SequentialPreferredZone: STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0,
+    pub SequentialRequiredZone: STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0,
+    pub SequentialPreferredZone: STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
+pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
     pub OptimalOpenZoneCount: u32,
     pub Reserved: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
+pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
     pub MaxOpenZoneCount: u32,
     pub UnrestrictedRead: super::super::Foundation::BOOLEAN,
     pub Reserved: [u8; 3],
@@ -5743,14 +5743,14 @@ pub struct STREAM_INFORMATION_ENTRY {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STREAM_INFORMATION_ENTRY_0 {
-    pub DesiredStorageClass: STREAM_INFORMATION_ENTRY_0_1,
-    pub DataStream: STREAM_INFORMATION_ENTRY_0_0,
-    pub Reparse: STREAM_INFORMATION_ENTRY_0_3,
-    pub Ea: STREAM_INFORMATION_ENTRY_0_2,
+    pub DesiredStorageClass: STREAM_INFORMATION_ENTRY_0_0,
+    pub DataStream: STREAM_INFORMATION_ENTRY_0_1,
+    pub Reparse: STREAM_INFORMATION_ENTRY_0_2,
+    pub Ea: STREAM_INFORMATION_ENTRY_0_3,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct STREAM_INFORMATION_ENTRY_0_0 {
+pub struct STREAM_INFORMATION_ENTRY_0_1 {
     pub Length: u16,
     pub Flags: u16,
     pub Reserved: u32,
@@ -5758,13 +5758,13 @@ pub struct STREAM_INFORMATION_ENTRY_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct STREAM_INFORMATION_ENTRY_0_1 {
+pub struct STREAM_INFORMATION_ENTRY_0_0 {
     pub Class: FILE_STORAGE_TIER_CLASS,
     pub Flags: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct STREAM_INFORMATION_ENTRY_0_2 {
+pub struct STREAM_INFORMATION_ENTRY_0_3 {
     pub Length: u16,
     pub Flags: u16,
     pub EaSize: u32,
@@ -5772,7 +5772,7 @@ pub struct STREAM_INFORMATION_ENTRY_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct STREAM_INFORMATION_ENTRY_0_3 {
+pub struct STREAM_INFORMATION_ENTRY_0_2 {
     pub Length: u16,
     pub Flags: u16,
     pub ReparseDataSize: u32,

--- a/crates/libs/sys/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Ole/mod.rs
@@ -2370,9 +2370,9 @@ pub struct PICTDESC {
 #[derive(Clone, Copy)]
 pub union PICTDESC_0 {
     pub bmp: PICTDESC_0_0,
-    pub wmf: PICTDESC_0_3,
+    pub wmf: PICTDESC_0_1,
     pub icon: PICTDESC_0_2,
-    pub emf: PICTDESC_0_1,
+    pub emf: PICTDESC_0_3,
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -2384,7 +2384,7 @@ pub struct PICTDESC_0_0 {
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
-pub struct PICTDESC_0_1 {
+pub struct PICTDESC_0_3 {
     pub hemf: super::super::Graphics::Gdi::HENHMETAFILE,
 }
 #[repr(C)]
@@ -2396,7 +2396,7 @@ pub struct PICTDESC_0_2 {
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
-pub struct PICTDESC_0_3 {
+pub struct PICTDESC_0_1 {
     pub hmeta: super::super::Graphics::Gdi::HMETAFILE,
     pub xExt: i32,
     pub yExt: i32,

--- a/crates/libs/sys/src/Windows/Win32/System/RemoteDesktop/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/RemoteDesktop/mod.rs
@@ -1518,19 +1518,19 @@ pub struct WTS_PROPERTY_VALUE {
 #[derive(Clone, Copy)]
 pub union WTS_PROPERTY_VALUE_0 {
     pub ulVal: u32,
-    pub strVal: WTS_PROPERTY_VALUE_0_1,
-    pub bVal: WTS_PROPERTY_VALUE_0_0,
+    pub strVal: WTS_PROPERTY_VALUE_0_0,
+    pub bVal: WTS_PROPERTY_VALUE_0_1,
     pub guidVal: windows_sys::core::GUID,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WTS_PROPERTY_VALUE_0_0 {
+pub struct WTS_PROPERTY_VALUE_0_1 {
     pub size: u32,
     pub pbVal: windows_sys::core::PSTR,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WTS_PROPERTY_VALUE_0_1 {
+pub struct WTS_PROPERTY_VALUE_0_0 {
     pub size: u32,
     pub pstrVal: windows_sys::core::PWSTR,
 }

--- a/crates/libs/sys/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Search/mod.rs
@@ -5860,27 +5860,27 @@ pub union SSVARIANT_0 {
     pub fltRealVal: f32,
     pub dblFloatVal: f64,
     pub cyMoneyVal: super::Com::CY,
-    pub NCharVal: SSVARIANT_0_3,
-    pub CharVal: SSVARIANT_0_2,
+    pub NCharVal: SSVARIANT_0_0,
+    pub CharVal: SSVARIANT_0_1,
     pub fBitVal: super::super::Foundation::VARIANT_BOOL,
     pub rgbGuidVal: [u8; 16],
     pub numNumericVal: DB_NUMERIC,
-    pub BinaryVal: SSVARIANT_0_1,
+    pub BinaryVal: SSVARIANT_0_2,
     pub tsDateTimeVal: DBTIMESTAMP,
-    pub UnknownType: SSVARIANT_0_4,
-    pub BLOBType: SSVARIANT_0_0,
+    pub UnknownType: SSVARIANT_0_3,
+    pub BLOBType: SSVARIANT_0_4,
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct SSVARIANT_0_0 {
+pub struct SSVARIANT_0_4 {
     pub dbobj: DBOBJECT,
     pub pUnk: *mut core::ffi::c_void,
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct SSVARIANT_0_1 {
+pub struct SSVARIANT_0_2 {
     pub sActualLength: i16,
     pub sMaxLength: i16,
     pub prgbBinaryVal: *mut u8,
@@ -5889,7 +5889,7 @@ pub struct SSVARIANT_0_1 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct SSVARIANT_0_2 {
+pub struct SSVARIANT_0_1 {
     pub sActualLength: i16,
     pub sMaxLength: i16,
     pub pchCharVal: windows_sys::core::PSTR,
@@ -5900,7 +5900,7 @@ pub struct SSVARIANT_0_2 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct SSVARIANT_0_3 {
+pub struct SSVARIANT_0_0 {
     pub sActualLength: i16,
     pub sMaxLength: i16,
     pub pwchNCharVal: windows_sys::core::PWSTR,
@@ -5911,7 +5911,7 @@ pub struct SSVARIANT_0_3 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct SSVARIANT_0_4 {
+pub struct SSVARIANT_0_3 {
     pub dwActualLength: u32,
     pub rgMetadata: [u8; 16],
     pub pUnknownData: *mut u8,

--- a/crates/libs/sys/src/Windows/Win32/System/SystemInformation/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/SystemInformation/mod.rs
@@ -702,19 +702,19 @@ pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0 {
-    pub ProcessorCore: SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1,
-    pub NumaNode: SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0,
+    pub ProcessorCore: SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0,
+    pub NumaNode: SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1,
     pub Cache: CACHE_DESCRIPTOR,
     pub Reserved: [u64; 2],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
+pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
     pub NodeNumber: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
+pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
     pub Flags: u8,
 }
 #[repr(C)]

--- a/crates/libs/sys/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/SystemServices/mod.rs
@@ -2850,15 +2850,15 @@ pub struct IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0_0 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_AUX_SYMBOL {
-    pub Sym: IMAGE_AUX_SYMBOL_3,
+    pub Sym: IMAGE_AUX_SYMBOL_0,
     pub File: IMAGE_AUX_SYMBOL_1,
     pub Section: IMAGE_AUX_SYMBOL_2,
     pub TokenDef: IMAGE_AUX_SYMBOL_TOKEN_DEF,
-    pub CRC: IMAGE_AUX_SYMBOL_0,
+    pub CRC: IMAGE_AUX_SYMBOL_3,
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_0 {
+pub struct IMAGE_AUX_SYMBOL_3 {
     pub crc: u32,
     pub rgbReserved: [u8; 14],
 }
@@ -2881,70 +2881,70 @@ pub struct IMAGE_AUX_SYMBOL_2 {
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_3 {
+pub struct IMAGE_AUX_SYMBOL_0 {
     pub TagIndex: u32,
-    pub Misc: IMAGE_AUX_SYMBOL_3_1,
-    pub FcnAry: IMAGE_AUX_SYMBOL_3_0,
+    pub Misc: IMAGE_AUX_SYMBOL_0_0,
+    pub FcnAry: IMAGE_AUX_SYMBOL_0_1,
     pub TvIndex: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union IMAGE_AUX_SYMBOL_3_0 {
-    pub Function: IMAGE_AUX_SYMBOL_3_0_1,
-    pub Array: IMAGE_AUX_SYMBOL_3_0_0,
+pub union IMAGE_AUX_SYMBOL_0_1 {
+    pub Function: IMAGE_AUX_SYMBOL_0_1_0,
+    pub Array: IMAGE_AUX_SYMBOL_0_1_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_3_0_0 {
+pub struct IMAGE_AUX_SYMBOL_0_1_1 {
     pub Dimension: [u16; 4],
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_3_0_1 {
+pub struct IMAGE_AUX_SYMBOL_0_1_0 {
     pub PointerToLinenumber: u32,
     pub PointerToNextFunction: u32,
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub union IMAGE_AUX_SYMBOL_3_1 {
-    pub LnSz: IMAGE_AUX_SYMBOL_3_1_0,
+pub union IMAGE_AUX_SYMBOL_0_0 {
+    pub LnSz: IMAGE_AUX_SYMBOL_0_0_0,
     pub TotalSize: u32,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_3_1_0 {
+pub struct IMAGE_AUX_SYMBOL_0_0_0 {
     pub Linenumber: u16,
     pub Size: u16,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_AUX_SYMBOL_EX {
-    pub Sym: IMAGE_AUX_SYMBOL_EX_4,
-    pub File: IMAGE_AUX_SYMBOL_EX_2,
-    pub Section: IMAGE_AUX_SYMBOL_EX_3,
-    pub Anonymous: IMAGE_AUX_SYMBOL_EX_0,
-    pub CRC: IMAGE_AUX_SYMBOL_EX_1,
+    pub Sym: IMAGE_AUX_SYMBOL_EX_0,
+    pub File: IMAGE_AUX_SYMBOL_EX_1,
+    pub Section: IMAGE_AUX_SYMBOL_EX_2,
+    pub Anonymous: IMAGE_AUX_SYMBOL_EX_3,
+    pub CRC: IMAGE_AUX_SYMBOL_EX_4,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_EX_0 {
+pub struct IMAGE_AUX_SYMBOL_EX_3 {
     pub TokenDef: IMAGE_AUX_SYMBOL_TOKEN_DEF,
     pub rgbReserved: [u8; 2],
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_EX_1 {
+pub struct IMAGE_AUX_SYMBOL_EX_4 {
     pub crc: u32,
     pub rgbReserved: [u8; 16],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_EX_2 {
+pub struct IMAGE_AUX_SYMBOL_EX_1 {
     pub Name: [u8; 20],
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_EX_3 {
+pub struct IMAGE_AUX_SYMBOL_EX_2 {
     pub Length: u32,
     pub NumberOfRelocations: u16,
     pub NumberOfLinenumbers: u16,
@@ -2957,7 +2957,7 @@ pub struct IMAGE_AUX_SYMBOL_EX_3 {
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_EX_4 {
+pub struct IMAGE_AUX_SYMBOL_EX_0 {
     pub WeakDefaultSymIndex: u32,
     pub WeakSearchType: u32,
     pub rgbReserved: [u8; 12],

--- a/crates/libs/sys/src/Windows/Win32/System/VirtualDosMachines/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/VirtualDosMachines/mod.rs
@@ -218,19 +218,19 @@ pub struct VDMLDT_ENTRY {
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
 pub union VDMLDT_ENTRY_0 {
-    pub Bytes: VDMLDT_ENTRY_0_1,
-    pub Bits: VDMLDT_ENTRY_0_0,
-}
-#[repr(C)]
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[derive(Clone, Copy)]
-pub struct VDMLDT_ENTRY_0_0 {
-    pub _bitfield: u32,
+    pub Bytes: VDMLDT_ENTRY_0_0,
+    pub Bits: VDMLDT_ENTRY_0_1,
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
 pub struct VDMLDT_ENTRY_0_1 {
+    pub _bitfield: u32,
+}
+#[repr(C)]
+#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
+#[derive(Clone, Copy)]
+pub struct VDMLDT_ENTRY_0_0 {
     pub BaseMid: u8,
     pub Flags1: u8,
     pub Flags2: u8,

--- a/crates/libs/sys/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -3366,18 +3366,18 @@ pub struct MENUTEMPLATEEX {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MENUTEMPLATEEX_0 {
-    pub Menu: MENUTEMPLATEEX_0_1,
-    pub MenuEx: MENUTEMPLATEEX_0_0,
+    pub Menu: MENUTEMPLATEEX_0_0,
+    pub MenuEx: MENUTEMPLATEEX_0_1,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MENUTEMPLATEEX_0_0 {
+pub struct MENUTEMPLATEEX_0_1 {
     pub mexHeader: MENUEX_TEMPLATE_HEADER,
     pub mexItem: [MENUEX_TEMPLATE_ITEM; 1],
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct MENUTEMPLATEEX_0_1 {
+pub struct MENUTEMPLATEEX_0_0 {
     pub mitHeader: MENUITEMTEMPLATEHEADER,
     pub miTemplate: [MENUITEMTEMPLATE; 1],
 }

--- a/crates/libs/windows/src/Windows/Wdk/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Foundation/mod.rs
@@ -976,45 +976,45 @@ impl Default for IO_STACK_LOCATION {
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
 pub union IO_STACK_LOCATION_0 {
-    pub Create: IO_STACK_LOCATION_0_2,
+    pub Create: IO_STACK_LOCATION_0_0,
     pub CreatePipe: IO_STACK_LOCATION_0_1,
-    pub CreateMailslot: IO_STACK_LOCATION_0_0,
-    pub Read: IO_STACK_LOCATION_0_25,
-    pub Write: IO_STACK_LOCATION_0_38,
-    pub QueryDirectory: IO_STACK_LOCATION_0_16,
-    pub NotifyDirectory: IO_STACK_LOCATION_0_10,
-    pub NotifyDirectoryEx: IO_STACK_LOCATION_0_9,
-    pub QueryFile: IO_STACK_LOCATION_0_18,
-    pub SetFile: IO_STACK_LOCATION_0_28,
-    pub QueryEa: IO_STACK_LOCATION_0_17,
-    pub SetEa: IO_STACK_LOCATION_0_27,
-    pub QueryVolume: IO_STACK_LOCATION_0_23,
-    pub SetVolume: IO_STACK_LOCATION_0_32,
-    pub FileSystemControl: IO_STACK_LOCATION_0_5,
-    pub LockControl: IO_STACK_LOCATION_0_7,
-    pub DeviceIoControl: IO_STACK_LOCATION_0_4,
-    pub QuerySecurity: IO_STACK_LOCATION_0_22,
-    pub SetSecurity: IO_STACK_LOCATION_0_31,
-    pub MountVolume: IO_STACK_LOCATION_0_8,
-    pub VerifyVolume: IO_STACK_LOCATION_0_35,
-    pub Scsi: IO_STACK_LOCATION_0_26,
-    pub QueryQuota: IO_STACK_LOCATION_0_21,
-    pub SetQuota: IO_STACK_LOCATION_0_30,
-    pub QueryDeviceRelations: IO_STACK_LOCATION_0_14,
-    pub QueryInterface: IO_STACK_LOCATION_0_20,
-    pub DeviceCapabilities: IO_STACK_LOCATION_0_3,
-    pub FilterResourceRequirements: IO_STACK_LOCATION_0_6,
-    pub ReadWriteConfig: IO_STACK_LOCATION_0_24,
+    pub CreateMailslot: IO_STACK_LOCATION_0_2,
+    pub Read: IO_STACK_LOCATION_0_3,
+    pub Write: IO_STACK_LOCATION_0_4,
+    pub QueryDirectory: IO_STACK_LOCATION_0_5,
+    pub NotifyDirectory: IO_STACK_LOCATION_0_6,
+    pub NotifyDirectoryEx: IO_STACK_LOCATION_0_7,
+    pub QueryFile: IO_STACK_LOCATION_0_8,
+    pub SetFile: IO_STACK_LOCATION_0_9,
+    pub QueryEa: IO_STACK_LOCATION_0_10,
+    pub SetEa: IO_STACK_LOCATION_0_11,
+    pub QueryVolume: IO_STACK_LOCATION_0_12,
+    pub SetVolume: IO_STACK_LOCATION_0_13,
+    pub FileSystemControl: IO_STACK_LOCATION_0_14,
+    pub LockControl: IO_STACK_LOCATION_0_15,
+    pub DeviceIoControl: IO_STACK_LOCATION_0_16,
+    pub QuerySecurity: IO_STACK_LOCATION_0_17,
+    pub SetSecurity: IO_STACK_LOCATION_0_18,
+    pub MountVolume: IO_STACK_LOCATION_0_19,
+    pub VerifyVolume: IO_STACK_LOCATION_0_20,
+    pub Scsi: IO_STACK_LOCATION_0_21,
+    pub QueryQuota: IO_STACK_LOCATION_0_22,
+    pub SetQuota: IO_STACK_LOCATION_0_23,
+    pub QueryDeviceRelations: IO_STACK_LOCATION_0_24,
+    pub QueryInterface: IO_STACK_LOCATION_0_25,
+    pub DeviceCapabilities: IO_STACK_LOCATION_0_26,
+    pub FilterResourceRequirements: IO_STACK_LOCATION_0_27,
+    pub ReadWriteConfig: IO_STACK_LOCATION_0_28,
     pub SetLock: IO_STACK_LOCATION_0_29,
-    pub QueryId: IO_STACK_LOCATION_0_19,
-    pub QueryDeviceText: IO_STACK_LOCATION_0_15,
-    pub UsageNotification: IO_STACK_LOCATION_0_34,
-    pub WaitWake: IO_STACK_LOCATION_0_37,
-    pub PowerSequence: IO_STACK_LOCATION_0_12,
-    pub Power: IO_STACK_LOCATION_0_13,
-    pub StartDevice: IO_STACK_LOCATION_0_33,
-    pub WMI: IO_STACK_LOCATION_0_36,
-    pub Others: IO_STACK_LOCATION_0_11,
+    pub QueryId: IO_STACK_LOCATION_0_30,
+    pub QueryDeviceText: IO_STACK_LOCATION_0_31,
+    pub UsageNotification: IO_STACK_LOCATION_0_32,
+    pub WaitWake: IO_STACK_LOCATION_0_33,
+    pub PowerSequence: IO_STACK_LOCATION_0_34,
+    pub Power: IO_STACK_LOCATION_0_35,
+    pub StartDevice: IO_STACK_LOCATION_0_36,
+    pub WMI: IO_STACK_LOCATION_0_37,
+    pub Others: IO_STACK_LOCATION_0_38,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for IO_STACK_LOCATION_0 {
@@ -1029,7 +1029,7 @@ impl Default for IO_STACK_LOCATION_0 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_0 {
+pub struct IO_STACK_LOCATION_0_2 {
     pub SecurityContext: *mut IO_SECURITY_CONTEXT,
     pub Options: u32,
     pub Reserved: u16,
@@ -1037,11 +1037,11 @@ pub struct IO_STACK_LOCATION_0_0 {
     pub Parameters: *mut super::System::SystemServices::MAILSLOT_CREATE_PARAMETERS,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_0 {
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_2 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_0 {
+impl Default for IO_STACK_LOCATION_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1069,7 +1069,7 @@ impl Default for IO_STACK_LOCATION_0_1 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_2 {
+pub struct IO_STACK_LOCATION_0_0 {
     pub SecurityContext: *mut IO_SECURITY_CONTEXT,
     pub Options: u32,
     pub FileAttributes: u16,
@@ -1077,436 +1077,11 @@ pub struct IO_STACK_LOCATION_0_2 {
     pub EaLength: u32,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_2 {
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_0 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_3 {
-    pub Capabilities: *mut super::System::SystemServices::DEVICE_CAPABILITIES,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_4 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub IoControlCode: u32,
-    pub Type3InputBuffer: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_4 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_5 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub FsControlCode: u32,
-    pub Type3InputBuffer: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_6 {
-    pub IoResourceRequirementList: *mut super::System::SystemServices::IO_RESOURCE_REQUIREMENTS_LIST,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_6 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_7 {
-    pub Length: *mut i64,
-    pub Key: u32,
-    pub ByteOffset: i64,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_7 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_8 {
-    pub Vpb: *mut VPB,
-    pub DeviceObject: *mut DEVICE_OBJECT,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_8 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_9 {
-    pub Length: u32,
-    pub CompletionFilter: u32,
-    pub DirectoryNotifyInformationClass: super::System::SystemServices::DIRECTORY_NOTIFY_INFORMATION_CLASS,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_9 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_10 {
-    pub Length: u32,
-    pub CompletionFilter: u32,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_10 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_10 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_11 {
-    pub Argument1: *mut core::ffi::c_void,
-    pub Argument2: *mut core::ffi::c_void,
-    pub Argument3: *mut core::ffi::c_void,
-    pub Argument4: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_11 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_11 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_12 {
-    pub PowerSequence: *mut super::System::SystemServices::POWER_SEQUENCE,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_12 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_12 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_13 {
-    pub Anonymous: IO_STACK_LOCATION_0_13_0,
-    pub Type: super::System::SystemServices::POWER_STATE_TYPE,
-    pub State: super::System::SystemServices::POWER_STATE,
-    pub ShutdownType: super::super::Win32::System::Power::POWER_ACTION,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_13 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_13 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub union IO_STACK_LOCATION_0_13_0 {
-    pub SystemContext: u32,
-    pub SystemPowerStateContext: super::System::SystemServices::SYSTEM_POWER_STATE_CONTEXT,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_13_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_13_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_14 {
-    pub Type: super::System::SystemServices::DEVICE_RELATION_TYPE,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_14 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_14 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_15 {
-    pub DeviceTextType: super::System::SystemServices::DEVICE_TEXT_TYPE,
-    pub LocaleId: u32,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_15 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_15 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_16 {
-    pub Length: u32,
-    pub FileName: *mut super::super::Win32::Foundation::UNICODE_STRING,
-    pub FileInformationClass: super::Storage::FileSystem::FILE_INFORMATION_CLASS,
-    pub FileIndex: u32,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_16 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_16 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_17 {
-    pub Length: u32,
-    pub EaList: *mut core::ffi::c_void,
-    pub EaListLength: u32,
-    pub EaIndex: u32,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_17 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_17 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_18 {
-    pub Length: u32,
-    pub FileInformationClass: super::Storage::FileSystem::FILE_INFORMATION_CLASS,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_18 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_18 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_19 {
-    pub IdType: super::System::SystemServices::BUS_QUERY_ID_TYPE,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_19 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_19 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_20 {
-    pub InterfaceType: *const windows_core::GUID,
-    pub Size: u16,
-    pub Version: u16,
-    pub Interface: *mut super::System::SystemServices::INTERFACE,
-    pub InterfaceSpecificData: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_20 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_20 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_21 {
-    pub Length: u32,
-    pub StartSid: super::super::Win32::Security::PSID,
-    pub SidList: *mut super::Storage::FileSystem::FILE_GET_QUOTA_INFORMATION,
-    pub SidListLength: u32,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_21 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_21 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_22 {
-    pub SecurityInformation: u32,
-    pub Length: u32,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_22 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_22 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_23 {
-    pub Length: u32,
-    pub FsInformationClass: super::Storage::FileSystem::FS_INFORMATION_CLASS,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_23 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_23 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_24 {
-    pub WhichSpace: u32,
-    pub Buffer: *mut core::ffi::c_void,
-    pub Offset: u32,
-    pub Length: u32,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_24 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_24 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_25 {
-    pub Length: u32,
-    pub Key: u32,
-    pub ByteOffset: i64,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_25 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_25 {
+impl Default for IO_STACK_LOCATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1515,7 +1090,7 @@ impl Default for IO_STACK_LOCATION_0_25 {
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IO_STACK_LOCATION_0_26 {
-    pub Srb: *mut _SCSI_REQUEST_BLOCK,
+    pub Capabilities: *mut super::System::SystemServices::DEVICE_CAPABILITIES,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for IO_STACK_LOCATION_0_26 {
@@ -1530,8 +1105,46 @@ impl Default for IO_STACK_LOCATION_0_26 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_16 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub IoControlCode: u32,
+    pub Type3InputBuffer: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_16 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_16 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_14 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub FsControlCode: u32,
+    pub Type3InputBuffer: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_14 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_14 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IO_STACK_LOCATION_0_27 {
-    pub Length: u32,
+    pub IoResourceRequirementList: *mut super::System::SystemServices::IO_RESOURCE_REQUIREMENTS_LIST,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for IO_STACK_LOCATION_0_27 {
@@ -1543,14 +1156,332 @@ impl Default for IO_STACK_LOCATION_0_27 {
         unsafe { core::mem::zeroed() }
     }
 }
+#[repr(C, packed(4))]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub struct IO_STACK_LOCATION_0_15 {
+    pub Length: *mut i64,
+    pub Key: u32,
+    pub ByteOffset: i64,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_15 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_15 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_19 {
+    pub Vpb: *mut VPB,
+    pub DeviceObject: *mut DEVICE_OBJECT,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_19 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_19 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_7 {
+    pub Length: u32,
+    pub CompletionFilter: u32,
+    pub DirectoryNotifyInformationClass: super::System::SystemServices::DIRECTORY_NOTIFY_INFORMATION_CLASS,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_7 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_6 {
+    pub Length: u32,
+    pub CompletionFilter: u32,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_6 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_6 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_38 {
+    pub Argument1: *mut core::ffi::c_void,
+    pub Argument2: *mut core::ffi::c_void,
+    pub Argument3: *mut core::ffi::c_void,
+    pub Argument4: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_38 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_38 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_34 {
+    pub PowerSequence: *mut super::System::SystemServices::POWER_SEQUENCE,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_34 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_34 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_28 {
+pub struct IO_STACK_LOCATION_0_35 {
+    pub Anonymous: IO_STACK_LOCATION_0_35_0,
+    pub Type: super::System::SystemServices::POWER_STATE_TYPE,
+    pub State: super::System::SystemServices::POWER_STATE,
+    pub ShutdownType: super::super::Win32::System::Power::POWER_ACTION,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_35 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_35 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub union IO_STACK_LOCATION_0_35_0 {
+    pub SystemContext: u32,
+    pub SystemPowerStateContext: super::System::SystemServices::SYSTEM_POWER_STATE_CONTEXT,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_35_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_35_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_24 {
+    pub Type: super::System::SystemServices::DEVICE_RELATION_TYPE,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_24 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_24 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_31 {
+    pub DeviceTextType: super::System::SystemServices::DEVICE_TEXT_TYPE,
+    pub LocaleId: u32,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_31 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_31 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_5 {
+    pub Length: u32,
+    pub FileName: *mut super::super::Win32::Foundation::UNICODE_STRING,
+    pub FileInformationClass: super::Storage::FileSystem::FILE_INFORMATION_CLASS,
+    pub FileIndex: u32,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_5 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_5 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_10 {
+    pub Length: u32,
+    pub EaList: *mut core::ffi::c_void,
+    pub EaListLength: u32,
+    pub EaIndex: u32,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_10 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_10 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_8 {
     pub Length: u32,
     pub FileInformationClass: super::Storage::FileSystem::FILE_INFORMATION_CLASS,
-    pub FileObject: *mut FILE_OBJECT,
-    pub Anonymous: IO_STACK_LOCATION_0_28_0,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_8 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_8 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_30 {
+    pub IdType: super::System::SystemServices::BUS_QUERY_ID_TYPE,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_30 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_30 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_25 {
+    pub InterfaceType: *const windows_core::GUID,
+    pub Size: u16,
+    pub Version: u16,
+    pub Interface: *mut super::System::SystemServices::INTERFACE,
+    pub InterfaceSpecificData: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_25 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_25 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_22 {
+    pub Length: u32,
+    pub StartSid: super::super::Win32::Security::PSID,
+    pub SidList: *mut super::Storage::FileSystem::FILE_GET_QUOTA_INFORMATION,
+    pub SidListLength: u32,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_22 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_22 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_17 {
+    pub SecurityInformation: u32,
+    pub Length: u32,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_17 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_17 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_12 {
+    pub Length: u32,
+    pub FsInformationClass: super::Storage::FileSystem::FS_INFORMATION_CLASS,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_12 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_12 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_28 {
+    pub WhichSpace: u32,
+    pub Buffer: *mut core::ffi::c_void,
+    pub Offset: u32,
+    pub Length: u32,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for IO_STACK_LOCATION_0_28 {
@@ -1562,20 +1493,20 @@ impl Default for IO_STACK_LOCATION_0_28 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[repr(C)]
+#[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union IO_STACK_LOCATION_0_28_0 {
-    pub Anonymous: IO_STACK_LOCATION_0_28_0_0,
-    pub ClusterCount: u32,
-    pub DeleteHandle: super::super::Win32::Foundation::HANDLE,
+pub struct IO_STACK_LOCATION_0_3 {
+    pub Length: u32,
+    pub Key: u32,
+    pub ByteOffset: i64,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_28_0 {
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_3 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_28_0 {
+impl Default for IO_STACK_LOCATION_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1583,16 +1514,85 @@ impl Default for IO_STACK_LOCATION_0_28_0 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_28_0_0 {
+pub struct IO_STACK_LOCATION_0_21 {
+    pub Srb: *mut _SCSI_REQUEST_BLOCK,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_21 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_21 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_11 {
+    pub Length: u32,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_11 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_11 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub struct IO_STACK_LOCATION_0_9 {
+    pub Length: u32,
+    pub FileInformationClass: super::Storage::FileSystem::FILE_INFORMATION_CLASS,
+    pub FileObject: *mut FILE_OBJECT,
+    pub Anonymous: IO_STACK_LOCATION_0_9_0,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_9 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_9 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub union IO_STACK_LOCATION_0_9_0 {
+    pub Anonymous: IO_STACK_LOCATION_0_9_0_0,
+    pub ClusterCount: u32,
+    pub DeleteHandle: super::super::Win32::Foundation::HANDLE,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_9_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_9_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_9_0_0 {
     pub ReplaceIfExists: super::super::Win32::Foundation::BOOLEAN,
     pub AdvanceOnly: super::super::Win32::Foundation::BOOLEAN,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_28_0_0 {
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_9_0_0 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_28_0_0 {
+impl Default for IO_STACK_LOCATION_0_9_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1616,15 +1616,15 @@ impl Default for IO_STACK_LOCATION_0_29 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_30 {
+pub struct IO_STACK_LOCATION_0_23 {
     pub Length: u32,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_30 {
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_23 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_30 {
+impl Default for IO_STACK_LOCATION_0_23 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1632,16 +1632,16 @@ impl Default for IO_STACK_LOCATION_0_30 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_31 {
+pub struct IO_STACK_LOCATION_0_18 {
     pub SecurityInformation: u32,
     pub SecurityDescriptor: super::super::Win32::Security::PSECURITY_DESCRIPTOR,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_31 {
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_18 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_31 {
+impl Default for IO_STACK_LOCATION_0_18 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1649,68 +1649,16 @@ impl Default for IO_STACK_LOCATION_0_31 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_32 {
+pub struct IO_STACK_LOCATION_0_13 {
     pub Length: u32,
     pub FsInformationClass: super::Storage::FileSystem::FS_INFORMATION_CLASS,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_32 {
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_13 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_32 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_33 {
-    pub AllocatedResources: *mut super::System::SystemServices::CM_RESOURCE_LIST,
-    pub AllocatedResourcesTranslated: *mut super::System::SystemServices::CM_RESOURCE_LIST,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_33 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_33 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_34 {
-    pub InPath: super::super::Win32::Foundation::BOOLEAN,
-    pub Reserved: [super::super::Win32::Foundation::BOOLEAN; 3],
-    pub Type: super::System::SystemServices::DEVICE_USAGE_NOTIFICATION_TYPE,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_34 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_34 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_STACK_LOCATION_0_35 {
-    pub Vpb: *mut VPB,
-    pub DeviceObject: *mut DEVICE_OBJECT,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_35 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_35 {
+impl Default for IO_STACK_LOCATION_0_13 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1719,10 +1667,8 @@ impl Default for IO_STACK_LOCATION_0_35 {
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IO_STACK_LOCATION_0_36 {
-    pub ProviderId: usize,
-    pub DataPath: *mut core::ffi::c_void,
-    pub BufferSize: u32,
-    pub Buffer: *mut core::ffi::c_void,
+    pub AllocatedResources: *mut super::System::SystemServices::CM_RESOURCE_LIST,
+    pub AllocatedResourcesTranslated: *mut super::System::SystemServices::CM_RESOURCE_LIST,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for IO_STACK_LOCATION_0_36 {
@@ -1737,8 +1683,46 @@ impl Default for IO_STACK_LOCATION_0_36 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_32 {
+    pub InPath: super::super::Win32::Foundation::BOOLEAN,
+    pub Reserved: [super::super::Win32::Foundation::BOOLEAN; 3],
+    pub Type: super::System::SystemServices::DEVICE_USAGE_NOTIFICATION_TYPE,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_32 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_32 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_20 {
+    pub Vpb: *mut VPB,
+    pub DeviceObject: *mut DEVICE_OBJECT,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_20 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_20 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IO_STACK_LOCATION_0_37 {
-    pub PowerState: super::super::Win32::System::Power::SYSTEM_POWER_STATE,
+    pub ProviderId: usize,
+    pub DataPath: *mut core::ffi::c_void,
+    pub BufferSize: u32,
+    pub Buffer: *mut core::ffi::c_void,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for IO_STACK_LOCATION_0_37 {
@@ -1750,20 +1734,36 @@ impl Default for IO_STACK_LOCATION_0_37 {
         unsafe { core::mem::zeroed() }
     }
 }
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_STACK_LOCATION_0_33 {
+    pub PowerState: super::super::Win32::System::Power::SYSTEM_POWER_STATE,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_33 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IO_STACK_LOCATION_0_33 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct IO_STACK_LOCATION_0_38 {
+pub struct IO_STACK_LOCATION_0_4 {
     pub Length: u32,
     pub Key: u32,
     pub ByteOffset: i64,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_38 {
+impl windows_core::TypeKind for IO_STACK_LOCATION_0_4 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IO_STACK_LOCATION_0_38 {
+impl Default for IO_STACK_LOCATION_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1776,7 +1776,7 @@ pub struct IRP {
     pub Size: u16,
     pub MdlAddress: *mut MDL,
     pub Flags: u32,
-    pub AssociatedIrp: IRP_1,
+    pub AssociatedIrp: IRP_0,
     pub ThreadListEntry: super::super::Win32::System::Kernel::LIST_ENTRY,
     pub IoStatus: super::super::Win32::System::IO::IO_STATUS_BLOCK,
     pub RequestorMode: i8,
@@ -1787,7 +1787,7 @@ pub struct IRP {
     pub CancelIrql: u8,
     pub ApcEnvironment: i8,
     pub AllocationFlags: u8,
-    pub Anonymous: IRP_0,
+    pub Anonymous: IRP_1,
     pub UserEvent: *mut KEVENT,
     pub Overlay: IRP_2,
     pub CancelRoutine: DRIVER_CANCEL,
@@ -1807,27 +1807,9 @@ impl Default for IRP {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union IRP_0 {
+pub union IRP_1 {
     pub UserIosb: *mut super::super::Win32::System::IO::IO_STATUS_BLOCK,
     pub IoRingContext: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for IRP_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub union IRP_1 {
-    pub MasterIrp: *mut IRP,
-    pub IrpCount: i32,
-    pub SystemBuffer: *mut core::ffi::c_void,
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for IRP_1 {
@@ -1835,6 +1817,24 @@ impl windows_core::TypeKind for IRP_1 {
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl Default for IRP_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub union IRP_0 {
+    pub MasterIrp: *mut IRP,
+    pub IrpCount: i32,
+    pub SystemBuffer: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for IRP_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for IRP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Wdk/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Graphics/Direct3D/mod.rs
@@ -4629,9 +4629,9 @@ pub struct D3DDDI_ALLOCATIONINFO2 {
     pub pPrivateDriverData: *mut core::ffi::c_void,
     pub PrivateDriverDataSize: u32,
     pub VidPnSourceId: u32,
-    pub Flags: D3DDDI_ALLOCATIONINFO2_2,
+    pub Flags: D3DDDI_ALLOCATIONINFO2_1,
     pub GpuVirtualAddress: u64,
-    pub Anonymous2: D3DDDI_ALLOCATIONINFO2_1,
+    pub Anonymous2: D3DDDI_ALLOCATIONINFO2_2,
     pub Reserved: [usize; 5],
 }
 impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2 {
@@ -4658,23 +4658,9 @@ impl Default for D3DDDI_ALLOCATIONINFO2_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union D3DDDI_ALLOCATIONINFO2_1 {
+pub union D3DDDI_ALLOCATIONINFO2_2 {
     pub Priority: u32,
     pub Unused: usize,
-}
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DDDI_ALLOCATIONINFO2_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub union D3DDDI_ALLOCATIONINFO2_2 {
-    pub Anonymous: D3DDDI_ALLOCATIONINFO2_2_0,
-    pub Value: u32,
 }
 impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2_2 {
     type TypeKind = windows_core::CopyType;
@@ -4685,14 +4671,28 @@ impl Default for D3DDDI_ALLOCATIONINFO2_2 {
     }
 }
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DDDI_ALLOCATIONINFO2_2_0 {
-    pub _bitfield: u32,
+#[derive(Clone, Copy)]
+pub union D3DDDI_ALLOCATIONINFO2_1 {
+    pub Anonymous: D3DDDI_ALLOCATIONINFO2_1_0,
+    pub Value: u32,
 }
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2_2_0 {
+impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for D3DDDI_ALLOCATIONINFO2_2_0 {
+impl Default for D3DDDI_ALLOCATIONINFO2_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DDDI_ALLOCATIONINFO2_1_0 {
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2_1_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DDDI_ALLOCATIONINFO2_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5676,9 +5676,9 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_SYNCHRONIZATIONOBJECTINFO_0 {
-    pub SynchronizationMutex: D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2,
+    pub SynchronizationMutex: D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0,
     pub Semaphore: D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_1,
-    pub Reserved: D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0,
+    pub Reserved: D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2,
 }
 impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0 {
     type TypeKind = windows_core::CopyType;
@@ -5690,13 +5690,13 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
     pub Reserved: [u32; 16],
 }
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
+impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
+impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5717,13 +5717,13 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
     pub InitialState: super::super::super::Win32::Foundation::BOOL,
 }
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
+impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
+impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5747,13 +5747,13 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0 {
-    pub SynchronizationMutex: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6,
-    pub Semaphore: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5,
-    pub Fence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1,
-    pub CPUNotification: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0,
-    pub MonitoredFence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2,
-    pub PeriodicMonitoredFence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3,
-    pub Reserved: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4,
+    pub SynchronizationMutex: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0,
+    pub Semaphore: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1,
+    pub Fence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2,
+    pub CPUNotification: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3,
+    pub MonitoredFence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4,
+    pub PeriodicMonitoredFence: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5,
+    pub Reserved: D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6,
 }
 impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0 {
     type TypeKind = windows_core::CopyType;
@@ -5765,57 +5765,8 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
-    pub Event: super::super::super::Win32::Foundation::HANDLE,
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1 {
-    pub FenceValue: u64,
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
-    pub InitialFenceValue: u64,
-    pub FenceValueCPUVirtualAddress: *mut core::ffi::c_void,
-    pub FenceValueGPUVirtualAddress: u64,
-    pub EngineAffinity: u32,
-    pub Padding: u32,
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3 {
-    pub hAdapter: u32,
-    pub VidPnTargetId: u32,
-    pub Time: u64,
-    pub FenceValueCPUVirtualAddress: *mut core::ffi::c_void,
-    pub FenceValueGPUVirtualAddress: u64,
-    pub EngineAffinity: u32,
-    pub Padding: u32,
+    pub Event: super::super::super::Win32::Foundation::HANDLE,
 }
 impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3 {
     type TypeKind = windows_core::CopyType;
@@ -5827,8 +5778,25 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
+    pub FenceValue: u64,
+}
+impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4 {
-    pub Reserved: [u64; 8],
+    pub InitialFenceValue: u64,
+    pub FenceValueCPUVirtualAddress: *mut core::ffi::c_void,
+    pub FenceValueGPUVirtualAddress: u64,
+    pub EngineAffinity: u32,
+    pub Padding: u32,
 }
 impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4 {
     type TypeKind = windows_core::CopyType;
@@ -5841,8 +5809,13 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5 {
-    pub MaxCount: u32,
-    pub InitialCount: u32,
+    pub hAdapter: u32,
+    pub VidPnTargetId: u32,
+    pub Time: u64,
+    pub FenceValueCPUVirtualAddress: *mut core::ffi::c_void,
+    pub FenceValueGPUVirtualAddress: u64,
+    pub EngineAffinity: u32,
+    pub Padding: u32,
 }
 impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5 {
     type TypeKind = windows_core::CopyType;
@@ -5855,12 +5828,39 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6 {
-    pub InitialState: super::super::super::Win32::Foundation::BOOL,
+    pub Reserved: [u64; 8],
 }
 impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1 {
+    pub MaxCount: u32,
+    pub InitialCount: u32,
+}
+impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
+    pub InitialState: super::super::super::Win32::Foundation::BOOL,
+}
+impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6048,10 +6048,10 @@ impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0 {
-    pub Map: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2,
+    pub Map: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0,
     pub MapProtect: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_1,
-    pub Unmap: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3,
-    pub Copy: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0,
+    pub Unmap: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2,
+    pub Copy: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3,
 }
 impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0 {
     type TypeKind = windows_core::CopyType;
@@ -6063,15 +6063,15 @@ impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
+pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
     pub SourceAddress: u64,
     pub SizeInBytes: u64,
     pub DestAddress: u64,
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
+impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
+impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6097,32 +6097,32 @@ impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
+pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
     pub BaseAddress: u64,
     pub SizeInBytes: u64,
     pub hAllocation: u32,
     pub AllocationOffsetInBytes: u64,
     pub AllocationSizeInBytes: u64,
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
+impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
+impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
+pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
     pub BaseAddress: u64,
     pub SizeInBytes: u64,
     pub Protection: D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE,
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
+impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
+impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -16178,21 +16178,21 @@ impl Default for D3DKMT_VIDMM_ESCAPE {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_VIDMM_ESCAPE_0 {
-    pub SetFault: D3DKMT_VIDMM_ESCAPE_0_9,
-    pub Evict: D3DKMT_VIDMM_ESCAPE_0_4,
-    pub EvictByNtHandle: D3DKMT_VIDMM_ESCAPE_0_3,
-    pub GetVads: D3DKMT_VIDMM_ESCAPE_0_6,
-    pub SetBudget: D3DKMT_VIDMM_ESCAPE_0_8,
-    pub SuspendProcess: D3DKMT_VIDMM_ESCAPE_0_11,
-    pub ResumeProcess: D3DKMT_VIDMM_ESCAPE_0_7,
-    pub GetBudget: D3DKMT_VIDMM_ESCAPE_0_5,
-    pub SetTrimIntervals: D3DKMT_VIDMM_ESCAPE_0_10,
+    pub SetFault: D3DKMT_VIDMM_ESCAPE_0_0,
+    pub Evict: D3DKMT_VIDMM_ESCAPE_0_1,
+    pub EvictByNtHandle: D3DKMT_VIDMM_ESCAPE_0_2,
+    pub GetVads: D3DKMT_VIDMM_ESCAPE_0_3,
+    pub SetBudget: D3DKMT_VIDMM_ESCAPE_0_4,
+    pub SuspendProcess: D3DKMT_VIDMM_ESCAPE_0_5,
+    pub ResumeProcess: D3DKMT_VIDMM_ESCAPE_0_6,
+    pub GetBudget: D3DKMT_VIDMM_ESCAPE_0_7,
+    pub SetTrimIntervals: D3DKMT_VIDMM_ESCAPE_0_8,
     pub EvictByCriteria: D3DKMT_EVICTION_CRITERIA,
-    pub Wake: D3DKMT_VIDMM_ESCAPE_0_13,
-    pub Defrag: D3DKMT_VIDMM_ESCAPE_0_0,
-    pub DelayExecution: D3DKMT_VIDMM_ESCAPE_0_1,
+    pub Wake: D3DKMT_VIDMM_ESCAPE_0_9,
+    pub Defrag: D3DKMT_VIDMM_ESCAPE_0_10,
+    pub DelayExecution: D3DKMT_VIDMM_ESCAPE_0_11,
     pub VerifyIntegrity: D3DKMT_VIDMM_ESCAPE_0_12,
-    pub DelayedEvictionConfig: D3DKMT_VIDMM_ESCAPE_0_2,
+    pub DelayedEvictionConfig: D3DKMT_VIDMM_ESCAPE_0_13,
 }
 impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0 {
     type TypeKind = windows_core::CopyType;
@@ -16204,211 +16204,13 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_0 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_10 {
     pub Operation: D3DKMT_DEFRAG_ESCAPE_OPERATION,
     pub SegmentId: u32,
     pub TotalCommitted: u64,
     pub TotalFree: u64,
     pub LargestGapBefore: u64,
     pub LargestGapAfter: u64,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_1 {
-    pub hPagingQueue: u32,
-    pub PhysicalAdapterIndex: u32,
-    pub Milliseconds: u32,
-    pub PagingFenceValue: u64,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_2 {
-    pub TimerValue: i64,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_3 {
-    pub NtHandle: u64,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_4 {
-    pub ResourceHandle: u32,
-    pub AllocationHandle: u32,
-    pub hProcess: super::super::super::Win32::Foundation::HANDLE,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_4 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_5 {
-    pub NumBytesToTrim: u64,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_6 {
-    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_6_0,
-    pub Command: D3DKMT_VAD_ESCAPE_COMMAND,
-    pub Status: super::super::super::Win32::Foundation::NTSTATUS,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_6 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub union D3DKMT_VIDMM_ESCAPE_0_6_0 {
-    pub GetNumVads: D3DKMT_VIDMM_ESCAPE_0_6_0_0,
-    pub GetVad: D3DKMT_VAD_DESC,
-    pub GetVadRange: D3DKMT_VA_RANGE_DESC,
-    pub GetGpuMmuCaps: D3DKMT_GET_GPUMMU_CAPS,
-    pub GetPte: D3DKMT_GET_PTE,
-    pub GetSegmentCaps: D3DKMT_GET_SEGMENT_CAPS,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_6_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_6_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_6_0_0 {
-    pub NumVads: u32,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_6_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_6_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_7 {
-    pub hProcess: super::super::super::Win32::Foundation::HANDLE,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_7 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_8 {
-    pub LocalMemoryBudget: u64,
-    pub SystemMemoryBudget: u64,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_8 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_9 {
-    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_9_0,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_9 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub union D3DKMT_VIDMM_ESCAPE_0_9_0 {
-    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_9_0_0,
-    pub Value: u32,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_9_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_9_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_9_0_0 {
-    pub _bitfield: u32,
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_9_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for D3DKMT_VIDMM_ESCAPE_0_9_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_10 {
-    pub MinTrimInterval: u32,
-    pub MaxTrimInterval: u32,
-    pub IdleTrimInterval: u32,
 }
 impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_10 {
     type TypeKind = windows_core::CopyType;
@@ -16421,13 +16223,211 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_10 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_11 {
-    pub hProcess: super::super::super::Win32::Foundation::HANDLE,
-    pub bAllowWakeOnSubmission: super::super::super::Win32::Foundation::BOOL,
+    pub hPagingQueue: u32,
+    pub PhysicalAdapterIndex: u32,
+    pub Milliseconds: u32,
+    pub PagingFenceValue: u64,
 }
 impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_11 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for D3DKMT_VIDMM_ESCAPE_0_11 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_13 {
+    pub TimerValue: i64,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_13 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_13 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_2 {
+    pub NtHandle: u64,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_1 {
+    pub ResourceHandle: u32,
+    pub AllocationHandle: u32,
+    pub hProcess: super::super::super::Win32::Foundation::HANDLE,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_1 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_7 {
+    pub NumBytesToTrim: u64,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_7 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_3 {
+    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_3_0,
+    pub Command: D3DKMT_VAD_ESCAPE_COMMAND,
+    pub Status: super::super::super::Win32::Foundation::NTSTATUS,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_3 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union D3DKMT_VIDMM_ESCAPE_0_3_0 {
+    pub GetNumVads: D3DKMT_VIDMM_ESCAPE_0_3_0_0,
+    pub GetVad: D3DKMT_VAD_DESC,
+    pub GetVadRange: D3DKMT_VA_RANGE_DESC,
+    pub GetGpuMmuCaps: D3DKMT_GET_GPUMMU_CAPS,
+    pub GetPte: D3DKMT_GET_PTE,
+    pub GetSegmentCaps: D3DKMT_GET_SEGMENT_CAPS,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_3_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_3_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_3_0_0 {
+    pub NumVads: u32,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_3_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_3_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_6 {
+    pub hProcess: super::super::super::Win32::Foundation::HANDLE,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_6 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_6 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_4 {
+    pub LocalMemoryBudget: u64,
+    pub SystemMemoryBudget: u64,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_4 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_4 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_0 {
+    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_0_0,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union D3DKMT_VIDMM_ESCAPE_0_0_0 {
+    pub Anonymous: D3DKMT_VIDMM_ESCAPE_0_0_0_0,
+    pub Value: u32,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_0_0_0 {
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_0_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_0_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_8 {
+    pub MinTrimInterval: u32,
+    pub MaxTrimInterval: u32,
+    pub IdleTrimInterval: u32,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_8 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_8 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct D3DKMT_VIDMM_ESCAPE_0_5 {
+    pub hProcess: super::super::super::Win32::Foundation::HANDLE,
+    pub bAllowWakeOnSubmission: super::super::super::Win32::Foundation::BOOL,
+}
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_5 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for D3DKMT_VIDMM_ESCAPE_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -16447,13 +16447,13 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_12 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3DKMT_VIDMM_ESCAPE_0_13 {
+pub struct D3DKMT_VIDMM_ESCAPE_0_9 {
     pub bFlush: super::super::super::Win32::Foundation::BOOL,
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_13 {
+impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_9 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for D3DKMT_VIDMM_ESCAPE_0_13 {
+impl Default for D3DKMT_VIDMM_ESCAPE_0_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Wdk/NetworkManagement/Ndis/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/NetworkManagement/Ndis/mod.rs
@@ -4210,27 +4210,14 @@ impl Default for NDIS_INTERRUPT_MODERATION_PARAMETERS {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_IPSEC_OFFLOAD_V1 {
-    pub Supported: NDIS_IPSEC_OFFLOAD_V1_2,
-    pub IPv4AH: NDIS_IPSEC_OFFLOAD_V1_0,
-    pub IPv4ESP: NDIS_IPSEC_OFFLOAD_V1_1,
+    pub Supported: NDIS_IPSEC_OFFLOAD_V1_0,
+    pub IPv4AH: NDIS_IPSEC_OFFLOAD_V1_1,
+    pub IPv4ESP: NDIS_IPSEC_OFFLOAD_V1_2,
 }
 impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_IPSEC_OFFLOAD_V1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_IPSEC_OFFLOAD_V1_0 {
-    pub _bitfield: u32,
-}
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NDIS_IPSEC_OFFLOAD_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4251,16 +4238,29 @@ impl Default for NDIS_IPSEC_OFFLOAD_V1_1 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_IPSEC_OFFLOAD_V1_2 {
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NDIS_IPSEC_OFFLOAD_V1_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NDIS_IPSEC_OFFLOAD_V1_0 {
     pub Encapsulation: u32,
     pub AhEspCombined: u32,
     pub TransportTunnelCombined: u32,
     pub IPv4Options: u32,
     pub Flags: u32,
 }
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_2 {
+impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NDIS_IPSEC_OFFLOAD_V1_2 {
+impl Default for NDIS_IPSEC_OFFLOAD_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5067,29 +5067,15 @@ impl Default for NDIS_TCP_CONNECTION_OFFLOAD {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD {
-    pub IPv4Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_1,
-    pub IPv4Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_0,
-    pub IPv6Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_3,
-    pub IPv6Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv4Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_0,
+    pub IPv4Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_1,
+    pub IPv6Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv6Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_3,
 }
 impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    pub Encapsulation: u32,
-    pub _bitfield: u32,
-}
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5110,14 +5096,14 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     pub Encapsulation: u32,
     pub _bitfield: u32,
 }
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5132,6 +5118,20 @@ impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+    pub Encapsulation: u32,
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5152,27 +5152,14 @@ impl Default for NDIS_TCP_IP_CHECKSUM_PACKET_INFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0 {
-    pub Transmit: NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1,
-    pub Receive: NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0,
+    pub Transmit: NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0,
+    pub Receive: NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1,
     pub Value: u32,
 }
 impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
-    pub _bitfield: u32,
-}
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5186,6 +5173,19 @@ impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5539,9 +5539,9 @@ impl Default for NDIS_WMI_EVENT_HEADER {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_WMI_IPSEC_OFFLOAD_V1 {
-    pub Supported: NDIS_WMI_IPSEC_OFFLOAD_V1_2,
-    pub IPv4AH: NDIS_WMI_IPSEC_OFFLOAD_V1_0,
-    pub IPv4ESP: NDIS_WMI_IPSEC_OFFLOAD_V1_1,
+    pub Supported: NDIS_WMI_IPSEC_OFFLOAD_V1_0,
+    pub IPv4AH: NDIS_WMI_IPSEC_OFFLOAD_V1_1,
+    pub IPv4ESP: NDIS_WMI_IPSEC_OFFLOAD_V1_2,
 }
 impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1 {
     type TypeKind = windows_core::CopyType;
@@ -5553,29 +5553,9 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
+pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
     pub Md5: u32,
     pub Sha_1: u32,
-    pub Transport: u32,
-    pub Tunnel: u32,
-    pub Send: u32,
-    pub Receive: u32,
-}
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
-    pub Des: u32,
-    pub Reserved: u32,
-    pub TripleDes: u32,
-    pub NullEsp: u32,
     pub Transport: u32,
     pub Tunnel: u32,
     pub Send: u32,
@@ -5592,16 +5572,36 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+    pub Des: u32,
+    pub Reserved: u32,
+    pub TripleDes: u32,
+    pub NullEsp: u32,
+    pub Transport: u32,
+    pub Tunnel: u32,
+    pub Send: u32,
+    pub Receive: u32,
+}
+impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     pub Encapsulation: u32,
     pub AhEspCombined: u32,
     pub TransportTunnelCombined: u32,
     pub IPv4Options: u32,
     pub Flags: u32,
 }
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5705,33 +5705,15 @@ impl Default for NDIS_WMI_TCP_CONNECTION_OFFLOAD {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
-    pub IPv4Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1,
-    pub IPv4Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0,
-    pub IPv6Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3,
-    pub IPv6Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv4Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0,
+    pub IPv4Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1,
+    pub IPv6Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv6Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3,
 }
 impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    pub Encapsulation: u32,
-    pub IpOptionsSupported: u32,
-    pub TcpOptionsSupported: u32,
-    pub TcpChecksum: u32,
-    pub UdpChecksum: u32,
-    pub IpChecksum: u32,
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5756,17 +5738,18 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
     pub Encapsulation: u32,
-    pub IpExtensionHeadersSupported: u32,
+    pub IpOptionsSupported: u32,
     pub TcpOptionsSupported: u32,
     pub TcpChecksum: u32,
     pub UdpChecksum: u32,
+    pub IpChecksum: u32,
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5784,6 +5767,23 @@ impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+    pub Encapsulation: u32,
+    pub IpExtensionHeadersSupported: u32,
+    pub TcpOptionsSupported: u32,
+    pub TcpChecksum: u32,
+    pub UdpChecksum: u32,
+}
+impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/Minifilters/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/Minifilters/mod.rs
@@ -2371,39 +2371,39 @@ impl Default for FLT_OPERATION_REGISTRATION {
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
 pub union FLT_PARAMETERS {
-    pub Create: FLT_PARAMETERS_4,
-    pub CreatePipe: FLT_PARAMETERS_3,
+    pub Create: FLT_PARAMETERS_0,
+    pub CreatePipe: FLT_PARAMETERS_1,
     pub CreateMailslot: FLT_PARAMETERS_2,
-    pub Read: FLT_PARAMETERS_24,
-    pub Write: FLT_PARAMETERS_32,
-    pub QueryFileInformation: FLT_PARAMETERS_19,
-    pub SetFileInformation: FLT_PARAMETERS_27,
-    pub QueryEa: FLT_PARAMETERS_18,
-    pub SetEa: FLT_PARAMETERS_26,
-    pub QueryVolumeInformation: FLT_PARAMETERS_23,
-    pub SetVolumeInformation: FLT_PARAMETERS_30,
-    pub DirectoryControl: FLT_PARAMETERS_6,
-    pub FileSystemControl: FLT_PARAMETERS_8,
-    pub DeviceIoControl: FLT_PARAMETERS_5,
-    pub LockControl: FLT_PARAMETERS_9,
-    pub QuerySecurity: FLT_PARAMETERS_22,
-    pub SetSecurity: FLT_PARAMETERS_29,
-    pub WMI: FLT_PARAMETERS_31,
-    pub QueryQuota: FLT_PARAMETERS_21,
-    pub SetQuota: FLT_PARAMETERS_28,
-    pub Pnp: FLT_PARAMETERS_16,
-    pub AcquireForSectionSynchronization: FLT_PARAMETERS_1,
-    pub AcquireForModifiedPageWriter: FLT_PARAMETERS_0,
-    pub ReleaseForModifiedPageWriter: FLT_PARAMETERS_25,
-    pub QueryOpen: FLT_PARAMETERS_20,
-    pub FastIoCheckIfPossible: FLT_PARAMETERS_7,
-    pub NetworkQueryOpen: FLT_PARAMETERS_14,
-    pub MdlRead: FLT_PARAMETERS_11,
-    pub MdlReadComplete: FLT_PARAMETERS_10,
-    pub PrepareMdlWrite: FLT_PARAMETERS_17,
-    pub MdlWriteComplete: FLT_PARAMETERS_12,
-    pub MountVolume: FLT_PARAMETERS_13,
-    pub Others: FLT_PARAMETERS_15,
+    pub Read: FLT_PARAMETERS_3,
+    pub Write: FLT_PARAMETERS_4,
+    pub QueryFileInformation: FLT_PARAMETERS_5,
+    pub SetFileInformation: FLT_PARAMETERS_6,
+    pub QueryEa: FLT_PARAMETERS_7,
+    pub SetEa: FLT_PARAMETERS_8,
+    pub QueryVolumeInformation: FLT_PARAMETERS_9,
+    pub SetVolumeInformation: FLT_PARAMETERS_10,
+    pub DirectoryControl: FLT_PARAMETERS_11,
+    pub FileSystemControl: FLT_PARAMETERS_12,
+    pub DeviceIoControl: FLT_PARAMETERS_13,
+    pub LockControl: FLT_PARAMETERS_14,
+    pub QuerySecurity: FLT_PARAMETERS_15,
+    pub SetSecurity: FLT_PARAMETERS_16,
+    pub WMI: FLT_PARAMETERS_17,
+    pub QueryQuota: FLT_PARAMETERS_18,
+    pub SetQuota: FLT_PARAMETERS_19,
+    pub Pnp: FLT_PARAMETERS_20,
+    pub AcquireForSectionSynchronization: FLT_PARAMETERS_21,
+    pub AcquireForModifiedPageWriter: FLT_PARAMETERS_22,
+    pub ReleaseForModifiedPageWriter: FLT_PARAMETERS_23,
+    pub QueryOpen: FLT_PARAMETERS_24,
+    pub FastIoCheckIfPossible: FLT_PARAMETERS_25,
+    pub NetworkQueryOpen: FLT_PARAMETERS_26,
+    pub MdlRead: FLT_PARAMETERS_27,
+    pub MdlReadComplete: FLT_PARAMETERS_28,
+    pub PrepareMdlWrite: FLT_PARAMETERS_29,
+    pub MdlWriteComplete: FLT_PARAMETERS_30,
+    pub MountVolume: FLT_PARAMETERS_31,
+    pub Others: FLT_PARAMETERS_32,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for FLT_PARAMETERS {
@@ -2418,16 +2418,16 @@ impl Default for FLT_PARAMETERS {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_0 {
+pub struct FLT_PARAMETERS_22 {
     pub EndingOffset: *mut i64,
     pub ResourceToRelease: *mut *mut super::super::super::Foundation::ERESOURCE,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_0 {
+impl windows_core::TypeKind for FLT_PARAMETERS_22 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_0 {
+impl Default for FLT_PARAMETERS_22 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2435,7 +2435,7 @@ impl Default for FLT_PARAMETERS_0 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_1 {
+pub struct FLT_PARAMETERS_21 {
     pub SyncType: super::FS_FILTER_SECTION_SYNC_TYPE,
     pub PageProtection: u32,
     pub OutputInformation: *mut super::FS_FILTER_SECTION_SYNC_OUTPUT,
@@ -2443,11 +2443,11 @@ pub struct FLT_PARAMETERS_1 {
     pub AllocationAttributes: u32,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_1 {
+impl windows_core::TypeKind for FLT_PARAMETERS_21 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_1 {
+impl Default for FLT_PARAMETERS_21 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2475,7 +2475,7 @@ impl Default for FLT_PARAMETERS_2 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_3 {
+pub struct FLT_PARAMETERS_1 {
     pub SecurityContext: *mut super::super::super::Foundation::IO_SECURITY_CONTEXT,
     pub Options: u32,
     pub Reserved: u16,
@@ -2483,11 +2483,11 @@ pub struct FLT_PARAMETERS_3 {
     pub Parameters: *mut core::ffi::c_void,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_3 {
+impl windows_core::TypeKind for FLT_PARAMETERS_1 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_3 {
+impl Default for FLT_PARAMETERS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2495,7 +2495,7 @@ impl Default for FLT_PARAMETERS_3 {
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_4 {
+pub struct FLT_PARAMETERS_0 {
     pub SecurityContext: *mut super::super::super::Foundation::IO_SECURITY_CONTEXT,
     pub Options: u32,
     pub FileAttributes: u16,
@@ -2505,11 +2505,11 @@ pub struct FLT_PARAMETERS_4 {
     pub AllocationSize: i64,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_4 {
+impl windows_core::TypeKind for FLT_PARAMETERS_0 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_4 {
+impl Default for FLT_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2517,416 +2517,12 @@ impl Default for FLT_PARAMETERS_4 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub union FLT_PARAMETERS_5 {
-    pub Common: FLT_PARAMETERS_5_1,
-    pub Neither: FLT_PARAMETERS_5_4,
-    pub Buffered: FLT_PARAMETERS_5_0,
-    pub Direct: FLT_PARAMETERS_5_2,
-    pub FastIo: FLT_PARAMETERS_5_3,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_5 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_5_0 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub IoControlCode: u32,
-    pub SystemBuffer: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_5_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_5_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_5_1 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub IoControlCode: u32,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_5_1 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_5_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_5_2 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub IoControlCode: u32,
-    pub InputSystemBuffer: *mut core::ffi::c_void,
-    pub OutputBuffer: *mut core::ffi::c_void,
-    pub OutputMdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_5_2 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_5_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_5_3 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub IoControlCode: u32,
-    pub InputBuffer: *mut core::ffi::c_void,
-    pub OutputBuffer: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_5_3 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_5_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_5_4 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub IoControlCode: u32,
-    pub InputBuffer: *mut core::ffi::c_void,
-    pub OutputBuffer: *mut core::ffi::c_void,
-    pub OutputMdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_5_4 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_5_4 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub union FLT_PARAMETERS_6 {
-    pub QueryDirectory: FLT_PARAMETERS_6_2,
-    pub NotifyDirectory: FLT_PARAMETERS_6_1,
-    pub NotifyDirectoryEx: FLT_PARAMETERS_6_0,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_6 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_6 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_6_0 {
-    pub Length: u32,
-    pub CompletionFilter: u32,
-    pub DirectoryNotifyInformationClass: super::super::super::System::SystemServices::DIRECTORY_NOTIFY_INFORMATION_CLASS,
-    pub Spare2: u32,
-    pub DirectoryBuffer: *mut core::ffi::c_void,
-    pub MdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_6_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_6_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_6_1 {
-    pub Length: u32,
-    pub CompletionFilter: u32,
-    pub Spare1: u32,
-    pub Spare2: u32,
-    pub DirectoryBuffer: *mut core::ffi::c_void,
-    pub MdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_6_1 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_6_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_6_2 {
-    pub Length: u32,
-    pub FileName: *mut super::super::super::super::Win32::Foundation::UNICODE_STRING,
-    pub FileInformationClass: super::FILE_INFORMATION_CLASS,
-    pub FileIndex: u32,
-    pub DirectoryBuffer: *mut core::ffi::c_void,
-    pub MdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_6_2 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_6_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_7 {
-    pub FileOffset: i64,
-    pub Length: u32,
-    pub LockKey: u32,
-    pub CheckForReadOperation: super::super::super::super::Win32::Foundation::BOOLEAN,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_7 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_7 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub union FLT_PARAMETERS_8 {
-    pub VerifyVolume: FLT_PARAMETERS_8_4,
-    pub Common: FLT_PARAMETERS_8_1,
-    pub Neither: FLT_PARAMETERS_8_3,
-    pub Buffered: FLT_PARAMETERS_8_0,
-    pub Direct: FLT_PARAMETERS_8_2,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_8 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_8 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_8_0 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub FsControlCode: u32,
-    pub SystemBuffer: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_8_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_8_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_8_1 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub FsControlCode: u32,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_8_1 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_8_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_8_2 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub FsControlCode: u32,
-    pub InputSystemBuffer: *mut core::ffi::c_void,
-    pub OutputBuffer: *mut core::ffi::c_void,
-    pub OutputMdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_8_2 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_8_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_8_3 {
-    pub OutputBufferLength: u32,
-    pub InputBufferLength: u32,
-    pub FsControlCode: u32,
-    pub InputBuffer: *mut core::ffi::c_void,
-    pub OutputBuffer: *mut core::ffi::c_void,
-    pub OutputMdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_8_3 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_8_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_8_4 {
-    pub Vpb: *mut super::super::super::Foundation::VPB,
-    pub DeviceObject: *mut super::super::super::Foundation::DEVICE_OBJECT,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_8_4 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_8_4 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_9 {
-    pub Length: *mut i64,
-    pub Key: u32,
-    pub ByteOffset: i64,
-    pub ProcessId: super::super::super::Foundation::PEPROCESS,
-    pub FailImmediately: super::super::super::super::Win32::Foundation::BOOLEAN,
-    pub ExclusiveLock: super::super::super::super::Win32::Foundation::BOOLEAN,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_9 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_9 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_10 {
-    pub MdlChain: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_10 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_10 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_11 {
-    pub FileOffset: i64,
-    pub Length: u32,
-    pub Key: u32,
-    pub MdlChain: *mut *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_11 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_11 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_12 {
-    pub FileOffset: i64,
-    pub MdlChain: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_12 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_12 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_13 {
-    pub DeviceType: u32,
+pub union FLT_PARAMETERS_13 {
+    pub Common: FLT_PARAMETERS_13_0,
+    pub Neither: FLT_PARAMETERS_13_1,
+    pub Buffered: FLT_PARAMETERS_13_2,
+    pub Direct: FLT_PARAMETERS_13_3,
+    pub FastIo: FLT_PARAMETERS_13_4,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for FLT_PARAMETERS_13 {
@@ -2941,62 +2537,116 @@ impl Default for FLT_PARAMETERS_13 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_14 {
-    pub Irp: *mut super::super::super::Foundation::IRP,
-    pub NetworkInformation: *mut super::FILE_NETWORK_OPEN_INFORMATION,
+pub struct FLT_PARAMETERS_13_2 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub IoControlCode: u32,
+    pub SystemBuffer: *mut core::ffi::c_void,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_14 {
+impl windows_core::TypeKind for FLT_PARAMETERS_13_2 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_14 {
+impl Default for FLT_PARAMETERS_13_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_13_0 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub IoControlCode: u32,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_13_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_13_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_13_3 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub IoControlCode: u32,
+    pub InputSystemBuffer: *mut core::ffi::c_void,
+    pub OutputBuffer: *mut core::ffi::c_void,
+    pub OutputMdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_13_3 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_13_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_13_4 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub IoControlCode: u32,
+    pub InputBuffer: *mut core::ffi::c_void,
+    pub OutputBuffer: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_13_4 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_13_4 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_13_1 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub IoControlCode: u32,
+    pub InputBuffer: *mut core::ffi::c_void,
+    pub OutputBuffer: *mut core::ffi::c_void,
+    pub OutputMdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_13_1 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_13_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_15 {
-    pub Argument1: *mut core::ffi::c_void,
-    pub Argument2: *mut core::ffi::c_void,
-    pub Argument3: *mut core::ffi::c_void,
-    pub Argument4: *mut core::ffi::c_void,
-    pub Argument5: *mut core::ffi::c_void,
-    pub Argument6: i64,
+pub union FLT_PARAMETERS_11 {
+    pub QueryDirectory: FLT_PARAMETERS_11_0,
+    pub NotifyDirectory: FLT_PARAMETERS_11_1,
+    pub NotifyDirectoryEx: FLT_PARAMETERS_11_2,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_15 {
+impl windows_core::TypeKind for FLT_PARAMETERS_11 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_15 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub union FLT_PARAMETERS_16 {
-    pub StartDevice: FLT_PARAMETERS_16_8,
-    pub QueryDeviceRelations: FLT_PARAMETERS_16_2,
-    pub QueryInterface: FLT_PARAMETERS_16_5,
-    pub DeviceCapabilities: FLT_PARAMETERS_16_0,
-    pub FilterResourceRequirements: FLT_PARAMETERS_16_1,
-    pub ReadWriteConfig: FLT_PARAMETERS_16_6,
-    pub SetLock: FLT_PARAMETERS_16_7,
-    pub QueryId: FLT_PARAMETERS_16_4,
-    pub QueryDeviceText: FLT_PARAMETERS_16_3,
-    pub UsageNotification: FLT_PARAMETERS_16_9,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16 {
+impl Default for FLT_PARAMETERS_11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3004,119 +2654,20 @@ impl Default for FLT_PARAMETERS_16 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_16_0 {
-    pub Capabilities: *mut super::super::super::System::SystemServices::DEVICE_CAPABILITIES,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_16_1 {
-    pub IoResourceRequirementList: *mut super::super::super::System::SystemServices::IO_RESOURCE_REQUIREMENTS_LIST,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16_1 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_16_2 {
-    pub Type: super::super::super::System::SystemServices::DEVICE_RELATION_TYPE,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16_2 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_16_3 {
-    pub DeviceTextType: super::super::super::System::SystemServices::DEVICE_TEXT_TYPE,
-    pub LocaleId: u32,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16_3 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_16_4 {
-    pub IdType: super::super::super::System::SystemServices::BUS_QUERY_ID_TYPE,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16_4 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16_4 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_16_5 {
-    pub InterfaceType: *const windows_core::GUID,
-    pub Size: u16,
-    pub Version: u16,
-    pub Interface: *mut super::super::super::System::SystemServices::INTERFACE,
-    pub InterfaceSpecificData: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16_5 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_16_6 {
-    pub WhichSpace: u32,
-    pub Buffer: *mut core::ffi::c_void,
-    pub Offset: u32,
+pub struct FLT_PARAMETERS_11_2 {
     pub Length: u32,
+    pub CompletionFilter: u32,
+    pub DirectoryNotifyInformationClass: super::super::super::System::SystemServices::DIRECTORY_NOTIFY_INFORMATION_CLASS,
+    pub Spare2: u32,
+    pub DirectoryBuffer: *mut core::ffi::c_void,
+    pub MdlAddress: *mut super::super::super::Foundation::MDL,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16_6 {
+impl windows_core::TypeKind for FLT_PARAMETERS_11_2 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16_6 {
+impl Default for FLT_PARAMETERS_11_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3124,15 +2675,20 @@ impl Default for FLT_PARAMETERS_16_6 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_16_7 {
-    pub Lock: super::super::super::super::Win32::Foundation::BOOLEAN,
+pub struct FLT_PARAMETERS_11_1 {
+    pub Length: u32,
+    pub CompletionFilter: u32,
+    pub Spare1: u32,
+    pub Spare2: u32,
+    pub DirectoryBuffer: *mut core::ffi::c_void,
+    pub MdlAddress: *mut super::super::super::Foundation::MDL,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16_7 {
+impl windows_core::TypeKind for FLT_PARAMETERS_11_1 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16_7 {
+impl Default for FLT_PARAMETERS_11_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3140,34 +2696,20 @@ impl Default for FLT_PARAMETERS_16_7 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_16_8 {
-    pub AllocatedResources: *mut super::super::super::System::SystemServices::CM_RESOURCE_LIST,
-    pub AllocatedResourcesTranslated: *mut super::super::super::System::SystemServices::CM_RESOURCE_LIST,
+pub struct FLT_PARAMETERS_11_0 {
+    pub Length: u32,
+    pub FileName: *mut super::super::super::super::Win32::Foundation::UNICODE_STRING,
+    pub FileInformationClass: super::FILE_INFORMATION_CLASS,
+    pub FileIndex: u32,
+    pub DirectoryBuffer: *mut core::ffi::c_void,
+    pub MdlAddress: *mut super::super::super::Foundation::MDL,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16_8 {
+impl windows_core::TypeKind for FLT_PARAMETERS_11_0 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16_8 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_16_9 {
-    pub InPath: super::super::super::super::Win32::Foundation::BOOLEAN,
-    pub Reserved: [super::super::super::super::Win32::Foundation::BOOLEAN; 3],
-    pub Type: super::super::super::System::SystemServices::DEVICE_USAGE_NOTIFICATION_TYPE,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16_9 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_16_9 {
+impl Default for FLT_PARAMETERS_11_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3175,163 +2717,11 @@ impl Default for FLT_PARAMETERS_16_9 {
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_17 {
+pub struct FLT_PARAMETERS_25 {
     pub FileOffset: i64,
     pub Length: u32,
-    pub Key: u32,
-    pub MdlChain: *mut *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_17 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_17 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_18 {
-    pub Length: u32,
-    pub EaList: *mut core::ffi::c_void,
-    pub EaListLength: u32,
-    pub EaIndex: u32,
-    pub EaBuffer: *mut core::ffi::c_void,
-    pub MdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_18 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_18 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_19 {
-    pub Length: u32,
-    pub FileInformationClass: super::FILE_INFORMATION_CLASS,
-    pub InfoBuffer: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_19 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_19 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_20 {
-    pub Irp: *mut super::super::super::Foundation::IRP,
-    pub FileInformation: *mut core::ffi::c_void,
-    pub Length: *mut u32,
-    pub FileInformationClass: super::FILE_INFORMATION_CLASS,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_20 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_21 {
-    pub Length: u32,
-    pub StartSid: super::super::super::super::Win32::Security::PSID,
-    pub SidList: *mut super::FILE_GET_QUOTA_INFORMATION,
-    pub SidListLength: u32,
-    pub QuotaBuffer: *mut core::ffi::c_void,
-    pub MdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_21 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_21 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_22 {
-    pub SecurityInformation: u32,
-    pub Length: u32,
-    pub SecurityBuffer: *mut core::ffi::c_void,
-    pub MdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_22 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_22 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_23 {
-    pub Length: u32,
-    pub FsInformationClass: super::FS_INFORMATION_CLASS,
-    pub VolumeBuffer: *mut core::ffi::c_void,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_23 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_23 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_24 {
-    pub Length: u32,
-    pub Key: u32,
-    pub ByteOffset: i64,
-    pub ReadBuffer: *mut core::ffi::c_void,
-    pub MdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_24 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_24 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_25 {
-    pub ResourceToRelease: *mut super::super::super::Foundation::ERESOURCE,
+    pub LockKey: u32,
+    pub CheckForReadOperation: super::super::super::super::Win32::Foundation::BOOLEAN,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for FLT_PARAMETERS_25 {
@@ -3345,56 +2735,20 @@ impl Default for FLT_PARAMETERS_25 {
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_26 {
-    pub Length: u32,
-    pub EaBuffer: *mut core::ffi::c_void,
-    pub MdlAddress: *mut super::super::super::Foundation::MDL,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_26 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_26 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
-pub struct FLT_PARAMETERS_27 {
-    pub Length: u32,
-    pub FileInformationClass: super::FILE_INFORMATION_CLASS,
-    pub ParentOfTarget: *mut super::super::super::Foundation::FILE_OBJECT,
-    pub Anonymous: FLT_PARAMETERS_27_0,
-    pub InfoBuffer: *mut core::ffi::c_void,
+pub union FLT_PARAMETERS_12 {
+    pub VerifyVolume: FLT_PARAMETERS_12_0,
+    pub Common: FLT_PARAMETERS_12_1,
+    pub Neither: FLT_PARAMETERS_12_2,
+    pub Buffered: FLT_PARAMETERS_12_3,
+    pub Direct: FLT_PARAMETERS_12_4,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_27 {
+impl windows_core::TypeKind for FLT_PARAMETERS_12 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_27 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy)]
-pub union FLT_PARAMETERS_27_0 {
-    pub Anonymous: FLT_PARAMETERS_27_0_0,
-    pub ClusterCount: u32,
-    pub DeleteHandle: super::super::super::super::Win32::Foundation::HANDLE,
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_27_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_27_0 {
+impl Default for FLT_PARAMETERS_12 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3402,16 +2756,116 @@ impl Default for FLT_PARAMETERS_27_0 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_27_0_0 {
-    pub ReplaceIfExists: super::super::super::super::Win32::Foundation::BOOLEAN,
-    pub AdvanceOnly: super::super::super::super::Win32::Foundation::BOOLEAN,
+pub struct FLT_PARAMETERS_12_3 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub FsControlCode: u32,
+    pub SystemBuffer: *mut core::ffi::c_void,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_27_0_0 {
+impl windows_core::TypeKind for FLT_PARAMETERS_12_3 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_27_0_0 {
+impl Default for FLT_PARAMETERS_12_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_12_1 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub FsControlCode: u32,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_12_1 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_12_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_12_4 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub FsControlCode: u32,
+    pub InputSystemBuffer: *mut core::ffi::c_void,
+    pub OutputBuffer: *mut core::ffi::c_void,
+    pub OutputMdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_12_4 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_12_4 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_12_2 {
+    pub OutputBufferLength: u32,
+    pub InputBufferLength: u32,
+    pub FsControlCode: u32,
+    pub InputBuffer: *mut core::ffi::c_void,
+    pub OutputBuffer: *mut core::ffi::c_void,
+    pub OutputMdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_12_2 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_12_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_12_0 {
+    pub Vpb: *mut super::super::super::Foundation::VPB,
+    pub DeviceObject: *mut super::super::super::Foundation::DEVICE_OBJECT,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_12_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_12_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub struct FLT_PARAMETERS_14 {
+    pub Length: *mut i64,
+    pub Key: u32,
+    pub ByteOffset: i64,
+    pub ProcessId: super::super::super::Foundation::PEPROCESS,
+    pub FailImmediately: super::super::super::super::Win32::Foundation::BOOLEAN,
+    pub ExclusiveLock: super::super::super::super::Win32::Foundation::BOOLEAN,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_14 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_14 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3420,9 +2874,7 @@ impl Default for FLT_PARAMETERS_27_0_0 {
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FLT_PARAMETERS_28 {
-    pub Length: u32,
-    pub QuotaBuffer: *mut core::ffi::c_void,
-    pub MdlAddress: *mut super::super::super::Foundation::MDL,
+    pub MdlChain: *mut super::super::super::Foundation::MDL,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for FLT_PARAMETERS_28 {
@@ -3434,30 +2886,31 @@ impl Default for FLT_PARAMETERS_28 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[repr(C)]
+#[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_PARAMETERS_29 {
-    pub SecurityInformation: u32,
-    pub SecurityDescriptor: super::super::super::super::Win32::Security::PSECURITY_DESCRIPTOR,
+#[derive(Clone, Copy)]
+pub struct FLT_PARAMETERS_27 {
+    pub FileOffset: i64,
+    pub Length: u32,
+    pub Key: u32,
+    pub MdlChain: *mut *mut super::super::super::Foundation::MDL,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_29 {
+impl windows_core::TypeKind for FLT_PARAMETERS_27 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FLT_PARAMETERS_29 {
+impl Default for FLT_PARAMETERS_27 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-#[repr(C)]
+#[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy)]
 pub struct FLT_PARAMETERS_30 {
-    pub Length: u32,
-    pub FsInformationClass: super::FS_INFORMATION_CLASS,
-    pub VolumeBuffer: *mut core::ffi::c_void,
+    pub FileOffset: i64,
+    pub MdlChain: *mut super::super::super::Foundation::MDL,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for FLT_PARAMETERS_30 {
@@ -3473,10 +2926,7 @@ impl Default for FLT_PARAMETERS_30 {
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FLT_PARAMETERS_31 {
-    pub ProviderId: usize,
-    pub DataPath: *mut core::ffi::c_void,
-    pub BufferSize: u32,
-    pub Buffer: *mut core::ffi::c_void,
+    pub DeviceType: u32,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for FLT_PARAMETERS_31 {
@@ -3488,15 +2938,33 @@ impl Default for FLT_PARAMETERS_31 {
         unsafe { core::mem::zeroed() }
     }
 }
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_26 {
+    pub Irp: *mut super::super::super::Foundation::IRP,
+    pub NetworkInformation: *mut super::FILE_NETWORK_OPEN_INFORMATION,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_26 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_26 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
 pub struct FLT_PARAMETERS_32 {
-    pub Length: u32,
-    pub Key: u32,
-    pub ByteOffset: i64,
-    pub WriteBuffer: *mut core::ffi::c_void,
-    pub MdlAddress: *mut super::super::super::Foundation::MDL,
+    pub Argument1: *mut core::ffi::c_void,
+    pub Argument2: *mut core::ffi::c_void,
+    pub Argument3: *mut core::ffi::c_void,
+    pub Argument4: *mut core::ffi::c_void,
+    pub Argument5: *mut core::ffi::c_void,
+    pub Argument6: i64,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for FLT_PARAMETERS_32 {
@@ -3504,6 +2972,538 @@ impl windows_core::TypeKind for FLT_PARAMETERS_32 {
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl Default for FLT_PARAMETERS_32 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub union FLT_PARAMETERS_20 {
+    pub StartDevice: FLT_PARAMETERS_20_0,
+    pub QueryDeviceRelations: FLT_PARAMETERS_20_1,
+    pub QueryInterface: FLT_PARAMETERS_20_2,
+    pub DeviceCapabilities: FLT_PARAMETERS_20_3,
+    pub FilterResourceRequirements: FLT_PARAMETERS_20_4,
+    pub ReadWriteConfig: FLT_PARAMETERS_20_5,
+    pub SetLock: FLT_PARAMETERS_20_6,
+    pub QueryId: FLT_PARAMETERS_20_7,
+    pub QueryDeviceText: FLT_PARAMETERS_20_8,
+    pub UsageNotification: FLT_PARAMETERS_20_9,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_20_3 {
+    pub Capabilities: *mut super::super::super::System::SystemServices::DEVICE_CAPABILITIES,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20_3 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_20_4 {
+    pub IoResourceRequirementList: *mut super::super::super::System::SystemServices::IO_RESOURCE_REQUIREMENTS_LIST,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20_4 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20_4 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_20_1 {
+    pub Type: super::super::super::System::SystemServices::DEVICE_RELATION_TYPE,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20_1 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_20_8 {
+    pub DeviceTextType: super::super::super::System::SystemServices::DEVICE_TEXT_TYPE,
+    pub LocaleId: u32,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20_8 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20_8 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_20_7 {
+    pub IdType: super::super::super::System::SystemServices::BUS_QUERY_ID_TYPE,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20_7 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_20_2 {
+    pub InterfaceType: *const windows_core::GUID,
+    pub Size: u16,
+    pub Version: u16,
+    pub Interface: *mut super::super::super::System::SystemServices::INTERFACE,
+    pub InterfaceSpecificData: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20_2 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_20_5 {
+    pub WhichSpace: u32,
+    pub Buffer: *mut core::ffi::c_void,
+    pub Offset: u32,
+    pub Length: u32,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20_5 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20_5 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_20_6 {
+    pub Lock: super::super::super::super::Win32::Foundation::BOOLEAN,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20_6 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20_6 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_20_0 {
+    pub AllocatedResources: *mut super::super::super::System::SystemServices::CM_RESOURCE_LIST,
+    pub AllocatedResourcesTranslated: *mut super::super::super::System::SystemServices::CM_RESOURCE_LIST,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_20_9 {
+    pub InPath: super::super::super::super::Win32::Foundation::BOOLEAN,
+    pub Reserved: [super::super::super::super::Win32::Foundation::BOOLEAN; 3],
+    pub Type: super::super::super::System::SystemServices::DEVICE_USAGE_NOTIFICATION_TYPE,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_20_9 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_20_9 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub struct FLT_PARAMETERS_29 {
+    pub FileOffset: i64,
+    pub Length: u32,
+    pub Key: u32,
+    pub MdlChain: *mut *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_29 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_29 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_7 {
+    pub Length: u32,
+    pub EaList: *mut core::ffi::c_void,
+    pub EaListLength: u32,
+    pub EaIndex: u32,
+    pub EaBuffer: *mut core::ffi::c_void,
+    pub MdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_7 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_5 {
+    pub Length: u32,
+    pub FileInformationClass: super::FILE_INFORMATION_CLASS,
+    pub InfoBuffer: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_5 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_5 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_24 {
+    pub Irp: *mut super::super::super::Foundation::IRP,
+    pub FileInformation: *mut core::ffi::c_void,
+    pub Length: *mut u32,
+    pub FileInformationClass: super::FILE_INFORMATION_CLASS,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_24 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_24 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_18 {
+    pub Length: u32,
+    pub StartSid: super::super::super::super::Win32::Security::PSID,
+    pub SidList: *mut super::FILE_GET_QUOTA_INFORMATION,
+    pub SidListLength: u32,
+    pub QuotaBuffer: *mut core::ffi::c_void,
+    pub MdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_18 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_18 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_15 {
+    pub SecurityInformation: u32,
+    pub Length: u32,
+    pub SecurityBuffer: *mut core::ffi::c_void,
+    pub MdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_15 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_15 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_9 {
+    pub Length: u32,
+    pub FsInformationClass: super::FS_INFORMATION_CLASS,
+    pub VolumeBuffer: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_9 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_9 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub struct FLT_PARAMETERS_3 {
+    pub Length: u32,
+    pub Key: u32,
+    pub ByteOffset: i64,
+    pub ReadBuffer: *mut core::ffi::c_void,
+    pub MdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_3 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_23 {
+    pub ResourceToRelease: *mut super::super::super::Foundation::ERESOURCE,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_23 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_23 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_8 {
+    pub Length: u32,
+    pub EaBuffer: *mut core::ffi::c_void,
+    pub MdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_8 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_8 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub struct FLT_PARAMETERS_6 {
+    pub Length: u32,
+    pub FileInformationClass: super::FILE_INFORMATION_CLASS,
+    pub ParentOfTarget: *mut super::super::super::Foundation::FILE_OBJECT,
+    pub Anonymous: FLT_PARAMETERS_6_0,
+    pub InfoBuffer: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_6 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_6 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub union FLT_PARAMETERS_6_0 {
+    pub Anonymous: FLT_PARAMETERS_6_0_0,
+    pub ClusterCount: u32,
+    pub DeleteHandle: super::super::super::super::Win32::Foundation::HANDLE,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_6_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_6_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_6_0_0 {
+    pub ReplaceIfExists: super::super::super::super::Win32::Foundation::BOOLEAN,
+    pub AdvanceOnly: super::super::super::super::Win32::Foundation::BOOLEAN,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_6_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_6_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_19 {
+    pub Length: u32,
+    pub QuotaBuffer: *mut core::ffi::c_void,
+    pub MdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_19 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_19 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_16 {
+    pub SecurityInformation: u32,
+    pub SecurityDescriptor: super::super::super::super::Win32::Security::PSECURITY_DESCRIPTOR,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_16 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_16 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_10 {
+    pub Length: u32,
+    pub FsInformationClass: super::FS_INFORMATION_CLASS,
+    pub VolumeBuffer: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_10 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_10 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_PARAMETERS_17 {
+    pub ProviderId: usize,
+    pub DataPath: *mut core::ffi::c_void,
+    pub BufferSize: u32,
+    pub Buffer: *mut core::ffi::c_void,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_17 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_17 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(4))]
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+#[derive(Clone, Copy)]
+pub struct FLT_PARAMETERS_4 {
+    pub Length: u32,
+    pub Key: u32,
+    pub ByteOffset: i64,
+    pub WriteBuffer: *mut core::ffi::c_void,
+    pub MdlAddress: *mut super::super::super::Foundation::MDL,
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl windows_core::TypeKind for FLT_PARAMETERS_4 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
+impl Default for FLT_PARAMETERS_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3617,10 +3617,10 @@ impl Default for FLT_TAG_DATA_BUFFER {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FLT_TAG_DATA_BUFFER_0 {
-    pub SymbolicLinkReparseBuffer: FLT_TAG_DATA_BUFFER_0_3,
-    pub MountPointReparseBuffer: FLT_TAG_DATA_BUFFER_0_2,
-    pub GenericReparseBuffer: FLT_TAG_DATA_BUFFER_0_1,
-    pub GenericGUIDReparseBuffer: FLT_TAG_DATA_BUFFER_0_0,
+    pub SymbolicLinkReparseBuffer: FLT_TAG_DATA_BUFFER_0_0,
+    pub MountPointReparseBuffer: FLT_TAG_DATA_BUFFER_0_1,
+    pub GenericReparseBuffer: FLT_TAG_DATA_BUFFER_0_2,
+    pub GenericGUIDReparseBuffer: FLT_TAG_DATA_BUFFER_0_3,
 }
 impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0 {
     type TypeKind = windows_core::CopyType;
@@ -3632,27 +3632,14 @@ impl Default for FLT_TAG_DATA_BUFFER_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_TAG_DATA_BUFFER_0_0 {
+pub struct FLT_TAG_DATA_BUFFER_0_3 {
     pub TagGuid: windows_core::GUID,
     pub DataBuffer: [u8; 1],
 }
-impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_0 {
+impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_3 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for FLT_TAG_DATA_BUFFER_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_TAG_DATA_BUFFER_0_1 {
-    pub DataBuffer: [u8; 1],
-}
-impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for FLT_TAG_DATA_BUFFER_0_1 {
+impl Default for FLT_TAG_DATA_BUFFER_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3660,11 +3647,7 @@ impl Default for FLT_TAG_DATA_BUFFER_0_1 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FLT_TAG_DATA_BUFFER_0_2 {
-    pub SubstituteNameOffset: u16,
-    pub SubstituteNameLength: u16,
-    pub PrintNameOffset: u16,
-    pub PrintNameLength: u16,
-    pub PathBuffer: [u16; 1],
+    pub DataBuffer: [u8; 1],
 }
 impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_2 {
     type TypeKind = windows_core::CopyType;
@@ -3676,7 +3659,24 @@ impl Default for FLT_TAG_DATA_BUFFER_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FLT_TAG_DATA_BUFFER_0_3 {
+pub struct FLT_TAG_DATA_BUFFER_0_1 {
+    pub SubstituteNameOffset: u16,
+    pub SubstituteNameLength: u16,
+    pub PrintNameOffset: u16,
+    pub PrintNameLength: u16,
+    pub PathBuffer: [u16; 1],
+}
+impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_1 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for FLT_TAG_DATA_BUFFER_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FLT_TAG_DATA_BUFFER_0_0 {
     pub SubstituteNameOffset: u16,
     pub SubstituteNameLength: u16,
     pub PrintNameOffset: u16,
@@ -3684,10 +3684,10 @@ pub struct FLT_TAG_DATA_BUFFER_0_3 {
     pub Flags: u32,
     pub PathBuffer: [u16; 1],
 }
-impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_3 {
+impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for FLT_TAG_DATA_BUFFER_0_3 {
+impl Default for FLT_TAG_DATA_BUFFER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/mod.rs
@@ -8492,10 +8492,10 @@ impl Default for FS_FILTER_CALLBACK_DATA {
 #[derive(Clone, Copy)]
 pub union FS_FILTER_PARAMETERS {
     pub AcquireForModifiedPageWriter: FS_FILTER_PARAMETERS_0,
-    pub ReleaseForModifiedPageWriter: FS_FILTER_PARAMETERS_4,
-    pub AcquireForSectionSynchronization: FS_FILTER_PARAMETERS_1,
+    pub ReleaseForModifiedPageWriter: FS_FILTER_PARAMETERS_1,
+    pub AcquireForSectionSynchronization: FS_FILTER_PARAMETERS_2,
     pub QueryOpen: FS_FILTER_PARAMETERS_3,
-    pub Others: FS_FILTER_PARAMETERS_2,
+    pub Others: FS_FILTER_PARAMETERS_4,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 impl windows_core::TypeKind for FS_FILTER_PARAMETERS {
@@ -8527,7 +8527,7 @@ impl Default for FS_FILTER_PARAMETERS_0 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FS_FILTER_PARAMETERS_1 {
+pub struct FS_FILTER_PARAMETERS_2 {
     pub SyncType: FS_FILTER_SECTION_SYNC_TYPE,
     pub PageProtection: u32,
     pub OutputInformation: *mut FS_FILTER_SECTION_SYNC_OUTPUT,
@@ -8535,11 +8535,11 @@ pub struct FS_FILTER_PARAMETERS_1 {
     pub AllocationAttributes: u32,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_PARAMETERS_1 {
+impl windows_core::TypeKind for FS_FILTER_PARAMETERS_2 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FS_FILTER_PARAMETERS_1 {
+impl Default for FS_FILTER_PARAMETERS_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -8547,7 +8547,7 @@ impl Default for FS_FILTER_PARAMETERS_1 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FS_FILTER_PARAMETERS_2 {
+pub struct FS_FILTER_PARAMETERS_4 {
     pub Argument1: *mut core::ffi::c_void,
     pub Argument2: *mut core::ffi::c_void,
     pub Argument3: *mut core::ffi::c_void,
@@ -8555,11 +8555,11 @@ pub struct FS_FILTER_PARAMETERS_2 {
     pub Argument5: *mut core::ffi::c_void,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_PARAMETERS_2 {
+impl windows_core::TypeKind for FS_FILTER_PARAMETERS_4 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FS_FILTER_PARAMETERS_2 {
+impl Default for FS_FILTER_PARAMETERS_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -8587,15 +8587,15 @@ impl Default for FS_FILTER_PARAMETERS_3 {
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FS_FILTER_PARAMETERS_4 {
+pub struct FS_FILTER_PARAMETERS_1 {
     pub ResourceToRelease: *mut super::super::Foundation::ERESOURCE,
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_PARAMETERS_4 {
+impl windows_core::TypeKind for FS_FILTER_PARAMETERS_1 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl Default for FS_FILTER_PARAMETERS_4 {
+impl Default for FS_FILTER_PARAMETERS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -10022,9 +10022,9 @@ impl Default for REPARSE_DATA_BUFFER {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union REPARSE_DATA_BUFFER_0 {
-    pub SymbolicLinkReparseBuffer: REPARSE_DATA_BUFFER_0_2,
+    pub SymbolicLinkReparseBuffer: REPARSE_DATA_BUFFER_0_0,
     pub MountPointReparseBuffer: REPARSE_DATA_BUFFER_0_1,
-    pub GenericReparseBuffer: REPARSE_DATA_BUFFER_0_0,
+    pub GenericReparseBuffer: REPARSE_DATA_BUFFER_0_2,
 }
 impl windows_core::TypeKind for REPARSE_DATA_BUFFER_0 {
     type TypeKind = windows_core::CopyType;
@@ -10036,13 +10036,13 @@ impl Default for REPARSE_DATA_BUFFER_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct REPARSE_DATA_BUFFER_0_0 {
+pub struct REPARSE_DATA_BUFFER_0_2 {
     pub DataBuffer: [u8; 1],
 }
-impl windows_core::TypeKind for REPARSE_DATA_BUFFER_0_0 {
+impl windows_core::TypeKind for REPARSE_DATA_BUFFER_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for REPARSE_DATA_BUFFER_0_0 {
+impl Default for REPARSE_DATA_BUFFER_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -10066,7 +10066,7 @@ impl Default for REPARSE_DATA_BUFFER_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct REPARSE_DATA_BUFFER_0_2 {
+pub struct REPARSE_DATA_BUFFER_0_0 {
     pub SubstituteNameOffset: u16,
     pub SubstituteNameLength: u16,
     pub PrintNameOffset: u16,
@@ -10074,10 +10074,10 @@ pub struct REPARSE_DATA_BUFFER_0_2 {
     pub Flags: u32,
     pub PathBuffer: [u16; 1],
 }
-impl windows_core::TypeKind for REPARSE_DATA_BUFFER_0_2 {
+impl windows_core::TypeKind for REPARSE_DATA_BUFFER_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for REPARSE_DATA_BUFFER_0_2 {
+impl Default for REPARSE_DATA_BUFFER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Wdk/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/System/SystemServices/mod.rs
@@ -12643,20 +12643,20 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CM_PARTIAL_RESOURCE_DESCRIPTOR_0 {
-    pub Generic: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6,
-    pub Port: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13,
-    pub Interrupt: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7,
-    pub MessageInterrupt: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12,
-    pub Memory: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11,
+    pub Generic: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0,
+    pub Port: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1,
+    pub Interrupt: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2,
+    pub MessageInterrupt: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3,
+    pub Memory: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4,
     pub Dma: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_5,
-    pub DmaV3: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4,
-    pub DevicePrivate: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2,
-    pub BusNumber: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0,
-    pub DeviceSpecificData: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3,
-    pub Memory40: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8,
-    pub Memory48: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9,
-    pub Memory64: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10,
-    pub Connection: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1,
+    pub DmaV3: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6,
+    pub DevicePrivate: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7,
+    pub BusNumber: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8,
+    pub DeviceSpecificData: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9,
+    pub Memory40: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10,
+    pub Memory48: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11,
+    pub Memory64: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12,
+    pub Connection: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13,
 }
 impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0 {
     type TypeKind = windows_core::CopyType;
@@ -12668,22 +12668,22 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
     pub Start: u32,
     pub Length: u32,
     pub Reserved: u32,
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13 {
     pub Class: u8,
     pub Type: u8,
     pub Reserved1: u8,
@@ -12691,45 +12691,45 @@ pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
     pub IdLowPart: u32,
     pub IdHighPart: u32,
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
     pub Data: [u32; 3],
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
     pub DataSize: u32,
     pub Reserved1: u32,
     pub Reserved2: u32,
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6 {
     pub Channel: u32,
     pub RequestLine: u32,
     pub TransferWidth: u8,
@@ -12737,10 +12737,10 @@ pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
     pub Reserved2: u8,
     pub Reserved3: u8,
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -12762,57 +12762,29 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_5 {
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
     pub Start: i64,
     pub Length: u32,
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2 {
     pub Level: u32,
     pub Vector: u32,
     pub Affinity: usize,
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
-    pub Start: i64,
-    pub Length40: u32,
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(4))]
-#[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
-    pub Start: i64,
-    pub Length48: u32,
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -12821,7 +12793,7 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
 #[derive(Clone, Copy)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10 {
     pub Start: i64,
-    pub Length64: u32,
+    pub Length40: u32,
 }
 impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10 {
     type TypeKind = windows_core::CopyType;
@@ -12835,7 +12807,7 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10 {
 #[derive(Clone, Copy)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11 {
     pub Start: i64,
-    pub Length: u32,
+    pub Length48: u32,
 }
 impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11 {
     type TypeKind = windows_core::CopyType;
@@ -12845,10 +12817,11 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[repr(C)]
+#[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12 {
-    pub Anonymous: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0,
+    pub Start: i64,
+    pub Length64: u32,
 }
 impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12 {
     type TypeKind = windows_core::CopyType;
@@ -12858,61 +12831,88 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[repr(C)]
+#[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub union CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0 {
-    pub Raw: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_0,
-    pub Translated: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_1,
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
+    pub Start: i64,
+    pub Length: u32,
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
+    pub Anonymous: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0,
+}
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0 {
+    pub Raw: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_0,
+    pub Translated: CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_1,
+}
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_0 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_0 {
     pub Reserved: u16,
     pub MessageCount: u16,
     pub Vector: u32,
     pub Affinity: usize,
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_0 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_0 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_1 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_1 {
     pub Level: u32,
     pub Vector: u32,
     pub Affinity: usize,
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_1 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12_0_1 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13 {
+pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
     pub Start: i64,
     pub Length: u32,
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13 {
+impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13 {
+impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -13505,27 +13505,14 @@ impl Default for DEVICE_BUS_SPECIFIC_RESET_INFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVICE_BUS_SPECIFIC_RESET_TYPE {
-    pub Pci: DEVICE_BUS_SPECIFIC_RESET_TYPE_1,
-    pub Acpi: DEVICE_BUS_SPECIFIC_RESET_TYPE_0,
+    pub Pci: DEVICE_BUS_SPECIFIC_RESET_TYPE_0,
+    pub Acpi: DEVICE_BUS_SPECIFIC_RESET_TYPE_1,
     pub AsULONGLONG: u64,
 }
 impl windows_core::TypeKind for DEVICE_BUS_SPECIFIC_RESET_TYPE {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for DEVICE_BUS_SPECIFIC_RESET_TYPE {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
-    pub _bitfield: u64,
-}
-impl windows_core::TypeKind for DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -13539,6 +13526,19 @@ impl windows_core::TypeKind for DEVICE_BUS_SPECIFIC_RESET_TYPE_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for DEVICE_BUS_SPECIFIC_RESET_TYPE_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
+    pub _bitfield: u64,
+}
+impl windows_core::TypeKind for DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -13729,8 +13729,8 @@ impl Default for DISK_SIGNATURE {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISK_SIGNATURE_0 {
-    pub Mbr: DISK_SIGNATURE_0_1,
-    pub Gpt: DISK_SIGNATURE_0_0,
+    pub Mbr: DISK_SIGNATURE_0_0,
+    pub Gpt: DISK_SIGNATURE_0_1,
 }
 impl windows_core::TypeKind for DISK_SIGNATURE_0 {
     type TypeKind = windows_core::CopyType;
@@ -13742,27 +13742,27 @@ impl Default for DISK_SIGNATURE_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DISK_SIGNATURE_0_0 {
+pub struct DISK_SIGNATURE_0_1 {
     pub DiskId: windows_core::GUID,
 }
-impl windows_core::TypeKind for DISK_SIGNATURE_0_0 {
+impl windows_core::TypeKind for DISK_SIGNATURE_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DISK_SIGNATURE_0_0 {
+impl Default for DISK_SIGNATURE_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DISK_SIGNATURE_0_1 {
+pub struct DISK_SIGNATURE_0_0 {
     pub Signature: u32,
     pub CheckSum: u32,
 }
-impl windows_core::TypeKind for DISK_SIGNATURE_0_1 {
+impl windows_core::TypeKind for DISK_SIGNATURE_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DISK_SIGNATURE_0_1 {
+impl Default for DISK_SIGNATURE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -15591,8 +15591,8 @@ impl Default for IOMMU_MAP_PHYSICAL_ADDRESS {
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
 pub union IOMMU_MAP_PHYSICAL_ADDRESS_0 {
-    pub Mdl: IOMMU_MAP_PHYSICAL_ADDRESS_0_1,
-    pub ContiguousRange: IOMMU_MAP_PHYSICAL_ADDRESS_0_0,
+    pub Mdl: IOMMU_MAP_PHYSICAL_ADDRESS_0_0,
+    pub ContiguousRange: IOMMU_MAP_PHYSICAL_ADDRESS_0_1,
     pub PfnArray: IOMMU_MAP_PHYSICAL_ADDRESS_0_2,
 }
 #[cfg(feature = "Wdk_Foundation")]
@@ -15608,25 +15608,9 @@ impl Default for IOMMU_MAP_PHYSICAL_ADDRESS_0 {
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IOMMU_MAP_PHYSICAL_ADDRESS_0_0 {
+pub struct IOMMU_MAP_PHYSICAL_ADDRESS_0_1 {
     pub Base: i64,
     pub Size: usize,
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IOMMU_MAP_PHYSICAL_ADDRESS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl Default for IOMMU_MAP_PHYSICAL_ADDRESS_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Wdk_Foundation")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IOMMU_MAP_PHYSICAL_ADDRESS_0_1 {
-    pub Mdl: *mut super::super::Foundation::MDL,
 }
 #[cfg(feature = "Wdk_Foundation")]
 impl windows_core::TypeKind for IOMMU_MAP_PHYSICAL_ADDRESS_0_1 {
@@ -15634,6 +15618,22 @@ impl windows_core::TypeKind for IOMMU_MAP_PHYSICAL_ADDRESS_0_1 {
 }
 #[cfg(feature = "Wdk_Foundation")]
 impl Default for IOMMU_MAP_PHYSICAL_ADDRESS_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Wdk_Foundation")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IOMMU_MAP_PHYSICAL_ADDRESS_0_0 {
+    pub Mdl: *mut super::super::Foundation::MDL,
+}
+#[cfg(feature = "Wdk_Foundation")]
+impl windows_core::TypeKind for IOMMU_MAP_PHYSICAL_ADDRESS_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Wdk_Foundation")]
+impl Default for IOMMU_MAP_PHYSICAL_ADDRESS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -16190,19 +16190,19 @@ impl Default for IO_RESOURCE_DESCRIPTOR {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IO_RESOURCE_DESCRIPTOR_0 {
-    pub Port: IO_RESOURCE_DESCRIPTOR_0_12,
-    pub Memory: IO_RESOURCE_DESCRIPTOR_0_11,
-    pub Interrupt: IO_RESOURCE_DESCRIPTOR_0_7,
-    pub Dma: IO_RESOURCE_DESCRIPTOR_0_5,
+    pub Port: IO_RESOURCE_DESCRIPTOR_0_0,
+    pub Memory: IO_RESOURCE_DESCRIPTOR_0_1,
+    pub Interrupt: IO_RESOURCE_DESCRIPTOR_0_2,
+    pub Dma: IO_RESOURCE_DESCRIPTOR_0_3,
     pub DmaV3: IO_RESOURCE_DESCRIPTOR_0_4,
-    pub Generic: IO_RESOURCE_DESCRIPTOR_0_6,
-    pub DevicePrivate: IO_RESOURCE_DESCRIPTOR_0_3,
-    pub BusNumber: IO_RESOURCE_DESCRIPTOR_0_0,
-    pub ConfigData: IO_RESOURCE_DESCRIPTOR_0_1,
-    pub Memory40: IO_RESOURCE_DESCRIPTOR_0_8,
-    pub Memory48: IO_RESOURCE_DESCRIPTOR_0_9,
-    pub Memory64: IO_RESOURCE_DESCRIPTOR_0_10,
-    pub Connection: IO_RESOURCE_DESCRIPTOR_0_2,
+    pub Generic: IO_RESOURCE_DESCRIPTOR_0_5,
+    pub DevicePrivate: IO_RESOURCE_DESCRIPTOR_0_6,
+    pub BusNumber: IO_RESOURCE_DESCRIPTOR_0_7,
+    pub ConfigData: IO_RESOURCE_DESCRIPTOR_0_8,
+    pub Memory40: IO_RESOURCE_DESCRIPTOR_0_9,
+    pub Memory48: IO_RESOURCE_DESCRIPTOR_0_10,
+    pub Memory64: IO_RESOURCE_DESCRIPTOR_0_11,
+    pub Connection: IO_RESOURCE_DESCRIPTOR_0_12,
 }
 impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0 {
     type TypeKind = windows_core::CopyType;
@@ -16214,38 +16214,38 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_0 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_7 {
     pub Length: u32,
     pub MinBusNumber: u32,
     pub MaxBusNumber: u32,
     pub Reserved: u32,
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_0 {
+impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_7 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IO_RESOURCE_DESCRIPTOR_0_0 {
+impl Default for IO_RESOURCE_DESCRIPTOR_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_1 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_8 {
     pub Priority: u32,
     pub Reserved1: u32,
     pub Reserved2: u32,
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_1 {
+impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_8 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IO_RESOURCE_DESCRIPTOR_0_1 {
+impl Default for IO_RESOURCE_DESCRIPTOR_0_8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_2 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_12 {
     pub Class: u8,
     pub Type: u8,
     pub Reserved1: u8,
@@ -16253,23 +16253,23 @@ pub struct IO_RESOURCE_DESCRIPTOR_0_2 {
     pub IdLowPart: u32,
     pub IdHighPart: u32,
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_2 {
+impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_12 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IO_RESOURCE_DESCRIPTOR_0_2 {
+impl Default for IO_RESOURCE_DESCRIPTOR_0_12 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_3 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_6 {
     pub Data: [u32; 3],
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_3 {
+impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_6 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IO_RESOURCE_DESCRIPTOR_0_3 {
+impl Default for IO_RESOURCE_DESCRIPTOR_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -16292,9 +16292,25 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_4 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_5 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_3 {
     pub MinimumChannel: u32,
     pub MaximumChannel: u32,
+}
+impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_3 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for IO_RESOURCE_DESCRIPTOR_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_RESOURCE_DESCRIPTOR_0_5 {
+    pub Length: u32,
+    pub Alignment: u32,
+    pub MinimumAddress: i64,
+    pub MaximumAddress: i64,
 }
 impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_5 {
     type TypeKind = windows_core::CopyType;
@@ -16306,49 +16322,17 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_5 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_6 {
-    pub Length: u32,
-    pub Alignment: u32,
-    pub MinimumAddress: i64,
-    pub MaximumAddress: i64,
-}
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for IO_RESOURCE_DESCRIPTOR_0_6 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_7 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_2 {
     pub MinimumVector: u32,
     pub MaximumVector: u32,
     pub AffinityPolicy: IRQ_DEVICE_POLICY,
     pub PriorityPolicy: IRQ_PRIORITY,
     pub TargetedProcessors: usize,
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_7 {
+impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IO_RESOURCE_DESCRIPTOR_0_7 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_8 {
-    pub Length40: u32,
-    pub Alignment40: u32,
-    pub MinimumAddress: i64,
-    pub MaximumAddress: i64,
-}
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for IO_RESOURCE_DESCRIPTOR_0_8 {
+impl Default for IO_RESOURCE_DESCRIPTOR_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -16356,8 +16340,8 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_8 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IO_RESOURCE_DESCRIPTOR_0_9 {
-    pub Length48: u32,
-    pub Alignment48: u32,
+    pub Length40: u32,
+    pub Alignment40: u32,
     pub MinimumAddress: i64,
     pub MaximumAddress: i64,
 }
@@ -16372,8 +16356,8 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_9 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IO_RESOURCE_DESCRIPTOR_0_10 {
-    pub Length64: u32,
-    pub Alignment64: u32,
+    pub Length48: u32,
+    pub Alignment48: u32,
     pub MinimumAddress: i64,
     pub MaximumAddress: i64,
 }
@@ -16388,8 +16372,8 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_10 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IO_RESOURCE_DESCRIPTOR_0_11 {
-    pub Length: u32,
-    pub Alignment: u32,
+    pub Length64: u32,
+    pub Alignment64: u32,
     pub MinimumAddress: i64,
     pub MaximumAddress: i64,
 }
@@ -16403,16 +16387,32 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_11 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IO_RESOURCE_DESCRIPTOR_0_12 {
+pub struct IO_RESOURCE_DESCRIPTOR_0_1 {
     pub Length: u32,
     pub Alignment: u32,
     pub MinimumAddress: i64,
     pub MaximumAddress: i64,
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_12 {
+impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IO_RESOURCE_DESCRIPTOR_0_12 {
+impl Default for IO_RESOURCE_DESCRIPTOR_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IO_RESOURCE_DESCRIPTOR_0_0 {
+    pub Length: u32,
+    pub Alignment: u32,
+    pub MinimumAddress: i64,
+    pub MaximumAddress: i64,
+}
+impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for IO_RESOURCE_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -18300,13 +18300,13 @@ impl Default for PCIBUSDATA {
 #[derive(Clone, Copy)]
 pub struct PCIX_BRIDGE_CAPABILITY {
     pub Header: PCI_CAPABILITIES_HEADER,
-    pub SecondaryStatus: PCIX_BRIDGE_CAPABILITY_2,
-    pub BridgeStatus: PCIX_BRIDGE_CAPABILITY_0,
+    pub SecondaryStatus: PCIX_BRIDGE_CAPABILITY_0,
+    pub BridgeStatus: PCIX_BRIDGE_CAPABILITY_1,
     pub UpstreamSplitTransactionCapacity: u16,
     pub UpstreamSplitTransactionLimit: u16,
     pub DownstreamSplitTransactionCapacity: u16,
     pub DownstreamSplitTransactionLimit: u16,
-    pub EccControlStatus: PCIX_BRIDGE_CAPABILITY_1,
+    pub EccControlStatus: PCIX_BRIDGE_CAPABILITY_2,
     pub EccFirstAddress: u32,
     pub EccSecondAddress: u32,
     pub EccAttribute: u32,
@@ -18315,33 +18315,6 @@ impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for PCIX_BRIDGE_CAPABILITY {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub union PCIX_BRIDGE_CAPABILITY_0 {
-    pub Anonymous: PCIX_BRIDGE_CAPABILITY_0_0,
-    pub AsULONG: u32,
-}
-impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for PCIX_BRIDGE_CAPABILITY_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PCIX_BRIDGE_CAPABILITY_0_0 {
-    pub _bitfield: u32,
-}
-impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for PCIX_BRIDGE_CAPABILITY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -18377,7 +18350,7 @@ impl Default for PCIX_BRIDGE_CAPABILITY_1_0 {
 #[derive(Clone, Copy)]
 pub union PCIX_BRIDGE_CAPABILITY_2 {
     pub Anonymous: PCIX_BRIDGE_CAPABILITY_2_0,
-    pub AsUSHORT: u16,
+    pub AsULONG: u32,
 }
 impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_2 {
     type TypeKind = windows_core::CopyType;
@@ -18390,12 +18363,39 @@ impl Default for PCIX_BRIDGE_CAPABILITY_2 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PCIX_BRIDGE_CAPABILITY_2_0 {
-    pub _bitfield: u16,
+    pub _bitfield: u32,
 }
 impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_2_0 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for PCIX_BRIDGE_CAPABILITY_2_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union PCIX_BRIDGE_CAPABILITY_0 {
+    pub Anonymous: PCIX_BRIDGE_CAPABILITY_0_0,
+    pub AsUSHORT: u16,
+}
+impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for PCIX_BRIDGE_CAPABILITY_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PCIX_BRIDGE_CAPABILITY_0_0 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for PCIX_BRIDGE_CAPABILITY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -18516,26 +18516,13 @@ impl Default for PCI_AGP_APERTURE_PAGE_SIZE {
 pub struct PCI_AGP_CAPABILITY {
     pub Header: PCI_CAPABILITIES_HEADER,
     pub _bitfield: u16,
-    pub AGPStatus: PCI_AGP_CAPABILITY_1,
-    pub AGPCommand: PCI_AGP_CAPABILITY_0,
+    pub AGPStatus: PCI_AGP_CAPABILITY_0,
+    pub AGPCommand: PCI_AGP_CAPABILITY_1,
 }
 impl windows_core::TypeKind for PCI_AGP_CAPABILITY {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for PCI_AGP_CAPABILITY {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PCI_AGP_CAPABILITY_0 {
-    pub _bitfield: u32,
-}
-impl windows_core::TypeKind for PCI_AGP_CAPABILITY_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for PCI_AGP_CAPABILITY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -18549,6 +18536,19 @@ impl windows_core::TypeKind for PCI_AGP_CAPABILITY_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for PCI_AGP_CAPABILITY_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PCI_AGP_CAPABILITY_0 {
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for PCI_AGP_CAPABILITY_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for PCI_AGP_CAPABILITY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -21954,9 +21954,9 @@ impl Default for PCI_PMCSR_BSE {
 #[derive(Clone, Copy)]
 pub struct PCI_PM_CAPABILITY {
     pub Header: PCI_CAPABILITIES_HEADER,
-    pub PMC: PCI_PM_CAPABILITY_2,
+    pub PMC: PCI_PM_CAPABILITY_0,
     pub PMCSR: PCI_PM_CAPABILITY_1,
-    pub PMCSR_BSE: PCI_PM_CAPABILITY_0,
+    pub PMCSR_BSE: PCI_PM_CAPABILITY_2,
     pub Data: u8,
 }
 impl windows_core::TypeKind for PCI_PM_CAPABILITY {
@@ -21969,14 +21969,14 @@ impl Default for PCI_PM_CAPABILITY {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union PCI_PM_CAPABILITY_0 {
+pub union PCI_PM_CAPABILITY_2 {
     pub BridgeSupport: PCI_PMCSR_BSE,
     pub AsUCHAR: u8,
 }
-impl windows_core::TypeKind for PCI_PM_CAPABILITY_0 {
+impl windows_core::TypeKind for PCI_PM_CAPABILITY_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PCI_PM_CAPABILITY_0 {
+impl Default for PCI_PM_CAPABILITY_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -21997,14 +21997,14 @@ impl Default for PCI_PM_CAPABILITY_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union PCI_PM_CAPABILITY_2 {
+pub union PCI_PM_CAPABILITY_0 {
     pub Capabilities: PCI_PMC,
     pub AsUSHORT: u16,
 }
-impl windows_core::TypeKind for PCI_PM_CAPABILITY_2 {
+impl windows_core::TypeKind for PCI_PM_CAPABILITY_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PCI_PM_CAPABILITY_2 {
+impl Default for PCI_PM_CAPABILITY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -23252,8 +23252,8 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROCESS_DEVICEMAP_INFORMATION_0 {
-    pub Set: PROCESS_DEVICEMAP_INFORMATION_0_1,
-    pub Query: PROCESS_DEVICEMAP_INFORMATION_0_0,
+    pub Set: PROCESS_DEVICEMAP_INFORMATION_0_0,
+    pub Query: PROCESS_DEVICEMAP_INFORMATION_0_1,
 }
 impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_0 {
     type TypeKind = windows_core::CopyType;
@@ -23265,27 +23265,27 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PROCESS_DEVICEMAP_INFORMATION_0_0 {
+pub struct PROCESS_DEVICEMAP_INFORMATION_0_1 {
     pub DriveMap: u32,
     pub DriveType: [u8; 32],
 }
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_0_0 {
+impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PROCESS_DEVICEMAP_INFORMATION_0_0 {
+impl Default for PROCESS_DEVICEMAP_INFORMATION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PROCESS_DEVICEMAP_INFORMATION_0_1 {
+pub struct PROCESS_DEVICEMAP_INFORMATION_0_0 {
     pub DirectoryHandle: super::super::super::Win32::Foundation::HANDLE,
 }
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_0_1 {
+impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PROCESS_DEVICEMAP_INFORMATION_0_1 {
+impl Default for PROCESS_DEVICEMAP_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -23307,8 +23307,8 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION_EX {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROCESS_DEVICEMAP_INFORMATION_EX_0 {
-    pub Set: PROCESS_DEVICEMAP_INFORMATION_EX_0_1,
-    pub Query: PROCESS_DEVICEMAP_INFORMATION_EX_0_0,
+    pub Set: PROCESS_DEVICEMAP_INFORMATION_EX_0_0,
+    pub Query: PROCESS_DEVICEMAP_INFORMATION_EX_0_1,
 }
 impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_EX_0 {
     type TypeKind = windows_core::CopyType;
@@ -23320,27 +23320,27 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION_EX_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
+pub struct PROCESS_DEVICEMAP_INFORMATION_EX_0_1 {
     pub DriveMap: u32,
     pub DriveType: [u8; 32],
 }
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
+impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_EX_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
+impl Default for PROCESS_DEVICEMAP_INFORMATION_EX_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PROCESS_DEVICEMAP_INFORMATION_EX_0_1 {
+pub struct PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
     pub DirectoryHandle: super::super::super::Win32::Foundation::HANDLE,
 }
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_EX_0_1 {
+impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PROCESS_DEVICEMAP_INFORMATION_EX_0_1 {
+impl Default for PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -28759,8 +28759,8 @@ impl Default for WHEA_XPF_TLB_CHECK_0 {
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct XPF_RECOVERY_INFO {
-    pub FailureReason: XPF_RECOVERY_INFO_1,
-    pub Action: XPF_RECOVERY_INFO_0,
+    pub FailureReason: XPF_RECOVERY_INFO_0,
+    pub Action: XPF_RECOVERY_INFO_1,
     pub ActionRequired: super::super::super::Win32::Foundation::BOOLEAN,
     pub RecoverySucceeded: super::super::super::Win32::Foundation::BOOLEAN,
     pub RecoveryKernel: super::super::super::Win32::Foundation::BOOLEAN,
@@ -28779,19 +28779,6 @@ impl Default for XPF_RECOVERY_INFO {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct XPF_RECOVERY_INFO_0 {
-    pub _bitfield: u32,
-}
-impl windows_core::TypeKind for XPF_RECOVERY_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for XPF_RECOVERY_INFO_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
 pub struct XPF_RECOVERY_INFO_1 {
     pub _bitfield: u32,
 }
@@ -28799,6 +28786,19 @@ impl windows_core::TypeKind for XPF_RECOVERY_INFO_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for XPF_RECOVERY_INFO_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct XPF_RECOVERY_INFO_0 {
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for XPF_RECOVERY_INFO_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for XPF_RECOVERY_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
@@ -611,27 +611,27 @@ impl Default for WINBIO_ASYNC_RESULT {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINBIO_ASYNC_RESULT_0 {
-    pub Verify: WINBIO_ASYNC_RESULT_0_20,
-    pub Identify: WINBIO_ASYNC_RESULT_0_15,
-    pub EnrollBegin: WINBIO_ASYNC_RESULT_0_3,
-    pub EnrollCapture: WINBIO_ASYNC_RESULT_0_4,
-    pub EnrollCommit: WINBIO_ASYNC_RESULT_0_5,
-    pub EnumEnrollments: WINBIO_ASYNC_RESULT_0_9,
-    pub CaptureSample: WINBIO_ASYNC_RESULT_0_0,
-    pub DeleteTemplate: WINBIO_ASYNC_RESULT_0_2,
-    pub GetProperty: WINBIO_ASYNC_RESULT_0_12,
-    pub SetProperty: WINBIO_ASYNC_RESULT_0_18,
-    pub GetEvent: WINBIO_ASYNC_RESULT_0_11,
-    pub ControlUnit: WINBIO_ASYNC_RESULT_0_1,
-    pub EnumServiceProviders: WINBIO_ASYNC_RESULT_0_10,
-    pub EnumBiometricUnits: WINBIO_ASYNC_RESULT_0_7,
-    pub EnumDatabases: WINBIO_ASYNC_RESULT_0_8,
-    pub VerifyAndReleaseTicket: WINBIO_ASYNC_RESULT_0_19,
-    pub IdentifyAndReleaseTicket: WINBIO_ASYNC_RESULT_0_14,
-    pub EnrollSelect: WINBIO_ASYNC_RESULT_0_6,
-    pub MonitorPresence: WINBIO_ASYNC_RESULT_0_16,
-    pub GetProtectionPolicy: WINBIO_ASYNC_RESULT_0_13,
-    pub NotifyUnitStatusChange: WINBIO_ASYNC_RESULT_0_17,
+    pub Verify: WINBIO_ASYNC_RESULT_0_0,
+    pub Identify: WINBIO_ASYNC_RESULT_0_1,
+    pub EnrollBegin: WINBIO_ASYNC_RESULT_0_2,
+    pub EnrollCapture: WINBIO_ASYNC_RESULT_0_3,
+    pub EnrollCommit: WINBIO_ASYNC_RESULT_0_4,
+    pub EnumEnrollments: WINBIO_ASYNC_RESULT_0_5,
+    pub CaptureSample: WINBIO_ASYNC_RESULT_0_6,
+    pub DeleteTemplate: WINBIO_ASYNC_RESULT_0_7,
+    pub GetProperty: WINBIO_ASYNC_RESULT_0_8,
+    pub SetProperty: WINBIO_ASYNC_RESULT_0_9,
+    pub GetEvent: WINBIO_ASYNC_RESULT_0_10,
+    pub ControlUnit: WINBIO_ASYNC_RESULT_0_11,
+    pub EnumServiceProviders: WINBIO_ASYNC_RESULT_0_12,
+    pub EnumBiometricUnits: WINBIO_ASYNC_RESULT_0_13,
+    pub EnumDatabases: WINBIO_ASYNC_RESULT_0_14,
+    pub VerifyAndReleaseTicket: WINBIO_ASYNC_RESULT_0_15,
+    pub IdentifyAndReleaseTicket: WINBIO_ASYNC_RESULT_0_16,
+    pub EnrollSelect: WINBIO_ASYNC_RESULT_0_17,
+    pub MonitorPresence: WINBIO_ASYNC_RESULT_0_18,
+    pub GetProtectionPolicy: WINBIO_ASYNC_RESULT_0_19,
+    pub NotifyUnitStatusChange: WINBIO_ASYNC_RESULT_0_20,
 }
 impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0 {
     type TypeKind = windows_core::CopyType;
@@ -643,22 +643,22 @@ impl Default for WINBIO_ASYNC_RESULT_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_ASYNC_RESULT_0_0 {
+pub struct WINBIO_ASYNC_RESULT_0_6 {
     pub Sample: *mut WINBIO_BIR,
     pub SampleSize: usize,
     pub RejectDetail: u32,
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_0 {
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_6 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WINBIO_ASYNC_RESULT_0_0 {
+impl Default for WINBIO_ASYNC_RESULT_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_ASYNC_RESULT_0_1 {
+pub struct WINBIO_ASYNC_RESULT_0_11 {
     pub Component: WINBIO_COMPONENT,
     pub ControlCode: u32,
     pub OperationStatus: u32,
@@ -668,18 +668,31 @@ pub struct WINBIO_ASYNC_RESULT_0_1 {
     pub ReceiveBufferSize: usize,
     pub ReceiveDataSize: usize,
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_1 {
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_11 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WINBIO_ASYNC_RESULT_0_1 {
+impl Default for WINBIO_ASYNC_RESULT_0_11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_2 {
+pub struct WINBIO_ASYNC_RESULT_0_7 {
     pub Identity: WINBIO_IDENTITY,
+    pub SubFactor: u8,
+}
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_7 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for WINBIO_ASYNC_RESULT_0_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WINBIO_ASYNC_RESULT_0_2 {
     pub SubFactor: u8,
 }
 impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_2 {
@@ -693,7 +706,7 @@ impl Default for WINBIO_ASYNC_RESULT_0_2 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_3 {
-    pub SubFactor: u8,
+    pub RejectDetail: u32,
 }
 impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_3 {
     type TypeKind = windows_core::CopyType;
@@ -704,9 +717,10 @@ impl Default for WINBIO_ASYNC_RESULT_0_3 {
     }
 }
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy)]
 pub struct WINBIO_ASYNC_RESULT_0_4 {
-    pub RejectDetail: u32,
+    pub Identity: WINBIO_IDENTITY,
+    pub IsNewTemplate: super::super::Foundation::BOOLEAN,
 }
 impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_4 {
     type TypeKind = windows_core::CopyType;
@@ -717,125 +731,23 @@ impl Default for WINBIO_ASYNC_RESULT_0_4 {
     }
 }
 #[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_5 {
-    pub Identity: WINBIO_IDENTITY,
-    pub IsNewTemplate: super::super::Foundation::BOOLEAN,
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for WINBIO_ASYNC_RESULT_0_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_ASYNC_RESULT_0_6 {
+pub struct WINBIO_ASYNC_RESULT_0_17 {
     pub SelectorValue: u64,
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_6 {
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_17 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WINBIO_ASYNC_RESULT_0_6 {
+impl Default for WINBIO_ASYNC_RESULT_0_17 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_ASYNC_RESULT_0_7 {
+pub struct WINBIO_ASYNC_RESULT_0_13 {
     pub UnitCount: usize,
     pub UnitSchemaArray: *mut WINBIO_UNIT_SCHEMA,
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for WINBIO_ASYNC_RESULT_0_7 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_ASYNC_RESULT_0_8 {
-    pub StorageCount: usize,
-    pub StorageSchemaArray: *mut WINBIO_STORAGE_SCHEMA,
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for WINBIO_ASYNC_RESULT_0_8 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_9 {
-    pub Identity: WINBIO_IDENTITY,
-    pub SubFactorCount: usize,
-    pub SubFactorArray: *mut u8,
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for WINBIO_ASYNC_RESULT_0_9 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_ASYNC_RESULT_0_10 {
-    pub BspCount: usize,
-    pub BspSchemaArray: *mut WINBIO_BSP_SCHEMA,
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_10 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for WINBIO_ASYNC_RESULT_0_10 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_11 {
-    pub Event: WINBIO_EVENT,
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_11 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for WINBIO_ASYNC_RESULT_0_11 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_12 {
-    pub PropertyType: u32,
-    pub PropertyId: u32,
-    pub Identity: WINBIO_IDENTITY,
-    pub SubFactor: u8,
-    pub PropertyBufferSize: usize,
-    pub PropertyBuffer: *mut core::ffi::c_void,
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_12 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for WINBIO_ASYNC_RESULT_0_12 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_13 {
-    pub Identity: WINBIO_IDENTITY,
-    pub Policy: WINBIO_PROTECTION_POLICY,
 }
 impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_13 {
     type TypeKind = windows_core::CopyType;
@@ -846,12 +758,10 @@ impl Default for WINBIO_ASYNC_RESULT_0_13 {
     }
 }
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_14 {
-    pub Identity: WINBIO_IDENTITY,
-    pub SubFactor: u8,
-    pub RejectDetail: u32,
-    pub Ticket: u64,
+    pub StorageCount: usize,
+    pub StorageSchemaArray: *mut WINBIO_STORAGE_SCHEMA,
 }
 impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_14 {
     type TypeKind = windows_core::CopyType;
@@ -863,25 +773,85 @@ impl Default for WINBIO_ASYNC_RESULT_0_14 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct WINBIO_ASYNC_RESULT_0_15 {
+pub struct WINBIO_ASYNC_RESULT_0_5 {
     pub Identity: WINBIO_IDENTITY,
-    pub SubFactor: u8,
-    pub RejectDetail: u32,
+    pub SubFactorCount: usize,
+    pub SubFactorArray: *mut u8,
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_15 {
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_5 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WINBIO_ASYNC_RESULT_0_15 {
+impl Default for WINBIO_ASYNC_RESULT_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WINBIO_ASYNC_RESULT_0_12 {
+    pub BspCount: usize,
+    pub BspSchemaArray: *mut WINBIO_BSP_SCHEMA,
+}
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_12 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for WINBIO_ASYNC_RESULT_0_12 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_10 {
+    pub Event: WINBIO_EVENT,
+}
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_10 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for WINBIO_ASYNC_RESULT_0_10 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_8 {
+    pub PropertyType: u32,
+    pub PropertyId: u32,
+    pub Identity: WINBIO_IDENTITY,
+    pub SubFactor: u8,
+    pub PropertyBufferSize: usize,
+    pub PropertyBuffer: *mut core::ffi::c_void,
+}
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_8 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for WINBIO_ASYNC_RESULT_0_8 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_19 {
+    pub Identity: WINBIO_IDENTITY,
+    pub Policy: WINBIO_PROTECTION_POLICY,
+}
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_19 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for WINBIO_ASYNC_RESULT_0_19 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
 pub struct WINBIO_ASYNC_RESULT_0_16 {
-    pub ChangeType: u32,
-    pub PresenceCount: usize,
-    pub PresenceArray: *mut WINBIO_PRESENCE,
+    pub Identity: WINBIO_IDENTITY,
+    pub SubFactor: u8,
+    pub RejectDetail: u32,
+    pub Ticket: u64,
 }
 impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_16 {
     type TypeKind = windows_core::CopyType;
@@ -892,27 +862,26 @@ impl Default for WINBIO_ASYNC_RESULT_0_16 {
     }
 }
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_ASYNC_RESULT_0_17 {
-    pub ExtendedStatus: WINBIO_EXTENDED_UNIT_STATUS,
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_1 {
+    pub Identity: WINBIO_IDENTITY,
+    pub SubFactor: u8,
+    pub RejectDetail: u32,
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_17 {
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WINBIO_ASYNC_RESULT_0_17 {
+impl Default for WINBIO_ASYNC_RESULT_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_18 {
-    pub PropertyType: u32,
-    pub PropertyId: u32,
-    pub Identity: WINBIO_IDENTITY,
-    pub SubFactor: u8,
-    pub PropertyBufferSize: usize,
-    pub PropertyBuffer: *mut core::ffi::c_void,
+    pub ChangeType: u32,
+    pub PresenceCount: usize,
+    pub PresenceArray: *mut WINBIO_PRESENCE,
 }
 impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_18 {
     type TypeKind = windows_core::CopyType;
@@ -924,29 +893,60 @@ impl Default for WINBIO_ASYNC_RESULT_0_18 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_ASYNC_RESULT_0_19 {
-    pub Match: super::super::Foundation::BOOLEAN,
-    pub RejectDetail: u32,
-    pub Ticket: u64,
+pub struct WINBIO_ASYNC_RESULT_0_20 {
+    pub ExtendedStatus: WINBIO_EXTENDED_UNIT_STATUS,
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_19 {
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_20 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WINBIO_ASYNC_RESULT_0_19 {
+impl Default for WINBIO_ASYNC_RESULT_0_20 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct WINBIO_ASYNC_RESULT_0_9 {
+    pub PropertyType: u32,
+    pub PropertyId: u32,
+    pub Identity: WINBIO_IDENTITY,
+    pub SubFactor: u8,
+    pub PropertyBufferSize: usize,
+    pub PropertyBuffer: *mut core::ffi::c_void,
+}
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_9 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for WINBIO_ASYNC_RESULT_0_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_ASYNC_RESULT_0_20 {
+pub struct WINBIO_ASYNC_RESULT_0_15 {
+    pub Match: super::super::Foundation::BOOLEAN,
+    pub RejectDetail: u32,
+    pub Ticket: u64,
+}
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_15 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for WINBIO_ASYNC_RESULT_0_15 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WINBIO_ASYNC_RESULT_0_0 {
     pub Match: super::super::Foundation::BOOLEAN,
     pub RejectDetail: u32,
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_20 {
+impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WINBIO_ASYNC_RESULT_0_20 {
+impl Default for WINBIO_ASYNC_RESULT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1272,9 +1272,9 @@ impl Default for WINBIO_EVENT {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINBIO_EVENT_0 {
-    pub Unclaimed: WINBIO_EVENT_0_2,
+    pub Unclaimed: WINBIO_EVENT_0_0,
     pub UnclaimedIdentify: WINBIO_EVENT_0_1,
-    pub Error: WINBIO_EVENT_0_0,
+    pub Error: WINBIO_EVENT_0_2,
 }
 impl windows_core::TypeKind for WINBIO_EVENT_0 {
     type TypeKind = windows_core::CopyType;
@@ -1286,13 +1286,13 @@ impl Default for WINBIO_EVENT_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_EVENT_0_0 {
+pub struct WINBIO_EVENT_0_2 {
     pub ErrorCode: windows_core::HRESULT,
 }
-impl windows_core::TypeKind for WINBIO_EVENT_0_0 {
+impl windows_core::TypeKind for WINBIO_EVENT_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WINBIO_EVENT_0_0 {
+impl Default for WINBIO_EVENT_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1315,14 +1315,14 @@ impl Default for WINBIO_EVENT_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WINBIO_EVENT_0_2 {
+pub struct WINBIO_EVENT_0_0 {
     pub UnitId: u32,
     pub RejectDetail: u32,
 }
-impl windows_core::TypeKind for WINBIO_EVENT_0_2 {
+impl windows_core::TypeKind for WINBIO_EVENT_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WINBIO_EVENT_0_2 {
+impl Default for WINBIO_EVENT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
@@ -1804,9 +1804,9 @@ impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE {
 #[derive(Clone, Copy)]
 pub union BTH_LE_GATT_DESCRIPTOR_VALUE_0 {
     pub CharacteristicExtendedProperties: BTH_LE_GATT_DESCRIPTOR_VALUE_0_0,
-    pub ClientCharacteristicConfiguration: BTH_LE_GATT_DESCRIPTOR_VALUE_0_2,
-    pub ServerCharacteristicConfiguration: BTH_LE_GATT_DESCRIPTOR_VALUE_0_3,
-    pub CharacteristicFormat: BTH_LE_GATT_DESCRIPTOR_VALUE_0_1,
+    pub ClientCharacteristicConfiguration: BTH_LE_GATT_DESCRIPTOR_VALUE_0_1,
+    pub ServerCharacteristicConfiguration: BTH_LE_GATT_DESCRIPTOR_VALUE_0_2,
+    pub CharacteristicFormat: BTH_LE_GATT_DESCRIPTOR_VALUE_0_3,
 }
 impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE_0 {
     type TypeKind = windows_core::CopyType;
@@ -1832,12 +1832,26 @@ impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
+pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
     pub Format: u8,
     pub Exponent: u8,
     pub Unit: BTH_LE_UUID,
     pub NameSpace: u8,
     pub Description: BTH_LE_UUID,
+}
+impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
+    pub IsSubscribeToNotification: super::super::Foundation::BOOLEAN,
+    pub IsSubscribeToIndication: super::super::Foundation::BOOLEAN,
 }
 impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
     type TypeKind = windows_core::CopyType;
@@ -1850,26 +1864,12 @@ impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_2 {
-    pub IsSubscribeToNotification: super::super::Foundation::BOOLEAN,
-    pub IsSubscribeToIndication: super::super::Foundation::BOOLEAN,
+    pub IsBroadcast: super::super::Foundation::BOOLEAN,
 }
 impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE_0_2 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
-    pub IsBroadcast: super::super::Foundation::BOOLEAN,
-}
-impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2179,15 +2179,43 @@ pub union SDP_ELEMENT_DATA_0 {
     pub uuid128: windows_core::GUID,
     pub uuid32: u32,
     pub uuid16: u16,
-    pub string: SDP_ELEMENT_DATA_0_2,
-    pub url: SDP_ELEMENT_DATA_0_3,
-    pub sequence: SDP_ELEMENT_DATA_0_1,
-    pub alternative: SDP_ELEMENT_DATA_0_0,
+    pub string: SDP_ELEMENT_DATA_0_0,
+    pub url: SDP_ELEMENT_DATA_0_1,
+    pub sequence: SDP_ELEMENT_DATA_0_2,
+    pub alternative: SDP_ELEMENT_DATA_0_3,
 }
 impl windows_core::TypeKind for SDP_ELEMENT_DATA_0 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for SDP_ELEMENT_DATA_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SDP_ELEMENT_DATA_0_3 {
+    pub value: *mut u8,
+    pub length: u32,
+}
+impl windows_core::TypeKind for SDP_ELEMENT_DATA_0_3 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for SDP_ELEMENT_DATA_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SDP_ELEMENT_DATA_0_2 {
+    pub value: *mut u8,
+    pub length: u32,
+}
+impl windows_core::TypeKind for SDP_ELEMENT_DATA_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for SDP_ELEMENT_DATA_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2216,34 +2244,6 @@ impl windows_core::TypeKind for SDP_ELEMENT_DATA_0_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for SDP_ELEMENT_DATA_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SDP_ELEMENT_DATA_0_2 {
-    pub value: *mut u8,
-    pub length: u32,
-}
-impl windows_core::TypeKind for SDP_ELEMENT_DATA_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for SDP_ELEMENT_DATA_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SDP_ELEMENT_DATA_0_3 {
-    pub value: *mut u8,
-    pub length: u32,
-}
-impl windows_core::TypeKind for SDP_ELEMENT_DATA_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for SDP_ELEMENT_DATA_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
@@ -7457,9 +7457,9 @@ impl Default for CM_NOTIFY_EVENT_DATA {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CM_NOTIFY_EVENT_DATA_0 {
-    pub DeviceInterface: CM_NOTIFY_EVENT_DATA_0_2,
-    pub DeviceHandle: CM_NOTIFY_EVENT_DATA_0_0,
-    pub DeviceInstance: CM_NOTIFY_EVENT_DATA_0_1,
+    pub DeviceInterface: CM_NOTIFY_EVENT_DATA_0_0,
+    pub DeviceHandle: CM_NOTIFY_EVENT_DATA_0_1,
+    pub DeviceInstance: CM_NOTIFY_EVENT_DATA_0_2,
 }
 impl windows_core::TypeKind for CM_NOTIFY_EVENT_DATA_0 {
     type TypeKind = windows_core::CopyType;
@@ -7471,24 +7471,11 @@ impl Default for CM_NOTIFY_EVENT_DATA_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_NOTIFY_EVENT_DATA_0_0 {
+pub struct CM_NOTIFY_EVENT_DATA_0_1 {
     pub EventGuid: windows_core::GUID,
     pub NameOffset: i32,
     pub DataSize: u32,
     pub Data: [u8; 1],
-}
-impl windows_core::TypeKind for CM_NOTIFY_EVENT_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for CM_NOTIFY_EVENT_DATA_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_NOTIFY_EVENT_DATA_0_1 {
-    pub InstanceId: [u16; 1],
 }
 impl windows_core::TypeKind for CM_NOTIFY_EVENT_DATA_0_1 {
     type TypeKind = windows_core::CopyType;
@@ -7501,13 +7488,26 @@ impl Default for CM_NOTIFY_EVENT_DATA_0_1 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CM_NOTIFY_EVENT_DATA_0_2 {
-    pub ClassGuid: windows_core::GUID,
-    pub SymbolicLink: [u16; 1],
+    pub InstanceId: [u16; 1],
 }
 impl windows_core::TypeKind for CM_NOTIFY_EVENT_DATA_0_2 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for CM_NOTIFY_EVENT_DATA_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CM_NOTIFY_EVENT_DATA_0_0 {
+    pub ClassGuid: windows_core::GUID,
+    pub SymbolicLink: [u16; 1],
+}
+impl windows_core::TypeKind for CM_NOTIFY_EVENT_DATA_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for CM_NOTIFY_EVENT_DATA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -7532,9 +7532,9 @@ impl Default for CM_NOTIFY_FILTER {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CM_NOTIFY_FILTER_0 {
-    pub DeviceInterface: CM_NOTIFY_FILTER_0_2,
-    pub DeviceHandle: CM_NOTIFY_FILTER_0_0,
-    pub DeviceInstance: CM_NOTIFY_FILTER_0_1,
+    pub DeviceInterface: CM_NOTIFY_FILTER_0_0,
+    pub DeviceHandle: CM_NOTIFY_FILTER_0_1,
+    pub DeviceInstance: CM_NOTIFY_FILTER_0_2,
 }
 impl windows_core::TypeKind for CM_NOTIFY_FILTER_0 {
     type TypeKind = windows_core::CopyType;
@@ -7546,21 +7546,8 @@ impl Default for CM_NOTIFY_FILTER_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CM_NOTIFY_FILTER_0_0 {
-    pub hTarget: super::super::Foundation::HANDLE,
-}
-impl windows_core::TypeKind for CM_NOTIFY_FILTER_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for CM_NOTIFY_FILTER_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CM_NOTIFY_FILTER_0_1 {
-    pub InstanceId: [u16; 200],
+    pub hTarget: super::super::Foundation::HANDLE,
 }
 impl windows_core::TypeKind for CM_NOTIFY_FILTER_0_1 {
     type TypeKind = windows_core::CopyType;
@@ -7573,12 +7560,25 @@ impl Default for CM_NOTIFY_FILTER_0_1 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CM_NOTIFY_FILTER_0_2 {
-    pub ClassGuid: windows_core::GUID,
+    pub InstanceId: [u16; 200],
 }
 impl windows_core::TypeKind for CM_NOTIFY_FILTER_0_2 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for CM_NOTIFY_FILTER_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CM_NOTIFY_FILTER_0_0 {
+    pub ClassGuid: windows_core::GUID,
+}
+impl windows_core::TypeKind for CM_NOTIFY_FILTER_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for CM_NOTIFY_FILTER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -5504,8 +5504,8 @@ impl Default for HIDP_BUTTON_CAPS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HIDP_BUTTON_CAPS_0 {
-    pub Range: HIDP_BUTTON_CAPS_0_1,
-    pub NotRange: HIDP_BUTTON_CAPS_0_0,
+    pub Range: HIDP_BUTTON_CAPS_0_0,
+    pub NotRange: HIDP_BUTTON_CAPS_0_1,
 }
 impl windows_core::TypeKind for HIDP_BUTTON_CAPS_0 {
     type TypeKind = windows_core::CopyType;
@@ -5517,7 +5517,7 @@ impl Default for HIDP_BUTTON_CAPS_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct HIDP_BUTTON_CAPS_0_0 {
+pub struct HIDP_BUTTON_CAPS_0_1 {
     pub Usage: u16,
     pub Reserved1: u16,
     pub StringIndex: u16,
@@ -5527,17 +5527,17 @@ pub struct HIDP_BUTTON_CAPS_0_0 {
     pub DataIndex: u16,
     pub Reserved4: u16,
 }
-impl windows_core::TypeKind for HIDP_BUTTON_CAPS_0_0 {
+impl windows_core::TypeKind for HIDP_BUTTON_CAPS_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for HIDP_BUTTON_CAPS_0_0 {
+impl Default for HIDP_BUTTON_CAPS_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct HIDP_BUTTON_CAPS_0_1 {
+pub struct HIDP_BUTTON_CAPS_0_0 {
     pub UsageMin: u16,
     pub UsageMax: u16,
     pub StringMin: u16,
@@ -5547,10 +5547,10 @@ pub struct HIDP_BUTTON_CAPS_0_1 {
     pub DataIndexMin: u16,
     pub DataIndexMax: u16,
 }
-impl windows_core::TypeKind for HIDP_BUTTON_CAPS_0_1 {
+impl windows_core::TypeKind for HIDP_BUTTON_CAPS_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for HIDP_BUTTON_CAPS_0_1 {
+impl Default for HIDP_BUTTON_CAPS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5741,8 +5741,8 @@ impl Default for HIDP_VALUE_CAPS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HIDP_VALUE_CAPS_0 {
-    pub Range: HIDP_VALUE_CAPS_0_1,
-    pub NotRange: HIDP_VALUE_CAPS_0_0,
+    pub Range: HIDP_VALUE_CAPS_0_0,
+    pub NotRange: HIDP_VALUE_CAPS_0_1,
 }
 impl windows_core::TypeKind for HIDP_VALUE_CAPS_0 {
     type TypeKind = windows_core::CopyType;
@@ -5754,7 +5754,7 @@ impl Default for HIDP_VALUE_CAPS_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct HIDP_VALUE_CAPS_0_0 {
+pub struct HIDP_VALUE_CAPS_0_1 {
     pub Usage: u16,
     pub Reserved1: u16,
     pub StringIndex: u16,
@@ -5764,17 +5764,17 @@ pub struct HIDP_VALUE_CAPS_0_0 {
     pub DataIndex: u16,
     pub Reserved4: u16,
 }
-impl windows_core::TypeKind for HIDP_VALUE_CAPS_0_0 {
+impl windows_core::TypeKind for HIDP_VALUE_CAPS_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for HIDP_VALUE_CAPS_0_0 {
+impl Default for HIDP_VALUE_CAPS_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct HIDP_VALUE_CAPS_0_1 {
+pub struct HIDP_VALUE_CAPS_0_0 {
     pub UsageMin: u16,
     pub UsageMax: u16,
     pub StringMin: u16,
@@ -5784,10 +5784,10 @@ pub struct HIDP_VALUE_CAPS_0_1 {
     pub DataIndexMin: u16,
     pub DataIndexMax: u16,
 }
-impl windows_core::TypeKind for HIDP_VALUE_CAPS_0_1 {
+impl windows_core::TypeKind for HIDP_VALUE_CAPS_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for HIDP_VALUE_CAPS_0_1 {
+impl Default for HIDP_VALUE_CAPS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
@@ -2986,8 +2986,8 @@ impl Default for VAL {
 pub struct WIAS_CHANGED_VALUE_INFO {
     pub bChanged: super::super::Foundation::BOOL,
     pub vt: i32,
-    pub Old: WIAS_CHANGED_VALUE_INFO_1,
-    pub Current: WIAS_CHANGED_VALUE_INFO_0,
+    pub Old: WIAS_CHANGED_VALUE_INFO_0,
+    pub Current: WIAS_CHANGED_VALUE_INFO_1,
 }
 impl Clone for WIAS_CHANGED_VALUE_INFO {
     fn clone(&self) -> Self {
@@ -2998,26 +2998,6 @@ impl windows_core::TypeKind for WIAS_CHANGED_VALUE_INFO {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for WIAS_CHANGED_VALUE_INFO {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-pub union WIAS_CHANGED_VALUE_INFO_0 {
-    pub lVal: i32,
-    pub fltVal: f32,
-    pub bstrVal: core::mem::ManuallyDrop<windows_core::BSTR>,
-    pub guidVal: windows_core::GUID,
-}
-impl Clone for WIAS_CHANGED_VALUE_INFO_0 {
-    fn clone(&self) -> Self {
-        unsafe { core::mem::transmute_copy(self) }
-    }
-}
-impl windows_core::TypeKind for WIAS_CHANGED_VALUE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for WIAS_CHANGED_VALUE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3038,6 +3018,26 @@ impl windows_core::TypeKind for WIAS_CHANGED_VALUE_INFO_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for WIAS_CHANGED_VALUE_INFO_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+pub union WIAS_CHANGED_VALUE_INFO_0 {
+    pub lVal: i32,
+    pub fltVal: f32,
+    pub bstrVal: core::mem::ManuallyDrop<windows_core::BSTR>,
+    pub guidVal: windows_core::GUID,
+}
+impl Clone for WIAS_CHANGED_VALUE_INFO_0 {
+    fn clone(&self) -> Self {
+        unsafe { core::mem::transmute_copy(self) }
+    }
+}
+impl windows_core::TypeKind for WIAS_CHANGED_VALUE_INFO_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for WIAS_CHANGED_VALUE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3368,14 +3368,14 @@ impl Default for WIA_PROPERTY_INFO {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 pub union WIA_PROPERTY_INFO_0 {
-    pub Range: WIA_PROPERTY_INFO_0_7,
-    pub RangeFloat: WIA_PROPERTY_INFO_0_6,
-    pub List: WIA_PROPERTY_INFO_0_4,
-    pub ListFloat: WIA_PROPERTY_INFO_0_2,
-    pub ListGuid: WIA_PROPERTY_INFO_0_3,
-    pub ListBStr: core::mem::ManuallyDrop<WIA_PROPERTY_INFO_0_1>,
-    pub Flag: WIA_PROPERTY_INFO_0_0,
-    pub None: WIA_PROPERTY_INFO_0_5,
+    pub Range: WIA_PROPERTY_INFO_0_0,
+    pub RangeFloat: WIA_PROPERTY_INFO_0_1,
+    pub List: WIA_PROPERTY_INFO_0_2,
+    pub ListFloat: WIA_PROPERTY_INFO_0_3,
+    pub ListGuid: WIA_PROPERTY_INFO_0_4,
+    pub ListBStr: core::mem::ManuallyDrop<WIA_PROPERTY_INFO_0_5>,
+    pub Flag: WIA_PROPERTY_INFO_0_6,
+    pub None: WIA_PROPERTY_INFO_0_7,
 }
 #[cfg(feature = "Win32_System_Variant")]
 impl Clone for WIA_PROPERTY_INFO_0 {
@@ -3396,16 +3396,16 @@ impl Default for WIA_PROPERTY_INFO_0 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WIA_PROPERTY_INFO_0_0 {
+pub struct WIA_PROPERTY_INFO_0_6 {
     pub Nom: i32,
     pub ValidBits: i32,
 }
 #[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_0 {
+impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_6 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Variant")]
-impl Default for WIA_PROPERTY_INFO_0_0 {
+impl Default for WIA_PROPERTY_INFO_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3413,23 +3413,23 @@ impl Default for WIA_PROPERTY_INFO_0_0 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Debug, Eq, PartialEq)]
-pub struct WIA_PROPERTY_INFO_0_1 {
+pub struct WIA_PROPERTY_INFO_0_5 {
     pub cNumList: i32,
     pub Nom: core::mem::ManuallyDrop<windows_core::BSTR>,
     pub pList: *mut windows_core::BSTR,
 }
 #[cfg(feature = "Win32_System_Variant")]
-impl Clone for WIA_PROPERTY_INFO_0_1 {
+impl Clone for WIA_PROPERTY_INFO_0_5 {
     fn clone(&self) -> Self {
         unsafe { core::mem::transmute_copy(self) }
     }
 }
 #[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_1 {
+impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_5 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Variant")]
-impl Default for WIA_PROPERTY_INFO_0_1 {
+impl Default for WIA_PROPERTY_INFO_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3437,28 +3437,10 @@ impl Default for WIA_PROPERTY_INFO_0_1 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct WIA_PROPERTY_INFO_0_2 {
+pub struct WIA_PROPERTY_INFO_0_3 {
     pub cNumList: i32,
     pub Nom: f64,
     pub pList: *mut u8,
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl Default for WIA_PROPERTY_INFO_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_System_Variant")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WIA_PROPERTY_INFO_0_3 {
-    pub cNumList: i32,
-    pub Nom: windows_core::GUID,
-    pub pList: *mut windows_core::GUID,
 }
 #[cfg(feature = "Win32_System_Variant")]
 impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_3 {
@@ -3475,8 +3457,8 @@ impl Default for WIA_PROPERTY_INFO_0_3 {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WIA_PROPERTY_INFO_0_4 {
     pub cNumList: i32,
-    pub Nom: i32,
-    pub pList: *mut u8,
+    pub Nom: windows_core::GUID,
+    pub pList: *mut windows_core::GUID,
 }
 #[cfg(feature = "Win32_System_Variant")]
 impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_4 {
@@ -3491,34 +3473,17 @@ impl Default for WIA_PROPERTY_INFO_0_4 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WIA_PROPERTY_INFO_0_5 {
-    pub Dummy: i32,
+pub struct WIA_PROPERTY_INFO_0_2 {
+    pub cNumList: i32,
+    pub Nom: i32,
+    pub pList: *mut u8,
 }
 #[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_5 {
+impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_2 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Variant")]
-impl Default for WIA_PROPERTY_INFO_0_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_System_Variant")]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct WIA_PROPERTY_INFO_0_6 {
-    pub Min: f64,
-    pub Nom: f64,
-    pub Max: f64,
-    pub Inc: f64,
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl Default for WIA_PROPERTY_INFO_0_6 {
+impl Default for WIA_PROPERTY_INFO_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3527,10 +3492,7 @@ impl Default for WIA_PROPERTY_INFO_0_6 {
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct WIA_PROPERTY_INFO_0_7 {
-    pub Min: i32,
-    pub Nom: i32,
-    pub Max: i32,
-    pub Inc: i32,
+    pub Dummy: i32,
 }
 #[cfg(feature = "Win32_System_Variant")]
 impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_7 {
@@ -3538,6 +3500,44 @@ impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_7 {
 }
 #[cfg(feature = "Win32_System_Variant")]
 impl Default for WIA_PROPERTY_INFO_0_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_System_Variant")]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct WIA_PROPERTY_INFO_0_1 {
+    pub Min: f64,
+    pub Nom: f64,
+    pub Max: f64,
+    pub Inc: f64,
+}
+#[cfg(feature = "Win32_System_Variant")]
+impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_1 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Variant")]
+impl Default for WIA_PROPERTY_INFO_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_System_Variant")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WIA_PROPERTY_INFO_0_0 {
+    pub Min: i32,
+    pub Nom: i32,
+    pub Max: i32,
+    pub Inc: i32,
+}
+#[cfg(feature = "Win32_System_Variant")]
+impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Variant")]
+impl Default for WIA_PROPERTY_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
@@ -11380,26 +11380,26 @@ impl Default for LINEPROXYREQUEST {
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
 pub union LINEPROXYREQUEST_0 {
-    pub SetAgentGroup: LINEPROXYREQUEST_0_14,
-    pub SetAgentState: LINEPROXYREQUEST_0_18,
-    pub SetAgentActivity: LINEPROXYREQUEST_0_13,
-    pub GetAgentCaps: LINEPROXYREQUEST_0_4,
-    pub GetAgentStatus: LINEPROXYREQUEST_0_9,
-    pub AgentSpecific: LINEPROXYREQUEST_0_0,
-    pub GetAgentActivityList: LINEPROXYREQUEST_0_3,
-    pub GetAgentGroupList: LINEPROXYREQUEST_0_5,
-    pub CreateAgent: LINEPROXYREQUEST_0_2,
-    pub SetAgentStateEx: LINEPROXYREQUEST_0_17,
-    pub SetAgentMeasurementPeriod: LINEPROXYREQUEST_0_15,
-    pub GetAgentInfo: LINEPROXYREQUEST_0_6,
-    pub CreateAgentSession: LINEPROXYREQUEST_0_1,
-    pub GetAgentSessionList: LINEPROXYREQUEST_0_8,
-    pub GetAgentSessionInfo: LINEPROXYREQUEST_0_7,
-    pub SetAgentSessionState: LINEPROXYREQUEST_0_16,
-    pub GetQueueList: LINEPROXYREQUEST_0_12,
-    pub SetQueueMeasurementPeriod: LINEPROXYREQUEST_0_19,
-    pub GetQueueInfo: LINEPROXYREQUEST_0_11,
-    pub GetGroupList: LINEPROXYREQUEST_0_10,
+    pub SetAgentGroup: LINEPROXYREQUEST_0_0,
+    pub SetAgentState: LINEPROXYREQUEST_0_1,
+    pub SetAgentActivity: LINEPROXYREQUEST_0_2,
+    pub GetAgentCaps: LINEPROXYREQUEST_0_3,
+    pub GetAgentStatus: LINEPROXYREQUEST_0_4,
+    pub AgentSpecific: LINEPROXYREQUEST_0_5,
+    pub GetAgentActivityList: LINEPROXYREQUEST_0_6,
+    pub GetAgentGroupList: LINEPROXYREQUEST_0_7,
+    pub CreateAgent: LINEPROXYREQUEST_0_8,
+    pub SetAgentStateEx: LINEPROXYREQUEST_0_9,
+    pub SetAgentMeasurementPeriod: LINEPROXYREQUEST_0_10,
+    pub GetAgentInfo: LINEPROXYREQUEST_0_11,
+    pub CreateAgentSession: LINEPROXYREQUEST_0_12,
+    pub GetAgentSessionList: LINEPROXYREQUEST_0_13,
+    pub GetAgentSessionInfo: LINEPROXYREQUEST_0_14,
+    pub SetAgentSessionState: LINEPROXYREQUEST_0_15,
+    pub GetQueueList: LINEPROXYREQUEST_0_16,
+    pub SetQueueMeasurementPeriod: LINEPROXYREQUEST_0_17,
+    pub GetQueueInfo: LINEPROXYREQUEST_0_18,
+    pub GetGroupList: LINEPROXYREQUEST_0_19,
 }
 #[cfg(feature = "Win32_System_Com")]
 impl windows_core::TypeKind for LINEPROXYREQUEST_0 {
@@ -11414,103 +11414,11 @@ impl Default for LINEPROXYREQUEST_0 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_0 {
+pub struct LINEPROXYREQUEST_0_5 {
     pub dwAddressID: u32,
     pub dwAgentExtensionIDIndex: u32,
     pub dwSize: u32,
     pub Params: [u8; 1],
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_1 {
-    pub hAgentSession: u32,
-    pub dwAgentPINSize: u32,
-    pub dwAgentPINOffset: u32,
-    pub hAgent: u32,
-    pub GroupID: windows_core::GUID,
-    pub dwWorkingAddressID: u32,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_2 {
-    pub hAgent: u32,
-    pub dwAgentIDSize: u32,
-    pub dwAgentIDOffset: u32,
-    pub dwAgentPINSize: u32,
-    pub dwAgentPINOffset: u32,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_3 {
-    pub dwAddressID: u32,
-    pub ActivityList: LINEAGENTACTIVITYLIST,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_4 {
-    pub dwAddressID: u32,
-    pub AgentCaps: LINEAGENTCAPS,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_4 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_5 {
-    pub dwAddressID: u32,
-    pub GroupList: LINEAGENTGROUPLIST,
 }
 #[cfg(feature = "Win32_System_Com")]
 impl windows_core::TypeKind for LINEPROXYREQUEST_0_5 {
@@ -11525,110 +11433,13 @@ impl Default for LINEPROXYREQUEST_0_5 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_6 {
-    pub hAgent: u32,
-    pub AgentInfo: LINEAGENTINFO,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_6 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_7 {
-    pub hAgentSession: u32,
-    pub SessionInfo: LINEAGENTSESSIONINFO,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_7 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_8 {
-    pub hAgent: u32,
-    pub SessionList: LINEAGENTSESSIONLIST,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_8 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_9 {
-    pub dwAddressID: u32,
-    pub AgentStatus: LINEAGENTSTATUS,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_9 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_10 {
-    pub GroupList: LINEAGENTGROUPLIST,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_10 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_10 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_11 {
-    pub dwQueueID: u32,
-    pub QueueInfo: LINEQUEUEINFO,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_11 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_11 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy)]
 pub struct LINEPROXYREQUEST_0_12 {
+    pub hAgentSession: u32,
+    pub dwAgentPINSize: u32,
+    pub dwAgentPINOffset: u32,
+    pub hAgent: u32,
     pub GroupID: windows_core::GUID,
-    pub QueueList: LINEQUEUELIST,
+    pub dwWorkingAddressID: u32,
 }
 #[cfg(feature = "Win32_System_Com")]
 impl windows_core::TypeKind for LINEPROXYREQUEST_0_12 {
@@ -11643,16 +11454,87 @@ impl Default for LINEPROXYREQUEST_0_12 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_13 {
-    pub dwAddressID: u32,
-    pub dwActivityID: u32,
+pub struct LINEPROXYREQUEST_0_8 {
+    pub hAgent: u32,
+    pub dwAgentIDSize: u32,
+    pub dwAgentIDOffset: u32,
+    pub dwAgentPINSize: u32,
+    pub dwAgentPINOffset: u32,
 }
 #[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_13 {
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_8 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_13 {
+impl Default for LINEPROXYREQUEST_0_8 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_6 {
+    pub dwAddressID: u32,
+    pub ActivityList: LINEAGENTACTIVITYLIST,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_6 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_6 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_3 {
+    pub dwAddressID: u32,
+    pub AgentCaps: LINEAGENTCAPS,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_3 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_7 {
+    pub dwAddressID: u32,
+    pub GroupList: LINEAGENTGROUPLIST,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_7 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_11 {
+    pub hAgent: u32,
+    pub AgentInfo: LINEAGENTINFO,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_11 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -11661,8 +11543,8 @@ impl Default for LINEPROXYREQUEST_0_13 {
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
 pub struct LINEPROXYREQUEST_0_14 {
-    pub dwAddressID: u32,
-    pub GroupList: LINEAGENTGROUPLIST,
+    pub hAgentSession: u32,
+    pub SessionInfo: LINEAGENTSESSIONINFO,
 }
 #[cfg(feature = "Win32_System_Com")]
 impl windows_core::TypeKind for LINEPROXYREQUEST_0_14 {
@@ -11677,16 +11559,16 @@ impl Default for LINEPROXYREQUEST_0_14 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_15 {
+pub struct LINEPROXYREQUEST_0_13 {
     pub hAgent: u32,
-    pub dwMeasurementPeriod: u32,
+    pub SessionList: LINEAGENTSESSIONLIST,
 }
 #[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_15 {
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_13 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_15 {
+impl Default for LINEPROXYREQUEST_0_13 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -11694,35 +11576,32 @@ impl Default for LINEPROXYREQUEST_0_15 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_16 {
-    pub hAgentSession: u32,
-    pub dwAgentSessionState: u32,
-    pub dwNextAgentSessionState: u32,
+pub struct LINEPROXYREQUEST_0_4 {
+    pub dwAddressID: u32,
+    pub AgentStatus: LINEAGENTSTATUS,
 }
 #[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_16 {
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_4 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_16 {
+impl Default for LINEPROXYREQUEST_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
-#[repr(C, packed(1))]
+#[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_17 {
-    pub hAgent: u32,
-    pub dwAgentState: u32,
-    pub dwNextAgentState: u32,
+pub struct LINEPROXYREQUEST_0_19 {
+    pub GroupList: LINEAGENTGROUPLIST,
 }
 #[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_17 {
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_19 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_17 {
+impl Default for LINEPROXYREQUEST_0_19 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -11731,9 +11610,8 @@ impl Default for LINEPROXYREQUEST_0_17 {
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
 pub struct LINEPROXYREQUEST_0_18 {
-    pub dwAddressID: u32,
-    pub dwAgentState: u32,
-    pub dwNextAgentState: u32,
+    pub dwQueueID: u32,
+    pub QueueInfo: LINEQUEUEINFO,
 }
 #[cfg(feature = "Win32_System_Com")]
 impl windows_core::TypeKind for LINEPROXYREQUEST_0_18 {
@@ -11748,16 +11626,138 @@ impl Default for LINEPROXYREQUEST_0_18 {
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
-pub struct LINEPROXYREQUEST_0_19 {
+pub struct LINEPROXYREQUEST_0_16 {
+    pub GroupID: windows_core::GUID,
+    pub QueueList: LINEQUEUELIST,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_16 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_16 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_2 {
+    pub dwAddressID: u32,
+    pub dwActivityID: u32,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_0 {
+    pub dwAddressID: u32,
+    pub GroupList: LINEAGENTGROUPLIST,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_10 {
+    pub hAgent: u32,
+    pub dwMeasurementPeriod: u32,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_10 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_10 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_15 {
+    pub hAgentSession: u32,
+    pub dwAgentSessionState: u32,
+    pub dwNextAgentSessionState: u32,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_15 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_15 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_9 {
+    pub hAgent: u32,
+    pub dwAgentState: u32,
+    pub dwNextAgentState: u32,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_9 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_9 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_1 {
+    pub dwAddressID: u32,
+    pub dwAgentState: u32,
+    pub dwNextAgentState: u32,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_1 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for LINEPROXYREQUEST_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy)]
+pub struct LINEPROXYREQUEST_0_17 {
     pub dwQueueID: u32,
     pub dwMeasurementPeriod: u32,
 }
 #[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_19 {
+impl windows_core::TypeKind for LINEPROXYREQUEST_0_17 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl Default for LINEPROXYREQUEST_0_19 {
+impl Default for LINEPROXYREQUEST_0_17 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -12002,13 +12002,13 @@ impl Default for MSP_EVENT_INFO {
 #[cfg(feature = "Win32_System_Com")]
 pub union MSP_EVENT_INFO_0 {
     pub MSP_ADDRESS_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_0>,
-    pub MSP_CALL_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_2>,
-    pub MSP_TSP_DATA: MSP_EVENT_INFO_0_6,
-    pub MSP_PRIVATE_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_4>,
-    pub MSP_FILE_TERMINAL_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_3>,
-    pub MSP_ASR_TERMINAL_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_1>,
-    pub MSP_TTS_TERMINAL_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_7>,
-    pub MSP_TONE_TERMINAL_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_5>,
+    pub MSP_CALL_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_1>,
+    pub MSP_TSP_DATA: MSP_EVENT_INFO_0_2,
+    pub MSP_PRIVATE_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_3>,
+    pub MSP_FILE_TERMINAL_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_4>,
+    pub MSP_ASR_TERMINAL_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_5>,
+    pub MSP_TTS_TERMINAL_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_6>,
+    pub MSP_TONE_TERMINAL_EVENT_INFO: core::mem::ManuallyDrop<MSP_EVENT_INFO_0_7>,
 }
 #[cfg(feature = "Win32_System_Com")]
 impl Clone for MSP_EVENT_INFO_0 {
@@ -12052,106 +12052,8 @@ impl Default for MSP_EVENT_INFO_0_0 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Debug, Eq, PartialEq)]
-pub struct MSP_EVENT_INFO_0_1 {
-    pub pASRTerminal: core::mem::ManuallyDrop<Option<ITTerminal>>,
-    pub hrErrorCode: windows_core::HRESULT,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Clone for MSP_EVENT_INFO_0_1 {
-    fn clone(&self) -> Self {
-        unsafe { core::mem::transmute_copy(self) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for MSP_EVENT_INFO_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Debug, Eq, PartialEq)]
-pub struct MSP_EVENT_INFO_0_2 {
-    pub Type: MSP_CALL_EVENT,
-    pub Cause: MSP_CALL_EVENT_CAUSE,
-    pub pStream: core::mem::ManuallyDrop<Option<ITStream>>,
-    pub pTerminal: core::mem::ManuallyDrop<Option<ITTerminal>>,
-    pub hrError: windows_core::HRESULT,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Clone for MSP_EVENT_INFO_0_2 {
-    fn clone(&self) -> Self {
-        unsafe { core::mem::transmute_copy(self) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for MSP_EVENT_INFO_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Debug, Eq, PartialEq)]
-pub struct MSP_EVENT_INFO_0_3 {
-    pub pParentFileTerminal: core::mem::ManuallyDrop<Option<ITTerminal>>,
-    pub pFileTrack: core::mem::ManuallyDrop<Option<ITFileTrack>>,
-    pub TerminalMediaState: TERMINAL_MEDIA_STATE,
-    pub ftecEventCause: FT_STATE_EVENT_CAUSE,
-    pub hrErrorCode: windows_core::HRESULT,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Clone for MSP_EVENT_INFO_0_3 {
-    fn clone(&self) -> Self {
-        unsafe { core::mem::transmute_copy(self) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for MSP_EVENT_INFO_0_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Debug, Eq, PartialEq)]
-pub struct MSP_EVENT_INFO_0_4 {
-    pub pEvent: core::mem::ManuallyDrop<Option<super::super::System::Com::IDispatch>>,
-    pub lEventCode: i32,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Clone for MSP_EVENT_INFO_0_4 {
-    fn clone(&self) -> Self {
-        unsafe { core::mem::transmute_copy(self) }
-    }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for MSP_EVENT_INFO_0_4 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Debug, Eq, PartialEq)]
 pub struct MSP_EVENT_INFO_0_5 {
-    pub pToneTerminal: core::mem::ManuallyDrop<Option<ITTerminal>>,
+    pub pASRTerminal: core::mem::ManuallyDrop<Option<ITTerminal>>,
     pub hrErrorCode: windows_core::HRESULT,
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -12172,17 +12074,75 @@ impl Default for MSP_EVENT_INFO_0_5 {
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct MSP_EVENT_INFO_0_6 {
-    pub dwBufferSize: u32,
-    pub pBuffer: [u8; 1],
+#[derive(Debug, Eq, PartialEq)]
+pub struct MSP_EVENT_INFO_0_1 {
+    pub Type: MSP_CALL_EVENT,
+    pub Cause: MSP_CALL_EVENT_CAUSE,
+    pub pStream: core::mem::ManuallyDrop<Option<ITStream>>,
+    pub pTerminal: core::mem::ManuallyDrop<Option<ITTerminal>>,
+    pub hrError: windows_core::HRESULT,
 }
 #[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_6 {
+impl Clone for MSP_EVENT_INFO_0_1 {
+    fn clone(&self) -> Self {
+        unsafe { core::mem::transmute_copy(self) }
+    }
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for MSP_EVENT_INFO_0_1 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl Default for MSP_EVENT_INFO_0_6 {
+impl Default for MSP_EVENT_INFO_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Debug, Eq, PartialEq)]
+pub struct MSP_EVENT_INFO_0_4 {
+    pub pParentFileTerminal: core::mem::ManuallyDrop<Option<ITTerminal>>,
+    pub pFileTrack: core::mem::ManuallyDrop<Option<ITFileTrack>>,
+    pub TerminalMediaState: TERMINAL_MEDIA_STATE,
+    pub ftecEventCause: FT_STATE_EVENT_CAUSE,
+    pub hrErrorCode: windows_core::HRESULT,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Clone for MSP_EVENT_INFO_0_4 {
+    fn clone(&self) -> Self {
+        unsafe { core::mem::transmute_copy(self) }
+    }
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for MSP_EVENT_INFO_0_4 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for MSP_EVENT_INFO_0_4 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Debug, Eq, PartialEq)]
+pub struct MSP_EVENT_INFO_0_3 {
+    pub pEvent: core::mem::ManuallyDrop<Option<super::super::System::Com::IDispatch>>,
+    pub lEventCode: i32,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Clone for MSP_EVENT_INFO_0_3 {
+    fn clone(&self) -> Self {
+        unsafe { core::mem::transmute_copy(self) }
+    }
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for MSP_EVENT_INFO_0_3 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for MSP_EVENT_INFO_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -12191,7 +12151,7 @@ impl Default for MSP_EVENT_INFO_0_6 {
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Debug, Eq, PartialEq)]
 pub struct MSP_EVENT_INFO_0_7 {
-    pub pTTSTerminal: core::mem::ManuallyDrop<Option<ITTerminal>>,
+    pub pToneTerminal: core::mem::ManuallyDrop<Option<ITTerminal>>,
     pub hrErrorCode: windows_core::HRESULT,
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -12206,6 +12166,46 @@ impl windows_core::TypeKind for MSP_EVENT_INFO_0_7 {
 }
 #[cfg(feature = "Win32_System_Com")]
 impl Default for MSP_EVENT_INFO_0_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MSP_EVENT_INFO_0_2 {
+    pub dwBufferSize: u32,
+    pub pBuffer: [u8; 1],
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for MSP_EVENT_INFO_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for MSP_EVENT_INFO_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Debug, Eq, PartialEq)]
+pub struct MSP_EVENT_INFO_0_6 {
+    pub pTTSTerminal: core::mem::ManuallyDrop<Option<ITTerminal>>,
+    pub hrErrorCode: windows_core::HRESULT,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Clone for MSP_EVENT_INFO_0_6 {
+    fn clone(&self) -> Self {
+        unsafe { core::mem::transmute_copy(self) }
+    }
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for MSP_EVENT_INFO_0_6 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for MSP_EVENT_INFO_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Usb/mod.rs
@@ -2566,42 +2566,14 @@ impl Default for USB_CYCLE_PORT_PARAMS {
 pub struct USB_DEFAULT_PIPE_SETUP_PACKET {
     pub bmRequestType: BM_REQUEST_TYPE,
     pub bRequest: u8,
-    pub wValue: USB_DEFAULT_PIPE_SETUP_PACKET_1,
-    pub wIndex: USB_DEFAULT_PIPE_SETUP_PACKET_0,
+    pub wValue: USB_DEFAULT_PIPE_SETUP_PACKET_0,
+    pub wIndex: USB_DEFAULT_PIPE_SETUP_PACKET_1,
     pub wLength: u16,
 }
 impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for USB_DEFAULT_PIPE_SETUP_PACKET {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub union USB_DEFAULT_PIPE_SETUP_PACKET_0 {
-    pub Anonymous: USB_DEFAULT_PIPE_SETUP_PACKET_0_0,
-    pub W: u16,
-}
-impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for USB_DEFAULT_PIPE_SETUP_PACKET_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
-    pub LowByte: u8,
-    pub HiByte: u8,
-}
-impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2630,6 +2602,34 @@ impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET_1_0 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for USB_DEFAULT_PIPE_SETUP_PACKET_1_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub union USB_DEFAULT_PIPE_SETUP_PACKET_0 {
+    pub Anonymous: USB_DEFAULT_PIPE_SETUP_PACKET_0_0,
+    pub W: u16,
+}
+impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for USB_DEFAULT_PIPE_SETUP_PACKET_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
+    pub LowByte: u8,
+    pub HiByte: u8,
+}
+impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2675,10 +2675,10 @@ pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {
     pub iAddtionalInfoURL: u8,
     pub bNumberOfAlternateModes: u8,
     pub bPreferredAlternateMode: u8,
-    pub VconnPower: USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1,
+    pub VconnPower: USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0,
     pub bmConfigured: [u8; 32],
     pub bReserved: u32,
-    pub AlternateMode: [USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0; 1],
+    pub AlternateMode: [USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1; 1],
 }
 impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {
     type TypeKind = windows_core::CopyType;
@@ -2690,24 +2690,10 @@ impl Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
+pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
     pub wSVID: u16,
     pub bAlternateMode: u8,
     pub iAlternateModeSetting: u8,
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub union USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
-    pub AsUshort: u16,
-    pub Anonymous: USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0,
 }
 impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
     type TypeKind = windows_core::CopyType;
@@ -2719,13 +2705,27 @@ impl Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0 {
-    pub _bitfield: u16,
+pub union USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
+    pub AsUshort: u16,
+    pub Anonymous: USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0_0,
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0 {
+impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1_0 {
+impl Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0_0 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -12403,12 +12403,12 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_INDIRECT_ARGUMENT_DESC_0 {
-    pub VertexBuffer: D3D12_INDIRECT_ARGUMENT_DESC_0_5,
+    pub VertexBuffer: D3D12_INDIRECT_ARGUMENT_DESC_0_0,
     pub Constant: D3D12_INDIRECT_ARGUMENT_DESC_0_1,
-    pub ConstantBufferView: D3D12_INDIRECT_ARGUMENT_DESC_0_0,
+    pub ConstantBufferView: D3D12_INDIRECT_ARGUMENT_DESC_0_2,
     pub ShaderResourceView: D3D12_INDIRECT_ARGUMENT_DESC_0_3,
     pub UnorderedAccessView: D3D12_INDIRECT_ARGUMENT_DESC_0_4,
-    pub IncrementingConstant: D3D12_INDIRECT_ARGUMENT_DESC_0_2,
+    pub IncrementingConstant: D3D12_INDIRECT_ARGUMENT_DESC_0_5,
 }
 impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0 {
     type TypeKind = windows_core::CopyType;
@@ -12420,13 +12420,13 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
+pub struct D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
     pub RootParameterIndex: u32,
 }
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
+impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
+impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -12448,14 +12448,14 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
+pub struct D3D12_INDIRECT_ARGUMENT_DESC_0_5 {
     pub RootParameterIndex: u32,
     pub DestOffsetIn32BitValues: u32,
 }
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
+impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_5 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
+impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -12488,13 +12488,13 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_4 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct D3D12_INDIRECT_ARGUMENT_DESC_0_5 {
+pub struct D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
     pub Slot: u32,
 }
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_5 {
+impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_5 {
+impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
@@ -6227,16 +6227,16 @@ impl Default for DWRITE_PAINT_ELEMENT {
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy)]
 pub union DWRITE_PAINT_ELEMENT_0 {
-    pub layers: DWRITE_PAINT_ELEMENT_0_3,
-    pub solidGlyph: DWRITE_PAINT_ELEMENT_0_6,
+    pub layers: DWRITE_PAINT_ELEMENT_0_0,
+    pub solidGlyph: DWRITE_PAINT_ELEMENT_0_1,
     pub solid: DWRITE_PAINT_COLOR,
-    pub linearGradient: DWRITE_PAINT_ELEMENT_0_4,
-    pub radialGradient: DWRITE_PAINT_ELEMENT_0_5,
-    pub sweepGradient: DWRITE_PAINT_ELEMENT_0_7,
-    pub glyph: DWRITE_PAINT_ELEMENT_0_2,
-    pub colorGlyph: DWRITE_PAINT_ELEMENT_0_0,
+    pub linearGradient: DWRITE_PAINT_ELEMENT_0_2,
+    pub radialGradient: DWRITE_PAINT_ELEMENT_0_3,
+    pub sweepGradient: DWRITE_PAINT_ELEMENT_0_4,
+    pub glyph: DWRITE_PAINT_ELEMENT_0_5,
+    pub colorGlyph: DWRITE_PAINT_ELEMENT_0_6,
     pub transform: DWRITE_MATRIX,
-    pub composite: DWRITE_PAINT_ELEMENT_0_1,
+    pub composite: DWRITE_PAINT_ELEMENT_0_7,
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0 {
@@ -6251,9 +6251,57 @@ impl Default for DWRITE_PAINT_ELEMENT_0 {
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct DWRITE_PAINT_ELEMENT_0_0 {
+pub struct DWRITE_PAINT_ELEMENT_0_6 {
     pub glyphIndex: u32,
     pub clipBox: super::Direct2D::Common::D2D_RECT_F,
+}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_6 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl Default for DWRITE_PAINT_ELEMENT_0_6 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DWRITE_PAINT_ELEMENT_0_7 {
+    pub mode: DWRITE_COLOR_COMPOSITE_MODE,
+}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_7 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl Default for DWRITE_PAINT_ELEMENT_0_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DWRITE_PAINT_ELEMENT_0_5 {
+    pub glyphIndex: u32,
+}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_5 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl Default for DWRITE_PAINT_ELEMENT_0_5 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DWRITE_PAINT_ELEMENT_0_0 {
+    pub childCount: u32,
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_0 {
@@ -6267,25 +6315,16 @@ impl Default for DWRITE_PAINT_ELEMENT_0_0 {
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DWRITE_PAINT_ELEMENT_0_1 {
-    pub mode: DWRITE_COLOR_COMPOSITE_MODE,
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl Default for DWRITE_PAINT_ELEMENT_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_PAINT_ELEMENT_0_2 {
-    pub glyphIndex: u32,
+    pub extendMode: u32,
+    pub gradientStopCount: u32,
+    pub x0: f32,
+    pub y0: f32,
+    pub x1: f32,
+    pub y1: f32,
+    pub x2: f32,
+    pub y2: f32,
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_2 {
@@ -6299,9 +6338,16 @@ impl Default for DWRITE_PAINT_ELEMENT_0_2 {
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_PAINT_ELEMENT_0_3 {
-    pub childCount: u32,
+    pub extendMode: u32,
+    pub gradientStopCount: u32,
+    pub x0: f32,
+    pub y0: f32,
+    pub radius0: f32,
+    pub x1: f32,
+    pub y1: f32,
+    pub radius1: f32,
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_3 {
@@ -6316,15 +6362,30 @@ impl Default for DWRITE_PAINT_ELEMENT_0_3 {
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DWRITE_PAINT_ELEMENT_0_1 {
+    pub glyphIndex: u32,
+    pub color: DWRITE_PAINT_COLOR,
+}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_1 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+impl Default for DWRITE_PAINT_ELEMENT_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_PAINT_ELEMENT_0_4 {
     pub extendMode: u32,
     pub gradientStopCount: u32,
-    pub x0: f32,
-    pub y0: f32,
-    pub x1: f32,
-    pub y1: f32,
-    pub x2: f32,
-    pub y2: f32,
+    pub centerX: f32,
+    pub centerY: f32,
+    pub startAngle: f32,
+    pub endAngle: f32,
 }
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_4 {
@@ -6337,75 +6398,14 @@ impl Default for DWRITE_PAINT_ELEMENT_0_4 {
     }
 }
 #[repr(C)]
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct DWRITE_PAINT_ELEMENT_0_5 {
-    pub extendMode: u32,
-    pub gradientStopCount: u32,
-    pub x0: f32,
-    pub y0: f32,
-    pub radius0: f32,
-    pub x1: f32,
-    pub y1: f32,
-    pub radius1: f32,
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl Default for DWRITE_PAINT_ELEMENT_0_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct DWRITE_PAINT_ELEMENT_0_6 {
-    pub glyphIndex: u32,
-    pub color: DWRITE_PAINT_COLOR,
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl Default for DWRITE_PAINT_ELEMENT_0_6 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct DWRITE_PAINT_ELEMENT_0_7 {
-    pub extendMode: u32,
-    pub gradientStopCount: u32,
-    pub centerX: f32,
-    pub centerY: f32,
-    pub startAngle: f32,
-    pub endAngle: f32,
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl Default for DWRITE_PAINT_ELEMENT_0_7 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
 #[derive(Clone, Copy)]
 pub union DWRITE_PANOSE {
     pub values: [u8; 10],
     pub familyKind: u8,
-    pub text: DWRITE_PANOSE_3,
+    pub text: DWRITE_PANOSE_0,
     pub script: DWRITE_PANOSE_1,
-    pub decorative: DWRITE_PANOSE_0,
-    pub symbol: DWRITE_PANOSE_2,
+    pub decorative: DWRITE_PANOSE_2,
+    pub symbol: DWRITE_PANOSE_3,
 }
 impl windows_core::TypeKind for DWRITE_PANOSE {
     type TypeKind = windows_core::CopyType;
@@ -6417,7 +6417,7 @@ impl Default for DWRITE_PANOSE {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DWRITE_PANOSE_0 {
+pub struct DWRITE_PANOSE_2 {
     pub familyKind: u8,
     pub decorativeClass: u8,
     pub weight: u8,
@@ -6429,10 +6429,10 @@ pub struct DWRITE_PANOSE_0 {
     pub decorativeTopology: u8,
     pub characterRange: u8,
 }
-impl windows_core::TypeKind for DWRITE_PANOSE_0 {
+impl windows_core::TypeKind for DWRITE_PANOSE_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DWRITE_PANOSE_0 {
+impl Default for DWRITE_PANOSE_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6461,7 +6461,7 @@ impl Default for DWRITE_PANOSE_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DWRITE_PANOSE_2 {
+pub struct DWRITE_PANOSE_3 {
     pub familyKind: u8,
     pub symbolKind: u8,
     pub weight: u8,
@@ -6473,17 +6473,17 @@ pub struct DWRITE_PANOSE_2 {
     pub aspectRatio163: u8,
     pub aspectRatio211: u8,
 }
-impl windows_core::TypeKind for DWRITE_PANOSE_2 {
+impl windows_core::TypeKind for DWRITE_PANOSE_3 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DWRITE_PANOSE_2 {
+impl Default for DWRITE_PANOSE_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DWRITE_PANOSE_3 {
+pub struct DWRITE_PANOSE_0 {
     pub familyKind: u8,
     pub serifStyle: u8,
     pub weight: u8,
@@ -6495,10 +6495,10 @@ pub struct DWRITE_PANOSE_3 {
     pub midline: u8,
     pub xHeight: u8,
 }
-impl windows_core::TypeKind for DWRITE_PANOSE_3 {
+impl windows_core::TypeKind for DWRITE_PANOSE_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DWRITE_PANOSE_3 {
+impl Default for DWRITE_PANOSE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Tv/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Tv/mod.rs
@@ -16307,9 +16307,9 @@ impl Default for ChannelInfo {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ChannelInfo_0 {
-    pub DVB: ChannelInfo_0_2,
+    pub DVB: ChannelInfo_0_0,
     pub DC: ChannelInfo_0_1,
-    pub ATSC: ChannelInfo_0_0,
+    pub ATSC: ChannelInfo_0_2,
 }
 impl windows_core::TypeKind for ChannelInfo_0 {
     type TypeKind = windows_core::CopyType;
@@ -16321,13 +16321,13 @@ impl Default for ChannelInfo_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ChannelInfo_0_0 {
+pub struct ChannelInfo_0_2 {
     pub lProgNumber: i32,
 }
-impl windows_core::TypeKind for ChannelInfo_0_0 {
+impl windows_core::TypeKind for ChannelInfo_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for ChannelInfo_0_0 {
+impl Default for ChannelInfo_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -16347,15 +16347,15 @@ impl Default for ChannelInfo_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ChannelInfo_0_2 {
+pub struct ChannelInfo_0_0 {
     pub lONID: i32,
     pub lTSID: i32,
     pub lSID: i32,
 }
-impl windows_core::TypeKind for ChannelInfo_0_2 {
+impl windows_core::TypeKind for ChannelInfo_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for ChannelInfo_0_2 {
+impl Default for ChannelInfo_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
@@ -5620,8 +5620,8 @@ impl Default for KSCAMERA_PROFILE_INFO {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct KSCAMERA_PROFILE_MEDIAINFO {
-    pub Resolution: KSCAMERA_PROFILE_MEDIAINFO_1,
-    pub MaxFrameRate: KSCAMERA_PROFILE_MEDIAINFO_0,
+    pub Resolution: KSCAMERA_PROFILE_MEDIAINFO_0,
+    pub MaxFrameRate: KSCAMERA_PROFILE_MEDIAINFO_1,
     pub Flags: u64,
     pub Data0: u32,
     pub Data1: u32,
@@ -5638,28 +5638,28 @@ impl Default for KSCAMERA_PROFILE_MEDIAINFO {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KSCAMERA_PROFILE_MEDIAINFO_0 {
+pub struct KSCAMERA_PROFILE_MEDIAINFO_1 {
     pub Numerator: u32,
     pub Denominator: u32,
 }
-impl windows_core::TypeKind for KSCAMERA_PROFILE_MEDIAINFO_0 {
+impl windows_core::TypeKind for KSCAMERA_PROFILE_MEDIAINFO_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for KSCAMERA_PROFILE_MEDIAINFO_0 {
+impl Default for KSCAMERA_PROFILE_MEDIAINFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KSCAMERA_PROFILE_MEDIAINFO_1 {
+pub struct KSCAMERA_PROFILE_MEDIAINFO_0 {
     pub X: u32,
     pub Y: u32,
 }
-impl windows_core::TypeKind for KSCAMERA_PROFILE_MEDIAINFO_1 {
+impl windows_core::TypeKind for KSCAMERA_PROFILE_MEDIAINFO_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for KSCAMERA_PROFILE_MEDIAINFO_1 {
+impl Default for KSCAMERA_PROFILE_MEDIAINFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6220,9 +6220,9 @@ impl Default for KSEVENTDATA {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSEVENTDATA_0 {
-    pub EventHandle: KSEVENTDATA_0_1,
-    pub SemaphoreHandle: KSEVENTDATA_0_2,
-    pub Alignment: KSEVENTDATA_0_0,
+    pub EventHandle: KSEVENTDATA_0_0,
+    pub SemaphoreHandle: KSEVENTDATA_0_1,
+    pub Alignment: KSEVENTDATA_0_2,
 }
 impl windows_core::TypeKind for KSEVENTDATA_0 {
     type TypeKind = windows_core::CopyType;
@@ -6234,9 +6234,23 @@ impl Default for KSEVENTDATA_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KSEVENTDATA_0_0 {
+pub struct KSEVENTDATA_0_2 {
     pub Unused: *mut core::ffi::c_void,
     pub Alignment: [isize; 2],
+}
+impl windows_core::TypeKind for KSEVENTDATA_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for KSEVENTDATA_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct KSEVENTDATA_0_0 {
+    pub Event: super::super::Foundation::HANDLE,
+    pub Reserved: [usize; 2],
 }
 impl windows_core::TypeKind for KSEVENTDATA_0_0 {
     type TypeKind = windows_core::CopyType;
@@ -6249,28 +6263,14 @@ impl Default for KSEVENTDATA_0_0 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct KSEVENTDATA_0_1 {
-    pub Event: super::super::Foundation::HANDLE,
-    pub Reserved: [usize; 2],
+    pub Semaphore: super::super::Foundation::HANDLE,
+    pub Reserved: u32,
+    pub Adjustment: i32,
 }
 impl windows_core::TypeKind for KSEVENTDATA_0_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for KSEVENTDATA_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KSEVENTDATA_0_2 {
-    pub Semaphore: super::super::Foundation::HANDLE,
-    pub Reserved: u32,
-    pub Adjustment: i32,
-}
-impl windows_core::TypeKind for KSEVENTDATA_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for KSEVENTDATA_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -7415,10 +7415,10 @@ pub union KSPROPERTY_EXTXPORT_NODE_S_0 {
     pub LoadMedium: u32,
     pub MediumInfo: MEDIUM_INFO,
     pub XPrtState: TRANSPORT_STATE,
-    pub Timecode: KSPROPERTY_EXTXPORT_NODE_S_0_1,
+    pub Timecode: KSPROPERTY_EXTXPORT_NODE_S_0_0,
     pub dwTimecode: u32,
     pub dwAbsTrackNumber: u32,
-    pub RawAVC: KSPROPERTY_EXTXPORT_NODE_S_0_0,
+    pub RawAVC: KSPROPERTY_EXTXPORT_NODE_S_0_1,
 }
 impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_NODE_S_0 {
     type TypeKind = windows_core::CopyType;
@@ -7430,30 +7430,30 @@ impl Default for KSPROPERTY_EXTXPORT_NODE_S_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KSPROPERTY_EXTXPORT_NODE_S_0_0 {
+pub struct KSPROPERTY_EXTXPORT_NODE_S_0_1 {
     pub PayloadSize: u32,
     pub Payload: [u8; 512],
 }
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_NODE_S_0_0 {
+impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_NODE_S_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for KSPROPERTY_EXTXPORT_NODE_S_0_0 {
+impl Default for KSPROPERTY_EXTXPORT_NODE_S_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KSPROPERTY_EXTXPORT_NODE_S_0_1 {
+pub struct KSPROPERTY_EXTXPORT_NODE_S_0_0 {
     pub frame: u8,
     pub second: u8,
     pub minute: u8,
     pub hour: u8,
 }
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_NODE_S_0_1 {
+impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_NODE_S_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for KSPROPERTY_EXTXPORT_NODE_S_0_1 {
+impl Default for KSPROPERTY_EXTXPORT_NODE_S_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -7480,10 +7480,10 @@ pub union KSPROPERTY_EXTXPORT_S_0 {
     pub LoadMedium: u32,
     pub MediumInfo: MEDIUM_INFO,
     pub XPrtState: TRANSPORT_STATE,
-    pub Timecode: KSPROPERTY_EXTXPORT_S_0_1,
+    pub Timecode: KSPROPERTY_EXTXPORT_S_0_0,
     pub dwTimecode: u32,
     pub dwAbsTrackNumber: u32,
-    pub RawAVC: KSPROPERTY_EXTXPORT_S_0_0,
+    pub RawAVC: KSPROPERTY_EXTXPORT_S_0_1,
 }
 impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_S_0 {
     type TypeKind = windows_core::CopyType;
@@ -7495,30 +7495,30 @@ impl Default for KSPROPERTY_EXTXPORT_S_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KSPROPERTY_EXTXPORT_S_0_0 {
+pub struct KSPROPERTY_EXTXPORT_S_0_1 {
     pub PayloadSize: u32,
     pub Payload: [u8; 512],
 }
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_S_0_0 {
+impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_S_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for KSPROPERTY_EXTXPORT_S_0_0 {
+impl Default for KSPROPERTY_EXTXPORT_S_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KSPROPERTY_EXTXPORT_S_0_1 {
+pub struct KSPROPERTY_EXTXPORT_S_0_0 {
     pub frame: u8,
     pub second: u8,
     pub minute: u8,
     pub hour: u8,
 }
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_S_0_1 {
+impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_S_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for KSPROPERTY_EXTXPORT_S_0_1 {
+impl Default for KSPROPERTY_EXTXPORT_S_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/mod.rs
@@ -319,8 +319,8 @@ pub union MMTIME_0 {
     pub sample: u32,
     pub cb: u32,
     pub ticks: u32,
-    pub smpte: MMTIME_0_1,
-    pub midi: MMTIME_0_0,
+    pub smpte: MMTIME_0_0,
+    pub midi: MMTIME_0_1,
 }
 impl windows_core::TypeKind for MMTIME_0 {
     type TypeKind = windows_core::CopyType;
@@ -332,20 +332,20 @@ impl Default for MMTIME_0 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct MMTIME_0_0 {
+pub struct MMTIME_0_1 {
     pub songptrpos: u32,
 }
-impl windows_core::TypeKind for MMTIME_0_0 {
+impl windows_core::TypeKind for MMTIME_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for MMTIME_0_0 {
+impl Default for MMTIME_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct MMTIME_0_1 {
+pub struct MMTIME_0_0 {
     pub hour: u8,
     pub min: u8,
     pub sec: u8,
@@ -354,10 +354,10 @@ pub struct MMTIME_0_1 {
     pub dummy: u8,
     pub pad: [u8; 2],
 }
-impl windows_core::TypeKind for MMTIME_0_1 {
+impl windows_core::TypeKind for MMTIME_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for MMTIME_0_1 {
+impl Default for MMTIME_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
@@ -1860,10 +1860,10 @@ pub struct DNS_RECORDA {
     pub pName: windows_core::PSTR,
     pub wType: u16,
     pub wDataLength: u16,
-    pub Flags: DNS_RECORDA_1,
+    pub Flags: DNS_RECORDA_0,
     pub dwTtl: u32,
     pub dwReserved: u32,
-    pub Data: DNS_RECORDA_0,
+    pub Data: DNS_RECORDA_1,
 }
 impl windows_core::TypeKind for DNS_RECORDA {
     type TypeKind = windows_core::CopyType;
@@ -1875,7 +1875,7 @@ impl Default for DNS_RECORDA {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORDA_0 {
+pub union DNS_RECORDA_1 {
     pub A: DNS_A_DATA,
     pub SOA: DNS_SOA_DATAA,
     pub Soa: DNS_SOA_DATAA,
@@ -1963,24 +1963,24 @@ pub union DNS_RECORDA_0 {
     pub Unknown: DNS_UNKNOWN_DATA,
     pub pDataPtr: *mut u8,
 }
-impl windows_core::TypeKind for DNS_RECORDA_0 {
+impl windows_core::TypeKind for DNS_RECORDA_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DNS_RECORDA_0 {
+impl Default for DNS_RECORDA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORDA_1 {
+pub union DNS_RECORDA_0 {
     pub DW: u32,
     pub S: DNS_RECORD_FLAGS,
 }
-impl windows_core::TypeKind for DNS_RECORDA_1 {
+impl windows_core::TypeKind for DNS_RECORDA_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DNS_RECORDA_1 {
+impl Default for DNS_RECORDA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1992,10 +1992,10 @@ pub struct DNS_RECORDW {
     pub pName: windows_core::PWSTR,
     pub wType: u16,
     pub wDataLength: u16,
-    pub Flags: DNS_RECORDW_1,
+    pub Flags: DNS_RECORDW_0,
     pub dwTtl: u32,
     pub dwReserved: u32,
-    pub Data: DNS_RECORDW_0,
+    pub Data: DNS_RECORDW_1,
 }
 impl windows_core::TypeKind for DNS_RECORDW {
     type TypeKind = windows_core::CopyType;
@@ -2007,7 +2007,7 @@ impl Default for DNS_RECORDW {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORDW_0 {
+pub union DNS_RECORDW_1 {
     pub A: DNS_A_DATA,
     pub SOA: DNS_SOA_DATAW,
     pub Soa: DNS_SOA_DATAW,
@@ -2095,24 +2095,24 @@ pub union DNS_RECORDW_0 {
     pub Unknown: DNS_UNKNOWN_DATA,
     pub pDataPtr: *mut u8,
 }
-impl windows_core::TypeKind for DNS_RECORDW_0 {
+impl windows_core::TypeKind for DNS_RECORDW_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DNS_RECORDW_0 {
+impl Default for DNS_RECORDW_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORDW_1 {
+pub union DNS_RECORDW_0 {
     pub DW: u32,
     pub S: DNS_RECORD_FLAGS,
 }
-impl windows_core::TypeKind for DNS_RECORDW_1 {
+impl windows_core::TypeKind for DNS_RECORDW_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DNS_RECORDW_1 {
+impl Default for DNS_RECORDW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2137,11 +2137,11 @@ pub struct DNS_RECORD_OPTW {
     pub pName: windows_core::PWSTR,
     pub wType: u16,
     pub wDataLength: u16,
-    pub Flags: DNS_RECORD_OPTW_1,
+    pub Flags: DNS_RECORD_OPTW_0,
     pub ExtHeader: DNS_HEADER_EXT,
     pub wPayloadSize: u16,
     pub wReserved: u16,
-    pub Data: DNS_RECORD_OPTW_0,
+    pub Data: DNS_RECORD_OPTW_1,
 }
 impl windows_core::TypeKind for DNS_RECORD_OPTW {
     type TypeKind = windows_core::CopyType;
@@ -2153,28 +2153,28 @@ impl Default for DNS_RECORD_OPTW {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORD_OPTW_0 {
+pub union DNS_RECORD_OPTW_1 {
     pub OPT: DNS_OPT_DATA,
     pub Opt: DNS_OPT_DATA,
 }
-impl windows_core::TypeKind for DNS_RECORD_OPTW_0 {
+impl windows_core::TypeKind for DNS_RECORD_OPTW_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DNS_RECORD_OPTW_0 {
+impl Default for DNS_RECORD_OPTW_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union DNS_RECORD_OPTW_1 {
+pub union DNS_RECORD_OPTW_0 {
     pub DW: u32,
     pub S: DNS_RECORD_FLAGS,
 }
-impl windows_core::TypeKind for DNS_RECORD_OPTW_1 {
+impl windows_core::TypeKind for DNS_RECORD_OPTW_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DNS_RECORD_OPTW_1 {
+impl Default for DNS_RECORD_OPTW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2893,11 +2893,11 @@ pub struct _DnsRecordOptA {
     pub pName: windows_core::PSTR,
     pub wType: u16,
     pub wDataLength: u16,
-    pub Flags: _DnsRecordOptA_1,
+    pub Flags: _DnsRecordOptA_0,
     pub ExtHeader: DNS_HEADER_EXT,
     pub wPayloadSize: u16,
     pub wReserved: u16,
-    pub Data: _DnsRecordOptA_0,
+    pub Data: _DnsRecordOptA_1,
 }
 impl windows_core::TypeKind for _DnsRecordOptA {
     type TypeKind = windows_core::CopyType;
@@ -2909,28 +2909,28 @@ impl Default for _DnsRecordOptA {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union _DnsRecordOptA_0 {
+pub union _DnsRecordOptA_1 {
     pub OPT: DNS_OPT_DATA,
     pub Opt: DNS_OPT_DATA,
 }
-impl windows_core::TypeKind for _DnsRecordOptA_0 {
+impl windows_core::TypeKind for _DnsRecordOptA_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for _DnsRecordOptA_0 {
+impl Default for _DnsRecordOptA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union _DnsRecordOptA_1 {
+pub union _DnsRecordOptA_0 {
     pub DW: u32,
     pub S: DNS_RECORD_FLAGS,
 }
-impl windows_core::TypeKind for _DnsRecordOptA_1 {
+impl windows_core::TypeKind for _DnsRecordOptA_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for _DnsRecordOptA_1 {
+impl Default for _DnsRecordOptA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Ndis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Ndis/mod.rs
@@ -3275,27 +3275,14 @@ impl Default for NDIS_INTERRUPT_MODERATION_PARAMETERS {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_IPSEC_OFFLOAD_V1 {
-    pub Supported: NDIS_IPSEC_OFFLOAD_V1_2,
-    pub IPv4AH: NDIS_IPSEC_OFFLOAD_V1_0,
-    pub IPv4ESP: NDIS_IPSEC_OFFLOAD_V1_1,
+    pub Supported: NDIS_IPSEC_OFFLOAD_V1_0,
+    pub IPv4AH: NDIS_IPSEC_OFFLOAD_V1_1,
+    pub IPv4ESP: NDIS_IPSEC_OFFLOAD_V1_2,
 }
 impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_IPSEC_OFFLOAD_V1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_IPSEC_OFFLOAD_V1_0 {
-    pub _bitfield: u32,
-}
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NDIS_IPSEC_OFFLOAD_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3316,16 +3303,29 @@ impl Default for NDIS_IPSEC_OFFLOAD_V1_1 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_IPSEC_OFFLOAD_V1_2 {
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NDIS_IPSEC_OFFLOAD_V1_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NDIS_IPSEC_OFFLOAD_V1_0 {
     pub Encapsulation: u32,
     pub AhEspCombined: u32,
     pub TransportTunnelCombined: u32,
     pub IPv4Options: u32,
     pub Flags: u32,
 }
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_2 {
+impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NDIS_IPSEC_OFFLOAD_V1_2 {
+impl Default for NDIS_IPSEC_OFFLOAD_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3819,29 +3819,15 @@ impl Default for NDIS_TCP_CONNECTION_OFFLOAD {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD {
-    pub IPv4Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_1,
-    pub IPv4Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_0,
-    pub IPv6Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_3,
-    pub IPv6Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv4Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_0,
+    pub IPv4Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_1,
+    pub IPv6Transmit: NDIS_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv6Receive: NDIS_TCP_IP_CHECKSUM_OFFLOAD_3,
 }
 impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    pub Encapsulation: u32,
-    pub _bitfield: u32,
-}
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3862,14 +3848,14 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     pub Encapsulation: u32,
     pub _bitfield: u32,
 }
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3884,6 +3870,20 @@ impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+    pub Encapsulation: u32,
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4137,9 +4137,9 @@ impl Default for NDIS_WMI_EVENT_HEADER {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_WMI_IPSEC_OFFLOAD_V1 {
-    pub Supported: NDIS_WMI_IPSEC_OFFLOAD_V1_2,
-    pub IPv4AH: NDIS_WMI_IPSEC_OFFLOAD_V1_0,
-    pub IPv4ESP: NDIS_WMI_IPSEC_OFFLOAD_V1_1,
+    pub Supported: NDIS_WMI_IPSEC_OFFLOAD_V1_0,
+    pub IPv4AH: NDIS_WMI_IPSEC_OFFLOAD_V1_1,
+    pub IPv4ESP: NDIS_WMI_IPSEC_OFFLOAD_V1_2,
 }
 impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1 {
     type TypeKind = windows_core::CopyType;
@@ -4151,29 +4151,9 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
+pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
     pub Md5: u32,
     pub Sha_1: u32,
-    pub Transport: u32,
-    pub Tunnel: u32,
-    pub Send: u32,
-    pub Receive: u32,
-}
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
-    pub Des: u32,
-    pub Reserved: u32,
-    pub TripleDes: u32,
-    pub NullEsp: u32,
     pub Transport: u32,
     pub Tunnel: u32,
     pub Send: u32,
@@ -4190,16 +4170,36 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+    pub Des: u32,
+    pub Reserved: u32,
+    pub TripleDes: u32,
+    pub NullEsp: u32,
+    pub Transport: u32,
+    pub Tunnel: u32,
+    pub Send: u32,
+    pub Receive: u32,
+}
+impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     pub Encapsulation: u32,
     pub AhEspCombined: u32,
     pub TransportTunnelCombined: u32,
     pub IPv4Options: u32,
     pub Flags: u32,
 }
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
+impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4297,33 +4297,15 @@ impl Default for NDIS_WMI_TCP_CONNECTION_OFFLOAD {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
-    pub IPv4Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1,
-    pub IPv4Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0,
-    pub IPv6Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3,
-    pub IPv6Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv4Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0,
+    pub IPv4Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1,
+    pub IPv6Transmit: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2,
+    pub IPv6Receive: NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3,
 }
 impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    pub Encapsulation: u32,
-    pub IpOptionsSupported: u32,
-    pub TcpOptionsSupported: u32,
-    pub TcpChecksum: u32,
-    pub UdpChecksum: u32,
-    pub IpChecksum: u32,
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4348,17 +4330,18 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
     pub Encapsulation: u32,
-    pub IpExtensionHeadersSupported: u32,
+    pub IpOptionsSupported: u32,
     pub TcpOptionsSupported: u32,
     pub TcpChecksum: u32,
     pub UdpChecksum: u32,
+    pub IpChecksum: u32,
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4376,6 +4359,23 @@ impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+    pub Encapsulation: u32,
+    pub IpExtensionHeadersSupported: u32,
+    pub TcpOptionsSupported: u32,
+    pub TcpChecksum: u32,
+    pub UdpChecksum: u32,
+}
+impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/QoS/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/QoS/mod.rs
@@ -1468,8 +1468,8 @@ impl Default for IP_PATTERN {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IP_PATTERN_0 {
-    pub S_un_ports: IP_PATTERN_0_1,
-    pub S_un_icmp: IP_PATTERN_0_0,
+    pub S_un_ports: IP_PATTERN_0_0,
+    pub S_un_icmp: IP_PATTERN_0_1,
     pub S_Spi: u32,
 }
 impl windows_core::TypeKind for IP_PATTERN_0 {
@@ -1482,29 +1482,29 @@ impl Default for IP_PATTERN_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IP_PATTERN_0_0 {
+pub struct IP_PATTERN_0_1 {
     pub s_type: u8,
     pub s_code: u8,
     pub filler: u16,
 }
-impl windows_core::TypeKind for IP_PATTERN_0_0 {
+impl windows_core::TypeKind for IP_PATTERN_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IP_PATTERN_0_0 {
+impl Default for IP_PATTERN_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IP_PATTERN_0_1 {
+pub struct IP_PATTERN_0_0 {
     pub s_srcport: u16,
     pub s_dstport: u16,
 }
-impl windows_core::TypeKind for IP_PATTERN_0_1 {
+impl windows_core::TypeKind for IP_PATTERN_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IP_PATTERN_0_1 {
+impl Default for IP_PATTERN_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Networking/HttpServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/HttpServer/mod.rs
@@ -1273,10 +1273,10 @@ impl Default for HTTP_DATA_CHUNK {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HTTP_DATA_CHUNK_0 {
-    pub FromMemory: HTTP_DATA_CHUNK_0_3,
-    pub FromFileHandle: HTTP_DATA_CHUNK_0_0,
+    pub FromMemory: HTTP_DATA_CHUNK_0_0,
+    pub FromFileHandle: HTTP_DATA_CHUNK_0_1,
     pub FromFragmentCache: HTTP_DATA_CHUNK_0_2,
-    pub FromFragmentCacheEx: HTTP_DATA_CHUNK_0_1,
+    pub FromFragmentCacheEx: HTTP_DATA_CHUNK_0_3,
     pub Trailers: HTTP_DATA_CHUNK_0_4,
 }
 impl windows_core::TypeKind for HTTP_DATA_CHUNK_0 {
@@ -1289,28 +1289,28 @@ impl Default for HTTP_DATA_CHUNK_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct HTTP_DATA_CHUNK_0_0 {
+pub struct HTTP_DATA_CHUNK_0_1 {
     pub ByteRange: HTTP_BYTE_RANGE,
     pub FileHandle: super::super::Foundation::HANDLE,
 }
-impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_0 {
+impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for HTTP_DATA_CHUNK_0_0 {
+impl Default for HTTP_DATA_CHUNK_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct HTTP_DATA_CHUNK_0_1 {
+pub struct HTTP_DATA_CHUNK_0_3 {
     pub ByteRange: HTTP_BYTE_RANGE,
     pub pFragmentName: windows_core::PCWSTR,
 }
-impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_1 {
+impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_3 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for HTTP_DATA_CHUNK_0_1 {
+impl Default for HTTP_DATA_CHUNK_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1331,14 +1331,14 @@ impl Default for HTTP_DATA_CHUNK_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct HTTP_DATA_CHUNK_0_3 {
+pub struct HTTP_DATA_CHUNK_0_0 {
     pub pBuffer: *mut core::ffi::c_void,
     pub BufferLength: u32,
 }
-impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_3 {
+impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for HTTP_DATA_CHUNK_0_3 {
+impl Default for HTTP_DATA_CHUNK_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Networking/WebSocket/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WebSocket/mod.rs
@@ -200,8 +200,8 @@ impl core::fmt::Debug for WEB_SOCKET_PROPERTY_TYPE {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WEB_SOCKET_BUFFER {
-    pub Data: WEB_SOCKET_BUFFER_1,
-    pub CloseStatus: WEB_SOCKET_BUFFER_0,
+    pub Data: WEB_SOCKET_BUFFER_0,
+    pub CloseStatus: WEB_SOCKET_BUFFER_1,
 }
 impl windows_core::TypeKind for WEB_SOCKET_BUFFER {
     type TypeKind = windows_core::CopyType;
@@ -213,29 +213,29 @@ impl Default for WEB_SOCKET_BUFFER {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WEB_SOCKET_BUFFER_0 {
+pub struct WEB_SOCKET_BUFFER_1 {
     pub pbReason: *mut u8,
     pub ulReasonLength: u32,
     pub usStatus: u16,
 }
-impl windows_core::TypeKind for WEB_SOCKET_BUFFER_0 {
+impl windows_core::TypeKind for WEB_SOCKET_BUFFER_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WEB_SOCKET_BUFFER_0 {
+impl Default for WEB_SOCKET_BUFFER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WEB_SOCKET_BUFFER_1 {
+pub struct WEB_SOCKET_BUFFER_0 {
     pub pbBuffer: *mut u8,
     pub ulBufferLength: u32,
 }
-impl windows_core::TypeKind for WEB_SOCKET_BUFFER_1 {
+impl windows_core::TypeKind for WEB_SOCKET_BUFFER_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WEB_SOCKET_BUFFER_1 {
+impl Default for WEB_SOCKET_BUFFER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -6422,8 +6422,8 @@ impl Default for NETRESOURCE2W {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NLA_BLOB {
-    pub header: NLA_BLOB_1,
-    pub data: NLA_BLOB_0,
+    pub header: NLA_BLOB_0,
+    pub data: NLA_BLOB_1,
 }
 impl windows_core::TypeKind for NLA_BLOB {
     type TypeKind = windows_core::CopyType;
@@ -6435,104 +6435,104 @@ impl Default for NLA_BLOB {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union NLA_BLOB_0 {
+pub union NLA_BLOB_1 {
     pub rawData: [i8; 1],
-    pub interfaceData: NLA_BLOB_0_2,
-    pub locationData: NLA_BLOB_0_3,
-    pub connectivity: NLA_BLOB_0_1,
-    pub ICS: NLA_BLOB_0_0,
+    pub interfaceData: NLA_BLOB_1_0,
+    pub locationData: NLA_BLOB_1_1,
+    pub connectivity: NLA_BLOB_1_2,
+    pub ICS: NLA_BLOB_1_3,
 }
-impl windows_core::TypeKind for NLA_BLOB_0 {
+impl windows_core::TypeKind for NLA_BLOB_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NLA_BLOB_0 {
+impl Default for NLA_BLOB_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NLA_BLOB_0_0 {
-    pub remote: NLA_BLOB_0_0_0,
+pub struct NLA_BLOB_1_3 {
+    pub remote: NLA_BLOB_1_3_0,
 }
-impl windows_core::TypeKind for NLA_BLOB_0_0 {
+impl windows_core::TypeKind for NLA_BLOB_1_3 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NLA_BLOB_0_0 {
+impl Default for NLA_BLOB_1_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NLA_BLOB_0_0_0 {
+pub struct NLA_BLOB_1_3_0 {
     pub speed: u32,
     pub r#type: u32,
     pub state: u32,
     pub machineName: [u16; 256],
     pub sharedAdapterName: [u16; 256],
 }
-impl windows_core::TypeKind for NLA_BLOB_0_0_0 {
+impl windows_core::TypeKind for NLA_BLOB_1_3_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NLA_BLOB_0_0_0 {
+impl Default for NLA_BLOB_1_3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NLA_BLOB_0_1 {
+pub struct NLA_BLOB_1_2 {
     pub r#type: NLA_CONNECTIVITY_TYPE,
     pub internet: NLA_INTERNET,
 }
-impl windows_core::TypeKind for NLA_BLOB_0_1 {
+impl windows_core::TypeKind for NLA_BLOB_1_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NLA_BLOB_0_1 {
+impl Default for NLA_BLOB_1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NLA_BLOB_0_2 {
+pub struct NLA_BLOB_1_0 {
     pub dwType: u32,
     pub dwSpeed: u32,
     pub adapterName: [i8; 1],
 }
-impl windows_core::TypeKind for NLA_BLOB_0_2 {
+impl windows_core::TypeKind for NLA_BLOB_1_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NLA_BLOB_0_2 {
+impl Default for NLA_BLOB_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NLA_BLOB_0_3 {
+pub struct NLA_BLOB_1_1 {
     pub information: [i8; 1],
 }
-impl windows_core::TypeKind for NLA_BLOB_0_3 {
+impl windows_core::TypeKind for NLA_BLOB_1_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NLA_BLOB_0_3 {
+impl Default for NLA_BLOB_1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NLA_BLOB_1 {
+pub struct NLA_BLOB_0 {
     pub r#type: NLA_BLOB_DATA_TYPE,
     pub dwSize: u32,
     pub nextOffset: u32,
 }
-impl windows_core::TypeKind for NLA_BLOB_1 {
+impl windows_core::TypeKind for NLA_BLOB_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NLA_BLOB_1 {
+impl Default for NLA_BLOB_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -8525,10 +8525,10 @@ impl Default for WSACOMPLETION {
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy)]
 pub union WSACOMPLETION_0 {
-    pub WindowMessage: WSACOMPLETION_0_3,
+    pub WindowMessage: WSACOMPLETION_0_0,
     pub Event: WSACOMPLETION_0_1,
-    pub Apc: WSACOMPLETION_0_0,
-    pub Port: WSACOMPLETION_0_2,
+    pub Apc: WSACOMPLETION_0_2,
+    pub Port: WSACOMPLETION_0_3,
 }
 #[cfg(feature = "Win32_System_IO")]
 impl windows_core::TypeKind for WSACOMPLETION_0 {
@@ -8543,16 +8543,16 @@ impl Default for WSACOMPLETION_0 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WSACOMPLETION_0_0 {
+pub struct WSACOMPLETION_0_2 {
     pub lpOverlapped: *mut super::super::System::IO::OVERLAPPED,
     pub lpfnCompletionProc: LPWSAOVERLAPPED_COMPLETION_ROUTINE,
 }
 #[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WSACOMPLETION_0_0 {
+impl windows_core::TypeKind for WSACOMPLETION_0_2 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_IO")]
-impl Default for WSACOMPLETION_0_0 {
+impl Default for WSACOMPLETION_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -8576,28 +8576,10 @@ impl Default for WSACOMPLETION_0_1 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WSACOMPLETION_0_2 {
+pub struct WSACOMPLETION_0_3 {
     pub lpOverlapped: *mut super::super::System::IO::OVERLAPPED,
     pub hPort: super::super::Foundation::HANDLE,
     pub Key: usize,
-}
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WSACOMPLETION_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_IO")]
-impl Default for WSACOMPLETION_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_System_IO")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WSACOMPLETION_0_3 {
-    pub hWnd: super::super::Foundation::HWND,
-    pub uMsg: u32,
-    pub context: super::super::Foundation::WPARAM,
 }
 #[cfg(feature = "Win32_System_IO")]
 impl windows_core::TypeKind for WSACOMPLETION_0_3 {
@@ -8605,6 +8587,24 @@ impl windows_core::TypeKind for WSACOMPLETION_0_3 {
 }
 #[cfg(feature = "Win32_System_IO")]
 impl Default for WSACOMPLETION_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_System_IO")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WSACOMPLETION_0_0 {
+    pub hWnd: super::super::Foundation::HWND,
+    pub uMsg: u32,
+    pub context: super::super::Foundation::WPARAM,
+}
+#[cfg(feature = "Win32_System_IO")]
+impl windows_core::TypeKind for WSACOMPLETION_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_IO")]
+impl Default for WSACOMPLETION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Cabinets/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Cabinets/mod.rs
@@ -263,8 +263,8 @@ impl Default for FDIDECRYPT {
 #[derive(Clone, Copy)]
 pub union FDIDECRYPT_0 {
     pub cabinet: FDIDECRYPT_0_0,
-    pub folder: FDIDECRYPT_0_2,
-    pub decrypt: FDIDECRYPT_0_1,
+    pub folder: FDIDECRYPT_0_1,
+    pub decrypt: FDIDECRYPT_0_2,
 }
 impl windows_core::TypeKind for FDIDECRYPT_0 {
     type TypeKind = windows_core::CopyType;
@@ -292,7 +292,7 @@ impl Default for FDIDECRYPT_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FDIDECRYPT_0_1 {
+pub struct FDIDECRYPT_0_2 {
     pub pDataReserve: *mut core::ffi::c_void,
     pub cbDataReserve: u16,
     pub pbData: *mut core::ffi::c_void,
@@ -300,25 +300,25 @@ pub struct FDIDECRYPT_0_1 {
     pub fSplit: super::super::Foundation::BOOL,
     pub cbPartial: u16,
 }
-impl windows_core::TypeKind for FDIDECRYPT_0_1 {
+impl windows_core::TypeKind for FDIDECRYPT_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for FDIDECRYPT_0_1 {
+impl Default for FDIDECRYPT_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FDIDECRYPT_0_2 {
+pub struct FDIDECRYPT_0_1 {
     pub pFolderReserve: *mut core::ffi::c_void,
     pub cbFolderReserve: u16,
     pub iFolder: u16,
 }
-impl windows_core::TypeKind for FDIDECRYPT_0_2 {
+impl windows_core::TypeKind for FDIDECRYPT_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for FDIDECRYPT_0_2 {
+impl Default for FDIDECRYPT_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
@@ -2331,17 +2331,17 @@ impl Default for CF_CALLBACK_PARAMETERS {
 #[derive(Clone, Copy)]
 pub union CF_CALLBACK_PARAMETERS_0 {
     pub Cancel: CF_CALLBACK_PARAMETERS_0_0,
-    pub FetchData: CF_CALLBACK_PARAMETERS_0_6,
-    pub ValidateData: CF_CALLBACK_PARAMETERS_0_11,
-    pub FetchPlaceholders: CF_CALLBACK_PARAMETERS_0_7,
-    pub OpenCompletion: CF_CALLBACK_PARAMETERS_0_8,
-    pub CloseCompletion: CF_CALLBACK_PARAMETERS_0_1,
-    pub Dehydrate: CF_CALLBACK_PARAMETERS_0_3,
-    pub DehydrateCompletion: CF_CALLBACK_PARAMETERS_0_2,
-    pub Delete: CF_CALLBACK_PARAMETERS_0_5,
-    pub DeleteCompletion: CF_CALLBACK_PARAMETERS_0_4,
+    pub FetchData: CF_CALLBACK_PARAMETERS_0_1,
+    pub ValidateData: CF_CALLBACK_PARAMETERS_0_2,
+    pub FetchPlaceholders: CF_CALLBACK_PARAMETERS_0_3,
+    pub OpenCompletion: CF_CALLBACK_PARAMETERS_0_4,
+    pub CloseCompletion: CF_CALLBACK_PARAMETERS_0_5,
+    pub Dehydrate: CF_CALLBACK_PARAMETERS_0_6,
+    pub DehydrateCompletion: CF_CALLBACK_PARAMETERS_0_7,
+    pub Delete: CF_CALLBACK_PARAMETERS_0_8,
+    pub DeleteCompletion: CF_CALLBACK_PARAMETERS_0_9,
     pub Rename: CF_CALLBACK_PARAMETERS_0_10,
-    pub RenameCompletion: CF_CALLBACK_PARAMETERS_0_9,
+    pub RenameCompletion: CF_CALLBACK_PARAMETERS_0_11,
 }
 impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0 {
     type TypeKind = windows_core::CopyType;
@@ -2394,8 +2394,81 @@ impl Default for CF_CALLBACK_PARAMETERS_0_0_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_CALLBACK_PARAMETERS_0_1 {
+pub struct CF_CALLBACK_PARAMETERS_0_5 {
     pub Flags: CF_CALLBACK_CLOSE_COMPLETION_FLAGS,
+}
+impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_5 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for CF_CALLBACK_PARAMETERS_0_5 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_CALLBACK_PARAMETERS_0_7 {
+    pub Flags: CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS,
+    pub Reason: CF_CALLBACK_DEHYDRATION_REASON,
+}
+impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_7 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for CF_CALLBACK_PARAMETERS_0_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_CALLBACK_PARAMETERS_0_6 {
+    pub Flags: CF_CALLBACK_DEHYDRATE_FLAGS,
+    pub Reason: CF_CALLBACK_DEHYDRATION_REASON,
+}
+impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_6 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for CF_CALLBACK_PARAMETERS_0_6 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_CALLBACK_PARAMETERS_0_9 {
+    pub Flags: CF_CALLBACK_DELETE_COMPLETION_FLAGS,
+}
+impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_9 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for CF_CALLBACK_PARAMETERS_0_9 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_CALLBACK_PARAMETERS_0_8 {
+    pub Flags: CF_CALLBACK_DELETE_FLAGS,
+}
+impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_8 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for CF_CALLBACK_PARAMETERS_0_8 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_CALLBACK_PARAMETERS_0_1 {
+    pub Flags: CF_CALLBACK_FETCH_DATA_FLAGS,
+    pub RequiredFileOffset: i64,
+    pub RequiredLength: i64,
+    pub OptionalFileOffset: i64,
+    pub OptionalLength: i64,
+    pub LastDehydrationTime: i64,
+    pub LastDehydrationReason: CF_CALLBACK_DEHYDRATION_REASON,
 }
 impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_1 {
     type TypeKind = windows_core::CopyType;
@@ -2407,23 +2480,9 @@ impl Default for CF_CALLBACK_PARAMETERS_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_CALLBACK_PARAMETERS_0_2 {
-    pub Flags: CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS,
-    pub Reason: CF_CALLBACK_DEHYDRATION_REASON,
-}
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for CF_CALLBACK_PARAMETERS_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CF_CALLBACK_PARAMETERS_0_3 {
-    pub Flags: CF_CALLBACK_DEHYDRATE_FLAGS,
-    pub Reason: CF_CALLBACK_DEHYDRATION_REASON,
+    pub Flags: CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS,
+    pub Pattern: windows_core::PCWSTR,
 }
 impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_3 {
     type TypeKind = windows_core::CopyType;
@@ -2436,7 +2495,7 @@ impl Default for CF_CALLBACK_PARAMETERS_0_3 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CF_CALLBACK_PARAMETERS_0_4 {
-    pub Flags: CF_CALLBACK_DELETE_COMPLETION_FLAGS,
+    pub Flags: CF_CALLBACK_OPEN_COMPLETION_FLAGS,
 }
 impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_4 {
     type TypeKind = windows_core::CopyType;
@@ -2448,73 +2507,14 @@ impl Default for CF_CALLBACK_PARAMETERS_0_4 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_CALLBACK_PARAMETERS_0_5 {
-    pub Flags: CF_CALLBACK_DELETE_FLAGS,
-}
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for CF_CALLBACK_PARAMETERS_0_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_CALLBACK_PARAMETERS_0_6 {
-    pub Flags: CF_CALLBACK_FETCH_DATA_FLAGS,
-    pub RequiredFileOffset: i64,
-    pub RequiredLength: i64,
-    pub OptionalFileOffset: i64,
-    pub OptionalLength: i64,
-    pub LastDehydrationTime: i64,
-    pub LastDehydrationReason: CF_CALLBACK_DEHYDRATION_REASON,
-}
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for CF_CALLBACK_PARAMETERS_0_6 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_CALLBACK_PARAMETERS_0_7 {
-    pub Flags: CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS,
-    pub Pattern: windows_core::PCWSTR,
-}
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for CF_CALLBACK_PARAMETERS_0_7 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_CALLBACK_PARAMETERS_0_8 {
-    pub Flags: CF_CALLBACK_OPEN_COMPLETION_FLAGS,
-}
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for CF_CALLBACK_PARAMETERS_0_8 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_CALLBACK_PARAMETERS_0_9 {
+pub struct CF_CALLBACK_PARAMETERS_0_11 {
     pub Flags: CF_CALLBACK_RENAME_COMPLETION_FLAGS,
     pub SourcePath: windows_core::PCWSTR,
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_9 {
+impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_11 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CF_CALLBACK_PARAMETERS_0_9 {
+impl Default for CF_CALLBACK_PARAMETERS_0_11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2535,15 +2535,15 @@ impl Default for CF_CALLBACK_PARAMETERS_0_10 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_CALLBACK_PARAMETERS_0_11 {
+pub struct CF_CALLBACK_PARAMETERS_0_2 {
     pub Flags: CF_CALLBACK_VALIDATE_DATA_FLAGS,
     pub RequiredFileOffset: i64,
     pub RequiredLength: i64,
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_11 {
+impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CF_CALLBACK_PARAMETERS_0_11 {
+impl Default for CF_CALLBACK_PARAMETERS_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2677,14 +2677,14 @@ impl Default for CF_OPERATION_PARAMETERS {
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
 pub union CF_OPERATION_PARAMETERS_0 {
-    pub TransferData: CF_OPERATION_PARAMETERS_0_6,
-    pub RetrieveData: CF_OPERATION_PARAMETERS_0_5,
-    pub AckData: CF_OPERATION_PARAMETERS_0_0,
-    pub RestartHydration: CF_OPERATION_PARAMETERS_0_4,
-    pub TransferPlaceholders: CF_OPERATION_PARAMETERS_0_7,
-    pub AckDehydrate: CF_OPERATION_PARAMETERS_0_1,
-    pub AckRename: CF_OPERATION_PARAMETERS_0_3,
-    pub AckDelete: CF_OPERATION_PARAMETERS_0_2,
+    pub TransferData: CF_OPERATION_PARAMETERS_0_0,
+    pub RetrieveData: CF_OPERATION_PARAMETERS_0_1,
+    pub AckData: CF_OPERATION_PARAMETERS_0_2,
+    pub RestartHydration: CF_OPERATION_PARAMETERS_0_3,
+    pub TransferPlaceholders: CF_OPERATION_PARAMETERS_0_4,
+    pub AckDehydrate: CF_OPERATION_PARAMETERS_0_5,
+    pub AckRename: CF_OPERATION_PARAMETERS_0_6,
+    pub AckDelete: CF_OPERATION_PARAMETERS_0_7,
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
 impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0 {
@@ -2699,9 +2699,121 @@ impl Default for CF_OPERATION_PARAMETERS_0 {
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_OPERATION_PARAMETERS_0_0 {
+pub struct CF_OPERATION_PARAMETERS_0_2 {
     pub Flags: CF_OPERATION_ACK_DATA_FLAGS,
     pub CompletionStatus: super::super::Foundation::NTSTATUS,
+    pub Offset: i64,
+    pub Length: i64,
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl Default for CF_OPERATION_PARAMETERS_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_Storage_FileSystem")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_OPERATION_PARAMETERS_0_5 {
+    pub Flags: CF_OPERATION_ACK_DEHYDRATE_FLAGS,
+    pub CompletionStatus: super::super::Foundation::NTSTATUS,
+    pub FileIdentity: *const core::ffi::c_void,
+    pub FileIdentityLength: u32,
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_5 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl Default for CF_OPERATION_PARAMETERS_0_5 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_Storage_FileSystem")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_OPERATION_PARAMETERS_0_7 {
+    pub Flags: CF_OPERATION_ACK_DELETE_FLAGS,
+    pub CompletionStatus: super::super::Foundation::NTSTATUS,
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_7 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl Default for CF_OPERATION_PARAMETERS_0_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_Storage_FileSystem")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_OPERATION_PARAMETERS_0_6 {
+    pub Flags: CF_OPERATION_ACK_RENAME_FLAGS,
+    pub CompletionStatus: super::super::Foundation::NTSTATUS,
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_6 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl Default for CF_OPERATION_PARAMETERS_0_6 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_Storage_FileSystem")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_OPERATION_PARAMETERS_0_3 {
+    pub Flags: CF_OPERATION_RESTART_HYDRATION_FLAGS,
+    pub FsMetadata: *const CF_FS_METADATA,
+    pub FileIdentity: *const core::ffi::c_void,
+    pub FileIdentityLength: u32,
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_3 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl Default for CF_OPERATION_PARAMETERS_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_Storage_FileSystem")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_OPERATION_PARAMETERS_0_1 {
+    pub Flags: CF_OPERATION_RETRIEVE_DATA_FLAGS,
+    pub Buffer: *mut core::ffi::c_void,
+    pub Offset: i64,
+    pub Length: i64,
+    pub ReturnedLength: i64,
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_1 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_Storage_FileSystem")]
+impl Default for CF_OPERATION_PARAMETERS_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_Storage_FileSystem")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CF_OPERATION_PARAMETERS_0_0 {
+    pub Flags: CF_OPERATION_TRANSFER_DATA_FLAGS,
+    pub CompletionStatus: super::super::Foundation::NTSTATUS,
+    pub Buffer: *const core::ffi::c_void,
     pub Offset: i64,
     pub Length: i64,
 }
@@ -2718,119 +2830,7 @@ impl Default for CF_OPERATION_PARAMETERS_0_0 {
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_OPERATION_PARAMETERS_0_1 {
-    pub Flags: CF_OPERATION_ACK_DEHYDRATE_FLAGS,
-    pub CompletionStatus: super::super::Foundation::NTSTATUS,
-    pub FileIdentity: *const core::ffi::c_void,
-    pub FileIdentityLength: u32,
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl Default for CF_OPERATION_PARAMETERS_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_Storage_FileSystem")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_OPERATION_PARAMETERS_0_2 {
-    pub Flags: CF_OPERATION_ACK_DELETE_FLAGS,
-    pub CompletionStatus: super::super::Foundation::NTSTATUS,
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl Default for CF_OPERATION_PARAMETERS_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_Storage_FileSystem")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_OPERATION_PARAMETERS_0_3 {
-    pub Flags: CF_OPERATION_ACK_RENAME_FLAGS,
-    pub CompletionStatus: super::super::Foundation::NTSTATUS,
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl Default for CF_OPERATION_PARAMETERS_0_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_Storage_FileSystem")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CF_OPERATION_PARAMETERS_0_4 {
-    pub Flags: CF_OPERATION_RESTART_HYDRATION_FLAGS,
-    pub FsMetadata: *const CF_FS_METADATA,
-    pub FileIdentity: *const core::ffi::c_void,
-    pub FileIdentityLength: u32,
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl Default for CF_OPERATION_PARAMETERS_0_4 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_Storage_FileSystem")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_OPERATION_PARAMETERS_0_5 {
-    pub Flags: CF_OPERATION_RETRIEVE_DATA_FLAGS,
-    pub Buffer: *mut core::ffi::c_void,
-    pub Offset: i64,
-    pub Length: i64,
-    pub ReturnedLength: i64,
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl Default for CF_OPERATION_PARAMETERS_0_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_Storage_FileSystem")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_OPERATION_PARAMETERS_0_6 {
-    pub Flags: CF_OPERATION_TRANSFER_DATA_FLAGS,
-    pub CompletionStatus: super::super::Foundation::NTSTATUS,
-    pub Buffer: *const core::ffi::c_void,
-    pub Offset: i64,
-    pub Length: i64,
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl Default for CF_OPERATION_PARAMETERS_0_6 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_Storage_FileSystem")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CF_OPERATION_PARAMETERS_0_7 {
     pub Flags: CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS,
     pub CompletionStatus: super::super::Foundation::NTSTATUS,
     pub PlaceholderTotalCount: i64,
@@ -2839,11 +2839,11 @@ pub struct CF_OPERATION_PARAMETERS_0_7 {
     pub EntriesProcessed: u32,
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_7 {
+impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_4 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_Storage_FileSystem")]
-impl Default for CF_OPERATION_PARAMETERS_0_7 {
+impl Default for CF_OPERATION_PARAMETERS_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -6756,16 +6756,16 @@ impl Default for CLFS_MGMT_POLICY {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CLFS_MGMT_POLICY_0 {
-    pub MaximumSize: CLFS_MGMT_POLICY_0_4,
-    pub MinimumSize: CLFS_MGMT_POLICY_0_5,
-    pub NewContainerSize: CLFS_MGMT_POLICY_0_8,
-    pub GrowthRate: CLFS_MGMT_POLICY_0_2,
-    pub LogTail: CLFS_MGMT_POLICY_0_3,
-    pub AutoShrink: CLFS_MGMT_POLICY_0_1,
-    pub AutoGrow: CLFS_MGMT_POLICY_0_0,
+    pub MaximumSize: CLFS_MGMT_POLICY_0_0,
+    pub MinimumSize: CLFS_MGMT_POLICY_0_1,
+    pub NewContainerSize: CLFS_MGMT_POLICY_0_2,
+    pub GrowthRate: CLFS_MGMT_POLICY_0_3,
+    pub LogTail: CLFS_MGMT_POLICY_0_4,
+    pub AutoShrink: CLFS_MGMT_POLICY_0_5,
+    pub AutoGrow: CLFS_MGMT_POLICY_0_6,
     pub NewContainerPrefix: CLFS_MGMT_POLICY_0_7,
-    pub NewContainerSuffix: CLFS_MGMT_POLICY_0_9,
-    pub NewContainerExtension: CLFS_MGMT_POLICY_0_6,
+    pub NewContainerSuffix: CLFS_MGMT_POLICY_0_8,
+    pub NewContainerExtension: CLFS_MGMT_POLICY_0_9,
 }
 impl windows_core::TypeKind for CLFS_MGMT_POLICY_0 {
     type TypeKind = windows_core::CopyType;
@@ -6777,40 +6777,26 @@ impl Default for CLFS_MGMT_POLICY_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CLFS_MGMT_POLICY_0_0 {
+pub struct CLFS_MGMT_POLICY_0_6 {
     pub Enabled: u32,
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_0 {
+impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_6 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CLFS_MGMT_POLICY_0_0 {
+impl Default for CLFS_MGMT_POLICY_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CLFS_MGMT_POLICY_0_1 {
+pub struct CLFS_MGMT_POLICY_0_5 {
     pub Percentage: u32,
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_1 {
+impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_5 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CLFS_MGMT_POLICY_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CLFS_MGMT_POLICY_0_2 {
-    pub AbsoluteGrowthInContainers: u32,
-    pub RelativeGrowthPercentage: u32,
-}
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for CLFS_MGMT_POLICY_0_2 {
+impl Default for CLFS_MGMT_POLICY_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6818,8 +6804,8 @@ impl Default for CLFS_MGMT_POLICY_0_2 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CLFS_MGMT_POLICY_0_3 {
-    pub MinimumAvailablePercentage: u32,
-    pub MinimumAvailableContainers: u32,
+    pub AbsoluteGrowthInContainers: u32,
+    pub RelativeGrowthPercentage: u32,
 }
 impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_3 {
     type TypeKind = windows_core::CopyType;
@@ -6832,7 +6818,8 @@ impl Default for CLFS_MGMT_POLICY_0_3 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CLFS_MGMT_POLICY_0_4 {
-    pub Containers: u32,
+    pub MinimumAvailablePercentage: u32,
+    pub MinimumAvailableContainers: u32,
 }
 impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_4 {
     type TypeKind = windows_core::CopyType;
@@ -6844,27 +6831,40 @@ impl Default for CLFS_MGMT_POLICY_0_4 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CLFS_MGMT_POLICY_0_5 {
+pub struct CLFS_MGMT_POLICY_0_0 {
     pub Containers: u32,
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_5 {
+impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CLFS_MGMT_POLICY_0_5 {
+impl Default for CLFS_MGMT_POLICY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CLFS_MGMT_POLICY_0_6 {
+pub struct CLFS_MGMT_POLICY_0_1 {
+    pub Containers: u32,
+}
+impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_1 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for CLFS_MGMT_POLICY_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CLFS_MGMT_POLICY_0_9 {
     pub ExtensionLengthInBytes: u16,
     pub ExtensionString: [u16; 1],
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_6 {
+impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_9 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CLFS_MGMT_POLICY_0_6 {
+impl Default for CLFS_MGMT_POLICY_0_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6885,26 +6885,26 @@ impl Default for CLFS_MGMT_POLICY_0_7 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CLFS_MGMT_POLICY_0_8 {
+pub struct CLFS_MGMT_POLICY_0_2 {
     pub SizeInBytes: u32,
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_8 {
+impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CLFS_MGMT_POLICY_0_8 {
+impl Default for CLFS_MGMT_POLICY_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CLFS_MGMT_POLICY_0_9 {
+pub struct CLFS_MGMT_POLICY_0_8 {
     pub NextContainerSuffix: u64,
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_9 {
+impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_8 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CLFS_MGMT_POLICY_0_9 {
+impl Default for CLFS_MGMT_POLICY_0_8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -7186,12 +7186,12 @@ impl Default for COPYFILE2_MESSAGE {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union COPYFILE2_MESSAGE_0 {
-    pub ChunkStarted: COPYFILE2_MESSAGE_0_1,
-    pub ChunkFinished: COPYFILE2_MESSAGE_0_0,
-    pub StreamStarted: COPYFILE2_MESSAGE_0_5,
-    pub StreamFinished: COPYFILE2_MESSAGE_0_4,
-    pub PollContinue: COPYFILE2_MESSAGE_0_3,
-    pub Error: COPYFILE2_MESSAGE_0_2,
+    pub ChunkStarted: COPYFILE2_MESSAGE_0_0,
+    pub ChunkFinished: COPYFILE2_MESSAGE_0_1,
+    pub StreamStarted: COPYFILE2_MESSAGE_0_2,
+    pub StreamFinished: COPYFILE2_MESSAGE_0_3,
+    pub PollContinue: COPYFILE2_MESSAGE_0_4,
+    pub Error: COPYFILE2_MESSAGE_0_5,
 }
 impl windows_core::TypeKind for COPYFILE2_MESSAGE_0 {
     type TypeKind = windows_core::CopyType;
@@ -7203,7 +7203,7 @@ impl Default for COPYFILE2_MESSAGE_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct COPYFILE2_MESSAGE_0_0 {
+pub struct COPYFILE2_MESSAGE_0_1 {
     pub dwStreamNumber: u32,
     pub dwFlags: u32,
     pub hSourceFile: super::super::Foundation::HANDLE,
@@ -7215,26 +7215,6 @@ pub struct COPYFILE2_MESSAGE_0_0 {
     pub uliTotalFileSize: u64,
     pub uliTotalBytesTransferred: u64,
 }
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for COPYFILE2_MESSAGE_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct COPYFILE2_MESSAGE_0_1 {
-    pub dwStreamNumber: u32,
-    pub dwReserved: u32,
-    pub hSourceFile: super::super::Foundation::HANDLE,
-    pub hDestinationFile: super::super::Foundation::HANDLE,
-    pub uliChunkNumber: u64,
-    pub uliChunkSize: u64,
-    pub uliStreamSize: u64,
-    pub uliTotalFileSize: u64,
-}
 impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_1 {
     type TypeKind = windows_core::CopyType;
 }
@@ -7245,7 +7225,27 @@ impl Default for COPYFILE2_MESSAGE_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct COPYFILE2_MESSAGE_0_2 {
+pub struct COPYFILE2_MESSAGE_0_0 {
+    pub dwStreamNumber: u32,
+    pub dwReserved: u32,
+    pub hSourceFile: super::super::Foundation::HANDLE,
+    pub hDestinationFile: super::super::Foundation::HANDLE,
+    pub uliChunkNumber: u64,
+    pub uliChunkSize: u64,
+    pub uliStreamSize: u64,
+    pub uliTotalFileSize: u64,
+}
+impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for COPYFILE2_MESSAGE_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct COPYFILE2_MESSAGE_0_5 {
     pub CopyPhase: COPYFILE2_COPY_PHASE,
     pub dwStreamNumber: u32,
     pub hrFailure: windows_core::HRESULT,
@@ -7256,23 +7256,10 @@ pub struct COPYFILE2_MESSAGE_0_2 {
     pub uliTotalFileSize: u64,
     pub uliTotalBytesTransferred: u64,
 }
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_2 {
+impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_5 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for COPYFILE2_MESSAGE_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct COPYFILE2_MESSAGE_0_3 {
-    pub dwReserved: u32,
-}
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for COPYFILE2_MESSAGE_0_3 {
+impl Default for COPYFILE2_MESSAGE_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -7280,14 +7267,7 @@ impl Default for COPYFILE2_MESSAGE_0_3 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct COPYFILE2_MESSAGE_0_4 {
-    pub dwStreamNumber: u32,
     pub dwReserved: u32,
-    pub hSourceFile: super::super::Foundation::HANDLE,
-    pub hDestinationFile: super::super::Foundation::HANDLE,
-    pub uliStreamSize: u64,
-    pub uliStreamBytesTransferred: u64,
-    pub uliTotalFileSize: u64,
-    pub uliTotalBytesTransferred: u64,
 }
 impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_4 {
     type TypeKind = windows_core::CopyType;
@@ -7299,7 +7279,27 @@ impl Default for COPYFILE2_MESSAGE_0_4 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct COPYFILE2_MESSAGE_0_5 {
+pub struct COPYFILE2_MESSAGE_0_3 {
+    pub dwStreamNumber: u32,
+    pub dwReserved: u32,
+    pub hSourceFile: super::super::Foundation::HANDLE,
+    pub hDestinationFile: super::super::Foundation::HANDLE,
+    pub uliStreamSize: u64,
+    pub uliStreamBytesTransferred: u64,
+    pub uliTotalFileSize: u64,
+    pub uliTotalBytesTransferred: u64,
+}
+impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_3 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for COPYFILE2_MESSAGE_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct COPYFILE2_MESSAGE_0_2 {
     pub dwStreamNumber: u32,
     pub dwReserved: u32,
     pub hSourceFile: super::super::Foundation::HANDLE,
@@ -7307,10 +7307,10 @@ pub struct COPYFILE2_MESSAGE_0_5 {
     pub uliStreamSize: u64,
     pub uliTotalFileSize: u64,
 }
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_5 {
+impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for COPYFILE2_MESSAGE_0_5 {
+impl Default for COPYFILE2_MESSAGE_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Storage/InstallableFileSystems/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/InstallableFileSystems/mod.rs
@@ -418,8 +418,8 @@ impl Default for FILTER_AGGREGATE_BASIC_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILTER_AGGREGATE_BASIC_INFORMATION_0 {
-    pub MiniFilter: FILTER_AGGREGATE_BASIC_INFORMATION_0_1,
-    pub LegacyFilter: FILTER_AGGREGATE_BASIC_INFORMATION_0_0,
+    pub MiniFilter: FILTER_AGGREGATE_BASIC_INFORMATION_0_0,
+    pub LegacyFilter: FILTER_AGGREGATE_BASIC_INFORMATION_0_1,
 }
 impl windows_core::TypeKind for FILTER_AGGREGATE_BASIC_INFORMATION_0 {
     type TypeKind = windows_core::CopyType;
@@ -431,21 +431,21 @@ impl Default for FILTER_AGGREGATE_BASIC_INFORMATION_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
+pub struct FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
     pub FilterNameLength: u16,
     pub FilterNameBufferOffset: u16,
 }
-impl windows_core::TypeKind for FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
+impl windows_core::TypeKind for FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
+impl Default for FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
+pub struct FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
     pub FrameID: u32,
     pub NumberOfInstances: u32,
     pub FilterNameLength: u16,
@@ -453,10 +453,10 @@ pub struct FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
     pub FilterAltitudeLength: u16,
     pub FilterAltitudeBufferOffset: u16,
 }
-impl windows_core::TypeKind for FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
+impl windows_core::TypeKind for FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
+impl Default for FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -479,8 +479,8 @@ impl Default for FILTER_AGGREGATE_STANDARD_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
-    pub MiniFilter: FILTER_AGGREGATE_STANDARD_INFORMATION_0_1,
-    pub LegacyFilter: FILTER_AGGREGATE_STANDARD_INFORMATION_0_0,
+    pub MiniFilter: FILTER_AGGREGATE_STANDARD_INFORMATION_0_0,
+    pub LegacyFilter: FILTER_AGGREGATE_STANDARD_INFORMATION_0_1,
 }
 impl windows_core::TypeKind for FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
     type TypeKind = windows_core::CopyType;
@@ -492,27 +492,8 @@ impl Default for FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
-    pub Flags: u32,
-    pub FilterNameLength: u16,
-    pub FilterNameBufferOffset: u16,
-    pub FilterAltitudeLength: u16,
-    pub FilterAltitudeBufferOffset: u16,
-}
-impl windows_core::TypeKind for FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct FILTER_AGGREGATE_STANDARD_INFORMATION_0_1 {
     pub Flags: u32,
-    pub FrameID: u32,
-    pub NumberOfInstances: u32,
     pub FilterNameLength: u16,
     pub FilterNameBufferOffset: u16,
     pub FilterAltitudeLength: u16,
@@ -522,6 +503,25 @@ impl windows_core::TypeKind for FILTER_AGGREGATE_STANDARD_INFORMATION_0_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for FILTER_AGGREGATE_STANDARD_INFORMATION_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
+    pub Flags: u32,
+    pub FrameID: u32,
+    pub NumberOfInstances: u32,
+    pub FilterNameLength: u16,
+    pub FilterNameBufferOffset: u16,
+    pub FilterAltitudeLength: u16,
+    pub FilterAltitudeBufferOffset: u16,
+}
+impl windows_core::TypeKind for FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -669,8 +669,8 @@ impl Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
-    pub MiniFilter: INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1,
-    pub LegacyFilter: INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0,
+    pub MiniFilter: INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0,
+    pub LegacyFilter: INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1,
 }
 impl windows_core::TypeKind for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
     type TypeKind = windows_core::CopyType;
@@ -682,7 +682,7 @@ impl Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
+pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
     pub Flags: u32,
     pub AltitudeLength: u16,
     pub AltitudeBufferOffset: u16,
@@ -692,17 +692,17 @@ pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
     pub FilterNameBufferOffset: u16,
     pub SupportedFeatures: u32,
 }
-impl windows_core::TypeKind for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
+impl windows_core::TypeKind for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
+impl Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
+pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
     pub Flags: u32,
     pub FrameID: u32,
     pub VolumeFileSystemType: FLT_FILESYSTEM_TYPE,
@@ -716,10 +716,10 @@ pub struct INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
     pub FilterNameBufferOffset: u16,
     pub SupportedFeatures: u32,
 }
-impl windows_core::TypeKind for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
+impl windows_core::TypeKind for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
+impl Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Nvme/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Nvme/mod.rs
@@ -3611,31 +3611,31 @@ impl Default for NVME_COMMAND {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_COMMAND_0 {
-    pub GENERAL: NVME_COMMAND_0_9,
-    pub IDENTIFY: NVME_COMMAND_0_12,
-    pub ABORT: NVME_COMMAND_0_0,
-    pub GETFEATURES: NVME_COMMAND_0_10,
-    pub SETFEATURES: NVME_COMMAND_0_21,
-    pub GETLOGPAGE: NVME_COMMAND_0_11,
-    pub CREATEIOCQ: NVME_COMMAND_0_1,
-    pub CREATEIOSQ: NVME_COMMAND_0_2,
-    pub DATASETMANAGEMENT: NVME_COMMAND_0_3,
-    pub SECURITYSEND: NVME_COMMAND_0_20,
-    pub SECURITYRECEIVE: NVME_COMMAND_0_19,
-    pub FIRMWAREDOWNLOAD: NVME_COMMAND_0_7,
-    pub FIRMWAREACTIVATE: NVME_COMMAND_0_6,
-    pub FORMATNVM: NVME_COMMAND_0_8,
-    pub DIRECTIVERECEIVE: NVME_COMMAND_0_4,
-    pub DIRECTIVESEND: NVME_COMMAND_0_5,
-    pub SANITIZE: NVME_COMMAND_0_18,
-    pub READWRITE: NVME_COMMAND_0_13,
-    pub RESERVATIONACQUIRE: NVME_COMMAND_0_14,
-    pub RESERVATIONREGISTER: NVME_COMMAND_0_15,
-    pub RESERVATIONRELEASE: NVME_COMMAND_0_16,
-    pub RESERVATIONREPORT: NVME_COMMAND_0_17,
-    pub ZONEMANAGEMENTSEND: NVME_COMMAND_0_24,
+    pub GENERAL: NVME_COMMAND_0_0,
+    pub IDENTIFY: NVME_COMMAND_0_1,
+    pub ABORT: NVME_COMMAND_0_2,
+    pub GETFEATURES: NVME_COMMAND_0_3,
+    pub SETFEATURES: NVME_COMMAND_0_4,
+    pub GETLOGPAGE: NVME_COMMAND_0_5,
+    pub CREATEIOCQ: NVME_COMMAND_0_6,
+    pub CREATEIOSQ: NVME_COMMAND_0_7,
+    pub DATASETMANAGEMENT: NVME_COMMAND_0_8,
+    pub SECURITYSEND: NVME_COMMAND_0_9,
+    pub SECURITYRECEIVE: NVME_COMMAND_0_10,
+    pub FIRMWAREDOWNLOAD: NVME_COMMAND_0_11,
+    pub FIRMWAREACTIVATE: NVME_COMMAND_0_12,
+    pub FORMATNVM: NVME_COMMAND_0_13,
+    pub DIRECTIVERECEIVE: NVME_COMMAND_0_14,
+    pub DIRECTIVESEND: NVME_COMMAND_0_15,
+    pub SANITIZE: NVME_COMMAND_0_16,
+    pub READWRITE: NVME_COMMAND_0_17,
+    pub RESERVATIONACQUIRE: NVME_COMMAND_0_18,
+    pub RESERVATIONREGISTER: NVME_COMMAND_0_19,
+    pub RESERVATIONRELEASE: NVME_COMMAND_0_20,
+    pub RESERVATIONREPORT: NVME_COMMAND_0_21,
+    pub ZONEMANAGEMENTSEND: NVME_COMMAND_0_22,
     pub ZONEMANAGEMENTRECEIVE: NVME_COMMAND_0_23,
-    pub ZONEAPPEND: NVME_COMMAND_0_22,
+    pub ZONEAPPEND: NVME_COMMAND_0_24,
 }
 impl windows_core::TypeKind for NVME_COMMAND_0 {
     type TypeKind = windows_core::CopyType;
@@ -3647,45 +3647,9 @@ impl Default for NVME_COMMAND_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_0 {
+pub struct NVME_COMMAND_0_2 {
     pub CDW10: NVME_CDW10_ABORT,
     pub CDW11: u32,
-    pub CDW12: u32,
-    pub CDW13: u32,
-    pub CDW14: u32,
-    pub CDW15: u32,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_1 {
-    pub CDW10: NVME_CDW10_CREATE_IO_QUEUE,
-    pub CDW11: NVME_CDW11_CREATE_IO_CQ,
-    pub CDW12: u32,
-    pub CDW13: u32,
-    pub CDW14: u32,
-    pub CDW15: u32,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_2 {
-    pub CDW10: NVME_CDW10_CREATE_IO_QUEUE,
-    pub CDW11: NVME_CDW11_CREATE_IO_SQ,
     pub CDW12: u32,
     pub CDW13: u32,
     pub CDW14: u32,
@@ -3701,63 +3665,9 @@ impl Default for NVME_COMMAND_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_3 {
-    pub CDW10: NVME_CDW10_DATASET_MANAGEMENT,
-    pub CDW11: NVME_CDW11_DATASET_MANAGEMENT,
-    pub CDW12: u32,
-    pub CDW13: u32,
-    pub CDW14: u32,
-    pub CDW15: u32,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_4 {
-    pub CDW10: NVME_CDW10_DIRECTIVE_RECEIVE,
-    pub CDW11: NVME_CDW11_DIRECTIVE_RECEIVE,
-    pub CDW12: NVME_CDW12_DIRECTIVE_RECEIVE,
-    pub CDW13: u32,
-    pub CDW14: u32,
-    pub CDW15: u32,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_4 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_5 {
-    pub CDW10: NVME_CDW10_DIRECTIVE_SEND,
-    pub CDW11: NVME_CDW11_DIRECTIVE_SEND,
-    pub CDW12: NVME_CDW12_DIRECTIVE_SEND,
-    pub CDW13: u32,
-    pub CDW14: u32,
-    pub CDW15: u32,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_6 {
-    pub CDW10: NVME_CDW10_FIRMWARE_ACTIVATE,
-    pub CDW11: u32,
+    pub CDW10: NVME_CDW10_CREATE_IO_QUEUE,
+    pub CDW11: NVME_CDW11_CREATE_IO_CQ,
     pub CDW12: u32,
     pub CDW13: u32,
     pub CDW14: u32,
@@ -3772,10 +3682,10 @@ impl Default for NVME_COMMAND_0_6 {
     }
 }
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_7 {
-    pub CDW10: NVME_CDW10_FIRMWARE_DOWNLOAD,
-    pub CDW11: NVME_CDW11_FIRMWARE_DOWNLOAD,
+    pub CDW10: NVME_CDW10_CREATE_IO_QUEUE,
+    pub CDW11: NVME_CDW11_CREATE_IO_SQ,
     pub CDW12: u32,
     pub CDW13: u32,
     pub CDW14: u32,
@@ -3792,8 +3702,8 @@ impl Default for NVME_COMMAND_0_7 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_8 {
-    pub CDW10: NVME_CDW10_FORMAT_NVM,
-    pub CDW11: u32,
+    pub CDW10: NVME_CDW10_DATASET_MANAGEMENT,
+    pub CDW11: NVME_CDW11_DATASET_MANAGEMENT,
     pub CDW12: u32,
     pub CDW13: u32,
     pub CDW14: u32,
@@ -3808,115 +3718,11 @@ impl Default for NVME_COMMAND_0_8 {
     }
 }
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_COMMAND_0_9 {
-    pub CDW10: u32,
-    pub CDW11: u32,
-    pub CDW12: u32,
-    pub CDW13: u32,
-    pub CDW14: u32,
-    pub CDW15: u32,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_9 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_10 {
-    pub CDW10: NVME_CDW10_GET_FEATURES,
-    pub CDW11: NVME_CDW11_FEATURES,
-    pub CDW12: u32,
-    pub CDW13: u32,
-    pub CDW14: u32,
-    pub CDW15: u32,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_10 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_10 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_11 {
-    pub Anonymous: NVME_COMMAND_0_11_0,
-    pub CDW11: NVME_CDW11_GET_LOG_PAGE,
-    pub CDW12: NVME_CDW12_GET_LOG_PAGE,
-    pub CDW13: NVME_CDW13_GET_LOG_PAGE,
-    pub CDW14: NVME_CDW14_GET_LOG_PAGE,
-    pub CDW15: u32,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_11 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_11 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub union NVME_COMMAND_0_11_0 {
-    pub CDW10: NVME_CDW10_GET_LOG_PAGE,
-    pub CDW10_V13: NVME_CDW10_GET_LOG_PAGE_V13,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_11_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_11_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_12 {
-    pub CDW10: NVME_CDW10_IDENTIFY,
-    pub CDW11: NVME_CDW11_IDENTIFY,
-    pub CDW12: u32,
-    pub CDW13: u32,
-    pub CDW14: u32,
-    pub CDW15: u32,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_12 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_12 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_13 {
-    pub LBALOW: u32,
-    pub LBAHIGH: u32,
-    pub CDW12: NVME_CDW12_READ_WRITE,
-    pub CDW13: NVME_CDW13_READ_WRITE,
-    pub CDW14: u32,
-    pub CDW15: NVME_CDW15_READ_WRITE,
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_13 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_COMMAND_0_13 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_14 {
-    pub CDW10: NVME_CDW10_RESERVATION_ACQUIRE,
-    pub CDW11: u32,
-    pub CDW12: u32,
+    pub CDW10: NVME_CDW10_DIRECTIVE_RECEIVE,
+    pub CDW11: NVME_CDW11_DIRECTIVE_RECEIVE,
+    pub CDW12: NVME_CDW12_DIRECTIVE_RECEIVE,
     pub CDW13: u32,
     pub CDW14: u32,
     pub CDW15: u32,
@@ -3932,9 +3738,9 @@ impl Default for NVME_COMMAND_0_14 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_15 {
-    pub CDW10: NVME_CDW10_RESERVATION_REGISTER,
-    pub CDW11: u32,
-    pub CDW12: u32,
+    pub CDW10: NVME_CDW10_DIRECTIVE_SEND,
+    pub CDW11: NVME_CDW11_DIRECTIVE_SEND,
+    pub CDW12: NVME_CDW12_DIRECTIVE_SEND,
     pub CDW13: u32,
     pub CDW14: u32,
     pub CDW15: u32,
@@ -3949,18 +3755,140 @@ impl Default for NVME_COMMAND_0_15 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_16 {
-    pub CDW10: NVME_CDW10_RESERVATION_RELEASE,
+pub struct NVME_COMMAND_0_12 {
+    pub CDW10: NVME_CDW10_FIRMWARE_ACTIVATE,
     pub CDW11: u32,
     pub CDW12: u32,
     pub CDW13: u32,
     pub CDW14: u32,
     pub CDW15: u32,
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_16 {
+impl windows_core::TypeKind for NVME_COMMAND_0_12 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_COMMAND_0_16 {
+impl Default for NVME_COMMAND_0_12 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_COMMAND_0_11 {
+    pub CDW10: NVME_CDW10_FIRMWARE_DOWNLOAD,
+    pub CDW11: NVME_CDW11_FIRMWARE_DOWNLOAD,
+    pub CDW12: u32,
+    pub CDW13: u32,
+    pub CDW14: u32,
+    pub CDW15: u32,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_11 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_11 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_COMMAND_0_13 {
+    pub CDW10: NVME_CDW10_FORMAT_NVM,
+    pub CDW11: u32,
+    pub CDW12: u32,
+    pub CDW13: u32,
+    pub CDW14: u32,
+    pub CDW15: u32,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_13 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_13 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_COMMAND_0_0 {
+    pub CDW10: u32,
+    pub CDW11: u32,
+    pub CDW12: u32,
+    pub CDW13: u32,
+    pub CDW14: u32,
+    pub CDW15: u32,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_COMMAND_0_3 {
+    pub CDW10: NVME_CDW10_GET_FEATURES,
+    pub CDW11: NVME_CDW11_FEATURES,
+    pub CDW12: u32,
+    pub CDW13: u32,
+    pub CDW14: u32,
+    pub CDW15: u32,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_3 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_COMMAND_0_5 {
+    pub Anonymous: NVME_COMMAND_0_5_0,
+    pub CDW11: NVME_CDW11_GET_LOG_PAGE,
+    pub CDW12: NVME_CDW12_GET_LOG_PAGE,
+    pub CDW13: NVME_CDW13_GET_LOG_PAGE,
+    pub CDW14: NVME_CDW14_GET_LOG_PAGE,
+    pub CDW15: u32,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_5 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_5 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union NVME_COMMAND_0_5_0 {
+    pub CDW10: NVME_CDW10_GET_LOG_PAGE,
+    pub CDW10_V13: NVME_CDW10_GET_LOG_PAGE_V13,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_5_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_5_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_COMMAND_0_1 {
+    pub CDW10: NVME_CDW10_IDENTIFY,
+    pub CDW11: NVME_CDW11_IDENTIFY,
+    pub CDW12: u32,
+    pub CDW13: u32,
+    pub CDW14: u32,
+    pub CDW15: u32,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_1 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3968,12 +3896,12 @@ impl Default for NVME_COMMAND_0_16 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_17 {
-    pub CDW10: NVME_CDW10_RESERVATION_REPORT,
-    pub CDW11: NVME_CDW11_RESERVATION_REPORT,
-    pub CDW12: u32,
-    pub CDW13: u32,
+    pub LBALOW: u32,
+    pub LBAHIGH: u32,
+    pub CDW12: NVME_CDW12_READ_WRITE,
+    pub CDW13: NVME_CDW13_READ_WRITE,
     pub CDW14: u32,
-    pub CDW15: u32,
+    pub CDW15: NVME_CDW15_READ_WRITE,
 }
 impl windows_core::TypeKind for NVME_COMMAND_0_17 {
     type TypeKind = windows_core::CopyType;
@@ -3986,8 +3914,8 @@ impl Default for NVME_COMMAND_0_17 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_18 {
-    pub CDW10: NVME_CDW10_SANITIZE,
-    pub CDW11: NVME_CDW11_SANITIZE,
+    pub CDW10: NVME_CDW10_RESERVATION_ACQUIRE,
+    pub CDW11: u32,
     pub CDW12: u32,
     pub CDW13: u32,
     pub CDW14: u32,
@@ -4004,8 +3932,8 @@ impl Default for NVME_COMMAND_0_18 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_19 {
-    pub CDW10: NVME_CDW10_SECURITY_SEND_RECEIVE,
-    pub CDW11: NVME_CDW11_SECURITY_RECEIVE,
+    pub CDW10: NVME_CDW10_RESERVATION_REGISTER,
+    pub CDW11: u32,
     pub CDW12: u32,
     pub CDW13: u32,
     pub CDW14: u32,
@@ -4022,8 +3950,8 @@ impl Default for NVME_COMMAND_0_19 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_20 {
-    pub CDW10: NVME_CDW10_SECURITY_SEND_RECEIVE,
-    pub CDW11: NVME_CDW11_SECURITY_SEND,
+    pub CDW10: NVME_CDW10_RESERVATION_RELEASE,
+    pub CDW11: u32,
     pub CDW12: u32,
     pub CDW13: u32,
     pub CDW14: u32,
@@ -4040,12 +3968,12 @@ impl Default for NVME_COMMAND_0_20 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_21 {
-    pub CDW10: NVME_CDW10_SET_FEATURES,
-    pub CDW11: NVME_CDW11_FEATURES,
-    pub CDW12: NVME_CDW12_FEATURES,
-    pub CDW13: NVME_CDW13_FEATURES,
-    pub CDW14: NVME_CDW14_FEATURES,
-    pub CDW15: NVME_CDW15_FEATURES,
+    pub CDW10: NVME_CDW10_RESERVATION_REPORT,
+    pub CDW11: NVME_CDW11_RESERVATION_REPORT,
+    pub CDW12: u32,
+    pub CDW13: u32,
+    pub CDW14: u32,
+    pub CDW15: u32,
 }
 impl windows_core::TypeKind for NVME_COMMAND_0_21 {
     type TypeKind = windows_core::CopyType;
@@ -4057,17 +3985,89 @@ impl Default for NVME_COMMAND_0_21 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_22 {
+pub struct NVME_COMMAND_0_16 {
+    pub CDW10: NVME_CDW10_SANITIZE,
+    pub CDW11: NVME_CDW11_SANITIZE,
+    pub CDW12: u32,
+    pub CDW13: u32,
+    pub CDW14: u32,
+    pub CDW15: u32,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_16 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_16 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_COMMAND_0_10 {
+    pub CDW10: NVME_CDW10_SECURITY_SEND_RECEIVE,
+    pub CDW11: NVME_CDW11_SECURITY_RECEIVE,
+    pub CDW12: u32,
+    pub CDW13: u32,
+    pub CDW14: u32,
+    pub CDW15: u32,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_10 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_10 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_COMMAND_0_9 {
+    pub CDW10: NVME_CDW10_SECURITY_SEND_RECEIVE,
+    pub CDW11: NVME_CDW11_SECURITY_SEND,
+    pub CDW12: u32,
+    pub CDW13: u32,
+    pub CDW14: u32,
+    pub CDW15: u32,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_9 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_9 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_COMMAND_0_4 {
+    pub CDW10: NVME_CDW10_SET_FEATURES,
+    pub CDW11: NVME_CDW11_FEATURES,
+    pub CDW12: NVME_CDW12_FEATURES,
+    pub CDW13: NVME_CDW13_FEATURES,
+    pub CDW14: NVME_CDW14_FEATURES,
+    pub CDW15: NVME_CDW15_FEATURES,
+}
+impl windows_core::TypeKind for NVME_COMMAND_0_4 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_COMMAND_0_4 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NVME_COMMAND_0_24 {
     pub CDW1011: NVME_CDW10_ZONE_APPEND,
     pub CDW12: NVME_CDW12_ZONE_APPEND,
     pub CDW13: u32,
     pub ILBRT: u32,
     pub CDW15: NVME_CDW15_ZONE_APPEND,
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_22 {
+impl windows_core::TypeKind for NVME_COMMAND_0_24 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_COMMAND_0_22 {
+impl Default for NVME_COMMAND_0_24 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4091,17 +4091,17 @@ impl Default for NVME_COMMAND_0_23 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct NVME_COMMAND_0_24 {
+pub struct NVME_COMMAND_0_22 {
     pub CDW1011: NVME_CDW10_ZONE_MANAGEMENT_SEND,
     pub CDW12: u32,
     pub CDW13: NVME_CDW13_ZONE_MANAGEMENT_SEND,
     pub CDW14: u32,
     pub CDW15: u32,
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_24 {
+impl windows_core::TypeKind for NVME_COMMAND_0_22 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_COMMAND_0_24 {
+impl Default for NVME_COMMAND_0_22 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4548,8 +4548,8 @@ impl Default for NVME_CONTROLLER_STATUS_0 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_DEVICE_SELF_TEST_LOG {
-    pub CurrentOperation: NVME_DEVICE_SELF_TEST_LOG_1,
-    pub CurrentCompletion: NVME_DEVICE_SELF_TEST_LOG_0,
+    pub CurrentOperation: NVME_DEVICE_SELF_TEST_LOG_0,
+    pub CurrentCompletion: NVME_DEVICE_SELF_TEST_LOG_1,
     pub Reserved: [u8; 2],
     pub ResultData: [NVME_DEVICE_SELF_TEST_RESULT_DATA; 20],
 }
@@ -4557,19 +4557,6 @@ impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_LOG {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NVME_DEVICE_SELF_TEST_LOG {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_DEVICE_SELF_TEST_LOG_0 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_LOG_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_DEVICE_SELF_TEST_LOG_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4587,17 +4574,30 @@ impl Default for NVME_DEVICE_SELF_TEST_LOG_1 {
         unsafe { core::mem::zeroed() }
     }
 }
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_DEVICE_SELF_TEST_LOG_0 {
+    pub _bitfield: u8,
+}
+impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_LOG_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_DEVICE_SELF_TEST_LOG_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_DEVICE_SELF_TEST_RESULT_DATA {
-    pub Status: NVME_DEVICE_SELF_TEST_RESULT_DATA_1,
+    pub Status: NVME_DEVICE_SELF_TEST_RESULT_DATA_0,
     pub SegmentNumber: u8,
-    pub ValidDiagnostics: NVME_DEVICE_SELF_TEST_RESULT_DATA_2,
+    pub ValidDiagnostics: NVME_DEVICE_SELF_TEST_RESULT_DATA_1,
     pub Reserved: u8,
     pub POH: u64,
     pub NSID: u32,
     pub FailingLBA: u64,
-    pub StatusCodeType: NVME_DEVICE_SELF_TEST_RESULT_DATA_0,
+    pub StatusCodeType: NVME_DEVICE_SELF_TEST_RESULT_DATA_2,
     pub StatusCode: u8,
     pub VendorSpecific: u16,
 }
@@ -4605,6 +4605,19 @@ impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_RESULT_DATA {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NVME_DEVICE_SELF_TEST_RESULT_DATA {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
+    pub _bitfield: u8,
+}
+impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4631,19 +4644,6 @@ impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_RESULT_DATA_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NVME_DEVICE_SELF_TEST_RESULT_DATA_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4988,15 +4988,15 @@ pub struct NVME_IDENTIFY_CONTROLLER_DATA {
     pub FR: [u8; 8],
     pub RAB: u8,
     pub IEEE: [u8; 3],
-    pub CMIC: NVME_IDENTIFY_CONTROLLER_DATA_3,
+    pub CMIC: NVME_IDENTIFY_CONTROLLER_DATA_0,
     pub MDTS: u8,
     pub CNTLID: u16,
     pub VER: u32,
     pub RTD3R: u32,
     pub RTD3E: u32,
-    pub OAES: NVME_IDENTIFY_CONTROLLER_DATA_14,
-    pub CTRATT: NVME_IDENTIFY_CONTROLLER_DATA_5,
-    pub RRLS: NVME_IDENTIFY_CONTROLLER_DATA_17,
+    pub OAES: NVME_IDENTIFY_CONTROLLER_DATA_1,
+    pub CTRATT: NVME_IDENTIFY_CONTROLLER_DATA_2,
+    pub RRLS: NVME_IDENTIFY_CONTROLLER_DATA_3,
     pub Reserved0: [u8; 9],
     pub CNTRLTYPE: u8,
     pub FGUID: [u8; 16],
@@ -5005,15 +5005,15 @@ pub struct NVME_IDENTIFY_CONTROLLER_DATA {
     pub CRDT3: u16,
     pub Reserved0_1: [u8; 106],
     pub ReservedForManagement: [u8; 16],
-    pub OACS: NVME_IDENTIFY_CONTROLLER_DATA_13,
+    pub OACS: NVME_IDENTIFY_CONTROLLER_DATA_4,
     pub ACL: u8,
     pub AERL: u8,
-    pub FRMW: NVME_IDENTIFY_CONTROLLER_DATA_7,
-    pub LPA: NVME_IDENTIFY_CONTROLLER_DATA_10,
+    pub FRMW: NVME_IDENTIFY_CONTROLLER_DATA_5,
+    pub LPA: NVME_IDENTIFY_CONTROLLER_DATA_6,
     pub ELPE: u8,
     pub NPSS: u8,
-    pub AVSCC: NVME_IDENTIFY_CONTROLLER_DATA_2,
-    pub APSTA: NVME_IDENTIFY_CONTROLLER_DATA_1,
+    pub AVSCC: NVME_IDENTIFY_CONTROLLER_DATA_7,
+    pub APSTA: NVME_IDENTIFY_CONTROLLER_DATA_8,
     pub WCTEMP: u16,
     pub CCTEMP: u16,
     pub MTFA: u16,
@@ -5021,40 +5021,40 @@ pub struct NVME_IDENTIFY_CONTROLLER_DATA {
     pub HMMIN: u32,
     pub TNVMCAP: [u8; 16],
     pub UNVMCAP: [u8; 16],
-    pub RPMBS: NVME_IDENTIFY_CONTROLLER_DATA_16,
+    pub RPMBS: NVME_IDENTIFY_CONTROLLER_DATA_9,
     pub EDSTT: u16,
     pub DSTO: u8,
     pub FWUG: u8,
     pub KAS: u16,
-    pub HCTMA: NVME_IDENTIFY_CONTROLLER_DATA_9,
+    pub HCTMA: NVME_IDENTIFY_CONTROLLER_DATA_10,
     pub MNTMT: u16,
     pub MXTMT: u16,
-    pub SANICAP: NVME_IDENTIFY_CONTROLLER_DATA_18,
+    pub SANICAP: NVME_IDENTIFY_CONTROLLER_DATA_11,
     pub HMMINDS: u32,
     pub HMMAXD: u16,
     pub NSETIDMAX: u16,
     pub ENDGIDMAX: u16,
     pub ANATT: u8,
-    pub ANACAP: NVME_IDENTIFY_CONTROLLER_DATA_0,
+    pub ANACAP: NVME_IDENTIFY_CONTROLLER_DATA_12,
     pub ANAGRPMAX: u32,
     pub NANAGRPID: u32,
     pub PELS: u32,
     pub Reserved1: [u8; 156],
-    pub SQES: NVME_IDENTIFY_CONTROLLER_DATA_20,
-    pub CQES: NVME_IDENTIFY_CONTROLLER_DATA_4,
+    pub SQES: NVME_IDENTIFY_CONTROLLER_DATA_13,
+    pub CQES: NVME_IDENTIFY_CONTROLLER_DATA_14,
     pub MAXCMD: u16,
     pub NN: u32,
     pub ONCS: NVME_IDENTIFY_CONTROLLER_DATA_15,
-    pub FUSES: NVME_IDENTIFY_CONTROLLER_DATA_8,
-    pub FNA: NVME_IDENTIFY_CONTROLLER_DATA_6,
-    pub VWC: NVME_IDENTIFY_CONTROLLER_DATA_21,
+    pub FUSES: NVME_IDENTIFY_CONTROLLER_DATA_16,
+    pub FNA: NVME_IDENTIFY_CONTROLLER_DATA_17,
+    pub VWC: NVME_IDENTIFY_CONTROLLER_DATA_18,
     pub AWUN: u16,
     pub AWUPF: u16,
-    pub NVSCC: NVME_IDENTIFY_CONTROLLER_DATA_11,
-    pub NWPC: NVME_IDENTIFY_CONTROLLER_DATA_12,
+    pub NVSCC: NVME_IDENTIFY_CONTROLLER_DATA_19,
+    pub NWPC: NVME_IDENTIFY_CONTROLLER_DATA_20,
     pub ACWU: u16,
     pub Reserved4: [u8; 2],
-    pub SGLS: NVME_IDENTIFY_CONTROLLER_DATA_19,
+    pub SGLS: NVME_IDENTIFY_CONTROLLER_DATA_21,
     pub MNAN: u32,
     pub Reserved6: [u8; 224],
     pub SUBNQN: [u8; 256],
@@ -5067,162 +5067,6 @@ impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NVME_IDENTIFY_CONTROLLER_DATA {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_0 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_1 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_2 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_3 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_3 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_4 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_4 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_4 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_5 {
-    pub _bitfield: u32,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_5 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_5 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_6 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_6 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_6 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_7 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_7 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_7 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_8 {
-    pub _bitfield: u16,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_8 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_8 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_9 {
-    pub _bitfield: u16,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_9 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_9 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_10 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_10 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_10 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_11 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_11 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5242,13 +5086,39 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_12 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_13 {
-    pub _bitfield: u16,
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_8 {
+    pub _bitfield: u8,
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_13 {
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_8 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_13 {
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_8 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_7 {
+    pub _bitfield: u8,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_7 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_7 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_0 {
+    pub _bitfield: u8,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5256,7 +5126,7 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_13 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_14 {
-    pub _bitfield: u32,
+    pub _bitfield: u8,
 }
 impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_14 {
     type TypeKind = windows_core::CopyType;
@@ -5268,26 +5138,13 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_14 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_15 {
-    pub _bitfield: u16,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_15 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_15 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_16 {
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_2 {
     pub _bitfield: u32,
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_16 {
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_16 {
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5295,7 +5152,7 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_16 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_17 {
-    pub _bitfield: u16,
+    pub _bitfield: u8,
 }
 impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_17 {
     type TypeKind = windows_core::CopyType;
@@ -5307,13 +5164,52 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_17 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_CONTROLLER_DATA_18 {
-    pub _bitfield: u32,
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_5 {
+    pub _bitfield: u8,
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_18 {
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_5 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_IDENTIFY_CONTROLLER_DATA_18 {
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_5 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_16 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_16 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_16 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_10 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_10 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_10 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_6 {
+    pub _bitfield: u8,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_6 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5321,7 +5217,7 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_18 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_19 {
-    pub _bitfield: u32,
+    pub _bitfield: u8,
 }
 impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_19 {
     type TypeKind = windows_core::CopyType;
@@ -5346,13 +5242,117 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_20 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_4 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_4 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_4 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_1 {
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_1 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_15 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_15 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_15 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_9 {
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_9 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_9 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_3 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_3 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_11 {
+    pub _bitfield: u32,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_11 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_11 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_21 {
-    pub _bitfield: u8,
+    pub _bitfield: u32,
 }
 impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_21 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NVME_IDENTIFY_CONTROLLER_DATA_21 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_13 {
+    pub _bitfield: u8,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_13 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_13 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_CONTROLLER_DATA_18 {
+    pub _bitfield: u8,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_18 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_CONTROLLER_DATA_18 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5376,16 +5376,16 @@ pub struct NVME_IDENTIFY_NAMESPACE_DATA {
     pub NSZE: u64,
     pub NCAP: u64,
     pub NUSE: u64,
-    pub NSFEAT: NVME_IDENTIFY_NAMESPACE_DATA_8,
+    pub NSFEAT: NVME_IDENTIFY_NAMESPACE_DATA_0,
     pub NLBAF: u8,
-    pub FLBAS: NVME_IDENTIFY_NAMESPACE_DATA_3,
-    pub MC: NVME_IDENTIFY_NAMESPACE_DATA_5,
-    pub DPC: NVME_IDENTIFY_NAMESPACE_DATA_1,
-    pub DPS: NVME_IDENTIFY_NAMESPACE_DATA_2,
-    pub NMIC: NVME_IDENTIFY_NAMESPACE_DATA_6,
+    pub FLBAS: NVME_IDENTIFY_NAMESPACE_DATA_1,
+    pub MC: NVME_IDENTIFY_NAMESPACE_DATA_2,
+    pub DPC: NVME_IDENTIFY_NAMESPACE_DATA_3,
+    pub DPS: NVME_IDENTIFY_NAMESPACE_DATA_4,
+    pub NMIC: NVME_IDENTIFY_NAMESPACE_DATA_5,
     pub RESCAP: NVM_RESERVATION_CAPABILITIES,
-    pub FPI: NVME_IDENTIFY_NAMESPACE_DATA_4,
-    pub DLFEAT: NVME_IDENTIFY_NAMESPACE_DATA_0,
+    pub FPI: NVME_IDENTIFY_NAMESPACE_DATA_6,
+    pub DLFEAT: NVME_IDENTIFY_NAMESPACE_DATA_7,
     pub NAWUN: u16,
     pub NAWUPF: u16,
     pub NACWU: u16,
@@ -5405,7 +5405,7 @@ pub struct NVME_IDENTIFY_NAMESPACE_DATA {
     pub Reserved2: [u8; 11],
     pub ANAGRPID: u32,
     pub Reserved3: [u8; 3],
-    pub NSATTR: NVME_IDENTIFY_NAMESPACE_DATA_7,
+    pub NSATTR: NVME_IDENTIFY_NAMESPACE_DATA_8,
     pub NVMSETID: u16,
     pub ENDGID: u16,
     pub NGUID: [u8; 16],
@@ -5424,39 +5424,13 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_NAMESPACE_DATA_0 {
+pub struct NVME_IDENTIFY_NAMESPACE_DATA_7 {
     pub _bitfield: u8,
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_0 {
+impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_7 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_IDENTIFY_NAMESPACE_DATA_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_NAMESPACE_DATA_1 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_NAMESPACE_DATA_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_NAMESPACE_DATA_2 {
-    pub _bitfield: u8,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_NAMESPACE_DATA_2 {
+impl Default for NVME_IDENTIFY_NAMESPACE_DATA_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5489,13 +5463,13 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_4 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_NAMESPACE_DATA_5 {
+pub struct NVME_IDENTIFY_NAMESPACE_DATA_1 {
     pub _bitfield: u8,
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_5 {
+impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_IDENTIFY_NAMESPACE_DATA_5 {
+impl Default for NVME_IDENTIFY_NAMESPACE_DATA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5515,13 +5489,26 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_6 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_NAMESPACE_DATA_7 {
+pub struct NVME_IDENTIFY_NAMESPACE_DATA_2 {
     pub _bitfield: u8,
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_7 {
+impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_IDENTIFY_NAMESPACE_DATA_7 {
+impl Default for NVME_IDENTIFY_NAMESPACE_DATA_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_NAMESPACE_DATA_5 {
+    pub _bitfield: u8,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_5 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_NAMESPACE_DATA_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5535,6 +5522,19 @@ impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_8 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NVME_IDENTIFY_NAMESPACE_DATA_8 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_NAMESPACE_DATA_0 {
+    pub _bitfield: u8,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_NAMESPACE_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5577,8 +5577,8 @@ impl Default for NVME_IDENTIFY_NVM_SPECIFIC_CONTROLLER_IO_COMMAND_SET {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET {
-    pub ZOC: NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1,
-    pub OZCS: NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0,
+    pub ZOC: NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0,
+    pub OZCS: NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1,
     pub MAR: u32,
     pub MOR: u32,
     pub RRL: u32,
@@ -5598,19 +5598,6 @@ impl Default for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0 {
-    pub _bitfield: u16,
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1 {
     pub _bitfield: u16,
 }
@@ -5618,6 +5605,19 @@ impl windows_core::TypeKind for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5744,12 +5744,12 @@ impl Default for NVME_NVM_SUBSYSTEM_RESET {
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG {
     pub PciePorts: u16,
-    pub OobMgmtSupport: NVME_OCP_DEVICE_CAPABILITIES_LOG_2,
-    pub WriteZeroesCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_5,
-    pub SanitizeCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_3,
-    pub DatasetMgmtCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_0,
+    pub OobMgmtSupport: NVME_OCP_DEVICE_CAPABILITIES_LOG_0,
+    pub WriteZeroesCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_1,
+    pub SanitizeCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_2,
+    pub DatasetMgmtCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_3,
     pub WriteUncorrectableCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_4,
-    pub FusedCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_1,
+    pub FusedCommand: NVME_OCP_DEVICE_CAPABILITIES_LOG_5,
     pub MinimumValidDSSDPowerState: u16,
     pub Reserved0: u8,
     pub DssdDescriptors: [DSSD_POWER_STATE_DESCRIPTOR; 127],
@@ -5761,87 +5761,6 @@ impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_0 {
-    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0,
-    pub AsUshort: u16,
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0 {
-    pub _bitfield: u16,
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_1 {
-    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0,
-    pub AsUshort: u16,
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
-    pub _bitfield: u16,
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_2 {
-    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0,
-    pub AsUshort: u16,
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0 {
-    pub _bitfield: u16,
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -5875,6 +5794,87 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_3_0 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
+pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_5 {
+    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0,
+    pub AsUshort: u16,
+}
+impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_5 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_5 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_0 {
+    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0,
+    pub AsUshort: u16,
+}
+impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_2 {
+    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0,
+    pub AsUshort: u16,
+}
+impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0 {
+    pub _bitfield: u16,
+}
+impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
 pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_4 {
     pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_4_0,
     pub AsUshort: u16,
@@ -5902,27 +5902,27 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_4_0 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_5 {
-    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0,
+pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_1 {
+    pub Anonymous: NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0,
     pub AsUshort: u16,
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_5 {
+impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_5 {
+impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
+pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
     pub _bitfield: u16,
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
+impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
+impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6053,16 +6053,16 @@ impl Default for NVME_OCP_DEVICE_LATENCY_MONITOR_LOG_0_0 {
 pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3 {
     pub MediaUnitsWritten: [u8; 16],
     pub MediaUnitsRead: [u8; 16],
-    pub BadUserNANDBlockCount: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1,
-    pub BadSystemNANDBlockCount: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0,
+    pub BadUserNANDBlockCount: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0,
+    pub BadSystemNANDBlockCount: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1,
     pub XORRecoveryCount: u64,
     pub UnrecoverableReadErrorCount: u64,
     pub SoftECCErrorCount: u64,
     pub EndToEndCorrectionCounts: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_2,
     pub PercentageSystemDataUsed: u8,
     pub RefreshCount: [u8; 7],
-    pub UserDataEraseCounts: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4,
-    pub ThermalThrottling: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3,
+    pub UserDataEraseCounts: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3,
+    pub ThermalThrottling: NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4,
     pub DSSDSpecVersion: [u8; 6],
     pub PCIeCorrectableErrorCount: u64,
     pub IncompleteShutdownCount: u32,
@@ -6093,20 +6093,6 @@ impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0 {
-    pub RawCount: [u8; 6],
-    pub Normalized: [u8; 2],
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1 {
     pub RawCount: [u8; 6],
     pub Normalized: [u8; 2],
@@ -6115,6 +6101,20 @@ impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0 {
+    pub RawCount: [u8; 6],
+    pub Normalized: [u8; 2],
+}
+impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6135,28 +6135,28 @@ impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
+pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4 {
     pub EventCount: u8,
     pub Status: u8,
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
+impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
+impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4 {
+pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
     pub MaximumCount: u32,
     pub MinimumCount: u32,
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4 {
+impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4 {
+impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6842,16 +6842,16 @@ impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG {
 pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2 {
     pub MediaUnitsWritten: [u8; 16],
     pub MediaUnitsRead: [u8; 16],
-    pub BadUserNANDBlockCount: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1,
-    pub BadSystemNANDBlockCount: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0,
+    pub BadUserNANDBlockCount: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0,
+    pub BadSystemNANDBlockCount: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1,
     pub XORRecoveryCount: u64,
     pub UnrecoverableReadErrorCount: u64,
     pub SoftECCErrorCount: u64,
     pub EndToEndCorrectionCounts: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_2,
     pub PercentageSystemDataUsed: u8,
     pub RefreshCount: [u8; 7],
-    pub UserDataEraseCounts: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4,
-    pub ThermalThrottling: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3,
+    pub UserDataEraseCounts: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3,
+    pub ThermalThrottling: NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4,
     pub Reserved0: [u8; 6],
     pub PCIeCorrectableErrorCount: u64,
     pub IncompleteShutdownCount: u32,
@@ -6879,20 +6879,6 @@ impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0 {
-    pub RawCount: [u8; 6],
-    pub Normalized: [u8; 2],
-}
-impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1 {
     pub RawCount: [u8; 6],
     pub Normalized: [u8; 2],
@@ -6901,6 +6887,20 @@ impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0 {
+    pub RawCount: [u8; 6],
+    pub Normalized: [u8; 2],
+}
+impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6921,28 +6921,28 @@ impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
+pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4 {
     pub EventCount: u8,
     pub Status: u8,
 }
-impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
+impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
+impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4 {
+pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
     pub MaximumCount: u32,
     pub MinimumCount: u32,
 }
-impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4 {
+impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4 {
+impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
@@ -546,8 +546,8 @@ impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
-    pub Notification: PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1,
-    pub Enumeration: PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0,
+    pub Notification: PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0,
+    pub Enumeration: PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1,
 }
 impl windows_core::TypeKind for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
     type TypeKind = windows_core::CopyType;
@@ -559,26 +559,26 @@ impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
+pub struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
     pub DirEntryBufferHandle: PRJ_DIR_ENTRY_BUFFER_HANDLE,
 }
-impl windows_core::TypeKind for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
+impl windows_core::TypeKind for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
+impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
+pub struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
     pub NotificationMask: PRJ_NOTIFY_TYPES,
 }
-impl windows_core::TypeKind for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
+impl windows_core::TypeKind for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
+impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -692,9 +692,9 @@ impl Default for PRJ_NOTIFICATION_MAPPING {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PRJ_NOTIFICATION_PARAMETERS {
-    pub PostCreate: PRJ_NOTIFICATION_PARAMETERS_2,
+    pub PostCreate: PRJ_NOTIFICATION_PARAMETERS_0,
     pub FileRenamed: PRJ_NOTIFICATION_PARAMETERS_1,
-    pub FileDeletedOnHandleClose: PRJ_NOTIFICATION_PARAMETERS_0,
+    pub FileDeletedOnHandleClose: PRJ_NOTIFICATION_PARAMETERS_2,
 }
 impl windows_core::TypeKind for PRJ_NOTIFICATION_PARAMETERS {
     type TypeKind = windows_core::CopyType;
@@ -706,13 +706,13 @@ impl Default for PRJ_NOTIFICATION_PARAMETERS {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PRJ_NOTIFICATION_PARAMETERS_0 {
+pub struct PRJ_NOTIFICATION_PARAMETERS_2 {
     pub IsFileModified: super::super::Foundation::BOOLEAN,
 }
-impl windows_core::TypeKind for PRJ_NOTIFICATION_PARAMETERS_0 {
+impl windows_core::TypeKind for PRJ_NOTIFICATION_PARAMETERS_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PRJ_NOTIFICATION_PARAMETERS_0 {
+impl Default for PRJ_NOTIFICATION_PARAMETERS_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -732,13 +732,13 @@ impl Default for PRJ_NOTIFICATION_PARAMETERS_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PRJ_NOTIFICATION_PARAMETERS_2 {
+pub struct PRJ_NOTIFICATION_PARAMETERS_0 {
     pub NotificationMask: PRJ_NOTIFY_TYPES,
 }
-impl windows_core::TypeKind for PRJ_NOTIFICATION_PARAMETERS_2 {
+impl windows_core::TypeKind for PRJ_NOTIFICATION_PARAMETERS_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PRJ_NOTIFICATION_PARAMETERS_2 {
+impl Default for PRJ_NOTIFICATION_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
@@ -1827,7 +1827,7 @@ impl Default for GET_VIRTUAL_DISK_INFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union GET_VIRTUAL_DISK_INFO_0 {
-    pub Size: GET_VIRTUAL_DISK_INFO_0_3,
+    pub Size: GET_VIRTUAL_DISK_INFO_0_0,
     pub Identifier: windows_core::GUID,
     pub ParentLocation: GET_VIRTUAL_DISK_INFO_0_1,
     pub ParentIdentifier: windows_core::GUID,
@@ -1841,7 +1841,7 @@ pub union GET_VIRTUAL_DISK_INFO_0 {
     pub SmallestSafeVirtualSize: u64,
     pub FragmentationPercentage: u32,
     pub VirtualDiskId: windows_core::GUID,
-    pub ChangeTrackingState: GET_VIRTUAL_DISK_INFO_0_0,
+    pub ChangeTrackingState: GET_VIRTUAL_DISK_INFO_0_3,
 }
 impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO_0 {
     type TypeKind = windows_core::CopyType;
@@ -1853,15 +1853,15 @@ impl Default for GET_VIRTUAL_DISK_INFO_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GET_VIRTUAL_DISK_INFO_0_0 {
+pub struct GET_VIRTUAL_DISK_INFO_0_3 {
     pub Enabled: super::super::Foundation::BOOL,
     pub NewerChanges: super::super::Foundation::BOOL,
     pub MostRecentId: [u16; 1],
 }
-impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO_0_0 {
+impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO_0_3 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for GET_VIRTUAL_DISK_INFO_0_0 {
+impl Default for GET_VIRTUAL_DISK_INFO_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -1897,16 +1897,16 @@ impl Default for GET_VIRTUAL_DISK_INFO_0_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GET_VIRTUAL_DISK_INFO_0_3 {
+pub struct GET_VIRTUAL_DISK_INFO_0_0 {
     pub VirtualSize: u64,
     pub PhysicalSize: u64,
     pub BlockSize: u32,
     pub SectorSize: u32,
 }
-impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO_0_3 {
+impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for GET_VIRTUAL_DISK_INFO_0_3 {
+impl Default for GET_VIRTUAL_DISK_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -2286,11 +2286,11 @@ impl Default for SET_VIRTUAL_DISK_INFO {
 pub union SET_VIRTUAL_DISK_INFO_0 {
     pub ParentFilePath: windows_core::PCWSTR,
     pub UniqueIdentifier: windows_core::GUID,
-    pub ParentPathWithDepthInfo: SET_VIRTUAL_DISK_INFO_0_1,
+    pub ParentPathWithDepthInfo: SET_VIRTUAL_DISK_INFO_0_0,
     pub VhdPhysicalSectorSize: u32,
     pub VirtualDiskId: windows_core::GUID,
     pub ChangeTrackingEnabled: super::super::Foundation::BOOL,
-    pub ParentLocator: SET_VIRTUAL_DISK_INFO_0_0,
+    pub ParentLocator: SET_VIRTUAL_DISK_INFO_0_1,
 }
 impl windows_core::TypeKind for SET_VIRTUAL_DISK_INFO_0 {
     type TypeKind = windows_core::CopyType;
@@ -2302,28 +2302,28 @@ impl Default for SET_VIRTUAL_DISK_INFO_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SET_VIRTUAL_DISK_INFO_0_0 {
-    pub LinkageId: windows_core::GUID,
-    pub ParentFilePath: windows_core::PCWSTR,
-}
-impl windows_core::TypeKind for SET_VIRTUAL_DISK_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for SET_VIRTUAL_DISK_INFO_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SET_VIRTUAL_DISK_INFO_0_1 {
-    pub ChildDepth: u32,
+    pub LinkageId: windows_core::GUID,
     pub ParentFilePath: windows_core::PCWSTR,
 }
 impl windows_core::TypeKind for SET_VIRTUAL_DISK_INFO_0_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for SET_VIRTUAL_DISK_INFO_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SET_VIRTUAL_DISK_INFO_0_0 {
+    pub ChildDepth: u32,
+    pub ParentFilePath: windows_core::PCWSTR,
+}
+impl windows_core::TypeKind for SET_VIRTUAL_DISK_INFO_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for SET_VIRTUAL_DISK_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
@@ -4366,8 +4366,8 @@ impl Default for CHANGE_ATTRIBUTES_PARAMETERS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CHANGE_ATTRIBUTES_PARAMETERS_0 {
-    pub MbrPartInfo: CHANGE_ATTRIBUTES_PARAMETERS_0_1,
-    pub GptPartInfo: CHANGE_ATTRIBUTES_PARAMETERS_0_0,
+    pub MbrPartInfo: CHANGE_ATTRIBUTES_PARAMETERS_0_0,
+    pub GptPartInfo: CHANGE_ATTRIBUTES_PARAMETERS_0_1,
 }
 impl windows_core::TypeKind for CHANGE_ATTRIBUTES_PARAMETERS_0 {
     type TypeKind = windows_core::CopyType;
@@ -4379,26 +4379,26 @@ impl Default for CHANGE_ATTRIBUTES_PARAMETERS_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CHANGE_ATTRIBUTES_PARAMETERS_0_0 {
+pub struct CHANGE_ATTRIBUTES_PARAMETERS_0_1 {
     pub attributes: u64,
 }
-impl windows_core::TypeKind for CHANGE_ATTRIBUTES_PARAMETERS_0_0 {
+impl windows_core::TypeKind for CHANGE_ATTRIBUTES_PARAMETERS_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CHANGE_ATTRIBUTES_PARAMETERS_0_0 {
+impl Default for CHANGE_ATTRIBUTES_PARAMETERS_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CHANGE_ATTRIBUTES_PARAMETERS_0_1 {
+pub struct CHANGE_ATTRIBUTES_PARAMETERS_0_0 {
     pub bootIndicator: super::super::Foundation::BOOLEAN,
 }
-impl windows_core::TypeKind for CHANGE_ATTRIBUTES_PARAMETERS_0_1 {
+impl windows_core::TypeKind for CHANGE_ATTRIBUTES_PARAMETERS_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CHANGE_ATTRIBUTES_PARAMETERS_0_1 {
+impl Default for CHANGE_ATTRIBUTES_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4420,8 +4420,8 @@ impl Default for CHANGE_PARTITION_TYPE_PARAMETERS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CHANGE_PARTITION_TYPE_PARAMETERS_0 {
-    pub MbrPartInfo: CHANGE_PARTITION_TYPE_PARAMETERS_0_1,
-    pub GptPartInfo: CHANGE_PARTITION_TYPE_PARAMETERS_0_0,
+    pub MbrPartInfo: CHANGE_PARTITION_TYPE_PARAMETERS_0_0,
+    pub GptPartInfo: CHANGE_PARTITION_TYPE_PARAMETERS_0_1,
 }
 impl windows_core::TypeKind for CHANGE_PARTITION_TYPE_PARAMETERS_0 {
     type TypeKind = windows_core::CopyType;
@@ -4433,26 +4433,26 @@ impl Default for CHANGE_PARTITION_TYPE_PARAMETERS_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CHANGE_PARTITION_TYPE_PARAMETERS_0_0 {
+pub struct CHANGE_PARTITION_TYPE_PARAMETERS_0_1 {
     pub partitionType: windows_core::GUID,
 }
-impl windows_core::TypeKind for CHANGE_PARTITION_TYPE_PARAMETERS_0_0 {
+impl windows_core::TypeKind for CHANGE_PARTITION_TYPE_PARAMETERS_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CHANGE_PARTITION_TYPE_PARAMETERS_0_0 {
+impl Default for CHANGE_PARTITION_TYPE_PARAMETERS_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CHANGE_PARTITION_TYPE_PARAMETERS_0_1 {
+pub struct CHANGE_PARTITION_TYPE_PARAMETERS_0_0 {
     pub partitionType: u8,
 }
-impl windows_core::TypeKind for CHANGE_PARTITION_TYPE_PARAMETERS_0_1 {
+impl windows_core::TypeKind for CHANGE_PARTITION_TYPE_PARAMETERS_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CHANGE_PARTITION_TYPE_PARAMETERS_0_1 {
+impl Default for CHANGE_PARTITION_TYPE_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4474,8 +4474,8 @@ impl Default for CREATE_PARTITION_PARAMETERS {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CREATE_PARTITION_PARAMETERS_0 {
-    pub MbrPartInfo: CREATE_PARTITION_PARAMETERS_0_1,
-    pub GptPartInfo: CREATE_PARTITION_PARAMETERS_0_0,
+    pub MbrPartInfo: CREATE_PARTITION_PARAMETERS_0_0,
+    pub GptPartInfo: CREATE_PARTITION_PARAMETERS_0_1,
 }
 impl windows_core::TypeKind for CREATE_PARTITION_PARAMETERS_0 {
     type TypeKind = windows_core::CopyType;
@@ -4487,30 +4487,30 @@ impl Default for CREATE_PARTITION_PARAMETERS_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CREATE_PARTITION_PARAMETERS_0_0 {
+pub struct CREATE_PARTITION_PARAMETERS_0_1 {
     pub partitionType: windows_core::GUID,
     pub partitionId: windows_core::GUID,
     pub attributes: u64,
     pub name: [u16; 36],
 }
-impl windows_core::TypeKind for CREATE_PARTITION_PARAMETERS_0_0 {
+impl windows_core::TypeKind for CREATE_PARTITION_PARAMETERS_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CREATE_PARTITION_PARAMETERS_0_0 {
+impl Default for CREATE_PARTITION_PARAMETERS_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CREATE_PARTITION_PARAMETERS_0_1 {
+pub struct CREATE_PARTITION_PARAMETERS_0_0 {
     pub partitionType: u8,
     pub bootIndicator: super::super::Foundation::BOOLEAN,
 }
-impl windows_core::TypeKind for CREATE_PARTITION_PARAMETERS_0_1 {
+impl windows_core::TypeKind for CREATE_PARTITION_PARAMETERS_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CREATE_PARTITION_PARAMETERS_0_1 {
+impl Default for CREATE_PARTITION_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4584,14 +4584,14 @@ impl Default for VDS_ASYNC_OUTPUT {
 }
 #[repr(C)]
 pub union VDS_ASYNC_OUTPUT_0 {
-    pub cp: VDS_ASYNC_OUTPUT_0_2,
-    pub cv: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_5>,
-    pub bvp: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_0>,
-    pub sv: VDS_ASYNC_OUTPUT_0_7,
-    pub cl: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_1>,
-    pub ct: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_4>,
-    pub cpg: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_3>,
-    pub cvd: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_6>,
+    pub cp: VDS_ASYNC_OUTPUT_0_0,
+    pub cv: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_1>,
+    pub bvp: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_2>,
+    pub sv: VDS_ASYNC_OUTPUT_0_3,
+    pub cl: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_4>,
+    pub ct: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_5>,
+    pub cpg: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_6>,
+    pub cvd: core::mem::ManuallyDrop<VDS_ASYNC_OUTPUT_0_7>,
 }
 impl Clone for VDS_ASYNC_OUTPUT_0 {
     fn clone(&self) -> Self {
@@ -4608,45 +4608,13 @@ impl Default for VDS_ASYNC_OUTPUT_0 {
 }
 #[repr(C)]
 #[derive(Debug, Eq, PartialEq)]
-pub struct VDS_ASYNC_OUTPUT_0_0 {
+pub struct VDS_ASYNC_OUTPUT_0_2 {
     pub pVolumeUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
 }
-impl Clone for VDS_ASYNC_OUTPUT_0_0 {
+impl Clone for VDS_ASYNC_OUTPUT_0_2 {
     fn clone(&self) -> Self {
         unsafe { core::mem::transmute_copy(self) }
     }
-}
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for VDS_ASYNC_OUTPUT_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Eq, PartialEq)]
-pub struct VDS_ASYNC_OUTPUT_0_1 {
-    pub pLunUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
-}
-impl Clone for VDS_ASYNC_OUTPUT_0_1 {
-    fn clone(&self) -> Self {
-        unsafe { core::mem::transmute_copy(self) }
-    }
-}
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for VDS_ASYNC_OUTPUT_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct VDS_ASYNC_OUTPUT_0_2 {
-    pub ullOffset: u64,
-    pub volumeId: windows_core::GUID,
 }
 impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_2 {
     type TypeKind = windows_core::CopyType;
@@ -4658,26 +4626,8 @@ impl Default for VDS_ASYNC_OUTPUT_0_2 {
 }
 #[repr(C)]
 #[derive(Debug, Eq, PartialEq)]
-pub struct VDS_ASYNC_OUTPUT_0_3 {
-    pub pPortalGroupUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
-}
-impl Clone for VDS_ASYNC_OUTPUT_0_3 {
-    fn clone(&self) -> Self {
-        unsafe { core::mem::transmute_copy(self) }
-    }
-}
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for VDS_ASYNC_OUTPUT_0_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Debug, Eq, PartialEq)]
 pub struct VDS_ASYNC_OUTPUT_0_4 {
-    pub pTargetUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
+    pub pLunUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
 }
 impl Clone for VDS_ASYNC_OUTPUT_0_4 {
     fn clone(&self) -> Self {
@@ -4693,9 +4643,41 @@ impl Default for VDS_ASYNC_OUTPUT_0_4 {
     }
 }
 #[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VDS_ASYNC_OUTPUT_0_0 {
+    pub ullOffset: u64,
+    pub volumeId: windows_core::GUID,
+}
+impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for VDS_ASYNC_OUTPUT_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
+pub struct VDS_ASYNC_OUTPUT_0_6 {
+    pub pPortalGroupUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
+}
+impl Clone for VDS_ASYNC_OUTPUT_0_6 {
+    fn clone(&self) -> Self {
+        unsafe { core::mem::transmute_copy(self) }
+    }
+}
+impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_6 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for VDS_ASYNC_OUTPUT_0_6 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
 #[derive(Debug, Eq, PartialEq)]
 pub struct VDS_ASYNC_OUTPUT_0_5 {
-    pub pVolumeUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
+    pub pTargetUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
 }
 impl Clone for VDS_ASYNC_OUTPUT_0_5 {
     fn clone(&self) -> Self {
@@ -4712,31 +4694,49 @@ impl Default for VDS_ASYNC_OUTPUT_0_5 {
 }
 #[repr(C)]
 #[derive(Debug, Eq, PartialEq)]
-pub struct VDS_ASYNC_OUTPUT_0_6 {
-    pub pVDiskUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
+pub struct VDS_ASYNC_OUTPUT_0_1 {
+    pub pVolumeUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
 }
-impl Clone for VDS_ASYNC_OUTPUT_0_6 {
+impl Clone for VDS_ASYNC_OUTPUT_0_1 {
     fn clone(&self) -> Self {
         unsafe { core::mem::transmute_copy(self) }
     }
 }
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_6 {
+impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for VDS_ASYNC_OUTPUT_0_6 {
+impl Default for VDS_ASYNC_OUTPUT_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
+pub struct VDS_ASYNC_OUTPUT_0_7 {
+    pub pVDiskUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
+}
+impl Clone for VDS_ASYNC_OUTPUT_0_7 {
+    fn clone(&self) -> Self {
+        unsafe { core::mem::transmute_copy(self) }
+    }
+}
+impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_7 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for VDS_ASYNC_OUTPUT_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct VDS_ASYNC_OUTPUT_0_7 {
+pub struct VDS_ASYNC_OUTPUT_0_3 {
     pub ullReclaimedBytes: u64,
 }
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_7 {
+impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_3 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for VDS_ASYNC_OUTPUT_0_7 {
+impl Default for VDS_ASYNC_OUTPUT_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
@@ -5322,9 +5322,9 @@ impl Default for XPS_COLOR {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union XPS_COLOR_0 {
-    pub sRGB: XPS_COLOR_0_1,
-    pub scRGB: XPS_COLOR_0_2,
-    pub context: XPS_COLOR_0_0,
+    pub sRGB: XPS_COLOR_0_0,
+    pub scRGB: XPS_COLOR_0_1,
+    pub context: XPS_COLOR_0_2,
 }
 impl windows_core::TypeKind for XPS_COLOR_0 {
     type TypeKind = windows_core::CopyType;
@@ -5336,9 +5336,25 @@ impl Default for XPS_COLOR_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct XPS_COLOR_0_0 {
+pub struct XPS_COLOR_0_2 {
     pub channelCount: u8,
     pub channels: [f32; 9],
+}
+impl windows_core::TypeKind for XPS_COLOR_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for XPS_COLOR_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct XPS_COLOR_0_0 {
+    pub alpha: u8,
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
 }
 impl windows_core::TypeKind for XPS_COLOR_0_0 {
     type TypeKind = windows_core::CopyType;
@@ -5349,33 +5365,17 @@ impl Default for XPS_COLOR_0_0 {
     }
 }
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct XPS_COLOR_0_1 {
-    pub alpha: u8,
-    pub red: u8,
-    pub green: u8,
-    pub blue: u8,
-}
-impl windows_core::TypeKind for XPS_COLOR_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for XPS_COLOR_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct XPS_COLOR_0_2 {
+pub struct XPS_COLOR_0_1 {
     pub alpha: f32,
     pub red: f32,
     pub green: f32,
     pub blue: f32,
 }
-impl windows_core::TypeKind for XPS_COLOR_0_2 {
+impl windows_core::TypeKind for XPS_COLOR_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for XPS_COLOR_0_2 {
+impl Default for XPS_COLOR_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/Extensions/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/Extensions/mod.rs
@@ -21433,8 +21433,8 @@ pub union DEBUG_VALUE_0 {
     pub VI64: [u64; 2],
     pub VF32: [f32; 4],
     pub VF64: [f64; 2],
-    pub I64Parts32: DEBUG_VALUE_0_2,
-    pub F128Parts64: DEBUG_VALUE_0_1,
+    pub I64Parts32: DEBUG_VALUE_0_1,
+    pub F128Parts64: DEBUG_VALUE_0_2,
     pub RawBytes: [u8; 24],
 }
 impl windows_core::TypeKind for DEBUG_VALUE_0 {
@@ -21461,28 +21461,28 @@ impl Default for DEBUG_VALUE_0_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DEBUG_VALUE_0_1 {
+pub struct DEBUG_VALUE_0_2 {
     pub LowPart: u64,
     pub HighPart: i64,
 }
-impl windows_core::TypeKind for DEBUG_VALUE_0_1 {
+impl windows_core::TypeKind for DEBUG_VALUE_0_2 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DEBUG_VALUE_0_1 {
+impl Default for DEBUG_VALUE_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DEBUG_VALUE_0_2 {
+pub struct DEBUG_VALUE_0_1 {
     pub LowPart: u32,
     pub HighPart: u32,
 }
-impl windows_core::TypeKind for DEBUG_VALUE_0_2 {
+impl windows_core::TypeKind for DEBUG_VALUE_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DEBUG_VALUE_0_2 {
+impl Default for DEBUG_VALUE_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -22756,8 +22756,8 @@ impl Default for ScriptDebugEventInformation {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ScriptDebugEventInformation_0 {
-    pub ExceptionInformation: ScriptDebugEventInformation_0_1,
-    pub BreakpointInformation: ScriptDebugEventInformation_0_0,
+    pub ExceptionInformation: ScriptDebugEventInformation_0_0,
+    pub BreakpointInformation: ScriptDebugEventInformation_0_1,
 }
 impl windows_core::TypeKind for ScriptDebugEventInformation_0 {
     type TypeKind = windows_core::CopyType;
@@ -22769,26 +22769,26 @@ impl Default for ScriptDebugEventInformation_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ScriptDebugEventInformation_0_0 {
+pub struct ScriptDebugEventInformation_0_1 {
     pub BreakpointId: u64,
 }
-impl windows_core::TypeKind for ScriptDebugEventInformation_0_0 {
+impl windows_core::TypeKind for ScriptDebugEventInformation_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for ScriptDebugEventInformation_0_0 {
+impl Default for ScriptDebugEventInformation_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ScriptDebugEventInformation_0_1 {
+pub struct ScriptDebugEventInformation_0_0 {
     pub IsUncaught: u8,
 }
-impl windows_core::TypeKind for ScriptDebugEventInformation_0_1 {
+impl windows_core::TypeKind for ScriptDebugEventInformation_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for ScriptDebugEventInformation_0_1 {
+impl Default for ScriptDebugEventInformation_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
@@ -6111,8 +6111,8 @@ impl Default for CONTEXT {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CPU_INFORMATION {
-    pub X86CpuInfo: CPU_INFORMATION_1,
-    pub OtherCpuInfo: CPU_INFORMATION_0,
+    pub X86CpuInfo: CPU_INFORMATION_0,
+    pub OtherCpuInfo: CPU_INFORMATION_1,
 }
 impl windows_core::TypeKind for CPU_INFORMATION {
     type TypeKind = windows_core::CopyType;
@@ -6124,29 +6124,29 @@ impl Default for CPU_INFORMATION {
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
-pub struct CPU_INFORMATION_0 {
+pub struct CPU_INFORMATION_1 {
     pub ProcessorFeatures: [u64; 2],
 }
-impl windows_core::TypeKind for CPU_INFORMATION_0 {
+impl windows_core::TypeKind for CPU_INFORMATION_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CPU_INFORMATION_0 {
+impl Default for CPU_INFORMATION_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct CPU_INFORMATION_1 {
+pub struct CPU_INFORMATION_0 {
     pub VendorId: [u32; 3],
     pub VersionInformation: u32,
     pub FeatureInformation: u32,
     pub AMDExtendedCpuFeatures: u32,
 }
-impl windows_core::TypeKind for CPU_INFORMATION_1 {
+impl windows_core::TypeKind for CPU_INFORMATION_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for CPU_INFORMATION_1 {
+impl Default for CPU_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -8111,8 +8111,8 @@ impl Default for LDT_ENTRY {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union LDT_ENTRY_0 {
-    pub Bytes: LDT_ENTRY_0_1,
-    pub Bits: LDT_ENTRY_0_0,
+    pub Bytes: LDT_ENTRY_0_0,
+    pub Bits: LDT_ENTRY_0_1,
 }
 impl windows_core::TypeKind for LDT_ENTRY_0 {
     type TypeKind = windows_core::CopyType;
@@ -8124,29 +8124,29 @@ impl Default for LDT_ENTRY_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct LDT_ENTRY_0_0 {
+pub struct LDT_ENTRY_0_1 {
     pub _bitfield: u32,
 }
-impl windows_core::TypeKind for LDT_ENTRY_0_0 {
+impl windows_core::TypeKind for LDT_ENTRY_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for LDT_ENTRY_0_0 {
+impl Default for LDT_ENTRY_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct LDT_ENTRY_0_1 {
+pub struct LDT_ENTRY_0_0 {
     pub BaseMid: u8,
     pub Flags1: u8,
     pub Flags2: u8,
     pub BaseHi: u8,
 }
-impl windows_core::TypeKind for LDT_ENTRY_0_1 {
+impl windows_core::TypeKind for LDT_ENTRY_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for LDT_ENTRY_0_1 {
+impl Default for LDT_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -10795,14 +10795,14 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHEA_NOTIFICATION_DESCRIPTOR_0 {
-    pub Polled: WHEA_NOTIFICATION_DESCRIPTOR_0_4,
+    pub Polled: WHEA_NOTIFICATION_DESCRIPTOR_0_0,
     pub Interrupt: WHEA_NOTIFICATION_DESCRIPTOR_0_1,
     pub LocalInterrupt: WHEA_NOTIFICATION_DESCRIPTOR_0_2,
-    pub Sci: WHEA_NOTIFICATION_DESCRIPTOR_0_5,
-    pub Nmi: WHEA_NOTIFICATION_DESCRIPTOR_0_3,
-    pub Sea: WHEA_NOTIFICATION_DESCRIPTOR_0_6,
-    pub Sei: WHEA_NOTIFICATION_DESCRIPTOR_0_7,
-    pub Gsiv: WHEA_NOTIFICATION_DESCRIPTOR_0_0,
+    pub Sci: WHEA_NOTIFICATION_DESCRIPTOR_0_3,
+    pub Nmi: WHEA_NOTIFICATION_DESCRIPTOR_0_4,
+    pub Sea: WHEA_NOTIFICATION_DESCRIPTOR_0_5,
+    pub Sei: WHEA_NOTIFICATION_DESCRIPTOR_0_6,
+    pub Gsiv: WHEA_NOTIFICATION_DESCRIPTOR_0_7,
 }
 impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0 {
     type TypeKind = windows_core::CopyType;
@@ -10814,7 +10814,7 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
+pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
     pub PollInterval: u32,
     pub Vector: u32,
     pub SwitchToPollingThreshold: u32,
@@ -10822,10 +10822,10 @@ pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
     pub ErrorThreshold: u32,
     pub ErrorThresholdWindow: u32,
 }
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
+impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
+impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -10868,6 +10868,37 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_2 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
+pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
+    pub PollInterval: u32,
+    pub Vector: u32,
+    pub SwitchToPollingThreshold: u32,
+    pub SwitchToPollingWindow: u32,
+    pub ErrorThreshold: u32,
+    pub ErrorThresholdWindow: u32,
+}
+impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
+pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
+    pub PollInterval: u32,
+}
+impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(1))]
+#[derive(Clone, Copy)]
 pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
     pub PollInterval: u32,
     pub Vector: u32,
@@ -10880,19 +10911,6 @@ impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
-    pub PollInterval: u32,
-}
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -10929,24 +10947,6 @@ impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_6 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_6 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(1))]
-#[derive(Clone, Copy)]
-pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
-    pub PollInterval: u32,
-    pub Vector: u32,
-    pub SwitchToPollingThreshold: u32,
-    pub SwitchToPollingWindow: u32,
-    pub ErrorThreshold: u32,
-    pub ErrorThresholdWindow: u32,
-}
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -11180,8 +11180,8 @@ impl Default for WOW64_LDT_ENTRY {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WOW64_LDT_ENTRY_0 {
-    pub Bytes: WOW64_LDT_ENTRY_0_1,
-    pub Bits: WOW64_LDT_ENTRY_0_0,
+    pub Bytes: WOW64_LDT_ENTRY_0_0,
+    pub Bits: WOW64_LDT_ENTRY_0_1,
 }
 impl windows_core::TypeKind for WOW64_LDT_ENTRY_0 {
     type TypeKind = windows_core::CopyType;
@@ -11193,29 +11193,29 @@ impl Default for WOW64_LDT_ENTRY_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WOW64_LDT_ENTRY_0_0 {
+pub struct WOW64_LDT_ENTRY_0_1 {
     pub _bitfield: u32,
 }
-impl windows_core::TypeKind for WOW64_LDT_ENTRY_0_0 {
+impl windows_core::TypeKind for WOW64_LDT_ENTRY_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WOW64_LDT_ENTRY_0_0 {
+impl Default for WOW64_LDT_ENTRY_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WOW64_LDT_ENTRY_0_1 {
+pub struct WOW64_LDT_ENTRY_0_0 {
     pub BaseMid: u8,
     pub Flags1: u8,
     pub Flags2: u8,
     pub BaseHi: u8,
 }
-impl windows_core::TypeKind for WOW64_LDT_ENTRY_0_1 {
+impl windows_core::TypeKind for WOW64_LDT_ENTRY_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WOW64_LDT_ENTRY_0_1 {
+impl Default for WOW64_LDT_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -2608,9 +2608,9 @@ impl Default for EVENT_PROPERTY_INFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_PROPERTY_INFO_0 {
-    pub nonStructType: EVENT_PROPERTY_INFO_0_1,
-    pub structType: EVENT_PROPERTY_INFO_0_2,
-    pub customSchemaType: EVENT_PROPERTY_INFO_0_0,
+    pub nonStructType: EVENT_PROPERTY_INFO_0_0,
+    pub structType: EVENT_PROPERTY_INFO_0_1,
+    pub customSchemaType: EVENT_PROPERTY_INFO_0_2,
 }
 impl windows_core::TypeKind for EVENT_PROPERTY_INFO_0 {
     type TypeKind = windows_core::CopyType;
@@ -2622,10 +2622,25 @@ impl Default for EVENT_PROPERTY_INFO_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct EVENT_PROPERTY_INFO_0_0 {
+pub struct EVENT_PROPERTY_INFO_0_2 {
     pub InType: u16,
     pub OutType: u16,
     pub CustomSchemaOffset: u32,
+}
+impl windows_core::TypeKind for EVENT_PROPERTY_INFO_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for EVENT_PROPERTY_INFO_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EVENT_PROPERTY_INFO_0_0 {
+    pub InType: u16,
+    pub OutType: u16,
+    pub MapNameOffset: u32,
 }
 impl windows_core::TypeKind for EVENT_PROPERTY_INFO_0_0 {
     type TypeKind = windows_core::CopyType;
@@ -2638,29 +2653,14 @@ impl Default for EVENT_PROPERTY_INFO_0_0 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct EVENT_PROPERTY_INFO_0_1 {
-    pub InType: u16,
-    pub OutType: u16,
-    pub MapNameOffset: u32,
+    pub StructStartIndex: u16,
+    pub NumOfStructMembers: u16,
+    pub padding: u32,
 }
 impl windows_core::TypeKind for EVENT_PROPERTY_INFO_0_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for EVENT_PROPERTY_INFO_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct EVENT_PROPERTY_INFO_0_2 {
-    pub StructStartIndex: u16,
-    pub NumOfStructMembers: u16,
-    pub padding: u32,
-}
-impl windows_core::TypeKind for EVENT_PROPERTY_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for EVENT_PROPERTY_INFO_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
@@ -508,12 +508,12 @@ impl Default for PSS_HANDLE_ENTRY {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PSS_HANDLE_ENTRY_0 {
-    pub Process: PSS_HANDLE_ENTRY_0_2,
-    pub Thread: PSS_HANDLE_ENTRY_0_5,
-    pub Mutant: PSS_HANDLE_ENTRY_0_1,
-    pub Event: PSS_HANDLE_ENTRY_0_0,
-    pub Section: PSS_HANDLE_ENTRY_0_3,
-    pub Semaphore: PSS_HANDLE_ENTRY_0_4,
+    pub Process: PSS_HANDLE_ENTRY_0_0,
+    pub Thread: PSS_HANDLE_ENTRY_0_1,
+    pub Mutant: PSS_HANDLE_ENTRY_0_2,
+    pub Event: PSS_HANDLE_ENTRY_0_3,
+    pub Section: PSS_HANDLE_ENTRY_0_4,
+    pub Semaphore: PSS_HANDLE_ENTRY_0_5,
 }
 impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0 {
     type TypeKind = windows_core::CopyType;
@@ -525,59 +525,9 @@ impl Default for PSS_HANDLE_ENTRY_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PSS_HANDLE_ENTRY_0_0 {
+pub struct PSS_HANDLE_ENTRY_0_3 {
     pub ManualReset: super::super::super::Foundation::BOOL,
     pub Signaled: super::super::super::Foundation::BOOL,
-}
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for PSS_HANDLE_ENTRY_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PSS_HANDLE_ENTRY_0_1 {
-    pub CurrentCount: i32,
-    pub Abandoned: super::super::super::Foundation::BOOL,
-    pub OwnerProcessId: u32,
-    pub OwnerThreadId: u32,
-}
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for PSS_HANDLE_ENTRY_0_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PSS_HANDLE_ENTRY_0_2 {
-    pub ExitStatus: u32,
-    pub PebBaseAddress: *mut core::ffi::c_void,
-    pub AffinityMask: usize,
-    pub BasePriority: i32,
-    pub ProcessId: u32,
-    pub ParentProcessId: u32,
-    pub Flags: u32,
-}
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for PSS_HANDLE_ENTRY_0_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PSS_HANDLE_ENTRY_0_3 {
-    pub BaseAddress: *mut core::ffi::c_void,
-    pub AllocationAttributes: u32,
-    pub MaximumSize: i64,
 }
 impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_3 {
     type TypeKind = windows_core::CopyType;
@@ -589,9 +539,45 @@ impl Default for PSS_HANDLE_ENTRY_0_3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PSS_HANDLE_ENTRY_0_4 {
+pub struct PSS_HANDLE_ENTRY_0_2 {
     pub CurrentCount: i32,
-    pub MaximumCount: i32,
+    pub Abandoned: super::super::super::Foundation::BOOL,
+    pub OwnerProcessId: u32,
+    pub OwnerThreadId: u32,
+}
+impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for PSS_HANDLE_ENTRY_0_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PSS_HANDLE_ENTRY_0_0 {
+    pub ExitStatus: u32,
+    pub PebBaseAddress: *mut core::ffi::c_void,
+    pub AffinityMask: usize,
+    pub BasePriority: i32,
+    pub ProcessId: u32,
+    pub ParentProcessId: u32,
+    pub Flags: u32,
+}
+impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for PSS_HANDLE_ENTRY_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PSS_HANDLE_ENTRY_0_4 {
+    pub BaseAddress: *mut core::ffi::c_void,
+    pub AllocationAttributes: u32,
+    pub MaximumSize: i64,
 }
 impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_4 {
     type TypeKind = windows_core::CopyType;
@@ -604,6 +590,20 @@ impl Default for PSS_HANDLE_ENTRY_0_4 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PSS_HANDLE_ENTRY_0_5 {
+    pub CurrentCount: i32,
+    pub MaximumCount: i32,
+}
+impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_5 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for PSS_HANDLE_ENTRY_0_5 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PSS_HANDLE_ENTRY_0_1 {
     pub ExitStatus: u32,
     pub TebBaseAddress: *mut core::ffi::c_void,
     pub ProcessId: u32,
@@ -613,10 +613,10 @@ pub struct PSS_HANDLE_ENTRY_0_5 {
     pub BasePriority: i32,
     pub Win32StartAddress: *mut core::ffi::c_void,
 }
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_5 {
+impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for PSS_HANDLE_ENTRY_0_5 {
+impl Default for PSS_HANDLE_ENTRY_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
@@ -2588,9 +2588,9 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_0 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIRTUAL_PROCESSOR_REGISTER_1 {
-    pub Segment: VIRTUAL_PROCESSOR_REGISTER_1_1,
-    pub Table: VIRTUAL_PROCESSOR_REGISTER_1_2,
-    pub FpControlStatus: VIRTUAL_PROCESSOR_REGISTER_1_0,
+    pub Segment: VIRTUAL_PROCESSOR_REGISTER_1_0,
+    pub Table: VIRTUAL_PROCESSOR_REGISTER_1_1,
+    pub FpControlStatus: VIRTUAL_PROCESSOR_REGISTER_1_2,
     pub XmmControlStatus: VIRTUAL_PROCESSOR_REGISTER_1_3,
 }
 impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1 {
@@ -2603,12 +2603,56 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct VIRTUAL_PROCESSOR_REGISTER_1_0 {
+pub struct VIRTUAL_PROCESSOR_REGISTER_1_2 {
     pub FpControl: u16,
     pub FpStatus: u16,
     pub FpTag: u8,
     pub Reserved: u8,
     pub LastFpOp: u16,
+    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_2_0,
+}
+impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for VIRTUAL_PROCESSOR_REGISTER_1_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union VIRTUAL_PROCESSOR_REGISTER_1_2_0 {
+    pub LastFpRip: u64,
+    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_2_0_0,
+}
+impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_2_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for VIRTUAL_PROCESSOR_REGISTER_1_2_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VIRTUAL_PROCESSOR_REGISTER_1_2_0_0 {
+    pub LastFpEip: u32,
+    pub LastFpCs: u16,
+}
+impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_2_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for VIRTUAL_PROCESSOR_REGISTER_1_2_0_0 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct VIRTUAL_PROCESSOR_REGISTER_1_0 {
+    pub Base: u64,
+    pub Limit: u32,
+    pub Selector: u16,
     pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_0_0,
 }
 impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_0 {
@@ -2622,7 +2666,7 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_0 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
-    pub LastFpRip: u64,
+    pub Attributes: u16,
     pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_0_0_0,
 }
 impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
@@ -2636,8 +2680,7 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {
-    pub LastFpEip: u32,
-    pub LastFpCs: u16,
+    pub _bitfield: u16,
 }
 impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {
     type TypeKind = windows_core::CopyType;
@@ -2648,58 +2691,15 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {
     }
 }
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct VIRTUAL_PROCESSOR_REGISTER_1_1 {
+    pub Limit: u16,
     pub Base: u64,
-    pub Limit: u32,
-    pub Selector: u16,
-    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_1_0,
 }
 impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_1 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for VIRTUAL_PROCESSOR_REGISTER_1_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub union VIRTUAL_PROCESSOR_REGISTER_1_1_0 {
-    pub Attributes: u16,
-    pub Anonymous: VIRTUAL_PROCESSOR_REGISTER_1_1_0_0,
-}
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for VIRTUAL_PROCESSOR_REGISTER_1_1_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct VIRTUAL_PROCESSOR_REGISTER_1_1_0_0 {
-    pub _bitfield: u16,
-}
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_1_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for VIRTUAL_PROCESSOR_REGISTER_1_1_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct VIRTUAL_PROCESSOR_REGISTER_1_2 {
-    pub Limit: u16,
-    pub Base: u64,
-}
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for VIRTUAL_PROCESSOR_REGISTER_1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
@@ -3751,8 +3751,8 @@ impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
-    pub ExternalStack: DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1,
-    pub AtaPort: DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0,
+    pub ExternalStack: DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0,
+    pub AtaPort: DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1,
     pub StorPort: DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2,
 }
 impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
@@ -3765,26 +3765,26 @@ impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
+pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
     pub dwAtaPortSpecific: u32,
 }
-impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
+impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
+impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
-pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
+pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
     pub dwReserved: u32,
 }
-impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
+impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
+impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4661,8 +4661,8 @@ impl Default for DISK_CACHE_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISK_CACHE_INFORMATION_0 {
-    pub ScalarPrefetch: DISK_CACHE_INFORMATION_0_1,
-    pub BlockPrefetch: DISK_CACHE_INFORMATION_0_0,
+    pub ScalarPrefetch: DISK_CACHE_INFORMATION_0_0,
+    pub BlockPrefetch: DISK_CACHE_INFORMATION_0_1,
 }
 impl windows_core::TypeKind for DISK_CACHE_INFORMATION_0 {
     type TypeKind = windows_core::CopyType;
@@ -4674,29 +4674,29 @@ impl Default for DISK_CACHE_INFORMATION_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DISK_CACHE_INFORMATION_0_0 {
+pub struct DISK_CACHE_INFORMATION_0_1 {
     pub Minimum: u16,
     pub Maximum: u16,
 }
-impl windows_core::TypeKind for DISK_CACHE_INFORMATION_0_0 {
+impl windows_core::TypeKind for DISK_CACHE_INFORMATION_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DISK_CACHE_INFORMATION_0_0 {
+impl Default for DISK_CACHE_INFORMATION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DISK_CACHE_INFORMATION_0_1 {
+pub struct DISK_CACHE_INFORMATION_0_0 {
     pub Minimum: u16,
     pub Maximum: u16,
     pub MaximumBlocks: u16,
 }
-impl windows_core::TypeKind for DISK_CACHE_INFORMATION_0_1 {
+impl windows_core::TypeKind for DISK_CACHE_INFORMATION_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DISK_CACHE_INFORMATION_0_1 {
+impl Default for DISK_CACHE_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -4911,8 +4911,8 @@ impl Default for DISK_PARTITION_INFO {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISK_PARTITION_INFO_0 {
-    pub Mbr: DISK_PARTITION_INFO_0_1,
-    pub Gpt: DISK_PARTITION_INFO_0_0,
+    pub Mbr: DISK_PARTITION_INFO_0_0,
+    pub Gpt: DISK_PARTITION_INFO_0_1,
 }
 impl windows_core::TypeKind for DISK_PARTITION_INFO_0 {
     type TypeKind = windows_core::CopyType;
@@ -4924,27 +4924,27 @@ impl Default for DISK_PARTITION_INFO_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DISK_PARTITION_INFO_0_0 {
+pub struct DISK_PARTITION_INFO_0_1 {
     pub DiskId: windows_core::GUID,
 }
-impl windows_core::TypeKind for DISK_PARTITION_INFO_0_0 {
+impl windows_core::TypeKind for DISK_PARTITION_INFO_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DISK_PARTITION_INFO_0_0 {
+impl Default for DISK_PARTITION_INFO_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct DISK_PARTITION_INFO_0_1 {
+pub struct DISK_PARTITION_INFO_0_0 {
     pub Signature: u32,
     pub CheckSum: u32,
 }
-impl windows_core::TypeKind for DISK_PARTITION_INFO_0_1 {
+impl windows_core::TypeKind for DISK_PARTITION_INFO_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for DISK_PARTITION_INFO_0_1 {
+impl Default for DISK_PARTITION_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6660,13 +6660,13 @@ pub struct NTFS_STATISTICS {
     pub MftReadBytes: u32,
     pub MftWrites: u32,
     pub MftWriteBytes: u32,
-    pub MftWritesUserLevel: NTFS_STATISTICS_4,
+    pub MftWritesUserLevel: NTFS_STATISTICS_0,
     pub MftWritesFlushForLogFileFull: u16,
     pub MftWritesLazyWriter: u16,
     pub MftWritesUserRequest: u16,
     pub Mft2Writes: u32,
     pub Mft2WriteBytes: u32,
-    pub Mft2WritesUserLevel: NTFS_STATISTICS_2,
+    pub Mft2WritesUserLevel: NTFS_STATISTICS_1,
     pub Mft2WritesFlushForLogFileFull: u16,
     pub Mft2WritesLazyWriter: u16,
     pub Mft2WritesUserRequest: u16,
@@ -6681,7 +6681,7 @@ pub struct NTFS_STATISTICS {
     pub BitmapWritesFlushForLogFileFull: u16,
     pub BitmapWritesLazyWriter: u16,
     pub BitmapWritesUserRequest: u16,
-    pub BitmapWritesUserLevel: NTFS_STATISTICS_1,
+    pub BitmapWritesUserLevel: NTFS_STATISTICS_2,
     pub MftBitmapReads: u32,
     pub MftBitmapReadBytes: u32,
     pub MftBitmapWrites: u32,
@@ -6698,7 +6698,7 @@ pub struct NTFS_STATISTICS {
     pub LogFileReadBytes: u32,
     pub LogFileWrites: u32,
     pub LogFileWriteBytes: u32,
-    pub Allocate: NTFS_STATISTICS_0,
+    pub Allocate: NTFS_STATISTICS_4,
     pub DiskResourcesExhausted: u32,
 }
 impl windows_core::TypeKind for NTFS_STATISTICS {
@@ -6711,7 +6711,7 @@ impl Default for NTFS_STATISTICS {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NTFS_STATISTICS_0 {
+pub struct NTFS_STATISTICS_4 {
     pub Calls: u32,
     pub Clusters: u32,
     pub Hints: u32,
@@ -6723,25 +6723,10 @@ pub struct NTFS_STATISTICS_0 {
     pub CacheMiss: u32,
     pub CacheMissClusters: u32,
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_0 {
+impl windows_core::TypeKind for NTFS_STATISTICS_4 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NTFS_STATISTICS_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NTFS_STATISTICS_1 {
-    pub Write: u16,
-    pub Create: u16,
-    pub SetInfo: u16,
-}
-impl windows_core::TypeKind for NTFS_STATISTICS_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NTFS_STATISTICS_1 {
+impl Default for NTFS_STATISTICS_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6752,12 +6737,27 @@ pub struct NTFS_STATISTICS_2 {
     pub Write: u16,
     pub Create: u16,
     pub SetInfo: u16,
-    pub Flush: u16,
 }
 impl windows_core::TypeKind for NTFS_STATISTICS_2 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for NTFS_STATISTICS_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NTFS_STATISTICS_1 {
+    pub Write: u16,
+    pub Create: u16,
+    pub SetInfo: u16,
+    pub Flush: u16,
+}
+impl windows_core::TypeKind for NTFS_STATISTICS_1 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NTFS_STATISTICS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6780,16 +6780,16 @@ impl Default for NTFS_STATISTICS_3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NTFS_STATISTICS_4 {
+pub struct NTFS_STATISTICS_0 {
     pub Write: u16,
     pub Create: u16,
     pub SetInfo: u16,
     pub Flush: u16,
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_4 {
+impl windows_core::TypeKind for NTFS_STATISTICS_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NTFS_STATISTICS_4 {
+impl Default for NTFS_STATISTICS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6803,13 +6803,13 @@ pub struct NTFS_STATISTICS_EX {
     pub MftReadBytes: u64,
     pub MftWrites: u64,
     pub MftWriteBytes: u64,
-    pub MftWritesUserLevel: NTFS_STATISTICS_EX_4,
+    pub MftWritesUserLevel: NTFS_STATISTICS_EX_0,
     pub MftWritesFlushForLogFileFull: u32,
     pub MftWritesLazyWriter: u32,
     pub MftWritesUserRequest: u32,
     pub Mft2Writes: u64,
     pub Mft2WriteBytes: u64,
-    pub Mft2WritesUserLevel: NTFS_STATISTICS_EX_2,
+    pub Mft2WritesUserLevel: NTFS_STATISTICS_EX_1,
     pub Mft2WritesFlushForLogFileFull: u32,
     pub Mft2WritesLazyWriter: u32,
     pub Mft2WritesUserRequest: u32,
@@ -6824,7 +6824,7 @@ pub struct NTFS_STATISTICS_EX {
     pub BitmapWritesFlushForLogFileFull: u32,
     pub BitmapWritesLazyWriter: u32,
     pub BitmapWritesUserRequest: u32,
-    pub BitmapWritesUserLevel: NTFS_STATISTICS_EX_1,
+    pub BitmapWritesUserLevel: NTFS_STATISTICS_EX_2,
     pub MftBitmapReads: u64,
     pub MftBitmapReadBytes: u64,
     pub MftBitmapWrites: u64,
@@ -6841,7 +6841,7 @@ pub struct NTFS_STATISTICS_EX {
     pub LogFileReadBytes: u64,
     pub LogFileWrites: u64,
     pub LogFileWriteBytes: u64,
-    pub Allocate: NTFS_STATISTICS_EX_0,
+    pub Allocate: NTFS_STATISTICS_EX_4,
     pub DiskResourcesExhausted: u32,
     pub VolumeTrimCount: u64,
     pub VolumeTrimTime: u64,
@@ -6865,7 +6865,7 @@ impl Default for NTFS_STATISTICS_EX {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NTFS_STATISTICS_EX_0 {
+pub struct NTFS_STATISTICS_EX_4 {
     pub Calls: u32,
     pub RunsReturned: u32,
     pub Hints: u32,
@@ -6877,26 +6877,10 @@ pub struct NTFS_STATISTICS_EX_0 {
     pub CacheClusters: u64,
     pub CacheMissClusters: u64,
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_EX_0 {
+impl windows_core::TypeKind for NTFS_STATISTICS_EX_4 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NTFS_STATISTICS_EX_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NTFS_STATISTICS_EX_1 {
-    pub Write: u32,
-    pub Create: u32,
-    pub SetInfo: u32,
-    pub Flush: u32,
-}
-impl windows_core::TypeKind for NTFS_STATISTICS_EX_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for NTFS_STATISTICS_EX_1 {
+impl Default for NTFS_STATISTICS_EX_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -6919,6 +6903,22 @@ impl Default for NTFS_STATISTICS_EX_2 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NTFS_STATISTICS_EX_1 {
+    pub Write: u32,
+    pub Create: u32,
+    pub SetInfo: u32,
+    pub Flush: u32,
+}
+impl windows_core::TypeKind for NTFS_STATISTICS_EX_1 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for NTFS_STATISTICS_EX_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct NTFS_STATISTICS_EX_3 {
     pub Write: u32,
     pub Create: u32,
@@ -6935,16 +6935,16 @@ impl Default for NTFS_STATISTICS_EX_3 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct NTFS_STATISTICS_EX_4 {
+pub struct NTFS_STATISTICS_EX_0 {
     pub Write: u32,
     pub Create: u32,
     pub SetInfo: u32,
     pub Flush: u32,
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_EX_4 {
+impl windows_core::TypeKind for NTFS_STATISTICS_EX_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for NTFS_STATISTICS_EX_4 {
+impl Default for NTFS_STATISTICS_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -9837,8 +9837,8 @@ impl Default for STORAGE_OPERATIONAL_REASON {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_OPERATIONAL_REASON_0 {
-    pub ScsiSenseKey: STORAGE_OPERATIONAL_REASON_0_1,
-    pub NVDIMM_N: STORAGE_OPERATIONAL_REASON_0_0,
+    pub ScsiSenseKey: STORAGE_OPERATIONAL_REASON_0_0,
+    pub NVDIMM_N: STORAGE_OPERATIONAL_REASON_0_1,
     pub AsUlong: u32,
 }
 impl windows_core::TypeKind for STORAGE_OPERATIONAL_REASON_0 {
@@ -9851,31 +9851,31 @@ impl Default for STORAGE_OPERATIONAL_REASON_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct STORAGE_OPERATIONAL_REASON_0_0 {
+pub struct STORAGE_OPERATIONAL_REASON_0_1 {
     pub CriticalHealth: u8,
     pub ModuleHealth: [u8; 2],
     pub ErrorThresholdStatus: u8,
 }
-impl windows_core::TypeKind for STORAGE_OPERATIONAL_REASON_0_0 {
+impl windows_core::TypeKind for STORAGE_OPERATIONAL_REASON_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for STORAGE_OPERATIONAL_REASON_0_0 {
+impl Default for STORAGE_OPERATIONAL_REASON_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct STORAGE_OPERATIONAL_REASON_0_1 {
+pub struct STORAGE_OPERATIONAL_REASON_0_0 {
     pub SenseKey: u8,
     pub ASC: u8,
     pub ASCQ: u8,
     pub Reserved: u8,
 }
-impl windows_core::TypeKind for STORAGE_OPERATIONAL_REASON_0_1 {
+impl windows_core::TypeKind for STORAGE_OPERATIONAL_REASON_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for STORAGE_OPERATIONAL_REASON_0_1 {
+impl Default for STORAGE_OPERATIONAL_REASON_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -10528,8 +10528,8 @@ impl Default for STORAGE_ZONED_DEVICE_DESCRIPTOR {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
-    pub SequentialRequiredZone: STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1,
-    pub SequentialPreferredZone: STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0,
+    pub SequentialRequiredZone: STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0,
+    pub SequentialPreferredZone: STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1,
 }
 impl windows_core::TypeKind for STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
     type TypeKind = windows_core::CopyType;
@@ -10541,29 +10541,29 @@ impl Default for STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
+pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
     pub OptimalOpenZoneCount: u32,
     pub Reserved: u32,
 }
-impl windows_core::TypeKind for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
+impl windows_core::TypeKind for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
+impl Default for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
+pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
     pub MaxOpenZoneCount: u32,
     pub UnrestrictedRead: super::super::Foundation::BOOLEAN,
     pub Reserved: [u8; 3],
 }
-impl windows_core::TypeKind for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
+impl windows_core::TypeKind for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
+impl Default for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -10690,10 +10690,10 @@ impl Default for STREAM_INFORMATION_ENTRY {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STREAM_INFORMATION_ENTRY_0 {
-    pub DesiredStorageClass: STREAM_INFORMATION_ENTRY_0_1,
-    pub DataStream: STREAM_INFORMATION_ENTRY_0_0,
-    pub Reparse: STREAM_INFORMATION_ENTRY_0_3,
-    pub Ea: STREAM_INFORMATION_ENTRY_0_2,
+    pub DesiredStorageClass: STREAM_INFORMATION_ENTRY_0_0,
+    pub DataStream: STREAM_INFORMATION_ENTRY_0_1,
+    pub Reparse: STREAM_INFORMATION_ENTRY_0_2,
+    pub Ea: STREAM_INFORMATION_ENTRY_0_3,
 }
 impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0 {
     type TypeKind = windows_core::CopyType;
@@ -10705,25 +10705,11 @@ impl Default for STREAM_INFORMATION_ENTRY_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct STREAM_INFORMATION_ENTRY_0_0 {
+pub struct STREAM_INFORMATION_ENTRY_0_1 {
     pub Length: u16,
     pub Flags: u16,
     pub Reserved: u32,
     pub Vdl: u64,
-}
-impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for STREAM_INFORMATION_ENTRY_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct STREAM_INFORMATION_ENTRY_0_1 {
-    pub Class: FILE_STORAGE_TIER_CLASS,
-    pub Flags: u32,
 }
 impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0_1 {
     type TypeKind = windows_core::CopyType;
@@ -10735,16 +10721,14 @@ impl Default for STREAM_INFORMATION_ENTRY_0_1 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct STREAM_INFORMATION_ENTRY_0_2 {
-    pub Length: u16,
-    pub Flags: u16,
-    pub EaSize: u32,
-    pub EaInformationOffset: u32,
+pub struct STREAM_INFORMATION_ENTRY_0_0 {
+    pub Class: FILE_STORAGE_TIER_CLASS,
+    pub Flags: u32,
 }
-impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0_2 {
+impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for STREAM_INFORMATION_ENTRY_0_2 {
+impl Default for STREAM_INFORMATION_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -10754,13 +10738,29 @@ impl Default for STREAM_INFORMATION_ENTRY_0_2 {
 pub struct STREAM_INFORMATION_ENTRY_0_3 {
     pub Length: u16,
     pub Flags: u16,
-    pub ReparseDataSize: u32,
-    pub ReparseDataOffset: u32,
+    pub EaSize: u32,
+    pub EaInformationOffset: u32,
 }
 impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0_3 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for STREAM_INFORMATION_ENTRY_0_3 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct STREAM_INFORMATION_ENTRY_0_2 {
+    pub Length: u16,
+    pub Flags: u16,
+    pub ReparseDataSize: u32,
+    pub ReparseDataOffset: u32,
+}
+impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for STREAM_INFORMATION_ENTRY_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
@@ -11075,9 +11075,9 @@ impl Default for PICTDESC {
 #[derive(Clone, Copy)]
 pub union PICTDESC_0 {
     pub bmp: PICTDESC_0_0,
-    pub wmf: PICTDESC_0_3,
+    pub wmf: PICTDESC_0_1,
     pub icon: PICTDESC_0_2,
-    pub emf: PICTDESC_0_1,
+    pub emf: PICTDESC_0_3,
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 impl windows_core::TypeKind for PICTDESC_0 {
@@ -11109,15 +11109,15 @@ impl Default for PICTDESC_0_0 {
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PICTDESC_0_1 {
+pub struct PICTDESC_0_3 {
     pub hemf: super::super::Graphics::Gdi::HENHMETAFILE,
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PICTDESC_0_1 {
+impl windows_core::TypeKind for PICTDESC_0_3 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl Default for PICTDESC_0_1 {
+impl Default for PICTDESC_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -11141,17 +11141,17 @@ impl Default for PICTDESC_0_2 {
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PICTDESC_0_3 {
+pub struct PICTDESC_0_1 {
     pub hmeta: super::super::Graphics::Gdi::HMETAFILE,
     pub xExt: i32,
     pub yExt: i32,
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PICTDESC_0_3 {
+impl windows_core::TypeKind for PICTDESC_0_1 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl Default for PICTDESC_0_3 {
+impl Default for PICTDESC_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
@@ -7243,8 +7243,8 @@ impl Default for WTS_PROPERTY_VALUE {
 #[derive(Clone, Copy)]
 pub union WTS_PROPERTY_VALUE_0 {
     pub ulVal: u32,
-    pub strVal: WTS_PROPERTY_VALUE_0_1,
-    pub bVal: WTS_PROPERTY_VALUE_0_0,
+    pub strVal: WTS_PROPERTY_VALUE_0_0,
+    pub bVal: WTS_PROPERTY_VALUE_0_1,
     pub guidVal: windows_core::GUID,
 }
 impl windows_core::TypeKind for WTS_PROPERTY_VALUE_0 {
@@ -7257,28 +7257,28 @@ impl Default for WTS_PROPERTY_VALUE_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WTS_PROPERTY_VALUE_0_0 {
+pub struct WTS_PROPERTY_VALUE_0_1 {
     pub size: u32,
     pub pbVal: windows_core::PSTR,
 }
-impl windows_core::TypeKind for WTS_PROPERTY_VALUE_0_0 {
+impl windows_core::TypeKind for WTS_PROPERTY_VALUE_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WTS_PROPERTY_VALUE_0_0 {
+impl Default for WTS_PROPERTY_VALUE_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct WTS_PROPERTY_VALUE_0_1 {
+pub struct WTS_PROPERTY_VALUE_0_0 {
     pub size: u32,
     pub pstrVal: windows_core::PWSTR,
 }
-impl windows_core::TypeKind for WTS_PROPERTY_VALUE_0_1 {
+impl windows_core::TypeKind for WTS_PROPERTY_VALUE_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for WTS_PROPERTY_VALUE_0_1 {
+impl Default for WTS_PROPERTY_VALUE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -16116,15 +16116,15 @@ pub union SSVARIANT_0 {
     pub fltRealVal: f32,
     pub dblFloatVal: f64,
     pub cyMoneyVal: super::Com::CY,
-    pub NCharVal: SSVARIANT_0_3,
-    pub CharVal: SSVARIANT_0_2,
+    pub NCharVal: SSVARIANT_0_0,
+    pub CharVal: SSVARIANT_0_1,
     pub fBitVal: super::super::Foundation::VARIANT_BOOL,
     pub rgbGuidVal: [u8; 16],
     pub numNumericVal: DB_NUMERIC,
-    pub BinaryVal: SSVARIANT_0_1,
+    pub BinaryVal: SSVARIANT_0_2,
     pub tsDateTimeVal: DBTIMESTAMP,
-    pub UnknownType: SSVARIANT_0_4,
-    pub BLOBType: core::mem::ManuallyDrop<SSVARIANT_0_0>,
+    pub UnknownType: SSVARIANT_0_3,
+    pub BLOBType: core::mem::ManuallyDrop<SSVARIANT_0_4>,
 }
 #[cfg(feature = "Win32_System_Com")]
 impl Clone for SSVARIANT_0 {
@@ -16144,41 +16144,22 @@ impl Default for SSVARIANT_0 {
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
-pub struct SSVARIANT_0_0 {
+pub struct SSVARIANT_0_4 {
     pub dbobj: DBOBJECT,
     pub pUnk: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
 }
 #[cfg(feature = "Win32_System_Com")]
-impl Clone for SSVARIANT_0_0 {
+impl Clone for SSVARIANT_0_4 {
     fn clone(&self) -> Self {
         unsafe { core::mem::transmute_copy(self) }
     }
 }
 #[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT_0_0 {
+impl windows_core::TypeKind for SSVARIANT_0_4 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl Default for SSVARIANT_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(feature = "Win32_System_Com")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SSVARIANT_0_1 {
-    pub sActualLength: i16,
-    pub sMaxLength: i16,
-    pub prgbBinaryVal: *mut u8,
-    pub dwReserved: u32,
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Com")]
-impl Default for SSVARIANT_0_1 {
+impl Default for SSVARIANT_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -16189,10 +16170,8 @@ impl Default for SSVARIANT_0_1 {
 pub struct SSVARIANT_0_2 {
     pub sActualLength: i16,
     pub sMaxLength: i16,
-    pub pchCharVal: windows_core::PSTR,
-    pub rgbReserved: [u8; 5],
+    pub prgbBinaryVal: *mut u8,
     pub dwReserved: u32,
-    pub pwchReserved: windows_core::PWSTR,
 }
 #[cfg(feature = "Win32_System_Com")]
 impl windows_core::TypeKind for SSVARIANT_0_2 {
@@ -16207,7 +16186,28 @@ impl Default for SSVARIANT_0_2 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SSVARIANT_0_3 {
+pub struct SSVARIANT_0_1 {
+    pub sActualLength: i16,
+    pub sMaxLength: i16,
+    pub pchCharVal: windows_core::PSTR,
+    pub rgbReserved: [u8; 5],
+    pub dwReserved: u32,
+    pub pwchReserved: windows_core::PWSTR,
+}
+#[cfg(feature = "Win32_System_Com")]
+impl windows_core::TypeKind for SSVARIANT_0_1 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(feature = "Win32_System_Com")]
+impl Default for SSVARIANT_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(feature = "Win32_System_Com")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SSVARIANT_0_0 {
     pub sActualLength: i16,
     pub sMaxLength: i16,
     pub pwchNCharVal: windows_core::PWSTR,
@@ -16216,11 +16216,11 @@ pub struct SSVARIANT_0_3 {
     pub pwchReserved: windows_core::PWSTR,
 }
 #[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT_0_3 {
+impl windows_core::TypeKind for SSVARIANT_0_0 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl Default for SSVARIANT_0_3 {
+impl Default for SSVARIANT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -16228,17 +16228,17 @@ impl Default for SSVARIANT_0_3 {
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SSVARIANT_0_4 {
+pub struct SSVARIANT_0_3 {
     pub dwActualLength: u32,
     pub rgMetadata: [u8; 16],
     pub pUnknownData: *mut u8,
 }
 #[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT_0_4 {
+impl windows_core::TypeKind for SSVARIANT_0_3 {
     type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
-impl Default for SSVARIANT_0_4 {
+impl Default for SSVARIANT_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/SystemInformation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemInformation/mod.rs
@@ -1394,8 +1394,8 @@ impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0 {
-    pub ProcessorCore: SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1,
-    pub NumaNode: SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0,
+    pub ProcessorCore: SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0,
+    pub NumaNode: SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1,
     pub Cache: CACHE_DESCRIPTOR,
     pub Reserved: [u64; 2],
 }
@@ -1409,26 +1409,26 @@ impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
+pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
     pub NodeNumber: u32,
 }
-impl windows_core::TypeKind for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
+impl windows_core::TypeKind for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
+impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
+pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
     pub Flags: u8,
 }
-impl windows_core::TypeKind for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
+impl windows_core::TypeKind for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
+impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
@@ -3708,11 +3708,11 @@ impl Default for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0_0 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_AUX_SYMBOL {
-    pub Sym: IMAGE_AUX_SYMBOL_3,
+    pub Sym: IMAGE_AUX_SYMBOL_0,
     pub File: IMAGE_AUX_SYMBOL_1,
     pub Section: IMAGE_AUX_SYMBOL_2,
     pub TokenDef: IMAGE_AUX_SYMBOL_TOKEN_DEF,
-    pub CRC: IMAGE_AUX_SYMBOL_0,
+    pub CRC: IMAGE_AUX_SYMBOL_3,
 }
 impl windows_core::TypeKind for IMAGE_AUX_SYMBOL {
     type TypeKind = windows_core::CopyType;
@@ -3724,14 +3724,14 @@ impl Default for IMAGE_AUX_SYMBOL {
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_0 {
+pub struct IMAGE_AUX_SYMBOL_3 {
     pub crc: u32,
     pub rgbReserved: [u8; 14],
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0 {
+impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_3 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IMAGE_AUX_SYMBOL_0 {
+impl Default for IMAGE_AUX_SYMBOL_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3771,85 +3771,85 @@ impl Default for IMAGE_AUX_SYMBOL_2 {
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_3 {
+pub struct IMAGE_AUX_SYMBOL_0 {
     pub TagIndex: u32,
-    pub Misc: IMAGE_AUX_SYMBOL_3_1,
-    pub FcnAry: IMAGE_AUX_SYMBOL_3_0,
+    pub Misc: IMAGE_AUX_SYMBOL_0_0,
+    pub FcnAry: IMAGE_AUX_SYMBOL_0_1,
     pub TvIndex: u16,
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_3 {
+impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IMAGE_AUX_SYMBOL_3 {
+impl Default for IMAGE_AUX_SYMBOL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union IMAGE_AUX_SYMBOL_3_0 {
-    pub Function: IMAGE_AUX_SYMBOL_3_0_1,
-    pub Array: IMAGE_AUX_SYMBOL_3_0_0,
+pub union IMAGE_AUX_SYMBOL_0_1 {
+    pub Function: IMAGE_AUX_SYMBOL_0_1_0,
+    pub Array: IMAGE_AUX_SYMBOL_0_1_1,
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_3_0 {
+impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IMAGE_AUX_SYMBOL_3_0 {
+impl Default for IMAGE_AUX_SYMBOL_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IMAGE_AUX_SYMBOL_3_0_0 {
+pub struct IMAGE_AUX_SYMBOL_0_1_1 {
     pub Dimension: [u16; 4],
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_3_0_0 {
+impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0_1_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IMAGE_AUX_SYMBOL_3_0_0 {
+impl Default for IMAGE_AUX_SYMBOL_0_1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_3_0_1 {
+pub struct IMAGE_AUX_SYMBOL_0_1_0 {
     pub PointerToLinenumber: u32,
     pub PointerToNextFunction: u32,
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_3_0_1 {
+impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0_1_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IMAGE_AUX_SYMBOL_3_0_1 {
+impl Default for IMAGE_AUX_SYMBOL_0_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
-pub union IMAGE_AUX_SYMBOL_3_1 {
-    pub LnSz: IMAGE_AUX_SYMBOL_3_1_0,
+pub union IMAGE_AUX_SYMBOL_0_0 {
+    pub LnSz: IMAGE_AUX_SYMBOL_0_0_0,
     pub TotalSize: u32,
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_3_1 {
+impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IMAGE_AUX_SYMBOL_3_1 {
+impl Default for IMAGE_AUX_SYMBOL_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IMAGE_AUX_SYMBOL_3_1_0 {
+pub struct IMAGE_AUX_SYMBOL_0_0_0 {
     pub Linenumber: u16,
     pub Size: u16,
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_3_1_0 {
+impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for IMAGE_AUX_SYMBOL_3_1_0 {
+impl Default for IMAGE_AUX_SYMBOL_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
@@ -3857,11 +3857,11 @@ impl Default for IMAGE_AUX_SYMBOL_3_1_0 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_AUX_SYMBOL_EX {
-    pub Sym: IMAGE_AUX_SYMBOL_EX_4,
-    pub File: IMAGE_AUX_SYMBOL_EX_2,
-    pub Section: IMAGE_AUX_SYMBOL_EX_3,
-    pub Anonymous: IMAGE_AUX_SYMBOL_EX_0,
-    pub CRC: IMAGE_AUX_SYMBOL_EX_1,
+    pub Sym: IMAGE_AUX_SYMBOL_EX_0,
+    pub File: IMAGE_AUX_SYMBOL_EX_1,
+    pub Section: IMAGE_AUX_SYMBOL_EX_2,
+    pub Anonymous: IMAGE_AUX_SYMBOL_EX_3,
+    pub CRC: IMAGE_AUX_SYMBOL_EX_4,
 }
 impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX {
     type TypeKind = windows_core::CopyType;
@@ -3873,56 +3873,8 @@ impl Default for IMAGE_AUX_SYMBOL_EX {
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_EX_0 {
-    pub TokenDef: IMAGE_AUX_SYMBOL_TOKEN_DEF,
-    pub rgbReserved: [u8; 2],
-}
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_0 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for IMAGE_AUX_SYMBOL_EX_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(2))]
-#[derive(Clone, Copy)]
-pub struct IMAGE_AUX_SYMBOL_EX_1 {
-    pub crc: u32,
-    pub rgbReserved: [u8; 16],
-}
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_1 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for IMAGE_AUX_SYMBOL_EX_1 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IMAGE_AUX_SYMBOL_EX_2 {
-    pub Name: [u8; 20],
-}
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_2 {
-    type TypeKind = windows_core::CopyType;
-}
-impl Default for IMAGE_AUX_SYMBOL_EX_2 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C, packed(2))]
-#[derive(Clone, Copy)]
 pub struct IMAGE_AUX_SYMBOL_EX_3 {
-    pub Length: u32,
-    pub NumberOfRelocations: u16,
-    pub NumberOfLinenumbers: u16,
-    pub CheckSum: u32,
-    pub Number: i16,
-    pub Selection: u8,
-    pub bReserved: u8,
-    pub HighNumber: i16,
+    pub TokenDef: IMAGE_AUX_SYMBOL_TOKEN_DEF,
     pub rgbReserved: [u8; 2],
 }
 impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_3 {
@@ -3936,14 +3888,62 @@ impl Default for IMAGE_AUX_SYMBOL_EX_3 {
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_AUX_SYMBOL_EX_4 {
-    pub WeakDefaultSymIndex: u32,
-    pub WeakSearchType: u32,
-    pub rgbReserved: [u8; 12],
+    pub crc: u32,
+    pub rgbReserved: [u8; 16],
 }
 impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_4 {
     type TypeKind = windows_core::CopyType;
 }
 impl Default for IMAGE_AUX_SYMBOL_EX_4 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct IMAGE_AUX_SYMBOL_EX_1 {
+    pub Name: [u8; 20],
+}
+impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_1 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for IMAGE_AUX_SYMBOL_EX_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(2))]
+#[derive(Clone, Copy)]
+pub struct IMAGE_AUX_SYMBOL_EX_2 {
+    pub Length: u32,
+    pub NumberOfRelocations: u16,
+    pub NumberOfLinenumbers: u16,
+    pub CheckSum: u32,
+    pub Number: i16,
+    pub Selection: u8,
+    pub bReserved: u8,
+    pub HighNumber: i16,
+    pub rgbReserved: [u8; 2],
+}
+impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_2 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for IMAGE_AUX_SYMBOL_EX_2 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C, packed(2))]
+#[derive(Clone, Copy)]
+pub struct IMAGE_AUX_SYMBOL_EX_0 {
+    pub WeakDefaultSymIndex: u32,
+    pub WeakSearchType: u32,
+    pub rgbReserved: [u8; 12],
+}
+impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_0 {
+    type TypeKind = windows_core::CopyType;
+}
+impl Default for IMAGE_AUX_SYMBOL_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/System/VirtualDosMachines/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/VirtualDosMachines/mod.rs
@@ -290,8 +290,8 @@ impl Default for VDMLDT_ENTRY {
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
 pub union VDMLDT_ENTRY_0 {
-    pub Bytes: VDMLDT_ENTRY_0_1,
-    pub Bits: VDMLDT_ENTRY_0_0,
+    pub Bytes: VDMLDT_ENTRY_0_0,
+    pub Bits: VDMLDT_ENTRY_0_1,
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 impl windows_core::TypeKind for VDMLDT_ENTRY_0 {
@@ -306,27 +306,8 @@ impl Default for VDMLDT_ENTRY_0 {
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct VDMLDT_ENTRY_0_0 {
-    pub _bitfield: u32,
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for VDMLDT_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl Default for VDMLDT_ENTRY_0_0 {
-    fn default() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
-}
-#[repr(C)]
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct VDMLDT_ENTRY_0_1 {
-    pub BaseMid: u8,
-    pub Flags1: u8,
-    pub Flags2: u8,
-    pub BaseHi: u8,
+    pub _bitfield: u32,
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 impl windows_core::TypeKind for VDMLDT_ENTRY_0_1 {
@@ -334,6 +315,25 @@ impl windows_core::TypeKind for VDMLDT_ENTRY_0_1 {
 }
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 impl Default for VDMLDT_ENTRY_0_1 {
+    fn default() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VDMLDT_ENTRY_0_0 {
+    pub BaseMid: u8,
+    pub Flags1: u8,
+    pub Flags2: u8,
+    pub BaseHi: u8,
+}
+#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
+impl windows_core::TypeKind for VDMLDT_ENTRY_0_0 {
+    type TypeKind = windows_core::CopyType;
+}
+#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
+impl Default for VDMLDT_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -8743,8 +8743,8 @@ impl Default for MENUTEMPLATEEX {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MENUTEMPLATEEX_0 {
-    pub Menu: MENUTEMPLATEEX_0_1,
-    pub MenuEx: MENUTEMPLATEEX_0_0,
+    pub Menu: MENUTEMPLATEEX_0_0,
+    pub MenuEx: MENUTEMPLATEEX_0_1,
 }
 impl windows_core::TypeKind for MENUTEMPLATEEX_0 {
     type TypeKind = windows_core::CopyType;
@@ -8756,28 +8756,28 @@ impl Default for MENUTEMPLATEEX_0 {
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct MENUTEMPLATEEX_0_0 {
+pub struct MENUTEMPLATEEX_0_1 {
     pub mexHeader: MENUEX_TEMPLATE_HEADER,
     pub mexItem: [MENUEX_TEMPLATE_ITEM; 1],
 }
-impl windows_core::TypeKind for MENUTEMPLATEEX_0_0 {
+impl windows_core::TypeKind for MENUTEMPLATEEX_0_1 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for MENUTEMPLATEEX_0_0 {
+impl Default for MENUTEMPLATEEX_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct MENUTEMPLATEEX_0_1 {
+pub struct MENUTEMPLATEEX_0_0 {
     pub mitHeader: MENUITEMTEMPLATEHEADER,
     pub miTemplate: [MENUITEMTEMPLATE; 1],
 }
-impl windows_core::TypeKind for MENUTEMPLATEEX_0_1 {
+impl windows_core::TypeKind for MENUTEMPLATEEX_0_0 {
     type TypeKind = windows_core::CopyType;
 }
-impl Default for MENUTEMPLATEEX_0_1 {
+impl Default for MENUTEMPLATEEX_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/crates/tests/misc/unions/tests/win.rs
+++ b/crates/tests/misc/unions/tests/win.rs
@@ -80,7 +80,7 @@ fn d3d() {
     let mut desc = D3D12_INDIRECT_ARGUMENT_DESC {
         Type: D3D12_INDIRECT_ARGUMENT_TYPE_VERTEX_BUFFER_VIEW,
         Anonymous: D3D12_INDIRECT_ARGUMENT_DESC_0 {
-            VertexBuffer: D3D12_INDIRECT_ARGUMENT_DESC_0_5 { Slot: 123 },
+            VertexBuffer: D3D12_INDIRECT_ARGUMENT_DESC_0_0 { Slot: 123 },
         },
     };
 


### PR DESCRIPTION
While working on the next version of `windows-bindgen` I noticed that the current version incorrectly sorts nested structs such that the mangled names (since Rust lacks support for nested types) are based on an internal sort order rather than the sort order provided by ECMA-335. 

This usually isn't too noticeable, but some structs like `FLT_PARAMETERS` are now far more sensible. 

I'm fixing it here in the current version to simplify diff validation of the next version of `windows-bindgen`. 