### PR TITLE
Harden reg-free class activation

### DIFF
--- a/crates/libs/core/src/imp/com_bindings.rs
+++ b/crates/libs/core/src/imp/com_bindings.rs
@@ -240,5 +240,6 @@ impl IWeakReferenceSource_Vtbl {
 }
 impl windows_core::RuntimeName for IWeakReferenceSource {}
 pub const JSCRIPT_E_CANTEXECUTE: windows_core::HRESULT = windows_core::HRESULT(0x89020001_u32 as _);
+pub const REGDB_E_CLASSNOTREG: windows_core::HRESULT = windows_core::HRESULT(0x80040154_u32 as _);
 pub const RPC_E_DISCONNECTED: windows_core::HRESULT = windows_core::HRESULT(0x80010108_u32 as _);
 pub const TYPE_E_TYPEMISMATCH: windows_core::HRESULT = windows_core::HRESULT(0x80028CA0_u32 as _);

--- a/crates/tools/bindings/src/core_com.txt
+++ b/crates/tools/bindings/src/core_com.txt
@@ -6,6 +6,7 @@
 
 --filter
     Windows.Win32.Foundation.CO_E_NOTINITIALIZED
+    Windows.Win32.Foundation.REGDB_E_CLASSNOTREG
     Windows.Win32.Foundation.E_BOUNDS
     Windows.Win32.Foundation.E_INVALIDARG
     Windows.Win32.Foundation.E_NOINTERFACE


### PR DESCRIPTION
Reg-free activation should only be attempted if the class is not registered.
It should not be attempted if the class is registered but fails to activate.

Fixes: #3339