### PR TITLE
fix: remove use of std in windows-strings h! macro

### DIFF
--- a/crates/libs/strings/src/literals.rs
+++ b/crates/libs/strings/src/literals.rs
@@ -44,7 +44,7 @@ macro_rules! h {
         #[allow(clippy::declare_interior_mutable_const)]
         const RESULT: $crate::HSTRING = {
             if OUTPUT_LEN == 1 {
-                unsafe { ::std::mem::transmute(::std::ptr::null::<u16>()) }
+                unsafe { ::core::mem::transmute(::core::ptr::null::<u16>()) }
             } else {
                 const OUTPUT: $crate::PCWSTR = $crate::w!($s);
                 const HEADER: $crate::HSTRING_HEADER = $crate::HSTRING_HEADER {
@@ -56,7 +56,7 @@ macro_rules! h {
                 };
                 // SAFETY: an `HSTRING` is exactly equivalent to a pointer to an `HSTRING_HEADER`
                 unsafe {
-                    ::std::mem::transmute::<&$crate::HSTRING_HEADER, $crate::HSTRING>(&HEADER)
+                    ::core::mem::transmute::<&$crate::HSTRING_HEADER, $crate::HSTRING>(&HEADER)
                 }
             }
         };


### PR DESCRIPTION
This crate can be used in no_std, but some use of std were left in the h! macro. They can be trivially converted to core.

On this subject, i've been using the windows crates in no_std setups, and this is the only issue I reached, the rest seems to work great.

However, the windows 0.58 does not have all the no_std fixes, is there a release planned soon to be able to get those changes?