### PR TITLE
Simpler code generation

### DIFF
--- a/crates/libs/bindgen/src/types/cpp_fn.rs
+++ b/crates/libs/bindgen/src/types/cpp_fn.rs
@@ -228,18 +228,6 @@ impl CppFn {
                     }
                 }
             }
-            ReturnHint::ReturnVoid => {
-                let where_clause = method.write_where(writer, false);
-
-                quote! {
-                    #cfg
-                    #[inline]
-                    pub unsafe fn #name<#generics>(#params) #abi_return_type #where_clause {
-                        #link
-                        #name(#args)
-                    }
-                }
-            }
         };
 
         quote! {

--- a/crates/libs/bindgen/src/types/cpp_struct.rs
+++ b/crates/libs/bindgen/src/types/cpp_struct.rs
@@ -146,24 +146,6 @@ impl CppStruct {
             derive.extend(["Debug", "PartialEq"]);
         }
 
-        let type_kind = if writer.config.sys {
-            quote! {}
-        } else if is_copyable {
-            quote! {
-               #cfg
-               impl windows_core::TypeKind for #name {
-                   type TypeKind = windows_core::CopyType;
-               }
-            }
-        } else {
-            quote! {
-               #cfg
-               impl windows_core::TypeKind for #name {
-                   type TypeKind = windows_core::CloneType;
-               }
-            }
-        };
-
         let default = if writer.config.sys {
             quote! {}
         } else {
@@ -230,7 +212,6 @@ impl CppStruct {
             #constants
             #manual_clone
             #default
-            #type_kind
         };
 
         for nested in self.nested.values() {

--- a/crates/libs/windows/src/Windows/Wdk/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Devices/HumanInterfaceDevice/mod.rs
@@ -41,9 +41,6 @@ impl Default for HID_XFER_PACKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HID_XFER_PACKET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VHF_CONFIG {
@@ -72,7 +69,4 @@ impl Default for VHF_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VHF_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Wdk/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Foundation/mod.rs
@@ -35,10 +35,6 @@ impl Default for ACCESS_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_System_SystemServices", feature = "Win32_Security"))]
-impl windows_core::TypeKind for ACCESS_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_System_SystemServices", feature = "Win32_Security"))]
 #[derive(Clone, Copy)]
@@ -51,10 +47,6 @@ impl Default for ACCESS_STATE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_System_SystemServices", feature = "Win32_Security"))]
-impl windows_core::TypeKind for ACCESS_STATE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -92,10 +84,6 @@ impl Default for DEVICE_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for DEVICE_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -108,10 +96,6 @@ impl Default for DEVICE_OBJECT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for DEVICE_OBJECT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -140,10 +124,6 @@ impl Default for DEVOBJ_EXTENSION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for DEVOBJ_EXTENSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -157,10 +137,6 @@ impl Default for DISPATCHER_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -180,10 +156,6 @@ impl Default for DISPATCHER_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -196,10 +168,6 @@ impl Default for DISPATCHER_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -216,10 +184,6 @@ impl Default for DISPATCHER_HEADER_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -235,10 +199,6 @@ impl Default for DISPATCHER_HEADER_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -252,10 +212,6 @@ impl Default for DISPATCHER_HEADER_0_2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -267,10 +223,6 @@ impl Default for DISPATCHER_HEADER_0_2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -285,10 +237,6 @@ impl Default for DISPATCHER_HEADER_0_2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -300,10 +248,6 @@ impl Default for DISPATCHER_HEADER_0_2_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_2_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -320,10 +264,6 @@ impl Default for DISPATCHER_HEADER_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -337,10 +277,6 @@ impl Default for DISPATCHER_HEADER_0_3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -352,10 +288,6 @@ impl Default for DISPATCHER_HEADER_0_3_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_3_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -372,10 +304,6 @@ impl Default for DISPATCHER_HEADER_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -389,10 +317,6 @@ impl Default for DISPATCHER_HEADER_0_4_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_4_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -404,10 +328,6 @@ impl Default for DISPATCHER_HEADER_0_4_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_4_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -424,10 +344,6 @@ impl Default for DISPATCHER_HEADER_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -441,10 +357,6 @@ impl Default for DISPATCHER_HEADER_0_5_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_5_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -457,10 +369,6 @@ impl Default for DISPATCHER_HEADER_0_5_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_5_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -472,10 +380,6 @@ impl Default for DISPATCHER_HEADER_0_5_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_5_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -491,10 +395,6 @@ impl Default for DISPATCHER_HEADER_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_HEADER_0_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -528,10 +428,6 @@ impl Default for DRIVER_EXTENSION {
     }
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for DRIVER_EXTENSION {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type DRIVER_FS_NOTIFICATION = Option<unsafe extern "system" fn(deviceobject: *const DEVICE_OBJECT, fsactive: super::super::Win32::Foundation::BOOLEAN)>;
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type DRIVER_INITIALIZE = Option<unsafe extern "system" fn(driverobject: *const DRIVER_OBJECT, registrypath: *const super::super::Win32::Foundation::UNICODE_STRING) -> super::super::Win32::Foundation::NTSTATUS>;
@@ -561,10 +457,6 @@ impl Default for DRIVER_OBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for DRIVER_OBJECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type DRIVER_REINITIALIZE = Option<unsafe extern "system" fn(driverobject: *const DRIVER_OBJECT, context: *const core::ffi::c_void, count: u32)>;
@@ -610,10 +502,6 @@ impl Default for ERESOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for ERESOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -626,10 +514,6 @@ impl Default for ERESOURCE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for ERESOURCE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -644,10 +528,6 @@ impl Default for ERESOURCE_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for ERESOURCE_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -660,10 +540,6 @@ impl Default for ERESOURCE_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for ERESOURCE_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type FAST_IO_ACQUIRE_FILE = Option<unsafe extern "system" fn(fileobject: *const FILE_OBJECT)>;
@@ -715,10 +591,6 @@ impl Default for FAST_IO_DISPATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FAST_IO_DISPATCH {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type FAST_IO_LOCK = Option<unsafe extern "system" fn(fileobject: *const FILE_OBJECT, fileoffset: *const i64, length: *const i64, processid: PEPROCESS, key: u32, failimmediately: super::super::Win32::Foundation::BOOLEAN, exclusivelock: super::super::Win32::Foundation::BOOLEAN, iostatus: *mut super::super::Win32::System::IO::IO_STATUS_BLOCK, deviceobject: *const DEVICE_OBJECT) -> super::super::Win32::Foundation::BOOLEAN>;
@@ -778,10 +650,6 @@ impl Default for FAST_MUTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for FAST_MUTEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -823,10 +691,6 @@ impl Default for FILE_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FILE_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct IOMMU_DMA_DEVICE(pub isize);
@@ -851,9 +715,6 @@ impl Default for IO_COMPLETION_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_COMPLETION_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct IO_PRIORITY_HINT(pub i32);
@@ -871,10 +732,6 @@ impl Default for IO_SECURITY_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_System_SystemServices", feature = "Win32_Security"))]
-impl windows_core::TypeKind for IO_SECURITY_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -895,10 +752,6 @@ impl Default for IO_STACK_LOCATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -950,10 +803,6 @@ impl Default for IO_STACK_LOCATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -969,10 +818,6 @@ impl Default for IO_STACK_LOCATION_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -990,10 +835,6 @@ impl Default for IO_STACK_LOCATION_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1010,10 +851,6 @@ impl Default for IO_STACK_LOCATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1025,10 +862,6 @@ impl Default for IO_STACK_LOCATION_0_26 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_26 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1045,10 +878,6 @@ impl Default for IO_STACK_LOCATION_0_16 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_16 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1064,10 +893,6 @@ impl Default for IO_STACK_LOCATION_0_14 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_14 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1079,10 +904,6 @@ impl Default for IO_STACK_LOCATION_0_27 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_27 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1098,10 +919,6 @@ impl Default for IO_STACK_LOCATION_0_15 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_15 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1114,10 +931,6 @@ impl Default for IO_STACK_LOCATION_0_19 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_19 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1133,10 +946,6 @@ impl Default for IO_STACK_LOCATION_0_7 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1149,10 +958,6 @@ impl Default for IO_STACK_LOCATION_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1169,10 +974,6 @@ impl Default for IO_STACK_LOCATION_0_38 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_38 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1184,10 +985,6 @@ impl Default for IO_STACK_LOCATION_0_34 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_34 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1204,10 +1001,6 @@ impl Default for IO_STACK_LOCATION_0_35 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_35 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -1221,10 +1014,6 @@ impl Default for IO_STACK_LOCATION_0_35_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_35_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1236,10 +1025,6 @@ impl Default for IO_STACK_LOCATION_0_24 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_24 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1253,10 +1038,6 @@ impl Default for IO_STACK_LOCATION_0_31 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_31 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1273,10 +1054,6 @@ impl Default for IO_STACK_LOCATION_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1292,10 +1069,6 @@ impl Default for IO_STACK_LOCATION_0_10 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_10 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1309,10 +1082,6 @@ impl Default for IO_STACK_LOCATION_0_8 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1324,10 +1093,6 @@ impl Default for IO_STACK_LOCATION_0_30 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_30 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1345,10 +1110,6 @@ impl Default for IO_STACK_LOCATION_0_25 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_25 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1364,10 +1125,6 @@ impl Default for IO_STACK_LOCATION_0_22 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_22 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1381,10 +1138,6 @@ impl Default for IO_STACK_LOCATION_0_17 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_17 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1397,10 +1150,6 @@ impl Default for IO_STACK_LOCATION_0_12 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_12 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1417,10 +1166,6 @@ impl Default for IO_STACK_LOCATION_0_28 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_28 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -1435,10 +1180,6 @@ impl Default for IO_STACK_LOCATION_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1451,10 +1192,6 @@ impl Default for IO_STACK_LOCATION_0_21 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_21 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1466,10 +1203,6 @@ impl Default for IO_STACK_LOCATION_0_11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_11 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1486,10 +1219,6 @@ impl Default for IO_STACK_LOCATION_0_9 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -1504,10 +1233,6 @@ impl Default for IO_STACK_LOCATION_0_9_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_9_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1521,10 +1246,6 @@ impl Default for IO_STACK_LOCATION_0_9_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_9_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1537,10 +1258,6 @@ impl Default for IO_STACK_LOCATION_0_29 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_29 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1552,10 +1269,6 @@ impl Default for IO_STACK_LOCATION_0_23 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_23 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1570,10 +1283,6 @@ impl Default for IO_STACK_LOCATION_0_18 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_18 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1587,10 +1296,6 @@ impl Default for IO_STACK_LOCATION_0_13 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_13 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1603,10 +1308,6 @@ impl Default for IO_STACK_LOCATION_0_36 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_36 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1622,10 +1323,6 @@ impl Default for IO_STACK_LOCATION_0_32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1638,10 +1335,6 @@ impl Default for IO_STACK_LOCATION_0_20 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_20 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1658,10 +1351,6 @@ impl Default for IO_STACK_LOCATION_0_37 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_37 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1673,10 +1362,6 @@ impl Default for IO_STACK_LOCATION_0_33 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_33 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1691,10 +1376,6 @@ impl Default for IO_STACK_LOCATION_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_STACK_LOCATION_0_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1728,10 +1409,6 @@ impl Default for IRP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -1744,10 +1421,6 @@ impl Default for IRP_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1763,10 +1436,6 @@ impl Default for IRP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -1779,10 +1448,6 @@ impl Default for IRP_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1797,10 +1462,6 @@ impl Default for IRP_2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -1813,10 +1474,6 @@ impl Default for IRP_2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1831,10 +1488,6 @@ impl Default for IRP_2_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_2_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -1848,10 +1501,6 @@ impl Default for IRP_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1869,10 +1518,6 @@ impl Default for IRP_3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -1886,10 +1531,6 @@ impl Default for IRP_3_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_3_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1901,10 +1542,6 @@ impl Default for IRP_3_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_3_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1919,10 +1556,6 @@ impl Default for IRP_3_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_3_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -1935,10 +1568,6 @@ impl Default for IRP_3_0_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IRP_3_0_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IoPriorityCritical: IO_PRIORITY_HINT = IO_PRIORITY_HINT(4i32);
 pub const IoPriorityHigh: IO_PRIORITY_HINT = IO_PRIORITY_HINT(3i32);
@@ -1961,10 +1590,6 @@ impl Default for KDEVICE_QUEUE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KDEVICE_QUEUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -1984,10 +1609,6 @@ impl Default for KDPC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KDPC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -2000,10 +1621,6 @@ impl Default for KDPC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KDPC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -2018,10 +1635,6 @@ impl Default for KDPC_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KDPC_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2040,10 +1653,6 @@ impl Default for KEVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KEVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2073,10 +1682,6 @@ impl Default for KMUTANT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KMUTANT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -2090,10 +1695,6 @@ impl Default for KMUTANT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KMUTANT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2105,10 +1706,6 @@ impl Default for KMUTANT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KMUTANT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2137,10 +1734,6 @@ impl Default for KQUEUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KQUEUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2187,10 +1780,6 @@ impl Default for KWAIT_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KWAIT_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -2204,10 +1793,6 @@ impl Default for KWAIT_BLOCK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KWAIT_BLOCK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2250,9 +1835,6 @@ impl Default for MDL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MDL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MaxIoPriorityTypes: IO_PRIORITY_HINT = IO_PRIORITY_HINT(5i32);
 pub const MaxPoolType: POOL_TYPE = POOL_TYPE(7i32);
 pub const NTSTRSAFE_MAX_CCH: u32 = 2147483647u32;
@@ -2292,10 +1874,6 @@ impl Default for OBJECT_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for OBJECT_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2312,10 +1890,6 @@ impl Default for OBJECT_ATTRIBUTES32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for OBJECT_ATTRIBUTES32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2334,10 +1908,6 @@ impl Default for OBJECT_ATTRIBUTES64 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for OBJECT_ATTRIBUTES64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct OBJECT_INFORMATION_CLASS(pub i32);
@@ -2351,9 +1921,6 @@ impl Default for OBJECT_NAME_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OBJECT_NAME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct OWNER_ENTRY {
@@ -2364,9 +1931,6 @@ impl Default for OWNER_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OWNER_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2379,9 +1943,6 @@ impl Default for OWNER_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OWNER_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OWNER_ENTRY_0_0 {
@@ -2391,9 +1952,6 @@ impl Default for OWNER_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OWNER_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ObjectBasicInformation: OBJECT_INFORMATION_CLASS = OBJECT_INFORMATION_CLASS(0i32);
 pub const ObjectTypeInformation: OBJECT_INFORMATION_CLASS = OBJECT_INFORMATION_CLASS(2i32);
@@ -2580,9 +2138,6 @@ impl Default for RTL_SPLAY_LINKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_SPLAY_LINKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECTION_OBJECT_POINTERS {
@@ -2594,9 +2149,6 @@ impl Default for SECTION_OBJECT_POINTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECTION_OBJECT_POINTERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2612,10 +2164,6 @@ impl Default for SECURITY_SUBJECT_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SECURITY_SUBJECT_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STRSAFE_FILL_BEHIND: u32 = 512u32;
 pub const STRSAFE_FILL_BEHIND_NULL: u32 = 512u32;
@@ -2647,10 +2195,6 @@ impl Default for TARGET_DEVICE_CUSTOM_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for TARGET_DEVICE_CUSTOM_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2671,10 +2215,6 @@ impl Default for VPB {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Storage_FileSystem", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for VPB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2688,10 +2228,6 @@ impl Default for WORK_QUEUE_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for WORK_QUEUE_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]

--- a/crates/libs/windows/src/Windows/Wdk/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Graphics/Direct3D/mod.rs
@@ -944,10 +944,6 @@ impl Default for D3DCAPS8 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DCAPS8 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DCLEAR_COMPUTERECTS: i32 = 8i32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -970,9 +966,6 @@ impl Default for D3DDDIARG_CREATERESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDIARG_CREATERESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -997,9 +990,6 @@ impl Default for D3DDDIARG_CREATERESOURCE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDIARG_CREATERESOURCE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDICB_DESTROYALLOCATION2FLAGS {
@@ -1009,9 +999,6 @@ impl Default for D3DDDICB_DESTROYALLOCATION2FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDICB_DESTROYALLOCATION2FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1024,9 +1011,6 @@ impl Default for D3DDDICB_DESTROYALLOCATION2FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDICB_DESTROYALLOCATION2FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDICB_DESTROYALLOCATION2FLAGS_0_0 {
@@ -1037,9 +1021,6 @@ impl Default for D3DDDICB_DESTROYALLOCATION2FLAGS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDICB_DESTROYALLOCATION2FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDICB_LOCK2FLAGS {
@@ -1049,9 +1030,6 @@ impl Default for D3DDDICB_LOCK2FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDICB_LOCK2FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1064,9 +1042,6 @@ impl Default for D3DDDICB_LOCK2FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDICB_LOCK2FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDICB_LOCK2FLAGS_0_0 {
@@ -1077,9 +1052,6 @@ impl Default for D3DDDICB_LOCK2FLAGS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDICB_LOCK2FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDICB_LOCKFLAGS {
@@ -1089,9 +1061,6 @@ impl Default for D3DDDICB_LOCKFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDICB_LOCKFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1104,9 +1073,6 @@ impl Default for D3DDDICB_LOCKFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDICB_LOCKFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDICB_LOCKFLAGS_0_0 {
@@ -1117,9 +1083,6 @@ impl Default for D3DDDICB_LOCKFLAGS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDICB_LOCKFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDICB_SIGNALFLAGS {
@@ -1129,9 +1092,6 @@ impl Default for D3DDDICB_SIGNALFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDICB_SIGNALFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1144,9 +1104,6 @@ impl Default for D3DDDICB_SIGNALFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDICB_SIGNALFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDICB_SIGNALFLAGS_0_0 {
@@ -1156,9 +1113,6 @@ impl Default for D3DDDICB_SIGNALFLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDICB_SIGNALFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDDIFMT_A1: D3DDDIFORMAT = D3DDDIFORMAT(118u32);
 pub const D3DDDIFMT_A16B16G16R16: D3DDDIFORMAT = D3DDDIFORMAT(36u32);
@@ -1279,9 +1233,6 @@ impl Default for D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE_0 {
@@ -1293,9 +1244,6 @@ impl Default for D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE_0_0 {
@@ -1305,9 +1253,6 @@ impl Default for D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDIGPUVIRTUALADDRESS_PROTECTION_TYPE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1353,9 +1298,6 @@ impl Default for D3DDDIRECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDIRECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_ALLOCATIONINFO {
@@ -1371,9 +1313,6 @@ impl Default for D3DDDI_ALLOCATIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_ALLOCATIONINFO_0 {
@@ -1385,9 +1324,6 @@ impl Default for D3DDDI_ALLOCATIONINFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_ALLOCATIONINFO_0_0 {
@@ -1397,9 +1333,6 @@ impl Default for D3DDDI_ALLOCATIONINFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1419,9 +1352,6 @@ impl Default for D3DDDI_ALLOCATIONINFO2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_ALLOCATIONINFO2_0 {
@@ -1432,9 +1362,6 @@ impl Default for D3DDDI_ALLOCATIONINFO2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1447,9 +1374,6 @@ impl Default for D3DDDI_ALLOCATIONINFO2_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_ALLOCATIONINFO2_1 {
@@ -1461,9 +1385,6 @@ impl Default for D3DDDI_ALLOCATIONINFO2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_ALLOCATIONINFO2_1_0 {
@@ -1473,9 +1394,6 @@ impl Default for D3DDDI_ALLOCATIONINFO2_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONINFO2_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1488,9 +1406,6 @@ impl Default for D3DDDI_ALLOCATIONLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_ALLOCATIONLIST_0 {
@@ -1502,9 +1417,6 @@ impl Default for D3DDDI_ALLOCATIONLIST_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONLIST_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_ALLOCATIONLIST_0_0 {
@@ -1514,9 +1426,6 @@ impl Default for D3DDDI_ALLOCATIONLIST_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_ALLOCATIONLIST_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDDI_ALLOCATIONPRIORITY_HIGH: u32 = 2684354560u32;
 pub const D3DDDI_ALLOCATIONPRIORITY_LOW: u32 = 1342177280u32;
@@ -1563,9 +1472,6 @@ impl Default for D3DDDI_CREATECONTEXTFLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_CREATECONTEXTFLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_CREATECONTEXTFLAGS_0 {
@@ -1577,9 +1483,6 @@ impl Default for D3DDDI_CREATECONTEXTFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_CREATECONTEXTFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_CREATECONTEXTFLAGS_0_0 {
@@ -1590,9 +1493,6 @@ impl Default for D3DDDI_CREATECONTEXTFLAGS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_CREATECONTEXTFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_CREATEHWCONTEXTFLAGS {
@@ -1602,9 +1502,6 @@ impl Default for D3DDDI_CREATEHWCONTEXTFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_CREATEHWCONTEXTFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1617,9 +1514,6 @@ impl Default for D3DDDI_CREATEHWCONTEXTFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_CREATEHWCONTEXTFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_CREATEHWCONTEXTFLAGS_0_0 {
@@ -1630,9 +1524,6 @@ impl Default for D3DDDI_CREATEHWCONTEXTFLAGS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_CREATEHWCONTEXTFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_CREATEHWQUEUEFLAGS {
@@ -1642,9 +1533,6 @@ impl Default for D3DDDI_CREATEHWQUEUEFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_CREATEHWQUEUEFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1657,9 +1545,6 @@ impl Default for D3DDDI_CREATEHWQUEUEFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_CREATEHWQUEUEFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_CREATEHWQUEUEFLAGS_0_0 {
@@ -1669,9 +1554,6 @@ impl Default for D3DDDI_CREATEHWQUEUEFLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_CREATEHWQUEUEFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1689,9 +1571,6 @@ impl Default for D3DDDI_CREATENATIVEFENCEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_CREATENATIVEFENCEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_DESTROYPAGINGQUEUE {
@@ -1701,9 +1580,6 @@ impl Default for D3DDDI_DESTROYPAGINGQUEUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_DESTROYPAGINGQUEUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1733,9 +1609,6 @@ impl Default for D3DDDI_DRIVERESCAPE_CPUEVENTUSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_DRIVERESCAPE_CPUEVENTUSAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_DRIVERESCAPE_TRANSLATEALLOCATIONEHANDLE {
@@ -1747,9 +1620,6 @@ impl Default for D3DDDI_DRIVERESCAPE_TRANSLATEALLOCATIONEHANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_DRIVERESCAPE_TRANSLATEALLOCATIONEHANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_DRIVERESCAPE_TRANSLATERESOURCEHANDLE {
@@ -1760,9 +1630,6 @@ impl Default for D3DDDI_DRIVERESCAPE_TRANSLATERESOURCEHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_DRIVERESCAPE_TRANSLATERESOURCEHANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1776,9 +1643,6 @@ impl Default for D3DDDI_DXGI_RGB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_DXGI_RGB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_ESCAPEFLAGS {
@@ -1788,9 +1652,6 @@ impl Default for D3DDDI_ESCAPEFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_ESCAPEFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1803,9 +1664,6 @@ impl Default for D3DDDI_ESCAPEFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_ESCAPEFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_ESCAPEFLAGS_0_0 {
@@ -1816,9 +1674,6 @@ impl Default for D3DDDI_ESCAPEFLAGS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_ESCAPEFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_EVICT_FLAGS {
@@ -1828,9 +1683,6 @@ impl Default for D3DDDI_EVICT_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_EVICT_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1843,9 +1695,6 @@ impl Default for D3DDDI_EVICT_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_EVICT_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_EVICT_FLAGS_0_0 {
@@ -1855,9 +1704,6 @@ impl Default for D3DDDI_EVICT_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_EVICT_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDDI_FENCE: D3DDDI_SYNCHRONIZATIONOBJECT_TYPE = D3DDDI_SYNCHRONIZATIONOBJECT_TYPE(3i32);
 pub const D3DDDI_FLIPINTERVAL_FOUR: D3DDDI_FLIPINTERVAL_TYPE = D3DDDI_FLIPINTERVAL_TYPE(4i32);
@@ -1890,9 +1736,6 @@ impl Default for D3DDDI_GAMMA_RAMP_DXGI_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_GAMMA_RAMP_DXGI_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_GAMMA_RAMP_RGB256x3x16 {
@@ -1905,9 +1748,6 @@ impl Default for D3DDDI_GAMMA_RAMP_RGB256x3x16 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_GAMMA_RAMP_RGB256x3x16 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_GETRESOURCEPRESENTPRIVATEDRIVERDATA {
@@ -1919,9 +1759,6 @@ impl Default for D3DDDI_GETRESOURCEPRESENTPRIVATEDRIVERDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_GETRESOURCEPRESENTPRIVATEDRIVERDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1940,9 +1777,6 @@ impl Default for D3DDDI_HDR_METADATA_HDR10 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_HDR_METADATA_HDR10 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_HDR_METADATA_HDR10PLUS {
@@ -1952,9 +1786,6 @@ impl Default for D3DDDI_HDR_METADATA_HDR10PLUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_HDR_METADATA_HDR10PLUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1976,9 +1807,6 @@ impl Default for D3DDDI_KERNELOVERLAYINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_KERNELOVERLAYINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_MAKERESIDENT {
@@ -1995,9 +1823,6 @@ impl Default for D3DDDI_MAKERESIDENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_MAKERESIDENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_MAKERESIDENT_FLAGS {
@@ -2007,9 +1832,6 @@ impl Default for D3DDDI_MAKERESIDENT_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_MAKERESIDENT_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2022,9 +1844,6 @@ impl Default for D3DDDI_MAKERESIDENT_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_MAKERESIDENT_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_MAKERESIDENT_FLAGS_0_0 {
@@ -2034,9 +1853,6 @@ impl Default for D3DDDI_MAKERESIDENT_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_MAKERESIDENT_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2060,9 +1876,6 @@ impl Default for D3DDDI_MAPGPUVIRTUALADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_MAPGPUVIRTUALADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DDDI_MAX_BROADCAST_CONTEXT: u32 = 64u32;
 pub const D3DDDI_MAX_MPO_PRESENT_DIRTY_RECTS: u32 = 4095u32;
 pub const D3DDDI_MAX_OBJECT_SIGNALED: u32 = 32u32;
@@ -2080,9 +1893,6 @@ impl Default for D3DDDI_MULTISAMPLINGMETHOD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_MULTISAMPLINGMETHOD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_NATIVEFENCEMAPPING {
@@ -2095,9 +1905,6 @@ impl Default for D3DDDI_NATIVEFENCEMAPPING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_NATIVEFENCEMAPPING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_OFFER_FLAGS {
@@ -2107,9 +1914,6 @@ impl Default for D3DDDI_OFFER_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_OFFER_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2122,9 +1926,6 @@ impl Default for D3DDDI_OFFER_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_OFFER_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_OFFER_FLAGS_0_0 {
@@ -2134,9 +1935,6 @@ impl Default for D3DDDI_OFFER_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_OFFER_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2158,9 +1956,6 @@ impl Default for D3DDDI_OPENALLOCATIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_OPENALLOCATIONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_OPENALLOCATIONINFO2 {
@@ -2174,9 +1969,6 @@ impl Default for D3DDDI_OPENALLOCATIONINFO2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_OPENALLOCATIONINFO2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDDI_OUTPUT_WIRE_COLOR_SPACE_G2084_P2020: D3DDDI_OUTPUT_WIRE_COLOR_SPACE_TYPE = D3DDDI_OUTPUT_WIRE_COLOR_SPACE_TYPE(12i32);
 pub const D3DDDI_OUTPUT_WIRE_COLOR_SPACE_G2084_P2020_DVLL: D3DDDI_OUTPUT_WIRE_COLOR_SPACE_TYPE = D3DDDI_OUTPUT_WIRE_COLOR_SPACE_TYPE(33i32);
@@ -2209,9 +2001,6 @@ impl Default for D3DDDI_PATCHLOCATIONLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_PATCHLOCATIONLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_PATCHLOCATIONLIST_0 {
@@ -2223,9 +2012,6 @@ impl Default for D3DDDI_PATCHLOCATIONLIST_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_PATCHLOCATIONLIST_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_PATCHLOCATIONLIST_0_0 {
@@ -2235,9 +2021,6 @@ impl Default for D3DDDI_PATCHLOCATIONLIST_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_PATCHLOCATIONLIST_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDDI_PERIODIC_MONITORED_FENCE: D3DDDI_SYNCHRONIZATIONOBJECT_TYPE = D3DDDI_SYNCHRONIZATIONOBJECT_TYPE(6i32);
 #[repr(transparent)]
@@ -2256,9 +2039,6 @@ impl Default for D3DDDI_QUERYREGISTRY_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_QUERYREGISTRY_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_QUERYREGISTRY_FLAGS_0 {
@@ -2270,9 +2050,6 @@ impl Default for D3DDDI_QUERYREGISTRY_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_QUERYREGISTRY_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_QUERYREGISTRY_FLAGS_0_0 {
@@ -2282,9 +2059,6 @@ impl Default for D3DDDI_QUERYREGISTRY_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_QUERYREGISTRY_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2303,9 +2077,6 @@ impl Default for D3DDDI_QUERYREGISTRY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_QUERYREGISTRY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_QUERYREGISTRY_INFO_0 {
@@ -2318,9 +2089,6 @@ impl Default for D3DDDI_QUERYREGISTRY_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_QUERYREGISTRY_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDDI_QUERYREGISTRY_MAX: D3DDDI_QUERYREGISTRY_TYPE = D3DDDI_QUERYREGISTRY_TYPE(4i32);
 pub const D3DDDI_QUERYREGISTRY_SERVICEKEY: D3DDDI_QUERYREGISTRY_TYPE = D3DDDI_QUERYREGISTRY_TYPE(0i32);
@@ -2344,9 +2112,6 @@ impl Default for D3DDDI_RATIONAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_RATIONAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2372,9 +2137,6 @@ impl Default for D3DDDI_RESERVEGPUVIRTUALADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_RESERVEGPUVIRTUALADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_RESERVEGPUVIRTUALADDRESS_0 {
@@ -2385,9 +2147,6 @@ impl Default for D3DDDI_RESERVEGPUVIRTUALADDRESS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_RESERVEGPUVIRTUALADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2400,9 +2159,6 @@ impl Default for D3DDDI_RESERVEGPUVIRTUALADDRESS_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_RESERVEGPUVIRTUALADDRESS_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_RESERVEGPUVIRTUALADDRESS_2 {
@@ -2413,9 +2169,6 @@ impl Default for D3DDDI_RESERVEGPUVIRTUALADDRESS_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_RESERVEGPUVIRTUALADDRESS_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2428,9 +2181,6 @@ impl Default for D3DDDI_RESERVEGPUVIRTUALADDRESS_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_RESERVEGPUVIRTUALADDRESS_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_RESOURCEFLAGS {
@@ -2440,9 +2190,6 @@ impl Default for D3DDDI_RESOURCEFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_RESOURCEFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2455,9 +2202,6 @@ impl Default for D3DDDI_RESOURCEFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_RESOURCEFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_RESOURCEFLAGS_0_0 {
@@ -2468,9 +2212,6 @@ impl Default for D3DDDI_RESOURCEFLAGS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_RESOURCEFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_RESOURCEFLAGS2 {
@@ -2480,9 +2221,6 @@ impl Default for D3DDDI_RESOURCEFLAGS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_RESOURCEFLAGS2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2495,9 +2233,6 @@ impl Default for D3DDDI_RESOURCEFLAGS2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_RESOURCEFLAGS2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_RESOURCEFLAGS2_0_0 {
@@ -2507,9 +2242,6 @@ impl Default for D3DDDI_RESOURCEFLAGS2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_RESOURCEFLAGS2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2534,9 +2266,6 @@ impl Default for D3DDDI_SEGMENTPREFERENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SEGMENTPREFERENCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_SEGMENTPREFERENCE_0 {
@@ -2548,9 +2277,6 @@ impl Default for D3DDDI_SEGMENTPREFERENCE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SEGMENTPREFERENCE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_SEGMENTPREFERENCE_0_0 {
@@ -2560,9 +2286,6 @@ impl Default for D3DDDI_SEGMENTPREFERENCE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_SEGMENTPREFERENCE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDDI_SEMAPHORE: D3DDDI_SYNCHRONIZATIONOBJECT_TYPE = D3DDDI_SYNCHRONIZATIONOBJECT_TYPE(2i32);
 #[repr(C)]
@@ -2580,9 +2303,6 @@ impl Default for D3DDDI_SURFACEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SURFACEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO {
@@ -2593,9 +2313,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2609,9 +2326,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
@@ -2621,9 +2335,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2636,9 +2347,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
@@ -2648,9 +2356,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2664,9 +2369,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2684,9 +2386,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3 {
@@ -2697,9 +2396,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
@@ -2709,9 +2405,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2726,9 +2419,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2746,9 +2436,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6 {
@@ -2758,9 +2445,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2773,9 +2457,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
@@ -2786,9 +2467,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECTINFO2_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS {
@@ -2798,9 +2476,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2813,9 +2488,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS_0_0 {
@@ -2825,9 +2497,6 @@ impl Default for D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_SYNCHRONIZATIONOBJECT_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2846,9 +2515,6 @@ impl Default for D3DDDI_TRIMRESIDENCYSET_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_TRIMRESIDENCYSET_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_TRIMRESIDENCYSET_FLAGS_0 {
@@ -2860,9 +2526,6 @@ impl Default for D3DDDI_TRIMRESIDENCYSET_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_TRIMRESIDENCYSET_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_TRIMRESIDENCYSET_FLAGS_0_0 {
@@ -2872,9 +2535,6 @@ impl Default for D3DDDI_TRIMRESIDENCYSET_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_TRIMRESIDENCYSET_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2892,9 +2552,6 @@ impl Default for D3DDDI_UPDATEALLOCPROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEALLOCPROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_UPDATEALLOCPROPERTY_0 {
@@ -2906,9 +2563,6 @@ impl Default for D3DDDI_UPDATEALLOCPROPERTY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEALLOCPROPERTY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_UPDATEALLOCPROPERTY_0_0 {
@@ -2919,9 +2573,6 @@ impl Default for D3DDDI_UPDATEALLOCPROPERTY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEALLOCPROPERTY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_UPDATEALLOCPROPERTY_FLAGS {
@@ -2931,9 +2582,6 @@ impl Default for D3DDDI_UPDATEALLOCPROPERTY_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_UPDATEALLOCPROPERTY_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2946,9 +2594,6 @@ impl Default for D3DDDI_UPDATEALLOCPROPERTY_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEALLOCPROPERTY_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_UPDATEALLOCPROPERTY_FLAGS_0_0 {
@@ -2958,9 +2603,6 @@ impl Default for D3DDDI_UPDATEALLOCPROPERTY_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_UPDATEALLOCPROPERTY_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDDI_UPDATEGPUVIRTUALADDRESS_COPY: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_TYPE = D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_TYPE(2i32);
 pub const D3DDDI_UPDATEGPUVIRTUALADDRESS_MAP: D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_TYPE = D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_TYPE(0i32);
@@ -2976,9 +2618,6 @@ impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0 {
@@ -2992,9 +2631,6 @@ impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
@@ -3006,9 +2642,6 @@ impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3026,9 +2659,6 @@ impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
@@ -3043,9 +2673,6 @@ impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
@@ -3057,9 +2684,6 @@ impl Default for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_UPDATEGPUVIRTUALADDRESS_OPERATION_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3083,9 +2707,6 @@ impl Default for D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS_0 {
@@ -3097,9 +2718,6 @@ impl Default for D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS_0_0 {
@@ -3109,9 +2727,6 @@ impl Default for D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDDI_WAITFORSYNCHRONIZATIONOBJECTFROMCPU_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDEVCAPS_HWINDEXBUFFER: i32 = 67108864i32;
 pub const D3DDEVCAPS_HWVERTEXBUFFER: i32 = 33554432i32;
@@ -3139,10 +2754,6 @@ impl Default for D3DDEVICEDESC_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DDEVICEDESC_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -3175,10 +2786,6 @@ impl Default for D3DDEVICEDESC_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DDEVICEDESC_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -3224,10 +2831,6 @@ impl Default for D3DDEVICEDESC_V3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DDEVICEDESC_V3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDEVINFOID_VCACHE: u32 = 4u32;
 pub const D3DDP2OP_ADDDIRTYBOX: D3DHAL_DP2OPERATION = D3DHAL_DP2OPERATION(67i32);
@@ -3342,9 +2945,6 @@ impl Default for D3DGPU_PHYSICAL_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DGPU_PHYSICAL_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DHAL2_CB32_CLEAR: i32 = 2i32;
 pub const D3DHAL2_CB32_DRAWONEINDEXEDPRIMITIVE: i32 = 8i32;
 pub const D3DHAL2_CB32_DRAWONEPRIMITIVE: i32 = 4i32;
@@ -3411,10 +3011,6 @@ impl Default for D3DHAL_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3433,10 +3029,6 @@ impl Default for D3DHAL_CALLBACKS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_CALLBACKS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3453,10 +3045,6 @@ impl Default for D3DHAL_CALLBACKS3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_CALLBACKS3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -3477,10 +3065,6 @@ impl Default for D3DHAL_CLEAR2DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_CLEAR2DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3499,10 +3083,6 @@ impl Default for D3DHAL_CLEARDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_CLEARDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_CLIPPEDTRIANGLEFAN {
@@ -3514,9 +3094,6 @@ impl Default for D3DHAL_CLIPPEDTRIANGLEFAN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_CLIPPEDTRIANGLEFAN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DHAL_COL_WEIGHTS: u32 = 2u32;
 #[repr(C)]
@@ -3541,10 +3118,6 @@ impl Default for D3DHAL_CONTEXTCREATEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_CONTEXTCREATEDATA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 #[derive(Clone, Copy)]
@@ -3557,10 +3130,6 @@ impl Default for D3DHAL_CONTEXTCREATEDATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_CONTEXTCREATEDATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
@@ -3580,10 +3149,6 @@ impl Default for D3DHAL_CONTEXTCREATEDATA_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_CONTEXTCREATEDATA_1 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 pub union D3DHAL_CONTEXTCREATEDATA_2 {
@@ -3602,10 +3167,6 @@ impl Default for D3DHAL_CONTEXTCREATEDATA_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_CONTEXTCREATEDATA_2 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 #[derive(Clone, Copy)]
@@ -3619,10 +3180,6 @@ impl Default for D3DHAL_CONTEXTCREATEDATA_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_CONTEXTCREATEDATA_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_CONTEXTDESTROYALLDATA {
@@ -3634,9 +3191,6 @@ impl Default for D3DHAL_CONTEXTDESTROYALLDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_CONTEXTDESTROYALLDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_CONTEXTDESTROYDATA {
@@ -3647,9 +3201,6 @@ impl Default for D3DHAL_CONTEXTDESTROYDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_CONTEXTDESTROYDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DHAL_CONTEXT_BAD: i64 = 512i64;
 #[repr(C)]
@@ -3682,9 +3233,6 @@ impl Default for D3DHAL_D3DDX6EXTENDEDCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_D3DDX6EXTENDEDCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3726,9 +3274,6 @@ impl Default for D3DHAL_D3DEXTENDEDCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_D3DEXTENDEDCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3742,10 +3287,6 @@ impl Default for D3DHAL_DP2ADDDIRTYBOX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2ADDDIRTYBOX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2ADDDIRTYRECT {
@@ -3756,9 +3297,6 @@ impl Default for D3DHAL_DP2ADDDIRTYRECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2ADDDIRTYRECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3776,9 +3314,6 @@ impl Default for D3DHAL_DP2BLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2BLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3795,10 +3330,6 @@ impl Default for D3DHAL_DP2BUFFERBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2BUFFERBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2CLEAR {
@@ -3813,9 +3344,6 @@ impl Default for D3DHAL_DP2CLEAR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2CLEAR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2COLORFILL {
@@ -3827,9 +3355,6 @@ impl Default for D3DHAL_DP2COLORFILL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2COLORFILL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3843,9 +3368,6 @@ impl Default for D3DHAL_DP2COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DHAL_DP2COMMAND_0 {
@@ -3856,9 +3378,6 @@ impl Default for D3DHAL_DP2COMMAND_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2COMMAND_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -3879,10 +3398,6 @@ impl Default for D3DHAL_DP2COMPOSERECTS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2COMPOSERECTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2CREATELIGHT {
@@ -3892,9 +3407,6 @@ impl Default for D3DHAL_DP2CREATELIGHT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2CREATELIGHT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3906,9 +3418,6 @@ impl Default for D3DHAL_DP2CREATEPIXELSHADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2CREATEPIXELSHADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -3923,10 +3432,6 @@ impl Default for D3DHAL_DP2CREATEQUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2CREATEQUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2CREATEVERTEXSHADER {
@@ -3939,9 +3444,6 @@ impl Default for D3DHAL_DP2CREATEVERTEXSHADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2CREATEVERTEXSHADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2CREATEVERTEXSHADERDECL {
@@ -3952,9 +3454,6 @@ impl Default for D3DHAL_DP2CREATEVERTEXSHADERDECL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2CREATEVERTEXSHADERDECL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3967,9 +3466,6 @@ impl Default for D3DHAL_DP2CREATEVERTEXSHADERFUNC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2CREATEVERTEXSHADERFUNC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2DELETEQUERY {
@@ -3979,9 +3475,6 @@ impl Default for D3DHAL_DP2DELETEQUERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2DELETEQUERY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -4000,10 +3493,6 @@ impl Default for D3DHAL_DP2DRAWINDEXEDPRIMITIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2DRAWINDEXEDPRIMITIVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4021,10 +3510,6 @@ impl Default for D3DHAL_DP2DRAWINDEXEDPRIMITIVE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2DRAWINDEXEDPRIMITIVE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4038,10 +3523,6 @@ impl Default for D3DHAL_DP2DRAWPRIMITIVE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2DRAWPRIMITIVE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -4057,10 +3538,6 @@ impl Default for D3DHAL_DP2DRAWPRIMITIVE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2DRAWPRIMITIVE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2DRAWRECTPATCH {
@@ -4071,9 +3548,6 @@ impl Default for D3DHAL_DP2DRAWRECTPATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2DRAWRECTPATCH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4086,9 +3560,6 @@ impl Default for D3DHAL_DP2DRAWTRIPATCH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2DRAWTRIPATCH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2EXT {
@@ -4099,9 +3570,6 @@ impl Default for D3DHAL_DP2EXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2EXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -4116,10 +3584,6 @@ impl Default for D3DHAL_DP2GENERATEMIPSUBLEVELS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2GENERATEMIPSUBLEVELS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2INDEXEDLINELIST {
@@ -4131,9 +3595,6 @@ impl Default for D3DHAL_DP2INDEXEDLINELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2INDEXEDLINELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2INDEXEDLINESTRIP {
@@ -4144,9 +3605,6 @@ impl Default for D3DHAL_DP2INDEXEDLINESTRIP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2INDEXEDLINESTRIP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2INDEXEDTRIANGLEFAN {
@@ -4156,9 +3614,6 @@ impl Default for D3DHAL_DP2INDEXEDTRIANGLEFAN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2INDEXEDTRIANGLEFAN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4173,9 +3628,6 @@ impl Default for D3DHAL_DP2INDEXEDTRIANGLELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2INDEXEDTRIANGLELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2INDEXEDTRIANGLELIST2 {
@@ -4188,9 +3640,6 @@ impl Default for D3DHAL_DP2INDEXEDTRIANGLELIST2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2INDEXEDTRIANGLELIST2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2INDEXEDTRIANGLESTRIP {
@@ -4200,9 +3649,6 @@ impl Default for D3DHAL_DP2INDEXEDTRIANGLESTRIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2INDEXEDTRIANGLESTRIP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4215,9 +3661,6 @@ impl Default for D3DHAL_DP2ISSUEQUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2ISSUEQUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2LINELIST {
@@ -4228,9 +3671,6 @@ impl Default for D3DHAL_DP2LINELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2LINELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2LINESTRIP {
@@ -4240,9 +3680,6 @@ impl Default for D3DHAL_DP2LINESTRIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2LINESTRIP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
@@ -4257,10 +3694,6 @@ impl Default for D3DHAL_DP2MULTIPLYTRANSFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
-impl windows_core::TypeKind for D3DHAL_DP2MULTIPLYTRANSFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DHAL_DP2OPERATION(pub i32);
@@ -4274,9 +3707,6 @@ impl Default for D3DHAL_DP2PIXELSHADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2PIXELSHADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2POINTS {
@@ -4287,9 +3717,6 @@ impl Default for D3DHAL_DP2POINTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2POINTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -4304,10 +3731,6 @@ impl Default for D3DHAL_DP2RENDERSTATE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2RENDERSTATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy)]
@@ -4320,10 +3743,6 @@ impl Default for D3DHAL_DP2RENDERSTATE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2RENDERSTATE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4338,9 +3757,6 @@ impl Default for D3DHAL_DP2RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2RESPONSEQUERY {
@@ -4352,9 +3768,6 @@ impl Default for D3DHAL_DP2RESPONSEQUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2RESPONSEQUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2SETCLIPPLANE {
@@ -4365,9 +3778,6 @@ impl Default for D3DHAL_DP2SETCLIPPLANE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2SETCLIPPLANE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4381,9 +3791,6 @@ impl Default for D3DHAL_DP2SETCONVOLUTIONKERNELMONO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2SETCONVOLUTIONKERNELMONO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2SETDEPTHSTENCIL {
@@ -4393,9 +3800,6 @@ impl Default for D3DHAL_DP2SETDEPTHSTENCIL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2SETDEPTHSTENCIL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4408,9 +3812,6 @@ impl Default for D3DHAL_DP2SETINDICES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2SETINDICES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2SETLIGHT {
@@ -4421,9 +3822,6 @@ impl Default for D3DHAL_DP2SETLIGHT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2SETLIGHT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4437,9 +3835,6 @@ impl Default for D3DHAL_DP2SETPALETTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2SETPALETTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2SETPIXELSHADERCONST {
@@ -4450,9 +3845,6 @@ impl Default for D3DHAL_DP2SETPIXELSHADERCONST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2SETPIXELSHADERCONST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4465,9 +3857,6 @@ impl Default for D3DHAL_DP2SETPRIORITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2SETPRIORITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2SETRENDERTARGET {
@@ -4478,9 +3867,6 @@ impl Default for D3DHAL_DP2SETRENDERTARGET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2SETRENDERTARGET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4493,9 +3879,6 @@ impl Default for D3DHAL_DP2SETRENDERTARGET2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2SETRENDERTARGET2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2SETSTREAMSOURCE {
@@ -4507,9 +3890,6 @@ impl Default for D3DHAL_DP2SETSTREAMSOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2SETSTREAMSOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4524,9 +3904,6 @@ impl Default for D3DHAL_DP2SETSTREAMSOURCE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2SETSTREAMSOURCE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2SETSTREAMSOURCEFREQ {
@@ -4537,9 +3914,6 @@ impl Default for D3DHAL_DP2SETSTREAMSOURCEFREQ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2SETSTREAMSOURCEFREQ {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4552,9 +3926,6 @@ impl Default for D3DHAL_DP2SETSTREAMSOURCEUM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2SETSTREAMSOURCEUM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2SETTEXLOD {
@@ -4565,9 +3936,6 @@ impl Default for D3DHAL_DP2SETTEXLOD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2SETTEXLOD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
@@ -4582,10 +3950,6 @@ impl Default for D3DHAL_DP2SETTRANSFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
-impl windows_core::TypeKind for D3DHAL_DP2SETTRANSFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2SETVERTEXSHADERCONST {
@@ -4597,9 +3961,6 @@ impl Default for D3DHAL_DP2SETVERTEXSHADERCONST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2SETVERTEXSHADERCONST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2STARTVERTEX {
@@ -4609,9 +3970,6 @@ impl Default for D3DHAL_DP2STARTVERTEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2STARTVERTEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -4626,10 +3984,6 @@ impl Default for D3DHAL_DP2STATESET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2STATESET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4647,9 +4001,6 @@ impl Default for D3DHAL_DP2SURFACEBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2SURFACEBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2TEXBLT {
@@ -4664,9 +4015,6 @@ impl Default for D3DHAL_DP2TEXBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2TEXBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2TEXTURESTAGESTATE {
@@ -4679,9 +4027,6 @@ impl Default for D3DHAL_DP2TEXTURESTAGESTATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2TEXTURESTAGESTATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2TRIANGLEFAN {
@@ -4691,9 +4036,6 @@ impl Default for D3DHAL_DP2TRIANGLEFAN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2TRIANGLEFAN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4705,9 +4047,6 @@ impl Default for D3DHAL_DP2TRIANGLEFAN_IMM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2TRIANGLEFAN_IMM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2TRIANGLELIST {
@@ -4718,9 +4057,6 @@ impl Default for D3DHAL_DP2TRIANGLELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2TRIANGLELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2TRIANGLESTRIP {
@@ -4730,9 +4066,6 @@ impl Default for D3DHAL_DP2TRIANGLESTRIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2TRIANGLESTRIP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4746,9 +4079,6 @@ impl Default for D3DHAL_DP2UPDATEPALETTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2UPDATEPALETTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2VERTEXSHADER {
@@ -4758,9 +4088,6 @@ impl Default for D3DHAL_DP2VERTEXSHADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2VERTEXSHADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4774,9 +4101,6 @@ impl Default for D3DHAL_DP2VIEWPORTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2VIEWPORTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -4796,10 +4120,6 @@ impl Default for D3DHAL_DP2VOLUMEBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DP2VOLUMEBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2WINFO {
@@ -4811,9 +4131,6 @@ impl Default for D3DHAL_DP2WINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_DP2WINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DP2ZRANGE {
@@ -4824,9 +4141,6 @@ impl Default for D3DHAL_DP2ZRANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DP2ZRANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -4848,10 +4162,6 @@ impl Default for D3DHAL_DRAWONEINDEXEDPRIMITIVEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DRAWONEINDEXEDPRIMITIVEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy)]
@@ -4864,10 +4174,6 @@ impl Default for D3DHAL_DRAWONEINDEXEDPRIMITIVEDATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DRAWONEINDEXEDPRIMITIVEDATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -4888,10 +4194,6 @@ impl Default for D3DHAL_DRAWONEPRIMITIVEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DRAWONEPRIMITIVEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy)]
@@ -4905,10 +4207,6 @@ impl Default for D3DHAL_DRAWONEPRIMITIVEDATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_DRAWONEPRIMITIVEDATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DRAWPRIMCOUNTS {
@@ -4921,9 +4219,6 @@ impl Default for D3DHAL_DRAWPRIMCOUNTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DRAWPRIMCOUNTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
@@ -4950,10 +4245,6 @@ impl Default for D3DHAL_DRAWPRIMITIVES2DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_DRAWPRIMITIVES2DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 #[derive(Clone, Copy)]
@@ -4966,10 +4257,6 @@ impl Default for D3DHAL_DRAWPRIMITIVES2DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_DRAWPRIMITIVES2DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
@@ -4984,10 +4271,6 @@ impl Default for D3DHAL_DRAWPRIMITIVES2DATA_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_DRAWPRIMITIVES2DATA_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_DRAWPRIMITIVESDATA {
@@ -5001,9 +4284,6 @@ impl Default for D3DHAL_DRAWPRIMITIVESDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_DRAWPRIMITIVESDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DHAL_EXECUTE_ABORT: i32 = 528i32;
 pub const D3DHAL_EXECUTE_NORMAL: i32 = 0i32;
@@ -5024,10 +4304,6 @@ impl Default for D3DHAL_GETSTATEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DHAL_GETSTATEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5044,10 +4320,6 @@ impl Default for D3DHAL_GLOBALDRIVERDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw"))]
-impl windows_core::TypeKind for D3DHAL_GLOBALDRIVERDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DHAL_MAX_RSTATES: u32 = 256u32;
 pub const D3DHAL_MAX_RSTATES_DX6: u32 = 256u32;
@@ -5076,10 +4348,6 @@ impl Default for D3DHAL_RENDERPRIMITIVEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw"))]
-impl windows_core::TypeKind for D3DHAL_RENDERPRIMITIVEDATA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 #[derive(Clone, Debug, PartialEq)]
@@ -5096,10 +4364,6 @@ impl Default for D3DHAL_RENDERSTATEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DHAL_RENDERSTATEDATA {
-    type TypeKind = windows_core::CloneType;
-}
 pub const D3DHAL_ROW_WEIGHTS: u32 = 1u32;
 pub const D3DHAL_SAMPLER_MAXSAMP: u32 = 16u32;
 pub const D3DHAL_SAMPLER_MAXVERTEXSAMP: u32 = 4u32;
@@ -5114,9 +4378,6 @@ impl Default for D3DHAL_SCENECAPTUREDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_SCENECAPTUREDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DHAL_SCENE_CAPTURE_END: i32 = 1i32;
 pub const D3DHAL_SCENE_CAPTURE_START: i32 = 0i32;
@@ -5143,10 +4404,6 @@ impl Default for D3DHAL_SETRENDERTARGETDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_SETRENDERTARGETDATA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 pub union D3DHAL_SETRENDERTARGETDATA_0 {
@@ -5165,10 +4422,6 @@ impl Default for D3DHAL_SETRENDERTARGETDATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_SETRENDERTARGETDATA_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 pub union D3DHAL_SETRENDERTARGETDATA_1 {
@@ -5186,10 +4439,6 @@ impl Default for D3DHAL_SETRENDERTARGETDATA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for D3DHAL_SETRENDERTARGETDATA_1 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const D3DHAL_STATESETBEGIN: u32 = 0u32;
 pub const D3DHAL_STATESETCAPTURE: u32 = 4u32;
@@ -5212,10 +4461,6 @@ impl Default for D3DHAL_TEXTURECREATEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DHAL_TEXTURECREATEDATA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DHAL_TEXTUREDESTROYDATA {
@@ -5227,9 +4472,6 @@ impl Default for D3DHAL_TEXTUREDESTROYDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_TEXTUREDESTROYDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5244,9 +4486,6 @@ impl Default for D3DHAL_TEXTUREGETSURFDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_TEXTUREGETSURFDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DHAL_TEXTURESTATEBUF_SIZE: u32 = 14u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5260,9 +4499,6 @@ impl Default for D3DHAL_TEXTURESWAPDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHAL_TEXTURESWAPDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DHAL_TSS_MAXSTAGES: u32 = 8u32;
 pub const D3DHAL_TSS_RENDERSTATEBASE: u32 = 256u32;
@@ -5281,9 +4517,6 @@ impl Default for D3DHAL_VALIDATETEXTURESTAGESTATEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHAL_VALIDATETEXTURESTAGESTATEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DINFINITEINSTRUCTIONS: u32 = 4294967295u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5296,9 +4529,6 @@ impl Default for D3DKMDT_2DREGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_2DREGION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMDT_3x4_COLORSPACE_TRANSFORM {
@@ -5310,9 +4540,6 @@ impl Default for D3DKMDT_3x4_COLORSPACE_TRANSFORM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_3x4_COLORSPACE_TRANSFORM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMDT_BITS_PER_COMPONENT_06: u32 = 1u32;
 pub const D3DKMDT_BITS_PER_COMPONENT_08: u32 = 2u32;
@@ -5341,9 +4568,6 @@ impl Default for D3DKMDT_COLORSPACE_TRANSFORM_MATRIX_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_COLORSPACE_TRANSFORM_MATRIX_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DKMDT_COLORSPACE_TRANSFORM_STAGE_CONTROL(pub i32);
@@ -5366,9 +4590,6 @@ impl Default for D3DKMDT_COLOR_COEFF_DYNAMIC_RANGES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_COLOR_COEFF_DYNAMIC_RANGES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DKMDT_COMPUTE_PREEMPTION_DISPATCH_BOUNDARY: D3DKMDT_COMPUTE_PREEMPTION_GRANULARITY = D3DKMDT_COMPUTE_PREEMPTION_GRANULARITY(200i32);
 pub const D3DKMDT_COMPUTE_PREEMPTION_DMA_BUFFER_BOUNDARY: D3DKMDT_COMPUTE_PREEMPTION_GRANULARITY = D3DKMDT_COMPUTE_PREEMPTION_GRANULARITY(100i32);
 #[repr(transparent)]
@@ -5388,9 +4609,6 @@ impl Default for D3DKMDT_DISPLAYMODE_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_DISPLAYMODE_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5414,9 +4632,6 @@ impl Default for D3DKMDT_FREQUENCY_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_FREQUENCY_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMDT_GAMMA_RAMP {
@@ -5428,9 +4643,6 @@ impl Default for D3DKMDT_GAMMA_RAMP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_GAMMA_RAMP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5445,9 +4657,6 @@ impl Default for D3DKMDT_GAMMA_RAMP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_GAMMA_RAMP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5464,9 +4673,6 @@ impl Default for D3DKMDT_GDISURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_GDISURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMDT_GDISURFACEFLAGS {
@@ -5476,9 +4682,6 @@ impl Default for D3DKMDT_GDISURFACEFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_GDISURFACEFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5491,9 +4694,6 @@ impl Default for D3DKMDT_GDISURFACEFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_GDISURFACEFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMDT_GDISURFACEFLAGS_0_0 {
@@ -5503,9 +4703,6 @@ impl Default for D3DKMDT_GDISURFACEFLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_GDISURFACEFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5542,9 +4739,6 @@ impl Default for D3DKMDT_GRAPHICS_RENDERING_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_GRAPHICS_RENDERING_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5601,9 +4795,6 @@ impl Default for D3DKMDT_MONITOR_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_MONITOR_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DKMDT_MONITOR_DESCRIPTOR_TYPE(pub i32);
@@ -5620,9 +4811,6 @@ impl Default for D3DKMDT_MONITOR_FREQUENCY_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_MONITOR_FREQUENCY_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMDT_MONITOR_FREQUENCY_RANGE_0 {
@@ -5633,9 +4821,6 @@ impl Default for D3DKMDT_MONITOR_FREQUENCY_RANGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_MONITOR_FREQUENCY_RANGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5660,9 +4845,6 @@ impl Default for D3DKMDT_MONITOR_SOURCE_MODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_MONITOR_SOURCE_MODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5706,9 +4888,6 @@ impl Default for D3DKMDT_PALETTEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_PALETTEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DKMDT_PIXEL_VALUE_ACCESS_MODE(pub i32);
@@ -5722,9 +4901,6 @@ impl Default for D3DKMDT_PREEMPTION_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_PREEMPTION_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMDT_PVAM_DIRECT: D3DKMDT_PIXEL_VALUE_ACCESS_MODE = D3DKMDT_PIXEL_VALUE_ACCESS_MODE(1i32);
 pub const D3DKMDT_PVAM_PRESETPALETTE: D3DKMDT_PIXEL_VALUE_ACCESS_MODE = D3DKMDT_PIXEL_VALUE_ACCESS_MODE(2i32);
@@ -5748,9 +4924,6 @@ impl Default for D3DKMDT_SHADOWSURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_SHADOWSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMDT_SHAREDPRIMARYSURFACEDATA {
@@ -5765,9 +4938,6 @@ impl Default for D3DKMDT_SHAREDPRIMARYSURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_SHAREDPRIMARYSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMDT_STAGINGSURFACEDATA {
@@ -5779,9 +4949,6 @@ impl Default for D3DKMDT_STAGINGSURFACEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_STAGINGSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMDT_STANDARDALLOCATION_GDISURFACE: D3DKMDT_STANDARDALLOCATION_TYPE = D3DKMDT_STANDARDALLOCATION_TYPE(4i32);
 pub const D3DKMDT_STANDARDALLOCATION_SHADOWSURFACE: D3DKMDT_STANDARDALLOCATION_TYPE = D3DKMDT_STANDARDALLOCATION_TYPE(2i32);
@@ -5809,9 +4976,6 @@ impl Default for D3DKMDT_VIDEO_PRESENT_SOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_VIDEO_PRESENT_SOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMDT_VIDEO_PRESENT_TARGET {
@@ -5825,9 +4989,6 @@ impl Default for D3DKMDT_VIDEO_PRESENT_TARGET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_VIDEO_PRESENT_TARGET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5845,9 +5006,6 @@ impl Default for D3DKMDT_VIDEO_SIGNAL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_VIDEO_SIGNAL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMDT_VIDEO_SIGNAL_INFO_0 {
@@ -5859,9 +5017,6 @@ impl Default for D3DKMDT_VIDEO_SIGNAL_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_VIDEO_SIGNAL_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMDT_VIDEO_SIGNAL_INFO_0_0 {
@@ -5871,9 +5026,6 @@ impl Default for D3DKMDT_VIDEO_SIGNAL_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_VIDEO_SIGNAL_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5887,9 +5039,6 @@ impl Default for D3DKMDT_VIDPN_HW_CAPABILITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_VIDPN_HW_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5911,9 +5060,6 @@ impl Default for D3DKMDT_VIDPN_PRESENT_PATH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_VIDPN_PRESENT_PATH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DKMDT_VIDPN_PRESENT_PATH_CONTENT(pub i32);
@@ -5930,9 +5076,6 @@ impl Default for D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION_SUPPORT {
@@ -5942,9 +5085,6 @@ impl Default for D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_VIDPN_PRESENT_PATH_COPYPROTECTION_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5965,9 +5105,6 @@ impl Default for D3DKMDT_VIDPN_PRESENT_PATH_ROTATION_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_VIDPN_PRESENT_PATH_ROTATION_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DKMDT_VIDPN_PRESENT_PATH_SCALING(pub i32);
@@ -5980,9 +5117,6 @@ impl Default for D3DKMDT_VIDPN_PRESENT_PATH_SCALING_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_VIDPN_PRESENT_PATH_SCALING_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5997,9 +5131,6 @@ impl Default for D3DKMDT_VIDPN_PRESENT_PATH_TRANSFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_VIDPN_PRESENT_PATH_TRANSFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMDT_VIDPN_SOURCE_MODE {
@@ -6012,9 +5143,6 @@ impl Default for D3DKMDT_VIDPN_SOURCE_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_VIDPN_SOURCE_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMDT_VIDPN_SOURCE_MODE_0 {
@@ -6025,9 +5153,6 @@ impl Default for D3DKMDT_VIDPN_SOURCE_MODE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_VIDPN_SOURCE_MODE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6045,9 +5170,6 @@ impl Default for D3DKMDT_VIDPN_TARGET_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_VIDPN_TARGET_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMDT_VIDPN_TARGET_MODE_0 {
@@ -6059,9 +5181,6 @@ impl Default for D3DKMDT_VIDPN_TARGET_MODE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_VIDPN_TARGET_MODE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMDT_VIDPN_TARGET_MODE_0_0 {
@@ -6071,9 +5190,6 @@ impl Default for D3DKMDT_VIDPN_TARGET_MODE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_VIDPN_TARGET_MODE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6087,9 +5203,6 @@ impl Default for D3DKMDT_VIRTUALGPUSURFACEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_VIRTUALGPUSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMDT_VOT_BNC: D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY = D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY(3i32);
 pub const D3DKMDT_VOT_COMPONENT_VIDEO: D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY = D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY(3i32);
@@ -6206,9 +5319,6 @@ impl Default for D3DKMDT_WIRE_FORMAT_AND_PREFERENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMDT_WIRE_FORMAT_AND_PREFERENCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMDT_WIRE_FORMAT_AND_PREFERENCE_0 {
@@ -6218,9 +5328,6 @@ impl Default for D3DKMDT_WIRE_FORMAT_AND_PREFERENCE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMDT_WIRE_FORMAT_AND_PREFERENCE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6234,9 +5341,6 @@ impl Default for D3DKMT_ACQUIREKEYEDMUTEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ACQUIREKEYEDMUTEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6253,9 +5357,6 @@ impl Default for D3DKMT_ACQUIREKEYEDMUTEX2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ACQUIREKEYEDMUTEX2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_ACTIVATE_SPECIFIC_DIAG_ESCAPE {
@@ -6266,9 +5367,6 @@ impl Default for D3DKMT_ACTIVATE_SPECIFIC_DIAG_ESCAPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ACTIVATE_SPECIFIC_DIAG_ESCAPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6287,9 +5385,6 @@ impl Default for D3DKMT_ADAPTERADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ADAPTERADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_ADAPTERINFO {
@@ -6302,9 +5397,6 @@ impl Default for D3DKMT_ADAPTERINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ADAPTERINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6319,9 +5411,6 @@ impl Default for D3DKMT_ADAPTERREGISTRYINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ADAPTERREGISTRYINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_ADAPTERTYPE {
@@ -6331,9 +5420,6 @@ impl Default for D3DKMT_ADAPTERTYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ADAPTERTYPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6346,9 +5432,6 @@ impl Default for D3DKMT_ADAPTERTYPE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ADAPTERTYPE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_ADAPTERTYPE_0_0 {
@@ -6358,9 +5441,6 @@ impl Default for D3DKMT_ADAPTERTYPE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ADAPTERTYPE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6381,9 +5461,6 @@ impl Default for D3DKMT_ADAPTER_PERFDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ADAPTER_PERFDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_ADAPTER_PERFDATACAPS {
@@ -6399,9 +5476,6 @@ impl Default for D3DKMT_ADAPTER_PERFDATACAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ADAPTER_PERFDATACAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_ADAPTER_VERIFIER_OPTION {
@@ -6414,9 +5488,6 @@ impl Default for D3DKMT_ADAPTER_VERIFIER_OPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ADAPTER_VERIFIER_OPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_ADAPTER_VERIFIER_OPTION_DATA {
@@ -6427,9 +5498,6 @@ impl Default for D3DKMT_ADAPTER_VERIFIER_OPTION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ADAPTER_VERIFIER_OPTION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6447,9 +5515,6 @@ impl Default for D3DKMT_ADAPTER_VERIFIER_VIDMM_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ADAPTER_VERIFIER_VIDMM_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_ADAPTER_VERIFIER_VIDMM_FLAGS_0 {
@@ -6459,9 +5524,6 @@ impl Default for D3DKMT_ADAPTER_VERIFIER_VIDMM_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ADAPTER_VERIFIER_VIDMM_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6475,9 +5537,6 @@ impl Default for D3DKMT_ADAPTER_VERIFIER_VIDMM_TRIM_INTERVAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ADAPTER_VERIFIER_VIDMM_TRIM_INTERVAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_ADJUSTFULLSCREENGAMMA {
@@ -6490,9 +5549,6 @@ impl Default for D3DKMT_ADJUSTFULLSCREENGAMMA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ADJUSTFULLSCREENGAMMA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6510,9 +5566,6 @@ impl Default for D3DKMT_AUXILIARYPRESENTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_AUXILIARYPRESENTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6533,9 +5586,6 @@ impl Default for D3DKMT_BDDFALLBACK_CTL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_BDDFALLBACK_CTL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_BLOCKLIST_INFO {
@@ -6546,9 +5596,6 @@ impl Default for D3DKMT_BLOCKLIST_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_BLOCKLIST_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6563,9 +5610,6 @@ impl Default for D3DKMT_BLTMODEL_PRESENTHISTORYTOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_BLTMODEL_PRESENTHISTORYTOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_BRIGHTNESS_INFO {
@@ -6577,9 +5621,6 @@ impl Default for D3DKMT_BRIGHTNESS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_BRIGHTNESS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6599,9 +5640,6 @@ impl Default for D3DKMT_BRIGHTNESS_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_BRIGHTNESS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_BRIGHTNESS_INFO_BEGIN_MANUAL_MODE: D3DKMT_BRIGHTNESS_INFO_TYPE = D3DKMT_BRIGHTNESS_INFO_TYPE(8i32);
 pub const D3DKMT_BRIGHTNESS_INFO_END_MANUAL_MODE: D3DKMT_BRIGHTNESS_INFO_TYPE = D3DKMT_BRIGHTNESS_INFO_TYPE(9i32);
@@ -6628,9 +5666,6 @@ impl Default for D3DKMT_BRIGHTNESS_POSSIBLE_LEVELS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_BRIGHTNESS_POSSIBLE_LEVELS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_BUDGETCHANGENOTIFICATION {
@@ -6641,9 +5676,6 @@ impl Default for D3DKMT_BUDGETCHANGENOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_BUDGETCHANGENOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6661,9 +5693,6 @@ impl Default for D3DKMT_CANCEL_PRESENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CANCEL_PRESENTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CANCEL_PRESENTS_FLAGS {
@@ -6673,9 +5702,6 @@ impl Default for D3DKMT_CANCEL_PRESENTS_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CANCEL_PRESENTS_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6688,9 +5714,6 @@ impl Default for D3DKMT_CANCEL_PRESENTS_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CANCEL_PRESENTS_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CANCEL_PRESENTS_FLAGS_0_0 {
@@ -6700,9 +5723,6 @@ impl Default for D3DKMT_CANCEL_PRESENTS_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CANCEL_PRESENTS_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6726,10 +5746,6 @@ impl Default for D3DKMT_CHANGESURFACEPOINTER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for D3DKMT_CHANGESURFACEPOINTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CHANGEVIDEOMEMORYRESERVATION {
@@ -6744,9 +5760,6 @@ impl Default for D3DKMT_CHANGEVIDEOMEMORYRESERVATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CHANGEVIDEOMEMORYRESERVATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CHECKMONITORPOWERSTATE {
@@ -6757,9 +5770,6 @@ impl Default for D3DKMT_CHECKMONITORPOWERSTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CHECKMONITORPOWERSTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6775,9 +5785,6 @@ impl Default for D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT2 {
@@ -6792,9 +5799,6 @@ impl Default for D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6813,9 +5817,6 @@ impl Default for D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CHECKMULTIPLANEOVERLAYSUPPORT3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CHECKOCCLUSION {
@@ -6825,9 +5826,6 @@ impl Default for D3DKMT_CHECKOCCLUSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CHECKOCCLUSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6840,9 +5838,6 @@ impl Default for D3DKMT_CHECKSHAREDRESOURCEACCESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CHECKSHAREDRESOURCEACCESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CHECKVIDPNEXCLUSIVEOWNERSHIP {
@@ -6853,9 +5848,6 @@ impl Default for D3DKMT_CHECKVIDPNEXCLUSIVEOWNERSHIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CHECKVIDPNEXCLUSIVEOWNERSHIP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6869,9 +5861,6 @@ impl Default for D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6887,9 +5876,6 @@ impl Default for D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE3 {
@@ -6904,9 +5890,6 @@ impl Default for D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CHECK_MULTIPLANE_OVERLAY_PLANE3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO {
@@ -6916,9 +5899,6 @@ impl Default for D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6931,9 +5911,6 @@ impl Default for D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO_0_0 {
@@ -6943,9 +5920,6 @@ impl Default for D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CHECK_MULTIPLANE_OVERLAY_SUPPORT_RETURN_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6982,9 +5956,6 @@ impl Default for D3DKMT_CLOSEADAPTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CLOSEADAPTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_COMPOSITION_PRESENTHISTORYTOKEN {
@@ -6994,9 +5965,6 @@ impl Default for D3DKMT_COMPOSITION_PRESENTHISTORYTOKEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_COMPOSITION_PRESENTHISTORYTOKEN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7012,9 +5980,6 @@ impl Default for D3DKMT_CONFIGURESHAREDRESOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CONFIGURESHAREDRESOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CONNECT_DOORBELL {
@@ -7026,9 +5991,6 @@ impl Default for D3DKMT_CONNECT_DOORBELL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CONNECT_DOORBELL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CONNECT_DOORBELL_FLAGS {
@@ -7038,9 +6000,6 @@ impl Default for D3DKMT_CONNECT_DOORBELL_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CONNECT_DOORBELL_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7053,9 +6012,6 @@ impl Default for D3DKMT_CONNECT_DOORBELL_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CONNECT_DOORBELL_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CONNECT_DOORBELL_FLAGS_0_0 {
@@ -7066,9 +6022,6 @@ impl Default for D3DKMT_CONNECT_DOORBELL_FLAGS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CONNECT_DOORBELL_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CPDRIVERNAME {
@@ -7078,9 +6031,6 @@ impl Default for D3DKMT_CPDRIVERNAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CPDRIVERNAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7102,9 +6052,6 @@ impl Default for D3DKMT_CREATEALLOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATEALLOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_CREATEALLOCATION_0 {
@@ -7115,9 +6062,6 @@ impl Default for D3DKMT_CREATEALLOCATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATEALLOCATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7130,9 +6074,6 @@ impl Default for D3DKMT_CREATEALLOCATION_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATEALLOCATION_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CREATEALLOCATIONFLAGS {
@@ -7142,9 +6083,6 @@ impl Default for D3DKMT_CREATEALLOCATIONFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATEALLOCATIONFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7170,9 +6108,6 @@ impl Default for D3DKMT_CREATECONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATECONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CREATECONTEXTVIRTUAL {
@@ -7189,9 +6124,6 @@ impl Default for D3DKMT_CREATECONTEXTVIRTUAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATECONTEXTVIRTUAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -7213,10 +6145,6 @@ impl Default for D3DKMT_CREATEDCFROMMEMORY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for D3DKMT_CREATEDCFROMMEMORY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CREATEDEVICE {
@@ -7235,9 +6163,6 @@ impl Default for D3DKMT_CREATEDEVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATEDEVICE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_CREATEDEVICE_0 {
@@ -7249,9 +6174,6 @@ impl Default for D3DKMT_CREATEDEVICE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATEDEVICE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CREATEDEVICEFLAGS {
@@ -7261,9 +6183,6 @@ impl Default for D3DKMT_CREATEDEVICEFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATEDEVICEFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7280,9 +6199,6 @@ impl Default for D3DKMT_CREATEHWCONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATEHWCONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7301,9 +6217,6 @@ impl Default for D3DKMT_CREATEHWQUEUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATEHWQUEUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CREATEKEYEDMUTEX {
@@ -7315,9 +6228,6 @@ impl Default for D3DKMT_CREATEKEYEDMUTEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATEKEYEDMUTEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7334,9 +6244,6 @@ impl Default for D3DKMT_CREATEKEYEDMUTEX2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATEKEYEDMUTEX2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CREATEKEYEDMUTEX2_FLAGS {
@@ -7346,9 +6253,6 @@ impl Default for D3DKMT_CREATEKEYEDMUTEX2_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATEKEYEDMUTEX2_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7361,9 +6265,6 @@ impl Default for D3DKMT_CREATEKEYEDMUTEX2_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATEKEYEDMUTEX2_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CREATEKEYEDMUTEX2_FLAGS_0_0 {
@@ -7373,9 +6274,6 @@ impl Default for D3DKMT_CREATEKEYEDMUTEX2_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATEKEYEDMUTEX2_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7387,9 +6285,6 @@ impl Default for D3DKMT_CREATENATIVEFENCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATENATIVEFENCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7403,9 +6298,6 @@ impl Default for D3DKMT_CREATEOVERLAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATEOVERLAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7421,9 +6313,6 @@ impl Default for D3DKMT_CREATEPAGINGQUEUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATEPAGINGQUEUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7441,9 +6330,6 @@ impl Default for D3DKMT_CREATEPROTECTEDSESSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATEPROTECTEDSESSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CREATESTANDARDALLOCATION {
@@ -7456,9 +6342,6 @@ impl Default for D3DKMT_CREATESTANDARDALLOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATESTANDARDALLOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_CREATESTANDARDALLOCATION_0 {
@@ -7469,9 +6352,6 @@ impl Default for D3DKMT_CREATESTANDARDALLOCATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATESTANDARDALLOCATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CREATESTANDARDALLOCATIONFLAGS {
@@ -7481,9 +6361,6 @@ impl Default for D3DKMT_CREATESTANDARDALLOCATIONFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATESTANDARDALLOCATIONFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7496,9 +6373,6 @@ impl Default for D3DKMT_CREATESTANDARDALLOCATIONFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATESTANDARDALLOCATIONFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CREATESTANDARDALLOCATIONFLAGS_0_0 {
@@ -7508,9 +6382,6 @@ impl Default for D3DKMT_CREATESTANDARDALLOCATIONFLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATESTANDARDALLOCATIONFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7525,9 +6396,6 @@ impl Default for D3DKMT_CREATESYNCFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATESYNCFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CREATESYNCHRONIZATIONOBJECT {
@@ -7540,9 +6408,6 @@ impl Default for D3DKMT_CREATESYNCHRONIZATIONOBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATESYNCHRONIZATIONOBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CREATESYNCHRONIZATIONOBJECT2 {
@@ -7554,9 +6419,6 @@ impl Default for D3DKMT_CREATESYNCHRONIZATIONOBJECT2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATESYNCHRONIZATIONOBJECT2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7576,9 +6438,6 @@ impl Default for D3DKMT_CREATE_DOORBELL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATE_DOORBELL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_CREATE_DOORBELL_FLAGS {
@@ -7588,9 +6447,6 @@ impl Default for D3DKMT_CREATE_DOORBELL_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATE_DOORBELL_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7603,9 +6459,6 @@ impl Default for D3DKMT_CREATE_DOORBELL_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATE_DOORBELL_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CREATE_DOORBELL_FLAGS_0_0 {
@@ -7615,9 +6468,6 @@ impl Default for D3DKMT_CREATE_DOORBELL_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CREATE_DOORBELL_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7634,9 +6484,6 @@ impl Default for D3DKMT_CREATE_OUTPUTDUPL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CREATE_OUTPUTDUPL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_CROSSADAPTERRESOURCE_SUPPORT {
@@ -7646,9 +6493,6 @@ impl Default for D3DKMT_CROSSADAPTERRESOURCE_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_CROSSADAPTERRESOURCE_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7670,9 +6514,6 @@ impl Default for D3DKMT_CURRENTDISPLAYMODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_CURRENTDISPLAYMODE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DKMT_ClientPagingBuffer: D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE = D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE(1i32);
 pub const D3DKMT_ClientRenderBuffer: D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE = D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE(0i32);
 #[repr(C)]
@@ -7685,9 +6526,6 @@ impl Default for D3DKMT_DEBUG_SNAPSHOT_ESCAPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DEBUG_SNAPSHOT_ESCAPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_DEFRAG_ESCAPE_DEFRAG_DOWNWARD: D3DKMT_DEFRAG_ESCAPE_OPERATION = D3DKMT_DEFRAG_ESCAPE_OPERATION(2i32);
 pub const D3DKMT_DEFRAG_ESCAPE_DEFRAG_PASS: D3DKMT_DEFRAG_ESCAPE_OPERATION = D3DKMT_DEFRAG_ESCAPE_OPERATION(3i32);
@@ -7710,9 +6548,6 @@ impl Default for D3DKMT_DESTROYALLOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DESTROYALLOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_DESTROYALLOCATION2 {
@@ -7727,9 +6562,6 @@ impl Default for D3DKMT_DESTROYALLOCATION2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DESTROYALLOCATION2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DESTROYCONTEXT {
@@ -7739,9 +6571,6 @@ impl Default for D3DKMT_DESTROYCONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DESTROYCONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -7756,10 +6585,6 @@ impl Default for D3DKMT_DESTROYDCFROMMEMORY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for D3DKMT_DESTROYDCFROMMEMORY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DESTROYDEVICE {
@@ -7769,9 +6594,6 @@ impl Default for D3DKMT_DESTROYDEVICE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DESTROYDEVICE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7783,9 +6605,6 @@ impl Default for D3DKMT_DESTROYHWCONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DESTROYHWCONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DESTROYHWQUEUE {
@@ -7796,9 +6615,6 @@ impl Default for D3DKMT_DESTROYHWQUEUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DESTROYHWQUEUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DESTROYKEYEDMUTEX {
@@ -7808,9 +6624,6 @@ impl Default for D3DKMT_DESTROYKEYEDMUTEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DESTROYKEYEDMUTEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7823,9 +6636,6 @@ impl Default for D3DKMT_DESTROYOVERLAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DESTROYOVERLAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DESTROYPROTECTEDSESSION {
@@ -7835,9 +6645,6 @@ impl Default for D3DKMT_DESTROYPROTECTEDSESSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DESTROYPROTECTEDSESSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7849,9 +6656,6 @@ impl Default for D3DKMT_DESTROYSYNCHRONIZATIONOBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DESTROYSYNCHRONIZATIONOBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DESTROY_DOORBELL {
@@ -7861,9 +6665,6 @@ impl Default for D3DKMT_DESTROY_DOORBELL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DESTROY_DOORBELL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7876,9 +6677,6 @@ impl Default for D3DKMT_DESTROY_OUTPUTDUPL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DESTROY_OUTPUTDUPL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_DEVICEESCAPE_RESTOREGAMMA: D3DKMT_DEVICEESCAPE_TYPE = D3DKMT_DEVICEESCAPE_TYPE(1i32);
 #[repr(transparent)]
@@ -7910,9 +6708,6 @@ impl Default for D3DKMT_DEVICEPAGEFAULT_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DEVICEPAGEFAULT_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DEVICEPRESENT_QUEUE_STATE {
@@ -7923,9 +6718,6 @@ impl Default for D3DKMT_DEVICEPRESENT_QUEUE_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DEVICEPRESENT_QUEUE_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7938,9 +6730,6 @@ impl Default for D3DKMT_DEVICEPRESENT_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DEVICEPRESENT_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DEVICEPRESENT_STATE_DWM {
@@ -7952,9 +6741,6 @@ impl Default for D3DKMT_DEVICEPRESENT_STATE_DWM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DEVICEPRESENT_STATE_DWM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_DEVICERESET_STATE {
@@ -7964,9 +6750,6 @@ impl Default for D3DKMT_DEVICERESET_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DEVICERESET_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7979,9 +6762,6 @@ impl Default for D3DKMT_DEVICERESET_STATE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DEVICERESET_STATE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DEVICERESET_STATE_0_0 {
@@ -7991,9 +6771,6 @@ impl Default for D3DKMT_DEVICERESET_STATE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DEVICERESET_STATE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_DEVICESTATE_EXECUTION: D3DKMT_DEVICESTATE_TYPE = D3DKMT_DEVICESTATE_TYPE(1i32);
 pub const D3DKMT_DEVICESTATE_PAGE_FAULT: D3DKMT_DEVICESTATE_TYPE = D3DKMT_DEVICESTATE_TYPE(5i32);
@@ -8020,9 +6797,6 @@ impl Default for D3DKMT_DEVICE_ESCAPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DEVICE_ESCAPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_DEVICE_ESCAPE_0 {
@@ -8032,9 +6806,6 @@ impl Default for D3DKMT_DEVICE_ESCAPE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DEVICE_ESCAPE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8046,9 +6817,6 @@ impl Default for D3DKMT_DEVICE_ESCAPE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DEVICE_ESCAPE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8065,9 +6833,6 @@ impl Default for D3DKMT_DEVICE_IDS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DEVICE_IDS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DIRECTFLIP_SUPPORT {
@@ -8077,9 +6842,6 @@ impl Default for D3DKMT_DIRECTFLIP_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DIRECTFLIP_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8091,9 +6853,6 @@ impl Default for D3DKMT_DIRTYREGIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DIRTYREGIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8113,9 +6872,6 @@ impl Default for D3DKMT_DISPLAYMODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DISPLAYMODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DISPLAYMODELIST {
@@ -8128,9 +6884,6 @@ impl Default for D3DKMT_DISPLAYMODELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DISPLAYMODELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_DISPLAY_CAPS {
@@ -8140,9 +6893,6 @@ impl Default for D3DKMT_DISPLAY_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DISPLAY_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8155,9 +6905,6 @@ impl Default for D3DKMT_DISPLAY_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DISPLAY_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_DISPLAY_CAPS_0_0 {
@@ -8167,9 +6914,6 @@ impl Default for D3DKMT_DISPLAY_CAPS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DISPLAY_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8182,9 +6926,6 @@ impl Default for D3DKMT_DISPLAY_UMD_FILENAMEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DISPLAY_UMD_FILENAMEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DLIST_DRIVER_NAME {
@@ -8194,9 +6935,6 @@ impl Default for D3DKMT_DLIST_DRIVER_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DLIST_DRIVER_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8229,9 +6967,6 @@ impl Default for D3DKMT_DMM_ESCAPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DMM_ESCAPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_DOD_SET_DIRTYRECT_MODE {
@@ -8242,9 +6977,6 @@ impl Default for D3DKMT_DOD_SET_DIRTYRECT_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DOD_SET_DIRTYRECT_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_DRIVERCAPS_EXT {
@@ -8254,9 +6986,6 @@ impl Default for D3DKMT_DRIVERCAPS_EXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DRIVERCAPS_EXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8269,9 +6998,6 @@ impl Default for D3DKMT_DRIVERCAPS_EXT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_DRIVERCAPS_EXT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_DRIVERCAPS_EXT_0_0 {
@@ -8281,9 +7007,6 @@ impl Default for D3DKMT_DRIVERCAPS_EXT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DRIVERCAPS_EXT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8297,9 +7020,6 @@ impl Default for D3DKMT_DRIVER_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_DRIVER_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_DeferredCommandBuffer: D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE = D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE(1i32);
 pub const D3DKMT_DeviceCommandBuffer: D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE = D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE(6i32);
@@ -8315,9 +7035,6 @@ impl Default for D3DKMT_ENUMADAPTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ENUMADAPTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_ENUMADAPTERS2 {
@@ -8328,9 +7045,6 @@ impl Default for D3DKMT_ENUMADAPTERS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ENUMADAPTERS2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8344,9 +7058,6 @@ impl Default for D3DKMT_ENUMADAPTERS3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ENUMADAPTERS3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_ENUMADAPTERS_FILTER {
@@ -8358,9 +7069,6 @@ impl Default for D3DKMT_ENUMADAPTERS_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ENUMADAPTERS_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_ENUMADAPTERS_FILTER_0 {
@@ -8370,9 +7078,6 @@ impl Default for D3DKMT_ENUMADAPTERS_FILTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ENUMADAPTERS_FILTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8389,9 +7094,6 @@ impl Default for D3DKMT_ESCAPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_ESCAPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8451,9 +7153,6 @@ impl Default for D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DKMT_ESCAPE_VIRTUAL_REFRESH_RATE_TYPE(pub i32);
@@ -8488,9 +7187,6 @@ impl Default for D3DKMT_EVICT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_EVICT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_EVICTION_CRITERIA {
@@ -8503,9 +7199,6 @@ impl Default for D3DKMT_EVICTION_CRITERIA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_EVICTION_CRITERIA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_EVICTION_CRITERIA_0 {
@@ -8515,9 +7208,6 @@ impl Default for D3DKMT_EVICTION_CRITERIA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_EVICTION_CRITERIA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8530,9 +7220,6 @@ impl Default for D3DKMT_EVICTION_CRITERIA_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_EVICTION_CRITERIA_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_EVICTION_CRITERIA_0_0_0 {
@@ -8542,9 +7229,6 @@ impl Default for D3DKMT_EVICTION_CRITERIA_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_EVICTION_CRITERIA_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8556,9 +7240,6 @@ impl Default for D3DKMT_FENCE_PRESENTHISTORYTOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_FENCE_PRESENTHISTORYTOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_FLIPINFOFLAGS {
@@ -8568,9 +7249,6 @@ impl Default for D3DKMT_FLIPINFOFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_FLIPINFOFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8591,9 +7269,6 @@ impl Default for D3DKMT_FLIPMANAGER_AUXILIARYPRESENTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_FLIPMANAGER_AUXILIARYPRESENTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN {
@@ -8606,9 +7281,6 @@ impl Default for D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN_0 {
@@ -8620,9 +7292,6 @@ impl Default for D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN_0_0 {
@@ -8632,9 +7301,6 @@ impl Default for D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_FLIPMANAGER_PRESENTHISTORYTOKEN_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8680,9 +7346,6 @@ impl Default for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN_0 {
@@ -8693,9 +7356,6 @@ impl Default for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8709,9 +7369,6 @@ impl Default for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN_0_0_0 {
@@ -8723,9 +7380,6 @@ impl Default for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN_0_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKEN_0_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS {
@@ -8735,9 +7389,6 @@ impl Default for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8750,9 +7401,6 @@ impl Default for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS_0_0 {
@@ -8762,9 +7410,6 @@ impl Default for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_FLIPMODEL_PRESENTHISTORYTOKENFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8780,9 +7425,6 @@ impl Default for D3DKMT_FLIPOVERLAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_FLIPOVERLAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_FLIPQUEUEINFO {
@@ -8795,9 +7437,6 @@ impl Default for D3DKMT_FLIPQUEUEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_FLIPQUEUEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_FLUSHHEAPTRANSITIONS {
@@ -8807,9 +7446,6 @@ impl Default for D3DKMT_FLUSHHEAPTRANSITIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_FLUSHHEAPTRANSITIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8822,9 +7458,6 @@ impl Default for D3DKMT_FREEGPUVIRTUALADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_FREEGPUVIRTUALADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8840,9 +7473,6 @@ impl Default for D3DKMT_GDIMODEL_PRESENTHISTORYTOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GDIMODEL_PRESENTHISTORYTOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GDIMODEL_SYSMEM_PRESENTHISTORYTOKEN {
@@ -8854,9 +7484,6 @@ impl Default for D3DKMT_GDIMODEL_SYSMEM_PRESENTHISTORYTOKEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GDIMODEL_SYSMEM_PRESENTHISTORYTOKEN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_GDI_STYLE_HANDLE_DECORATION: u32 = 2u32;
 #[repr(C)]
@@ -8873,9 +7500,6 @@ impl Default for D3DKMT_GETALLOCATIONPRIORITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GETALLOCATIONPRIORITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GETCONTEXTINPROCESSSCHEDULINGPRIORITY {
@@ -8886,9 +7510,6 @@ impl Default for D3DKMT_GETCONTEXTINPROCESSSCHEDULINGPRIORITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GETCONTEXTINPROCESSSCHEDULINGPRIORITY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8901,9 +7522,6 @@ impl Default for D3DKMT_GETCONTEXTSCHEDULINGPRIORITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GETCONTEXTSCHEDULINGPRIORITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_GETDEVICESTATE {
@@ -8915,9 +7533,6 @@ impl Default for D3DKMT_GETDEVICESTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GETDEVICESTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8934,9 +7549,6 @@ impl Default for D3DKMT_GETDEVICESTATE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GETDEVICESTATE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GETDISPLAYMODELIST {
@@ -8949,9 +7561,6 @@ impl Default for D3DKMT_GETDISPLAYMODELIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GETDISPLAYMODELIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8969,9 +7578,6 @@ impl Default for D3DKMT_GETMULTISAMPLEMETHODLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GETMULTISAMPLEMETHODLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GETOVERLAYSTATE {
@@ -8983,9 +7589,6 @@ impl Default for D3DKMT_GETOVERLAYSTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GETOVERLAYSTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9001,9 +7604,6 @@ impl Default for D3DKMT_GETPRESENTHISTORY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GETPRESENTHISTORY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DKMT_GETPRESENTHISTORY_MAXTOKENS: u32 = 2048u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9016,9 +7616,6 @@ impl Default for D3DKMT_GETPROCESSDEVICEREMOVALSUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GETPROCESSDEVICEREMOVALSUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9033,9 +7630,6 @@ impl Default for D3DKMT_GETRUNTIMEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GETRUNTIMEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GETSCANLINE {
@@ -9049,9 +7643,6 @@ impl Default for D3DKMT_GETSCANLINE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GETSCANLINE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GETSHAREDPRIMARYHANDLE {
@@ -9064,9 +7655,6 @@ impl Default for D3DKMT_GETSHAREDPRIMARYHANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GETSHAREDPRIMARYHANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GETSHAREDRESOURCEADAPTERLUID {
@@ -9078,9 +7666,6 @@ impl Default for D3DKMT_GETSHAREDRESOURCEADAPTERLUID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GETSHAREDRESOURCEADAPTERLUID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9095,9 +7680,6 @@ impl Default for D3DKMT_GETVERTICALBLANKEVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GETVERTICALBLANKEVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GET_DEVICE_VIDPN_OWNERSHIP_INFO {
@@ -9109,9 +7691,6 @@ impl Default for D3DKMT_GET_DEVICE_VIDPN_OWNERSHIP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GET_DEVICE_VIDPN_OWNERSHIP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GET_GPUMMU_CAPS {
@@ -9122,9 +7701,6 @@ impl Default for D3DKMT_GET_GPUMMU_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GET_GPUMMU_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9143,9 +7719,6 @@ impl Default for D3DKMT_GET_MULTIPLANE_OVERLAY_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GET_MULTIPLANE_OVERLAY_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GET_POST_COMPOSITION_CAPS {
@@ -9158,9 +7731,6 @@ impl Default for D3DKMT_GET_POST_COMPOSITION_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GET_POST_COMPOSITION_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9178,9 +7748,6 @@ impl Default for D3DKMT_GET_PTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GET_PTE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DKMT_GET_PTE_MAX: u32 = 64u32;
 pub const D3DKMT_GET_QUEUEDLIMIT_PRESENT: D3DKMT_QUEUEDLIMIT_TYPE = D3DKMT_QUEUEDLIMIT_TYPE(2i32);
 #[repr(C)]
@@ -9195,9 +7762,6 @@ impl Default for D3DKMT_GET_SEGMENT_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GET_SEGMENT_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_GPUMMU_CAPS {
@@ -9208,9 +7772,6 @@ impl Default for D3DKMT_GPUMMU_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GPUMMU_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9223,9 +7784,6 @@ impl Default for D3DKMT_GPUMMU_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_GPUMMU_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_GPUMMU_CAPS_0_0 {
@@ -9235,9 +7793,6 @@ impl Default for D3DKMT_GPUMMU_CAPS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GPUMMU_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9250,9 +7805,6 @@ impl Default for D3DKMT_GPUVERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_GPUVERSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9280,9 +7832,6 @@ impl Default for D3DKMT_HISTORY_BUFFER_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_HISTORY_BUFFER_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_HWDRM_SUPPORT {
@@ -9293,9 +7842,6 @@ impl Default for D3DKMT_HWDRM_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_HWDRM_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_HYBRID_DLIST_DLL_SUPPORT {
@@ -9305,9 +7851,6 @@ impl Default for D3DKMT_HYBRID_DLIST_DLL_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_HYBRID_DLIST_DLL_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9322,9 +7865,6 @@ impl Default for D3DKMT_HYBRID_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_HYBRID_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_INDEPENDENTFLIP_SECONDARY_SUPPORT {
@@ -9335,9 +7875,6 @@ impl Default for D3DKMT_INDEPENDENTFLIP_SECONDARY_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_INDEPENDENTFLIP_SECONDARY_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_INDEPENDENTFLIP_SUPPORT {
@@ -9347,9 +7884,6 @@ impl Default for D3DKMT_INDEPENDENTFLIP_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_INDEPENDENTFLIP_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9362,9 +7896,6 @@ impl Default for D3DKMT_INVALIDATEACTIVEVIDPN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_INVALIDATEACTIVEVIDPN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9379,9 +7910,6 @@ impl Default for D3DKMT_INVALIDATECACHE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_INVALIDATECACHE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_ISBADDRIVERFORHWPROTECTIONDISABLED {
@@ -9392,9 +7920,6 @@ impl Default for D3DKMT_ISBADDRIVERFORHWPROTECTIONDISABLED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_ISBADDRIVERFORHWPROTECTIONDISABLED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_KMD_DRIVER_VERSION {
@@ -9404,9 +7929,6 @@ impl Default for D3DKMT_KMD_DRIVER_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_KMD_DRIVER_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9425,9 +7947,6 @@ impl Default for D3DKMT_LOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_LOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_LOCK2 {
@@ -9441,9 +7960,6 @@ impl Default for D3DKMT_LOCK2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_LOCK2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_MARKDEVICEASERROR {
@@ -9454,9 +7970,6 @@ impl Default for D3DKMT_MARKDEVICEASERROR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MARKDEVICEASERROR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_MAX_BUNDLE_OBJECTS_PER_HANDLE: u32 = 16u32;
 pub const D3DKMT_MAX_DMM_ESCAPE_DATASIZE: i32 = 102400i32;
@@ -9482,9 +7995,6 @@ impl Default for D3DKMT_MIRACASTCOMPANIONDRIVERNAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MIRACASTCOMPANIONDRIVERNAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_MIRACAST_CHUNK_DATA {
@@ -9496,9 +8006,6 @@ impl Default for D3DKMT_MIRACAST_CHUNK_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MIRACAST_CHUNK_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9529,9 +8036,6 @@ impl Default for D3DKMT_MIRACAST_DISPLAY_DEVICE_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MIRACAST_DISPLAY_DEVICE_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DKMT_MIRACAST_DISPLAY_DEVICE_STATE(pub i32);
@@ -9545,9 +8049,6 @@ impl Default for D3DKMT_MIRACAST_DISPLAY_DEVICE_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MIRACAST_DISPLAY_DEVICE_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_MIRACAST_DISPLAY_STOP_SESSIONS {
@@ -9559,9 +8060,6 @@ impl Default for D3DKMT_MIRACAST_DISPLAY_STOP_SESSIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MIRACAST_DISPLAY_STOP_SESSIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_MIRACAST_DRIVER_IHV: D3DKMT_MIRACAST_DRIVER_TYPE = D3DKMT_MIRACAST_DRIVER_TYPE(1i32);
 pub const D3DKMT_MIRACAST_DRIVER_MS: D3DKMT_MIRACAST_DRIVER_TYPE = D3DKMT_MIRACAST_DRIVER_TYPE(2i32);
@@ -9580,9 +8078,6 @@ impl Default for D3DKMT_MOVE_RECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MOVE_RECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_MPO3DDI_SUPPORT {
@@ -9592,9 +8087,6 @@ impl Default for D3DKMT_MPO3DDI_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MPO3DDI_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9606,9 +8098,6 @@ impl Default for D3DKMT_MPOKERNELCAPS_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MPOKERNELCAPS_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DKMT_MULIIPLANE_OVERLAY_VIDEO_FRAME_FORMAT_PROGRESSIVE: D3DKMT_MULTIPLANE_OVERLAY_VIDEO_FRAME_FORMAT = D3DKMT_MULTIPLANE_OVERLAY_VIDEO_FRAME_FORMAT(0i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9619,9 +8108,6 @@ impl Default for D3DKMT_MULTIPLANEOVERLAY_DECODE_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MULTIPLANEOVERLAY_DECODE_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9636,9 +8122,6 @@ impl Default for D3DKMT_MULTIPLANEOVERLAY_HUD_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MULTIPLANEOVERLAY_HUD_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_MULTIPLANEOVERLAY_SECONDARY_SUPPORT {
@@ -9648,9 +8131,6 @@ impl Default for D3DKMT_MULTIPLANEOVERLAY_SECONDARY_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MULTIPLANEOVERLAY_SECONDARY_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9664,9 +8144,6 @@ impl Default for D3DKMT_MULTIPLANEOVERLAY_STRETCH_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MULTIPLANEOVERLAY_STRETCH_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_MULTIPLANEOVERLAY_SUPPORT {
@@ -9676,9 +8153,6 @@ impl Default for D3DKMT_MULTIPLANEOVERLAY_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MULTIPLANEOVERLAY_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9693,9 +8167,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_MULTIPLANE_OVERLAY2 {
@@ -9708,9 +8179,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9733,9 +8201,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9760,9 +8225,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9789,9 +8251,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES3 {
@@ -9812,9 +8271,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_ATTRIBUTES3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DKMT_MULTIPLANE_OVERLAY_BLEND(pub i32);
@@ -9830,9 +8286,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_MULTIPLANE_OVERLAY_CAPS_0 {
@@ -9844,9 +8297,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_MULTIPLANE_OVERLAY_CAPS_0_0 {
@@ -9856,9 +8306,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_CAPS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9879,9 +8326,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS {
@@ -9891,9 +8335,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9906,9 +8347,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS_0_0 {
@@ -9918,9 +8356,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9932,9 +8367,6 @@ impl Default for D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_WITH_SOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_MULTIPLANE_OVERLAY_POST_COMPOSITION_WITH_SOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9964,9 +8396,6 @@ impl Default for D3DKMT_MULTISAMPLEMETHOD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_MULTISAMPLEMETHOD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DKMT_MaxAllocationPriorityClass: D3DKMT_QUERYSTATISTICS_ALLOCATION_PRIORITY_CLASS = D3DKMT_QUERYSTATISTICS_ALLOCATION_PRIORITY_CLASS(5i32);
 pub const D3DKMT_MmIoFlipCommandBuffer: D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE = D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE(3i32);
 #[repr(C, packed(1))]
@@ -9979,9 +8408,6 @@ impl Default for D3DKMT_NODEMETADATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_NODEMETADATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10001,9 +8427,6 @@ impl Default for D3DKMT_NODE_PERFDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_NODE_PERFDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_NOTIFY_WORK_SUBMISSION {
@@ -10015,9 +8438,6 @@ impl Default for D3DKMT_NOTIFY_WORK_SUBMISSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_NOTIFY_WORK_SUBMISSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_NOTIFY_WORK_SUBMISSION_FLAGS {
@@ -10027,9 +8447,6 @@ impl Default for D3DKMT_NOTIFY_WORK_SUBMISSION_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_NOTIFY_WORK_SUBMISSION_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10042,9 +8459,6 @@ impl Default for D3DKMT_NOTIFY_WORK_SUBMISSION_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_NOTIFY_WORK_SUBMISSION_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_NOTIFY_WORK_SUBMISSION_FLAGS_0_0 {
@@ -10054,9 +8468,6 @@ impl Default for D3DKMT_NOTIFY_WORK_SUBMISSION_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_NOTIFY_WORK_SUBMISSION_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10073,9 +8484,6 @@ impl Default for D3DKMT_OFFERALLOCATIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OFFERALLOCATIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_OFFER_FLAGS {
@@ -10085,9 +8493,6 @@ impl Default for D3DKMT_OFFER_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OFFER_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10100,9 +8505,6 @@ impl Default for D3DKMT_OFFER_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OFFER_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OFFER_FLAGS_0_0 {
@@ -10112,9 +8514,6 @@ impl Default for D3DKMT_OFFER_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OFFER_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10135,9 +8534,6 @@ impl Default for D3DKMT_OPENADAPTERFROMDEVICENAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OPENADAPTERFROMDEVICENAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME {
@@ -10150,9 +8546,6 @@ impl Default for D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OPENADAPTERFROMGDIDISPLAYNAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -10169,10 +8562,6 @@ impl Default for D3DKMT_OPENADAPTERFROMHDC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for D3DKMT_OPENADAPTERFROMHDC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OPENADAPTERFROMLUID {
@@ -10183,9 +8572,6 @@ impl Default for D3DKMT_OPENADAPTERFROMLUID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OPENADAPTERFROMLUID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10199,9 +8585,6 @@ impl Default for D3DKMT_OPENGLINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OPENGLINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OPENKEYEDMUTEX {
@@ -10212,9 +8595,6 @@ impl Default for D3DKMT_OPENKEYEDMUTEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OPENKEYEDMUTEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10229,9 +8609,6 @@ impl Default for D3DKMT_OPENKEYEDMUTEX2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OPENKEYEDMUTEX2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OPENKEYEDMUTEXFROMNTHANDLE {
@@ -10244,9 +8621,6 @@ impl Default for D3DKMT_OPENKEYEDMUTEXFROMNTHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OPENKEYEDMUTEXFROMNTHANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10263,9 +8637,6 @@ impl Default for D3DKMT_OPENNATIVEFENCEFROMNTHANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OPENNATIVEFENCEFROMNTHANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_Security"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10280,10 +8651,6 @@ impl Default for D3DKMT_OPENNTHANDLEFROMNAME {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_Security"))]
-impl windows_core::TypeKind for D3DKMT_OPENNTHANDLEFROMNAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OPENPROTECTEDSESSIONFROMNTHANDLE {
@@ -10294,9 +8661,6 @@ impl Default for D3DKMT_OPENPROTECTEDSESSIONFROMNTHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OPENPROTECTEDSESSIONFROMNTHANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10318,9 +8682,6 @@ impl Default for D3DKMT_OPENRESOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OPENRESOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_OPENRESOURCE_0 {
@@ -10331,9 +8692,6 @@ impl Default for D3DKMT_OPENRESOURCE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OPENRESOURCE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10359,9 +8717,6 @@ impl Default for D3DKMT_OPENRESOURCEFROMNTHANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OPENRESOURCEFROMNTHANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OPENSYNCHRONIZATIONOBJECT {
@@ -10374,9 +8729,6 @@ impl Default for D3DKMT_OPENSYNCHRONIZATIONOBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OPENSYNCHRONIZATIONOBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OPENSYNCOBJECTFROMNTHANDLE {
@@ -10387,9 +8739,6 @@ impl Default for D3DKMT_OPENSYNCOBJECTFROMNTHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OPENSYNCOBJECTFROMNTHANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10405,9 +8754,6 @@ impl Default for D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2_0 {
@@ -10418,9 +8764,6 @@ impl Default for D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10433,9 +8776,6 @@ impl Default for D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OPENSYNCOBJECTFROMNTHANDLE2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_Security"))]
@@ -10451,10 +8791,6 @@ impl Default for D3DKMT_OPENSYNCOBJECTNTHANDLEFROMNAME {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_Security"))]
-impl windows_core::TypeKind for D3DKMT_OPENSYNCOBJECTNTHANDLEFROMNAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OUTDUPL_POINTER_SHAPE_INFO {
@@ -10468,9 +8804,6 @@ impl Default for D3DKMT_OUTDUPL_POINTER_SHAPE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OUTDUPL_POINTER_SHAPE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10489,9 +8822,6 @@ impl Default for D3DKMT_OUTPUTDUPLCONTEXTSCOUNT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPLCONTEXTSCOUNT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_OUTPUTDUPLCREATIONFLAGS {
@@ -10501,9 +8831,6 @@ impl Default for D3DKMT_OUTPUTDUPLCREATIONFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPLCREATIONFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10516,9 +8843,6 @@ impl Default for D3DKMT_OUTPUTDUPLCREATIONFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPLCREATIONFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OUTPUTDUPLCREATIONFLAGS_0_0 {
@@ -10528,9 +8852,6 @@ impl Default for D3DKMT_OUTPUTDUPLCREATIONFLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPLCREATIONFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10549,9 +8870,6 @@ impl Default for D3DKMT_OUTPUTDUPLPRESENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPLPRESENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_OUTPUTDUPLPRESENTFLAGS {
@@ -10561,9 +8879,6 @@ impl Default for D3DKMT_OUTPUTDUPLPRESENTFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPLPRESENTFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10576,9 +8891,6 @@ impl Default for D3DKMT_OUTPUTDUPLPRESENTFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPLPRESENTFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OUTPUTDUPLPRESENTFLAGS_0_0 {
@@ -10588,9 +8900,6 @@ impl Default for D3DKMT_OUTPUTDUPLPRESENTFLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPLPRESENTFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10607,9 +8916,6 @@ impl Default for D3DKMT_OUTPUTDUPLPRESENTTOHWQUEUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPLPRESENTTOHWQUEUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10628,9 +8934,6 @@ impl Default for D3DKMT_OUTPUTDUPL_FRAMEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPL_FRAMEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OUTPUTDUPL_GET_FRAMEINFO {
@@ -10642,9 +8945,6 @@ impl Default for D3DKMT_OUTPUTDUPL_GET_FRAMEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPL_GET_FRAMEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10661,9 +8961,6 @@ impl Default for D3DKMT_OUTPUTDUPL_GET_POINTER_SHAPE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPL_GET_POINTER_SHAPE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OUTPUTDUPL_KEYEDMUTEX {
@@ -10673,9 +8970,6 @@ impl Default for D3DKMT_OUTPUTDUPL_KEYEDMUTEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPL_KEYEDMUTEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10691,9 +8985,6 @@ impl Default for D3DKMT_OUTPUTDUPL_METADATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPL_METADATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10711,9 +9002,6 @@ impl Default for D3DKMT_OUTPUTDUPL_POINTER_POSITION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPL_POINTER_POSITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_OUTPUTDUPL_RELEASE_FRAME {
@@ -10725,9 +9013,6 @@ impl Default for D3DKMT_OUTPUTDUPL_RELEASE_FRAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPL_RELEASE_FRAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10745,9 +9030,6 @@ impl Default for D3DKMT_OUTPUTDUPL_SNAPSHOT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_OUTPUTDUPL_SNAPSHOT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_PAGE_TABLE_LEVEL_DESC {
@@ -10762,9 +9044,6 @@ impl Default for D3DKMT_PAGE_TABLE_LEVEL_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PAGE_TABLE_LEVEL_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_PANELFITTER_SUPPORT {
@@ -10774,9 +9053,6 @@ impl Default for D3DKMT_PANELFITTER_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PANELFITTER_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10788,9 +9064,6 @@ impl Default for D3DKMT_PARAVIRTUALIZATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PARAVIRTUALIZATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_PHYSICAL_ADAPTER_COUNT {
@@ -10800,9 +9073,6 @@ impl Default for D3DKMT_PHYSICAL_ADAPTER_COUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PHYSICAL_ADAPTER_COUNT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10816,9 +9086,6 @@ impl Default for D3DKMT_PINDIRECTFLIPRESOURCES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PINDIRECTFLIPRESOURCES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS {
@@ -10828,9 +9095,6 @@ impl Default for D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10843,9 +9107,6 @@ impl Default for D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS_0_0 {
@@ -10856,9 +9117,6 @@ impl Default for D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PLANE_SPECIFIC_INPUT_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_PLANE_SPECIFIC_OUTPUT_FLAGS {
@@ -10868,9 +9126,6 @@ impl Default for D3DKMT_PLANE_SPECIFIC_OUTPUT_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PLANE_SPECIFIC_OUTPUT_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10883,9 +9138,6 @@ impl Default for D3DKMT_PLANE_SPECIFIC_OUTPUT_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PLANE_SPECIFIC_OUTPUT_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_PLANE_SPECIFIC_OUTPUT_FLAGS_0_0 {
@@ -10895,9 +9147,6 @@ impl Default for D3DKMT_PLANE_SPECIFIC_OUTPUT_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PLANE_SPECIFIC_OUTPUT_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_PM_FLIPMANAGER: D3DKMT_PRESENT_MODEL = D3DKMT_PRESENT_MODEL(9i32);
 pub const D3DKMT_PM_REDIRECTED_BLT: D3DKMT_PRESENT_MODEL = D3DKMT_PRESENT_MODEL(3i32);
@@ -10924,9 +9173,6 @@ impl Default for D3DKMT_POLLDISPLAYCHILDREN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_POLLDISPLAYCHILDREN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10962,9 +9208,6 @@ impl Default for D3DKMT_PRESENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_PRESENT_0 {
@@ -10975,9 +9218,6 @@ impl Default for D3DKMT_PRESENT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10990,9 +9230,6 @@ impl Default for D3DKMT_PRESENT_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENT_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_PRESENTFLAGS {
@@ -11002,9 +9239,6 @@ impl Default for D3DKMT_PRESENTFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENTFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11017,9 +9251,6 @@ impl Default for D3DKMT_PRESENTFLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENTFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_PRESENTFLAGS_0_0 {
@@ -11029,9 +9260,6 @@ impl Default for D3DKMT_PRESENTFLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENTFLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11045,9 +9273,6 @@ impl Default for D3DKMT_PRESENTHISTORYTOKEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENTHISTORYTOKEN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11066,9 +9291,6 @@ impl Default for D3DKMT_PRESENTHISTORYTOKEN_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENTHISTORYTOKEN_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11092,9 +9314,6 @@ impl Default for D3DKMT_PRESENT_MULTIPLANE_OVERLAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENT_MULTIPLANE_OVERLAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_PRESENT_MULTIPLANE_OVERLAY_0 {
@@ -11105,9 +9324,6 @@ impl Default for D3DKMT_PRESENT_MULTIPLANE_OVERLAY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENT_MULTIPLANE_OVERLAY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11129,9 +9345,6 @@ impl Default for D3DKMT_PRESENT_MULTIPLANE_OVERLAY2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENT_MULTIPLANE_OVERLAY2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_PRESENT_MULTIPLANE_OVERLAY2_0 {
@@ -11142,9 +9355,6 @@ impl Default for D3DKMT_PRESENT_MULTIPLANE_OVERLAY2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENT_MULTIPLANE_OVERLAY2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11169,9 +9379,6 @@ impl Default for D3DKMT_PRESENT_MULTIPLANE_OVERLAY3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENT_MULTIPLANE_OVERLAY3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS {
@@ -11181,9 +9388,6 @@ impl Default for D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11196,9 +9400,6 @@ impl Default for D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS_0_0 {
@@ -11208,9 +9409,6 @@ impl Default for D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENT_MULTIPLANE_OVERLAY_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11229,9 +9427,6 @@ impl Default for D3DKMT_PRESENT_REDIRECTED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENT_REDIRECTED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_PRESENT_REDIRECTED_FLAGS {
@@ -11241,9 +9436,6 @@ impl Default for D3DKMT_PRESENT_REDIRECTED_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENT_REDIRECTED_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11256,9 +9448,6 @@ impl Default for D3DKMT_PRESENT_REDIRECTED_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENT_REDIRECTED_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_PRESENT_REDIRECTED_FLAGS_0_0 {
@@ -11268,9 +9457,6 @@ impl Default for D3DKMT_PRESENT_REDIRECTED_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENT_REDIRECTED_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11284,9 +9470,6 @@ impl Default for D3DKMT_PRESENT_RGNS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENT_RGNS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11302,9 +9485,6 @@ impl Default for D3DKMT_PRESENT_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENT_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_PRESENT_STATS_DWM {
@@ -11319,9 +9499,6 @@ impl Default for D3DKMT_PRESENT_STATS_DWM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PRESENT_STATS_DWM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11341,9 +9518,6 @@ impl Default for D3DKMT_PRESENT_STATS_DWM2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PRESENT_STATS_DWM2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_PROCESS_VERIFIER_OPTION {
@@ -11357,9 +9531,6 @@ impl Default for D3DKMT_PROCESS_VERIFIER_OPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PROCESS_VERIFIER_OPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_PROCESS_VERIFIER_OPTION_DATA {
@@ -11370,9 +9541,6 @@ impl Default for D3DKMT_PROCESS_VERIFIER_OPTION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PROCESS_VERIFIER_OPTION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11390,9 +9558,6 @@ impl Default for D3DKMT_PROCESS_VERIFIER_VIDMM_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_PROCESS_VERIFIER_VIDMM_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_PROCESS_VERIFIER_VIDMM_FLAGS_0 {
@@ -11402,9 +9567,6 @@ impl Default for D3DKMT_PROCESS_VERIFIER_VIDMM_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PROCESS_VERIFIER_VIDMM_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11416,9 +9578,6 @@ impl Default for D3DKMT_PROCESS_VERIFIER_VIDMM_RESTRICT_BUDGET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_PROCESS_VERIFIER_VIDMM_RESTRICT_BUDGET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11455,9 +9614,6 @@ impl Default for D3DKMT_QUERYADAPTERINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYADAPTERINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYALLOCATIONRESIDENCY {
@@ -11472,9 +9628,6 @@ impl Default for D3DKMT_QUERYALLOCATIONRESIDENCY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYALLOCATIONRESIDENCY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_QUERYCLOCKCALIBRATION {
@@ -11487,9 +9640,6 @@ impl Default for D3DKMT_QUERYCLOCKCALIBRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYCLOCKCALIBRATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11504,9 +9654,6 @@ impl Default for D3DKMT_QUERYFSEBLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYFSEBLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_QUERYFSEBLOCKFLAGS {
@@ -11518,9 +9665,6 @@ impl Default for D3DKMT_QUERYFSEBLOCKFLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYFSEBLOCKFLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYFSEBLOCKFLAGS_0 {
@@ -11530,9 +9674,6 @@ impl Default for D3DKMT_QUERYFSEBLOCKFLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYFSEBLOCKFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11546,9 +9687,6 @@ impl Default for D3DKMT_QUERYPROCESSOFFERINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYPROCESSOFFERINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11564,9 +9702,6 @@ impl Default for D3DKMT_QUERYPROTECTEDSESSIONINFOFROMNTHANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYPROTECTEDSESSIONINFOFROMNTHANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYPROTECTEDSESSIONSTATUS {
@@ -11578,9 +9713,6 @@ impl Default for D3DKMT_QUERYPROTECTEDSESSIONSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYPROTECTEDSESSIONSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYREMOTEVIDPNSOURCEFROMGDIDISPLAYNAME {
@@ -11591,9 +9723,6 @@ impl Default for D3DKMT_QUERYREMOTEVIDPNSOURCEFROMGDIDISPLAYNAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYREMOTEVIDPNSOURCEFROMGDIDISPLAYNAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11611,9 +9740,6 @@ impl Default for D3DKMT_QUERYRESOURCEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYRESOURCEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYRESOURCEINFOFROMNTHANDLE {
@@ -11629,9 +9755,6 @@ impl Default for D3DKMT_QUERYRESOURCEINFOFROMNTHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYRESOURCEINFOFROMNTHANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11650,9 +9773,6 @@ impl Default for D3DKMT_QUERYSTATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11679,9 +9799,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_QUERYSTATISTICS_ADAPTER: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(0i32);
 pub const D3DKMT_QUERYSTATISTICS_ADAPTER2: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(11i32);
@@ -11712,9 +9829,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS {
@@ -11724,9 +9838,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11739,9 +9850,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS_0_0 {
@@ -11751,9 +9859,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11770,9 +9875,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_COMMITMENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_COMMITMENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_COUNTER {
@@ -11783,9 +9885,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_COUNTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_COUNTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11798,9 +9897,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_DMA_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_DMA_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11818,9 +9914,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DKMT_QUERYSTATISTICS_DMA_PACKET_TYPE_MAX: u32 = 4u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11833,9 +9926,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_MEMORY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_MEMORY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11850,9 +9940,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_MEMORY_USAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_MEMORY_USAGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_QUERYSTATISTICS_NODE: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(5i32);
 pub const D3DKMT_QUERYSTATISTICS_NODE2: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(18i32);
@@ -11869,9 +9956,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_NODE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_NODE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_PACKET_INFORMATION {
@@ -11882,9 +9966,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PACKET_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PACKET_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_QUERYSTATISTICS_PHYSICAL_ADAPTER: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(10i32);
 #[repr(C)]
@@ -11898,9 +9979,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PHYSICAL_ADAPTER_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PHYSICAL_ADAPTER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11916,9 +9994,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_PREEMPTION_INFORMATION {
@@ -11928,9 +10003,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PREEMPTION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PREEMPTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_QUERYSTATISTICS_PROCESS: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(1i32);
 pub const D3DKMT_QUERYSTATISTICS_PROCESS_ADAPTER: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(2i32);
@@ -11953,9 +10025,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PROCESS_ADAPTER_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PROCESS_ADAPTER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_PROCESS_INFORMATION {
@@ -11969,9 +10038,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PROCESS_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PROCESS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DKMT_QUERYSTATISTICS_PROCESS_INTERFERENCE_BUCKET_COUNT: u32 = 9u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11982,9 +10048,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PROCESS_INTERFERENCE_COUNTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PROCESS_INTERFERENCE_COUNTERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_QUERYSTATISTICS_PROCESS_NODE: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(6i32);
 pub const D3DKMT_QUERYSTATISTICS_PROCESS_NODE2: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(19i32);
@@ -12001,9 +10064,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PROCESS_NODE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PROCESS_NODE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(4i32);
 pub const D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT2: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(14i32);
@@ -12022,9 +10082,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_GROUP_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_GROUP_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_INFORMATION {
@@ -12042,9 +10099,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_POLICY {
@@ -12054,9 +10108,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_QUERYSTATISTICS_PROCESS_VIDPNSOURCE: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(8i32);
 #[repr(C)]
@@ -12077,9 +10128,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_PROCESS_VIDPNSOURCE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_PROCESS_VIDPNSOURCE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_QUERY_ADAPTER2 {
@@ -12089,9 +10137,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_ADAPTER2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_ADAPTER2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12103,9 +10148,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_ADAPTER_INFORMATION2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_ADAPTER_INFORMATION2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_QUERY_NODE {
@@ -12115,9 +10157,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_NODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_NODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12130,9 +10169,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_NODE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_NODE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_QUERY_PHYSICAL_ADAPTER {
@@ -12142,9 +10178,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_PHYSICAL_ADAPTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_PHYSICAL_ADAPTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12157,9 +10190,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_PROCESS_SEGMENT_GROUP2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_PROCESS_SEGMENT_GROUP2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT {
@@ -12169,9 +10199,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12184,9 +10211,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT_GROUP_USAGE {
@@ -12197,9 +10221,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT_GROUP_USAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT_GROUP_USAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12212,9 +10233,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT_USAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_SEGMENT_USAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_QUERY_VIDPNSOURCE {
@@ -12224,9 +10242,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUERY_VIDPNSOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUERY_VIDPNSOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12241,9 +10256,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE_MAX: u32 = 8u32;
 #[repr(C)]
@@ -12268,9 +10280,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_RESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_RESULT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DKMT_QUERYSTATISTICS_SEGMENT: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(3i32);
 pub const D3DKMT_QUERYSTATISTICS_SEGMENT2: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(12i32);
 pub const D3DKMT_QUERYSTATISTICS_SEGMENT_GROUP_USAGE: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(17i32);
@@ -12293,9 +10302,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION_0 {
@@ -12306,9 +10312,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION_1 {
@@ -12318,9 +10321,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_QUERYSTATISTICS_SEGMENT_PREFERENCE_MAX: u32 = 5u32;
 #[repr(transparent)]
@@ -12350,9 +10350,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_SYSTEM_MEMORY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_SYSTEM_MEMORY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DKMT_QUERYSTATISTICS_TYPE(pub i32);
@@ -12369,9 +10366,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_VIDEO_MEMORY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_VIDEO_MEMORY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DKMT_QUERYSTATISTICS_VIDPNSOURCE: D3DKMT_QUERYSTATISTICS_TYPE = D3DKMT_QUERYSTATISTICS_TYPE(7i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12384,9 +10378,6 @@ impl Default for D3DKMT_QUERYSTATISTICS_VIDPNSOURCE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATISTICS_VIDPNSOURCE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12404,9 +10395,6 @@ impl Default for D3DKMT_QUERYSTATSTICS_ALLOCATIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATSTICS_ALLOCATIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATSTICS_LOCKS {
@@ -12422,9 +10410,6 @@ impl Default for D3DKMT_QUERYSTATSTICS_LOCKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATSTICS_LOCKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12453,9 +10438,6 @@ impl Default for D3DKMT_QUERYSTATSTICS_PAGING_FAULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATSTICS_PAGING_FAULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATSTICS_PAGING_TRANSFER {
@@ -12473,9 +10455,6 @@ impl Default for D3DKMT_QUERYSTATSTICS_PAGING_TRANSFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATSTICS_PAGING_TRANSFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATSTICS_PREPRATION {
@@ -12489,9 +10468,6 @@ impl Default for D3DKMT_QUERYSTATSTICS_PREPRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATSTICS_PREPRATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12516,9 +10492,6 @@ impl Default for D3DKMT_QUERYSTATSTICS_REFERENCE_DMA_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATSTICS_REFERENCE_DMA_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATSTICS_RENAMING {
@@ -12537,9 +10510,6 @@ impl Default for D3DKMT_QUERYSTATSTICS_RENAMING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYSTATSTICS_RENAMING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYSTATSTICS_SWIZZLING_RANGE {
@@ -12550,9 +10520,6 @@ impl Default for D3DKMT_QUERYSTATSTICS_SWIZZLING_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATSTICS_SWIZZLING_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12566,9 +10533,6 @@ impl Default for D3DKMT_QUERYSTATSTICS_TERMINATIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERYSTATSTICS_TERMINATIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12587,9 +10551,6 @@ impl Default for D3DKMT_QUERYVIDEOMEMORYINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYVIDEOMEMORYINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERYVIDPNEXCLUSIVEOWNERSHIP {
@@ -12604,9 +10565,6 @@ impl Default for D3DKMT_QUERYVIDPNEXCLUSIVEOWNERSHIP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERYVIDPNEXCLUSIVEOWNERSHIP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERY_ADAPTER_UNIQUE_GUID {
@@ -12616,9 +10574,6 @@ impl Default for D3DKMT_QUERY_ADAPTER_UNIQUE_GUID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERY_ADAPTER_UNIQUE_GUID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12631,9 +10586,6 @@ impl Default for D3DKMT_QUERY_DEVICE_IDS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERY_DEVICE_IDS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_QUERY_GPUMMU_CAPS {
@@ -12645,9 +10597,6 @@ impl Default for D3DKMT_QUERY_GPUMMU_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERY_GPUMMU_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERY_MIRACAST_DRIVER_TYPE {
@@ -12657,9 +10606,6 @@ impl Default for D3DKMT_QUERY_MIRACAST_DRIVER_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERY_MIRACAST_DRIVER_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12674,9 +10620,6 @@ impl Default for D3DKMT_QUERY_PHYSICAL_ADAPTER_PNP_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_QUERY_PHYSICAL_ADAPTER_PNP_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_QUERY_SCANOUT_CAPS {
@@ -12687,9 +10630,6 @@ impl Default for D3DKMT_QUERY_SCANOUT_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_QUERY_SCANOUT_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12709,9 +10649,6 @@ impl Default for D3DKMT_RECLAIMALLOCATIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_RECLAIMALLOCATIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_RECLAIMALLOCATIONS2 {
@@ -12727,9 +10664,6 @@ impl Default for D3DKMT_RECLAIMALLOCATIONS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_RECLAIMALLOCATIONS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_RECLAIMALLOCATIONS2_0 {
@@ -12740,9 +10674,6 @@ impl Default for D3DKMT_RECLAIMALLOCATIONS2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_RECLAIMALLOCATIONS2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12756,9 +10687,6 @@ impl Default for D3DKMT_REGISTERBUDGETCHANGENOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_REGISTERBUDGETCHANGENOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12774,9 +10702,6 @@ impl Default for D3DKMT_REGISTERTRIMNOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_REGISTERTRIMNOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_RELEASEKEYEDMUTEX {
@@ -12788,9 +10713,6 @@ impl Default for D3DKMT_RELEASEKEYEDMUTEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_RELEASEKEYEDMUTEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12805,9 +10727,6 @@ impl Default for D3DKMT_RELEASEKEYEDMUTEX2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_RELEASEKEYEDMUTEX2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -12837,9 +10756,6 @@ impl Default for D3DKMT_RENDER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_RENDER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_RENDER_0 {
@@ -12851,9 +10767,6 @@ impl Default for D3DKMT_RENDER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_RENDER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_RENDERFLAGS {
@@ -12863,9 +10776,6 @@ impl Default for D3DKMT_RENDERFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_RENDERFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12878,9 +10788,6 @@ impl Default for D3DKMT_REQUEST_MACHINE_CRASH_ESCAPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_REQUEST_MACHINE_CRASH_ESCAPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_RenderCommandBuffer: D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE = D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE(0i32);
 #[repr(C)]
@@ -12897,9 +10804,6 @@ impl Default for D3DKMT_SCATTERBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SCATTERBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SCATTERBLTS {
@@ -12910,9 +10814,6 @@ impl Default for D3DKMT_SCATTERBLTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SCATTERBLTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12937,9 +10838,6 @@ impl Default for D3DKMT_SEGMENTGROUPSIZEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SEGMENTGROUPSIZEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SEGMENTSIZEINFO {
@@ -12951,9 +10849,6 @@ impl Default for D3DKMT_SEGMENTSIZEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SEGMENTSIZEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12970,9 +10865,6 @@ impl Default for D3DKMT_SEGMENT_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SEGMENT_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SETALLOCATIONPRIORITY {
@@ -12987,9 +10879,6 @@ impl Default for D3DKMT_SETALLOCATIONPRIORITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETALLOCATIONPRIORITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SETCONTEXTINPROCESSSCHEDULINGPRIORITY {
@@ -13001,9 +10890,6 @@ impl Default for D3DKMT_SETCONTEXTINPROCESSSCHEDULINGPRIORITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETCONTEXTINPROCESSSCHEDULINGPRIORITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SETCONTEXTSCHEDULINGPRIORITY {
@@ -13014,9 +10900,6 @@ impl Default for D3DKMT_SETCONTEXTSCHEDULINGPRIORITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SETCONTEXTSCHEDULINGPRIORITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_SETCONTEXTSCHEDULINGPRIORITY_ABSOLUTE: u32 = 1073741824u32;
 #[repr(C)]
@@ -13034,9 +10917,6 @@ impl Default for D3DKMT_SETDISPLAYMODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETDISPLAYMODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SETDISPLAYMODE_FLAGS {
@@ -13047,9 +10927,6 @@ impl Default for D3DKMT_SETDISPLAYMODE_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SETDISPLAYMODE_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13062,9 +10939,6 @@ impl Default for D3DKMT_SETDISPLAYPRIVATEDRIVERFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SETDISPLAYPRIVATEDRIVERFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13079,9 +10953,6 @@ impl Default for D3DKMT_SETFSEBLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETFSEBLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_SETFSEBLOCKFLAGS {
@@ -13093,9 +10964,6 @@ impl Default for D3DKMT_SETFSEBLOCKFLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETFSEBLOCKFLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SETFSEBLOCKFLAGS_0 {
@@ -13105,9 +10973,6 @@ impl Default for D3DKMT_SETFSEBLOCKFLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SETFSEBLOCKFLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13123,9 +10988,6 @@ impl Default for D3DKMT_SETGAMMARAMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETGAMMARAMP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_SETGAMMARAMP_0 {
@@ -13137,9 +10999,6 @@ impl Default for D3DKMT_SETGAMMARAMP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETGAMMARAMP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SETHWPROTECTIONTEARDOWNRECOVERY {
@@ -13150,9 +11009,6 @@ impl Default for D3DKMT_SETHWPROTECTIONTEARDOWNRECOVERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SETHWPROTECTIONTEARDOWNRECOVERY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13166,9 +11022,6 @@ impl Default for D3DKMT_SETQUEUEDLIMIT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETQUEUEDLIMIT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_SETQUEUEDLIMIT_0 {
@@ -13179,9 +11032,6 @@ impl Default for D3DKMT_SETQUEUEDLIMIT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SETQUEUEDLIMIT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13194,9 +11044,6 @@ impl Default for D3DKMT_SETQUEUEDLIMIT_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETQUEUEDLIMIT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SETSTABLEPOWERSTATE {
@@ -13207,9 +11054,6 @@ impl Default for D3DKMT_SETSTABLEPOWERSTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SETSTABLEPOWERSTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13224,9 +11068,6 @@ impl Default for D3DKMT_SETSYNCREFRESHCOUNTWAITTARGET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETSYNCREFRESHCOUNTWAITTARGET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SETVIDPNSOURCEHWPROTECTION {
@@ -13238,9 +11079,6 @@ impl Default for D3DKMT_SETVIDPNSOURCEHWPROTECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SETVIDPNSOURCEHWPROTECTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13255,9 +11093,6 @@ impl Default for D3DKMT_SETVIDPNSOURCEOWNER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETVIDPNSOURCEOWNER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_SETVIDPNSOURCEOWNER1 {
@@ -13269,9 +11104,6 @@ impl Default for D3DKMT_SETVIDPNSOURCEOWNER1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SETVIDPNSOURCEOWNER1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_SETVIDPNSOURCEOWNER2 {
@@ -13282,9 +11114,6 @@ impl Default for D3DKMT_SETVIDPNSOURCEOWNER2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SETVIDPNSOURCEOWNER2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13300,9 +11129,6 @@ impl Default for D3DKMT_SET_COLORSPACE_TRANSFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SET_COLORSPACE_TRANSFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_SET_COLORSPACE_TRANSFORM_0 {
@@ -13312,9 +11138,6 @@ impl Default for D3DKMT_SET_COLORSPACE_TRANSFORM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SET_COLORSPACE_TRANSFORM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_SET_QUEUEDLIMIT_PRESENT: D3DKMT_QUEUEDLIMIT_TYPE = D3DKMT_QUEUEDLIMIT_TYPE(1i32);
 #[repr(C)]
@@ -13329,9 +11152,6 @@ impl Default for D3DKMT_SHAREDPRIMARYLOCKNOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SHAREDPRIMARYLOCKNOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SHAREDPRIMARYUNLOCKNOTIFICATION {
@@ -13342,9 +11162,6 @@ impl Default for D3DKMT_SHAREDPRIMARYUNLOCKNOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SHAREDPRIMARYUNLOCKNOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13359,9 +11176,6 @@ impl Default for D3DKMT_SHAREOBJECTWITHHOST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SHAREOBJECTWITHHOST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_SIGNALSYNCHRONIZATIONOBJECT {
@@ -13374,9 +11188,6 @@ impl Default for D3DKMT_SIGNALSYNCHRONIZATIONOBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SIGNALSYNCHRONIZATIONOBJECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13394,9 +11205,6 @@ impl Default for D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2_0 {
@@ -13409,9 +11217,6 @@ impl Default for D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2_0_0 {
@@ -13421,9 +11226,6 @@ impl Default for D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SIGNALSYNCHRONIZATIONOBJECT2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13439,9 +11241,6 @@ impl Default for D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMCPU {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMCPU {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU {
@@ -13455,9 +11254,6 @@ impl Default for D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU_0 {
@@ -13468,9 +11264,6 @@ impl Default for D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13487,9 +11280,6 @@ impl Default for D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU2_0 {
@@ -13502,9 +11292,6 @@ impl Default for D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SIGNALSYNCHRONIZATIONOBJECTFROMGPU2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13521,9 +11308,6 @@ impl Default for D3DKMT_STANDARDALLOCATION_EXISTINGHEAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_STANDARDALLOCATION_EXISTINGHEAP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_SUBKEY_DX9: windows_core::PCWSTR = windows_core::w!("DX9");
 pub const D3DKMT_SUBKEY_OPENGL: windows_core::PCWSTR = windows_core::w!("OpenGL");
@@ -13548,9 +11332,6 @@ impl Default for D3DKMT_SUBMITCOMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SUBMITCOMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SUBMITCOMMANDFLAGS {
@@ -13560,9 +11341,6 @@ impl Default for D3DKMT_SUBMITCOMMANDFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SUBMITCOMMANDFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13581,9 +11359,6 @@ impl Default for D3DKMT_SUBMITCOMMANDTOHWQUEUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SUBMITCOMMANDTOHWQUEUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_SUBMITPRESENTBLTTOHWQUEUE {
@@ -13596,9 +11371,6 @@ impl Default for D3DKMT_SUBMITPRESENTBLTTOHWQUEUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SUBMITPRESENTBLTTOHWQUEUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_SUBMITPRESENTTOHWQUEUE {
@@ -13609,9 +11381,6 @@ impl Default for D3DKMT_SUBMITPRESENTTOHWQUEUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SUBMITPRESENTTOHWQUEUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13628,9 +11397,6 @@ impl Default for D3DKMT_SUBMITSIGNALSYNCOBJECTSTOHWQUEUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SUBMITSIGNALSYNCOBJECTSTOHWQUEUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SUBMITWAITFORSYNCOBJECTSTOHWQUEUE {
@@ -13644,9 +11410,6 @@ impl Default for D3DKMT_SUBMITWAITFORSYNCOBJECTSTOHWQUEUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_SUBMITWAITFORSYNCOBJECTSTOHWQUEUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_SURFACECOMPLETE_PRESENTHISTORYTOKEN {
@@ -13656,9 +11419,6 @@ impl Default for D3DKMT_SURFACECOMPLETE_PRESENTHISTORYTOKEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_SURFACECOMPLETE_PRESENTHISTORYTOKEN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_SignalCommandBuffer: D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE = D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE(5i32);
 pub const D3DKMT_SoftwareCommandBuffer: D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE = D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE(7i32);
@@ -13688,9 +11448,6 @@ impl Default for D3DKMT_TDRDBGCTRL_ESCAPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_TDRDBGCTRL_ESCAPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_TDRDBGCTRL_ESCAPE_0 {
@@ -13700,9 +11457,6 @@ impl Default for D3DKMT_TDRDBGCTRL_ESCAPE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_TDRDBGCTRL_ESCAPE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -13716,9 +11470,6 @@ impl Default for D3DKMT_TRACKEDWORKLOAD_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_TRACKEDWORKLOAD_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_TRIMNOTIFICATION {
@@ -13730,9 +11481,6 @@ impl Default for D3DKMT_TRIMNOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_TRIMNOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13748,9 +11496,6 @@ impl Default for D3DKMT_TRIMPROCESSCOMMITMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_TRIMPROCESSCOMMITMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_TRIMPROCESSCOMMITMENT_FLAGS {
@@ -13762,9 +11507,6 @@ impl Default for D3DKMT_TRIMPROCESSCOMMITMENT_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_TRIMPROCESSCOMMITMENT_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_TRIMPROCESSCOMMITMENT_FLAGS_0 {
@@ -13774,9 +11516,6 @@ impl Default for D3DKMT_TRIMPROCESSCOMMITMENT_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_TRIMPROCESSCOMMITMENT_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13789,9 +11528,6 @@ impl Default for D3DKMT_UMDFILENAMEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_UMDFILENAMEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_UMD_DRIVER_VERSION {
@@ -13801,9 +11537,6 @@ impl Default for D3DKMT_UMD_DRIVER_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_UMD_DRIVER_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13817,9 +11550,6 @@ impl Default for D3DKMT_UNLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_UNLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_UNLOCK2 {
@@ -13830,9 +11560,6 @@ impl Default for D3DKMT_UNLOCK2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_UNLOCK2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13846,9 +11573,6 @@ impl Default for D3DKMT_UNPINDIRECTFLIPRESOURCES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_UNPINDIRECTFLIPRESOURCES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_UNREGISTERBUDGETCHANGENOTIFICATION {
@@ -13858,9 +11582,6 @@ impl Default for D3DKMT_UNREGISTERBUDGETCHANGENOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_UNREGISTERBUDGETCHANGENOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13872,9 +11593,6 @@ impl Default for D3DKMT_UNREGISTERTRIMNOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_UNREGISTERTRIMNOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13894,9 +11612,6 @@ impl Default for D3DKMT_UPDATEGPUVIRTUALADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_UPDATEGPUVIRTUALADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_UPDATEGPUVIRTUALADDRESS_0 {
@@ -13908,9 +11623,6 @@ impl Default for D3DKMT_UPDATEGPUVIRTUALADDRESS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_UPDATEGPUVIRTUALADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_UPDATEGPUVIRTUALADDRESS_0_0 {
@@ -13920,9 +11632,6 @@ impl Default for D3DKMT_UPDATEGPUVIRTUALADDRESS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_UPDATEGPUVIRTUALADDRESS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13935,9 +11644,6 @@ impl Default for D3DKMT_UPDATEOVERLAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_UPDATEOVERLAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13953,9 +11659,6 @@ impl Default for D3DKMT_VAD_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VAD_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13985,9 +11688,6 @@ impl Default for D3DKMT_VA_RANGE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VA_RANGE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DKMT_VERIFIER_OPTION_MODE(pub i32);
@@ -14002,9 +11702,6 @@ impl Default for D3DKMT_VGPUINTERFACEID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VGPUINTERFACEID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14039,9 +11736,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_VIDMM_ESCAPE_0 {
@@ -14066,9 +11760,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_10 {
@@ -14084,9 +11775,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_10 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_10 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_11 {
@@ -14100,9 +11788,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_11 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_11 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_13 {
@@ -14113,9 +11798,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_13 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_13 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_2 {
@@ -14125,9 +11807,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14141,9 +11820,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_7 {
@@ -14153,9 +11829,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14168,9 +11841,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14187,9 +11857,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_3_0_0 {
@@ -14200,9 +11867,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_3_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_3_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_6 {
@@ -14212,9 +11876,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14227,9 +11888,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_0 {
@@ -14239,9 +11897,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14254,9 +11909,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_0_0_0 {
@@ -14266,9 +11918,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14282,9 +11931,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_8 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_5 {
@@ -14296,9 +11942,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_12 {
@@ -14309,9 +11952,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_12 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_12 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDMM_ESCAPE_0_9 {
@@ -14321,9 +11961,6 @@ impl Default for D3DKMT_VIDMM_ESCAPE_0_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VIDMM_ESCAPE_0_9 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_VIDPNSOURCEOWNER_EMULATED: D3DKMT_VIDPNSOURCEOWNER_TYPE = D3DKMT_VIDPNSOURCEOWNER_TYPE(4i32);
 pub const D3DKMT_VIDPNSOURCEOWNER_EXCLUSIVE: D3DKMT_VIDPNSOURCEOWNER_TYPE = D3DKMT_VIDPNSOURCEOWNER_TYPE(2i32);
@@ -14338,9 +11975,6 @@ impl Default for D3DKMT_VIDPNSOURCEOWNER_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDPNSOURCEOWNER_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_VIDPNSOURCEOWNER_FLAGS_0 {
@@ -14352,9 +11986,6 @@ impl Default for D3DKMT_VIDPNSOURCEOWNER_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDPNSOURCEOWNER_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIDPNSOURCEOWNER_FLAGS_0_0 {
@@ -14364,9 +11995,6 @@ impl Default for D3DKMT_VIDPNSOURCEOWNER_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VIDPNSOURCEOWNER_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_VIDPNSOURCEOWNER_SHARED: D3DKMT_VIDPNSOURCEOWNER_TYPE = D3DKMT_VIDPNSOURCEOWNER_TYPE(1i32);
 #[repr(transparent)]
@@ -14397,9 +12025,6 @@ impl Default for D3DKMT_VIDSCH_ESCAPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDSCH_ESCAPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_VIDSCH_ESCAPE_0 {
@@ -14417,9 +12042,6 @@ impl Default for D3DKMT_VIDSCH_ESCAPE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDSCH_ESCAPE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_VIDSCH_ESCAPE_0_0 {
@@ -14431,9 +12053,6 @@ impl Default for D3DKMT_VIDSCH_ESCAPE_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDSCH_ESCAPE_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_VIDSCH_ESCAPE_0_0_0 {
@@ -14443,9 +12062,6 @@ impl Default for D3DKMT_VIDSCH_ESCAPE_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VIDSCH_ESCAPE_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14458,9 +12074,6 @@ impl Default for D3DKMT_VIDSCH_ESCAPE_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIDSCH_ESCAPE_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_VIRTUALADDRESSFLAGS {
@@ -14470,9 +12083,6 @@ impl Default for D3DKMT_VIRTUALADDRESSFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_VIRTUALADDRESSFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14484,9 +12094,6 @@ impl Default for D3DKMT_VIRTUALADDRESSINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_VIRTUALADDRESSINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_WAITFORIDLE {
@@ -14496,9 +12103,6 @@ impl Default for D3DKMT_WAITFORIDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WAITFORIDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14511,9 +12115,6 @@ impl Default for D3DKMT_WAITFORSYNCHRONIZATIONOBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WAITFORSYNCHRONIZATIONOBJECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14528,9 +12129,6 @@ impl Default for D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2_0 {
@@ -14542,9 +12140,6 @@ impl Default for D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2_0_0 {
@@ -14554,9 +12149,6 @@ impl Default for D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WAITFORSYNCHRONIZATIONOBJECT2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14573,9 +12165,6 @@ impl Default for D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMCPU {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMCPU {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU {
@@ -14589,9 +12178,6 @@ impl Default for D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU_0 {
@@ -14604,9 +12190,6 @@ impl Default for D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WAITFORSYNCHRONIZATIONOBJECTFROMGPU_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_WAITFORVERTICALBLANKEVENT {
@@ -14618,9 +12201,6 @@ impl Default for D3DKMT_WAITFORVERTICALBLANKEVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WAITFORVERTICALBLANKEVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14636,9 +12216,6 @@ impl Default for D3DKMT_WAITFORVERTICALBLANKEVENT2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WAITFORVERTICALBLANKEVENT2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_1_2_CAPS {
@@ -14649,9 +12226,6 @@ impl Default for D3DKMT_WDDM_1_2_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WDDM_1_2_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14664,9 +12238,6 @@ impl Default for D3DKMT_WDDM_1_2_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_1_2_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_WDDM_1_2_CAPS_0_0 {
@@ -14677,9 +12248,6 @@ impl Default for D3DKMT_WDDM_1_2_CAPS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_1_2_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_1_3_CAPS {
@@ -14689,9 +12257,6 @@ impl Default for D3DKMT_WDDM_1_3_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WDDM_1_3_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -14704,9 +12269,6 @@ impl Default for D3DKMT_WDDM_1_3_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_1_3_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_1_3_CAPS_0_0 {
@@ -14717,9 +12279,6 @@ impl Default for D3DKMT_WDDM_1_3_CAPS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_1_3_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_2_0_CAPS {
@@ -14729,9 +12288,6 @@ impl Default for D3DKMT_WDDM_2_0_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WDDM_2_0_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -14744,9 +12300,6 @@ impl Default for D3DKMT_WDDM_2_0_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_2_0_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_2_0_CAPS_0_0 {
@@ -14757,9 +12310,6 @@ impl Default for D3DKMT_WDDM_2_0_CAPS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_2_0_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_2_7_CAPS {
@@ -14769,9 +12319,6 @@ impl Default for D3DKMT_WDDM_2_7_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WDDM_2_7_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -14784,9 +12331,6 @@ impl Default for D3DKMT_WDDM_2_7_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_2_7_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_2_7_CAPS_0_0 {
@@ -14797,9 +12341,6 @@ impl Default for D3DKMT_WDDM_2_7_CAPS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_2_7_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_2_9_CAPS {
@@ -14809,9 +12350,6 @@ impl Default for D3DKMT_WDDM_2_9_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WDDM_2_9_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -14824,9 +12362,6 @@ impl Default for D3DKMT_WDDM_2_9_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_2_9_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_2_9_CAPS_0_0 {
@@ -14837,9 +12372,6 @@ impl Default for D3DKMT_WDDM_2_9_CAPS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_2_9_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_3_0_CAPS {
@@ -14849,9 +12381,6 @@ impl Default for D3DKMT_WDDM_3_0_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WDDM_3_0_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -14864,9 +12393,6 @@ impl Default for D3DKMT_WDDM_3_0_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_3_0_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_3_0_CAPS_0_0 {
@@ -14877,9 +12403,6 @@ impl Default for D3DKMT_WDDM_3_0_CAPS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_3_0_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_3_1_CAPS {
@@ -14889,9 +12412,6 @@ impl Default for D3DKMT_WDDM_3_1_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WDDM_3_1_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -14904,9 +12424,6 @@ impl Default for D3DKMT_WDDM_3_1_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_3_1_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct D3DKMT_WDDM_3_1_CAPS_0_0 {
@@ -14917,9 +12434,6 @@ impl Default for D3DKMT_WDDM_3_1_CAPS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WDDM_3_1_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_WORKINGSETFLAGS {
@@ -14929,9 +12443,6 @@ impl Default for D3DKMT_WORKINGSETFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WORKINGSETFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14945,9 +12456,6 @@ impl Default for D3DKMT_WORKINGSETINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_WORKINGSETINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DKMT_WSAUMDIMAGENAME {
@@ -14957,9 +12465,6 @@ impl Default for D3DKMT_WSAUMDIMAGENAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DKMT_WSAUMDIMAGENAME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DKMT_WaitCommandBuffer: D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE = D3DKMT_QUERYSTATISTICS_QUEUE_PACKET_TYPE(4i32);
 #[repr(C)]
@@ -14972,9 +12477,6 @@ impl Default for D3DKMT_XBOX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DKMT_XBOX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DLINEPATTERN {
@@ -14985,9 +12487,6 @@ impl Default for D3DLINEPATTERN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DLINEPATTERN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DNTCLEAR_COMPUTERECTS: i32 = 8i32;
 #[repr(C)]
@@ -15034,10 +12533,6 @@ impl Default for D3DNTDEVICEDESC_V3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTDEVICEDESC_V3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DNTDP2OP_ADDDIRTYBOX: D3DNTHAL_DP2OPERATION = D3DNTHAL_DP2OPERATION(67i32);
 pub const D3DNTDP2OP_ADDDIRTYRECT: D3DNTHAL_DP2OPERATION = D3DNTHAL_DP2OPERATION(66i32);
@@ -15150,10 +12645,6 @@ impl Default for D3DNTHALDEVICEDESC_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHALDEVICEDESC_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15185,10 +12676,6 @@ impl Default for D3DNTHALDEVICEDESC_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHALDEVICEDESC_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DNTHALDP2_EXECUTEBUFFER: i32 = 2i32;
 pub const D3DNTHALDP2_REQCOMMANDBUFSIZE: i32 = 32i32;
@@ -15244,10 +12731,6 @@ impl Default for D3DNTHAL_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DNTHAL_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15266,10 +12749,6 @@ impl Default for D3DNTHAL_CALLBACKS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DNTHAL_CALLBACKS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15286,10 +12765,6 @@ impl Default for D3DNTHAL_CALLBACKS3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw"))]
-impl windows_core::TypeKind for D3DNTHAL_CALLBACKS3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -15310,10 +12785,6 @@ impl Default for D3DNTHAL_CLEAR2DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_CLEAR2DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_CLIPPEDTRIANGLEFAN {
@@ -15325,9 +12796,6 @@ impl Default for D3DNTHAL_CLIPPEDTRIANGLEFAN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_CLIPPEDTRIANGLEFAN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DNTHAL_COL_WEIGHTS: u32 = 2u32;
 #[repr(C)]
@@ -15347,10 +12815,6 @@ impl Default for D3DNTHAL_CONTEXTCREATEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DNTHAL_CONTEXTCREATEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 #[derive(Clone, Copy)]
@@ -15363,10 +12827,6 @@ impl Default for D3DNTHAL_CONTEXTCREATEDATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DNTHAL_CONTEXTCREATEDATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
@@ -15381,10 +12841,6 @@ impl Default for D3DNTHAL_CONTEXTCREATEDATA_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DNTHAL_CONTEXTCREATEDATA_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 #[derive(Clone, Copy)]
@@ -15398,10 +12854,6 @@ impl Default for D3DNTHAL_CONTEXTCREATEDATA_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DNTHAL_CONTEXTCREATEDATA_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_CONTEXTDESTROYALLDATA {
@@ -15413,9 +12865,6 @@ impl Default for D3DNTHAL_CONTEXTDESTROYALLDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_CONTEXTDESTROYALLDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_CONTEXTDESTROYDATA {
@@ -15426,9 +12875,6 @@ impl Default for D3DNTHAL_CONTEXTDESTROYDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_CONTEXTDESTROYDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DNTHAL_CONTEXT_BAD: i64 = 512i64;
 #[repr(C)]
@@ -15461,9 +12907,6 @@ impl Default for D3DNTHAL_D3DDX6EXTENDEDCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_D3DDX6EXTENDEDCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15505,9 +12948,6 @@ impl Default for D3DNTHAL_D3DEXTENDEDCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_D3DEXTENDEDCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15521,10 +12961,6 @@ impl Default for D3DNTHAL_DP2ADDDIRTYBOX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2ADDDIRTYBOX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2ADDDIRTYRECT {
@@ -15535,9 +12971,6 @@ impl Default for D3DNTHAL_DP2ADDDIRTYRECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2ADDDIRTYRECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15555,9 +12988,6 @@ impl Default for D3DNTHAL_DP2BLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2BLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15574,10 +13004,6 @@ impl Default for D3DNTHAL_DP2BUFFERBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2BUFFERBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2CLEAR {
@@ -15592,9 +13018,6 @@ impl Default for D3DNTHAL_DP2CLEAR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2CLEAR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2COLORFILL {
@@ -15606,9 +13029,6 @@ impl Default for D3DNTHAL_DP2COLORFILL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2COLORFILL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -15622,9 +13042,6 @@ impl Default for D3DNTHAL_DP2COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DNTHAL_DP2COMMAND_0 {
@@ -15635,9 +13052,6 @@ impl Default for D3DNTHAL_DP2COMMAND_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2COMMAND_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -15658,10 +13072,6 @@ impl Default for D3DNTHAL_DP2COMPOSERECTS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2COMPOSERECTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2CREATELIGHT {
@@ -15671,9 +13081,6 @@ impl Default for D3DNTHAL_DP2CREATELIGHT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2CREATELIGHT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15685,9 +13092,6 @@ impl Default for D3DNTHAL_DP2CREATEPIXELSHADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2CREATEPIXELSHADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -15702,10 +13106,6 @@ impl Default for D3DNTHAL_DP2CREATEQUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2CREATEQUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2CREATEVERTEXSHADER {
@@ -15718,9 +13118,6 @@ impl Default for D3DNTHAL_DP2CREATEVERTEXSHADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2CREATEVERTEXSHADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2CREATEVERTEXSHADERDECL {
@@ -15731,9 +13128,6 @@ impl Default for D3DNTHAL_DP2CREATEVERTEXSHADERDECL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2CREATEVERTEXSHADERDECL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15746,9 +13140,6 @@ impl Default for D3DNTHAL_DP2CREATEVERTEXSHADERFUNC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2CREATEVERTEXSHADERFUNC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2DELETEQUERY {
@@ -15758,9 +13149,6 @@ impl Default for D3DNTHAL_DP2DELETEQUERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2DELETEQUERY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -15779,10 +13167,6 @@ impl Default for D3DNTHAL_DP2DRAWINDEXEDPRIMITIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2DRAWINDEXEDPRIMITIVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15800,10 +13184,6 @@ impl Default for D3DNTHAL_DP2DRAWINDEXEDPRIMITIVE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2DRAWINDEXEDPRIMITIVE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15817,10 +13197,6 @@ impl Default for D3DNTHAL_DP2DRAWPRIMITIVE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2DRAWPRIMITIVE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -15836,10 +13212,6 @@ impl Default for D3DNTHAL_DP2DRAWPRIMITIVE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2DRAWPRIMITIVE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2DRAWRECTPATCH {
@@ -15850,9 +13222,6 @@ impl Default for D3DNTHAL_DP2DRAWRECTPATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2DRAWRECTPATCH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15865,9 +13234,6 @@ impl Default for D3DNTHAL_DP2DRAWTRIPATCH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2DRAWTRIPATCH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2EXT {
@@ -15878,9 +13244,6 @@ impl Default for D3DNTHAL_DP2EXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2EXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -15895,10 +13258,6 @@ impl Default for D3DNTHAL_DP2GENERATEMIPSUBLEVELS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2GENERATEMIPSUBLEVELS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2INDEXEDLINELIST {
@@ -15910,9 +13269,6 @@ impl Default for D3DNTHAL_DP2INDEXEDLINELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2INDEXEDLINELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2INDEXEDLINESTRIP {
@@ -15923,9 +13279,6 @@ impl Default for D3DNTHAL_DP2INDEXEDLINESTRIP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2INDEXEDLINESTRIP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2INDEXEDTRIANGLEFAN {
@@ -15935,9 +13288,6 @@ impl Default for D3DNTHAL_DP2INDEXEDTRIANGLEFAN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2INDEXEDTRIANGLEFAN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15952,9 +13302,6 @@ impl Default for D3DNTHAL_DP2INDEXEDTRIANGLELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2INDEXEDTRIANGLELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2INDEXEDTRIANGLELIST2 {
@@ -15967,9 +13314,6 @@ impl Default for D3DNTHAL_DP2INDEXEDTRIANGLELIST2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2INDEXEDTRIANGLELIST2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2INDEXEDTRIANGLESTRIP {
@@ -15979,9 +13323,6 @@ impl Default for D3DNTHAL_DP2INDEXEDTRIANGLESTRIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2INDEXEDTRIANGLESTRIP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15994,9 +13335,6 @@ impl Default for D3DNTHAL_DP2ISSUEQUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2ISSUEQUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2LINELIST {
@@ -16007,9 +13345,6 @@ impl Default for D3DNTHAL_DP2LINELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2LINELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2LINESTRIP {
@@ -16019,9 +13354,6 @@ impl Default for D3DNTHAL_DP2LINESTRIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2LINESTRIP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
@@ -16036,10 +13368,6 @@ impl Default for D3DNTHAL_DP2MULTIPLYTRANSFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
-impl windows_core::TypeKind for D3DNTHAL_DP2MULTIPLYTRANSFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DNTHAL_DP2OPERATION(pub i32);
@@ -16053,9 +13381,6 @@ impl Default for D3DNTHAL_DP2PIXELSHADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2PIXELSHADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2POINTS {
@@ -16066,9 +13391,6 @@ impl Default for D3DNTHAL_DP2POINTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2POINTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -16083,10 +13405,6 @@ impl Default for D3DNTHAL_DP2RENDERSTATE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2RENDERSTATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy)]
@@ -16099,10 +13417,6 @@ impl Default for D3DNTHAL_DP2RENDERSTATE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2RENDERSTATE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16117,9 +13431,6 @@ impl Default for D3DNTHAL_DP2RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2RESPONSEQUERY {
@@ -16131,9 +13442,6 @@ impl Default for D3DNTHAL_DP2RESPONSEQUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2RESPONSEQUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2SETCLIPPLANE {
@@ -16144,9 +13452,6 @@ impl Default for D3DNTHAL_DP2SETCLIPPLANE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2SETCLIPPLANE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16160,9 +13465,6 @@ impl Default for D3DNTHAL_DP2SETCONVOLUTIONKERNELMONO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2SETCONVOLUTIONKERNELMONO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2SETDEPTHSTENCIL {
@@ -16172,9 +13474,6 @@ impl Default for D3DNTHAL_DP2SETDEPTHSTENCIL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2SETDEPTHSTENCIL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16187,9 +13486,6 @@ impl Default for D3DNTHAL_DP2SETINDICES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2SETINDICES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DNTHAL_DP2SETLIGHT {
@@ -16201,9 +13497,6 @@ impl Default for D3DNTHAL_DP2SETLIGHT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2SETLIGHT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DNTHAL_DP2SETLIGHT_0 {
@@ -16214,9 +13507,6 @@ impl Default for D3DNTHAL_DP2SETLIGHT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2SETLIGHT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16230,9 +13520,6 @@ impl Default for D3DNTHAL_DP2SETPALETTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2SETPALETTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2SETPIXELSHADERCONST {
@@ -16243,9 +13530,6 @@ impl Default for D3DNTHAL_DP2SETPIXELSHADERCONST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2SETPIXELSHADERCONST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16258,9 +13542,6 @@ impl Default for D3DNTHAL_DP2SETPRIORITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2SETPRIORITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2SETRENDERTARGET {
@@ -16271,9 +13552,6 @@ impl Default for D3DNTHAL_DP2SETRENDERTARGET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2SETRENDERTARGET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16286,9 +13564,6 @@ impl Default for D3DNTHAL_DP2SETRENDERTARGET2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2SETRENDERTARGET2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2SETSTREAMSOURCE {
@@ -16300,9 +13575,6 @@ impl Default for D3DNTHAL_DP2SETSTREAMSOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2SETSTREAMSOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16317,9 +13589,6 @@ impl Default for D3DNTHAL_DP2SETSTREAMSOURCE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2SETSTREAMSOURCE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2SETSTREAMSOURCEFREQ {
@@ -16330,9 +13599,6 @@ impl Default for D3DNTHAL_DP2SETSTREAMSOURCEFREQ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2SETSTREAMSOURCEFREQ {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16345,9 +13611,6 @@ impl Default for D3DNTHAL_DP2SETSTREAMSOURCEUM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2SETSTREAMSOURCEUM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2SETTEXLOD {
@@ -16358,9 +13621,6 @@ impl Default for D3DNTHAL_DP2SETTEXLOD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2SETTEXLOD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
@@ -16375,10 +13635,6 @@ impl Default for D3DNTHAL_DP2SETTRANSFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
-impl windows_core::TypeKind for D3DNTHAL_DP2SETTRANSFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2SETVERTEXSHADERCONST {
@@ -16390,9 +13646,6 @@ impl Default for D3DNTHAL_DP2SETVERTEXSHADERCONST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2SETVERTEXSHADERCONST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2STARTVERTEX {
@@ -16402,9 +13655,6 @@ impl Default for D3DNTHAL_DP2STARTVERTEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2STARTVERTEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -16419,10 +13669,6 @@ impl Default for D3DNTHAL_DP2STATESET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2STATESET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16440,9 +13686,6 @@ impl Default for D3DNTHAL_DP2SURFACEBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2SURFACEBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2TEXBLT {
@@ -16457,9 +13700,6 @@ impl Default for D3DNTHAL_DP2TEXBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2TEXBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2TEXTURESTAGESTATE {
@@ -16472,9 +13712,6 @@ impl Default for D3DNTHAL_DP2TEXTURESTAGESTATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2TEXTURESTAGESTATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2TRIANGLEFAN {
@@ -16484,9 +13721,6 @@ impl Default for D3DNTHAL_DP2TRIANGLEFAN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2TRIANGLEFAN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16498,9 +13732,6 @@ impl Default for D3DNTHAL_DP2TRIANGLEFAN_IMM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2TRIANGLEFAN_IMM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2TRIANGLELIST {
@@ -16511,9 +13742,6 @@ impl Default for D3DNTHAL_DP2TRIANGLELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2TRIANGLELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2TRIANGLESTRIP {
@@ -16523,9 +13751,6 @@ impl Default for D3DNTHAL_DP2TRIANGLESTRIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2TRIANGLESTRIP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16539,9 +13764,6 @@ impl Default for D3DNTHAL_DP2UPDATEPALETTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2UPDATEPALETTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2VERTEXSHADER {
@@ -16551,9 +13773,6 @@ impl Default for D3DNTHAL_DP2VERTEXSHADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2VERTEXSHADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16567,9 +13786,6 @@ impl Default for D3DNTHAL_DP2VIEWPORTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2VIEWPORTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -16589,10 +13805,6 @@ impl Default for D3DNTHAL_DP2VOLUMEBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for D3DNTHAL_DP2VOLUMEBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2WINFO {
@@ -16604,9 +13816,6 @@ impl Default for D3DNTHAL_DP2WINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_DP2WINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_DP2ZRANGE {
@@ -16617,9 +13826,6 @@ impl Default for D3DNTHAL_DP2ZRANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_DP2ZRANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
@@ -16646,10 +13852,6 @@ impl Default for D3DNTHAL_DRAWPRIMITIVES2DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DNTHAL_DRAWPRIMITIVES2DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 #[derive(Clone, Copy)]
@@ -16663,10 +13865,6 @@ impl Default for D3DNTHAL_DRAWPRIMITIVES2DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DNTHAL_DRAWPRIMITIVES2DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 #[derive(Clone, Copy)]
@@ -16679,10 +13877,6 @@ impl Default for D3DNTHAL_DRAWPRIMITIVES2DATA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DNTHAL_DRAWPRIMITIVES2DATA_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw"))]
@@ -16701,10 +13895,6 @@ impl Default for D3DNTHAL_GLOBALDRIVERDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_DirectDraw"))]
-impl windows_core::TypeKind for D3DNTHAL_GLOBALDRIVERDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DNTHAL_NUMCLIPVERTICES: u32 = 20u32;
 pub const D3DNTHAL_OUTOFCONTEXTS: i64 = 513i64;
 pub const D3DNTHAL_ROW_WEIGHTS: u32 = 1u32;
@@ -16719,9 +13909,6 @@ impl Default for D3DNTHAL_SCENECAPTUREDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_SCENECAPTUREDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DNTHAL_SCENE_CAPTURE_END: i32 = 1i32;
 pub const D3DNTHAL_SCENE_CAPTURE_START: i32 = 0i32;
@@ -16740,10 +13927,6 @@ impl Default for D3DNTHAL_SETRENDERTARGETDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for D3DNTHAL_SETRENDERTARGETDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DNTHAL_STATESETCREATE: u32 = 5u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16758,9 +13941,6 @@ impl Default for D3DNTHAL_TEXTURECREATEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_TEXTURECREATEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_TEXTUREDESTROYDATA {
@@ -16772,9 +13952,6 @@ impl Default for D3DNTHAL_TEXTUREDESTROYDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_TEXTUREDESTROYDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16789,9 +13966,6 @@ impl Default for D3DNTHAL_TEXTUREGETSURFDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DNTHAL_TEXTUREGETSURFDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DNTHAL_TEXTURESWAPDATA {
@@ -16804,9 +13978,6 @@ impl Default for D3DNTHAL_TEXTURESWAPDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_TEXTURESWAPDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DNTHAL_TSS_MAXSTAGES: u32 = 8u32;
 pub const D3DNTHAL_TSS_RENDERSTATEBASE: u32 = 256u32;
@@ -16824,9 +13995,6 @@ impl Default for D3DNTHAL_VALIDATETEXTURESTAGESTATEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DNTHAL_VALIDATETEXTURESTAGESTATEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DPMISCCAPS_FOGINFVF: i32 = 8192i32;
 pub const D3DPMISCCAPS_LINEPATTERNREP: i32 = 4i32;
@@ -17046,9 +14214,6 @@ impl Default for DDNT_DEFERRED_AGP_AWARE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDNT_DEFERRED_AGP_AWARE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDNT_DXVERSION {
@@ -17061,9 +14226,6 @@ impl Default for DDNT_DXVERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDNT_DXVERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDNT_FREE_DEFERRED_AGP_DATA {
@@ -17074,9 +14236,6 @@ impl Default for DDNT_FREE_DEFERRED_AGP_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDNT_FREE_DEFERRED_AGP_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -17091,9 +14250,6 @@ impl Default for DDNT_GETADAPTERGROUPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDNT_GETADAPTERGROUPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDNT_GETD3DQUERYCOUNTDATA {
@@ -17104,9 +14260,6 @@ impl Default for DDNT_GETD3DQUERYCOUNTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDNT_GETD3DQUERYCOUNTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -17121,10 +14274,6 @@ impl Default for DDNT_GETD3DQUERYDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DDNT_GETD3DQUERYDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy)]
@@ -17138,10 +14287,6 @@ impl Default for DDNT_GETD3DQUERYDATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DDNT_GETD3DQUERYDATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDNT_GETDDIVERSIONDATA {
@@ -17153,9 +14298,6 @@ impl Default for DDNT_GETDDIVERSIONDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDNT_GETDDIVERSIONDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -17170,9 +14312,6 @@ impl Default for DDNT_GETDRIVERINFO2DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDNT_GETDRIVERINFO2DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDNT_GETEXTENDEDMODECOUNTDATA {
@@ -17184,9 +14323,6 @@ impl Default for DDNT_GETEXTENDEDMODECOUNTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDNT_GETEXTENDEDMODECOUNTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -17202,10 +14338,6 @@ impl Default for DDNT_GETEXTENDEDMODEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DDNT_GETEXTENDEDMODEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDNT_GETFORMATCOUNTDATA {
@@ -17217,9 +14349,6 @@ impl Default for DDNT_GETFORMATCOUNTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDNT_GETFORMATCOUNTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
@@ -17234,10 +14363,6 @@ impl Default for DDNT_GETFORMATDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for DDNT_GETFORMATDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -17254,10 +14379,6 @@ impl Default for DDNT_MULTISAMPLEQUALITYLEVELSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DDNT_MULTISAMPLEQUALITYLEVELSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_DEFERRED_AGP_AWARE_DATA {
@@ -17267,9 +14388,6 @@ impl Default for DD_DEFERRED_AGP_AWARE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_DEFERRED_AGP_AWARE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -17283,9 +14401,6 @@ impl Default for DD_DXVERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_DXVERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_FREE_DEFERRED_AGP_DATA {
@@ -17296,9 +14411,6 @@ impl Default for DD_FREE_DEFERRED_AGP_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_FREE_DEFERRED_AGP_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -17313,9 +14425,6 @@ impl Default for DD_GETADAPTERGROUPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETADAPTERGROUPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETD3DQUERYCOUNTDATA {
@@ -17326,9 +14435,6 @@ impl Default for DD_GETD3DQUERYCOUNTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETD3DQUERYCOUNTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -17343,10 +14449,6 @@ impl Default for DD_GETD3DQUERYDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DD_GETD3DQUERYDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy)]
@@ -17360,10 +14462,6 @@ impl Default for DD_GETD3DQUERYDATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DD_GETD3DQUERYDATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETDDIVERSIONDATA {
@@ -17375,9 +14473,6 @@ impl Default for DD_GETDDIVERSIONDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETDDIVERSIONDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -17392,9 +14487,6 @@ impl Default for DD_GETDRIVERINFO2DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETDRIVERINFO2DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETEXTENDEDMODECOUNTDATA {
@@ -17406,9 +14498,6 @@ impl Default for DD_GETEXTENDEDMODECOUNTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETEXTENDEDMODECOUNTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -17424,10 +14513,6 @@ impl Default for DD_GETEXTENDEDMODEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DD_GETEXTENDEDMODEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETFORMATCOUNTDATA {
@@ -17439,9 +14524,6 @@ impl Default for DD_GETFORMATCOUNTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETFORMATCOUNTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
@@ -17457,10 +14539,6 @@ impl Default for DD_GETFORMATDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for DD_GETFORMATDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -17475,10 +14553,6 @@ impl Default for DD_MULTISAMPLEQUALITYLEVELSDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DD_MULTISAMPLEQUALITYLEVELSDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIDDT1_AspectRatio_15x9: DISPLAYID_DETAILED_TIMING_TYPE_I_ASPECT_RATIO = DISPLAYID_DETAILED_TIMING_TYPE_I_ASPECT_RATIO(3i32);
 pub const DIDDT1_AspectRatio_16x10: DISPLAYID_DETAILED_TIMING_TYPE_I_ASPECT_RATIO = DISPLAYID_DETAILED_TIMING_TYPE_I_ASPECT_RATIO(5i32);
@@ -17511,9 +14585,6 @@ impl Default for DISPLAYID_DETAILED_TIMING_TYPE_I {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYID_DETAILED_TIMING_TYPE_I {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DISPLAYID_DETAILED_TIMING_TYPE_I_0 {
@@ -17523,9 +14594,6 @@ impl Default for DISPLAYID_DETAILED_TIMING_TYPE_I_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYID_DETAILED_TIMING_TYPE_I_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -17537,9 +14605,6 @@ impl Default for DISPLAYID_DETAILED_TIMING_TYPE_I_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYID_DETAILED_TIMING_TYPE_I_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DISPLAYID_DETAILED_TIMING_TYPE_I_2 {
@@ -17549,9 +14614,6 @@ impl Default for DISPLAYID_DETAILED_TIMING_TYPE_I_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYID_DETAILED_TIMING_TYPE_I_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17581,9 +14643,6 @@ impl Default for DXGKARG_SETPALETTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKARG_SETPALETTE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGKDDI_INTERFACE_VERSION: u32 = 65540u32;
 pub const DXGKDDI_INTERFACE_VERSION_VISTA: u32 = 4178u32;
@@ -17639,9 +14698,6 @@ impl Default for DXGKMDT_OPM_ACP_AND_CGMSA_SIGNALING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKMDT_OPM_ACP_AND_CGMSA_SIGNALING {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXGKMDT_OPM_ACP_LEVEL_ONE: DXGKMDT_OPM_ACP_PROTECTION_LEVEL = DXGKMDT_OPM_ACP_PROTECTION_LEVEL(1i32);
 pub const DXGKMDT_OPM_ACP_LEVEL_THREE: DXGKMDT_OPM_ACP_PROTECTION_LEVEL = DXGKMDT_OPM_ACP_PROTECTION_LEVEL(3i32);
 pub const DXGKMDT_OPM_ACP_LEVEL_TWO: DXGKMDT_OPM_ACP_PROTECTION_LEVEL = DXGKMDT_OPM_ACP_PROTECTION_LEVEL(2i32);
@@ -17665,9 +14721,6 @@ impl Default for DXGKMDT_OPM_ACTUAL_OUTPUT_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKMDT_OPM_ACTUAL_OUTPUT_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGKMDT_OPM_ASPECT_RATIO_EN300294_BOX_14_BY_9_CENTER: DXGKMDT_OPM_IMAGE_ASPECT_RATIO_EN300294 = DXGKMDT_OPM_IMAGE_ASPECT_RATIO_EN300294(1i32);
 pub const DXGKMDT_OPM_ASPECT_RATIO_EN300294_BOX_14_BY_9_TOP: DXGKMDT_OPM_IMAGE_ASPECT_RATIO_EN300294 = DXGKMDT_OPM_IMAGE_ASPECT_RATIO_EN300294(2i32);
@@ -17714,9 +14767,6 @@ impl Default for DXGKMDT_OPM_CONFIGURE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKMDT_OPM_CONFIGURE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXGKMDT_OPM_CONFIGURE_SETTING_DATA_SIZE: u32 = 4056u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -17733,9 +14783,6 @@ impl Default for DXGKMDT_OPM_CONNECTED_HDCP_DEVICE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKMDT_OPM_CONNECTED_HDCP_DEVICE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17774,9 +14821,6 @@ impl Default for DXGKMDT_OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKMDT_OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGKMDT_OPM_CREATE_VIDEO_OUTPUT_FOR_TARGET_PARAMETERS {
@@ -17788,9 +14832,6 @@ impl Default for DXGKMDT_OPM_CREATE_VIDEO_OUTPUT_FOR_TARGET_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKMDT_OPM_CREATE_VIDEO_OUTPUT_FOR_TARGET_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGKMDT_OPM_DPCP_OFF: DXGKMDT_OPM_DPCP_PROTECTION_LEVEL = DXGKMDT_OPM_DPCP_PROTECTION_LEVEL(0i32);
 pub const DXGKMDT_OPM_DPCP_ON: DXGKMDT_OPM_DPCP_PROTECTION_LEVEL = DXGKMDT_OPM_DPCP_PROTECTION_LEVEL(1i32);
@@ -17808,9 +14849,6 @@ impl Default for DXGKMDT_OPM_ENCRYPTED_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKMDT_OPM_ENCRYPTED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGKMDT_OPM_ENCRYPTED_PARAMETERS_SIZE: u32 = 256u32;
 pub const DXGKMDT_OPM_GET_ACP_AND_CGMSA_SIGNALING: windows_core::GUID = windows_core::GUID::from_u128(0x6629a591_3b79_4cf3_924a_11e8e7811671);
@@ -17838,9 +14876,6 @@ impl Default for DXGKMDT_OPM_GET_INFO_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKMDT_OPM_GET_INFO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXGKMDT_OPM_GET_OUTPUT_HARDWARE_PROTECTION_SUPPORT: windows_core::GUID = windows_core::GUID::from_u128(0x3b129589_2af8_4ef0_96a2_704a845a218e);
 pub const DXGKMDT_OPM_GET_OUTPUT_ID: windows_core::GUID = windows_core::GUID::from_u128(0x72cb6df3_244f_40ce_b09e_20506af6302f);
 pub const DXGKMDT_OPM_GET_SUPPORTED_PROTECTION_TYPES: windows_core::GUID = windows_core::GUID::from_u128(0x38f2a801_9a6c_48bb_9107_b6696e6f1797);
@@ -17859,9 +14894,6 @@ impl Default for DXGKMDT_OPM_HDCP_KEY_SELECTION_VECTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKMDT_OPM_HDCP_KEY_SELECTION_VECTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGKMDT_OPM_HDCP_KEY_SELECTION_VECTOR_SIZE: u32 = 5u32;
 pub const DXGKMDT_OPM_HDCP_OFF: DXGKMDT_OPM_HDCP_PROTECTION_LEVEL = DXGKMDT_OPM_HDCP_PROTECTION_LEVEL(0i32);
@@ -17889,9 +14921,6 @@ impl Default for DXGKMDT_OPM_OMAC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKMDT_OPM_OMAC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXGKMDT_OPM_OMAC_SIZE: u32 = 16u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17909,9 +14938,6 @@ impl Default for DXGKMDT_OPM_OUTPUT_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKMDT_OPM_OUTPUT_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17956,9 +14982,6 @@ impl Default for DXGKMDT_OPM_RANDOM_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKMDT_OPM_RANDOM_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXGKMDT_OPM_REDISTRIBUTION_CONTROL_REQUIRED: DXGKMDT_OPM_CGMSA = DXGKMDT_OPM_CGMSA(8i32);
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -17971,9 +14994,6 @@ impl Default for DXGKMDT_OPM_REQUESTED_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKMDT_OPM_REQUESTED_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGKMDT_OPM_REQUESTED_INFORMATION_SIZE: u32 = 4076u32;
 pub const DXGKMDT_OPM_SET_ACP_AND_CGMSA_SIGNALING: windows_core::GUID = windows_core::GUID::from_u128(0x09a631a5_d684_4c60_8e4d_d3bb0f0be3ee);
@@ -17996,9 +15016,6 @@ impl Default for DXGKMDT_OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKMDT_OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXGKMDT_OPM_SET_HDCP_SRM: windows_core::GUID = windows_core::GUID::from_u128(0x8b5ef5d1_c30d_44ff_84a5_ea71dce78f13);
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18009,9 +15026,6 @@ impl Default for DXGKMDT_OPM_SET_HDCP_SRM_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKMDT_OPM_SET_HDCP_SRM_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGKMDT_OPM_SET_PROTECTION_LEVEL: windows_core::GUID = windows_core::GUID::from_u128(0x9bb9327c_4eb5_4727_9f00_b42b0919c0da);
 pub const DXGKMDT_OPM_SET_PROTECTION_LEVEL_ACCORDING_TO_CSS_DVD: windows_core::GUID = windows_core::GUID::from_u128(0x39ce333e_4cc0_44ae_bfcc_da50b5f82e72);
@@ -18028,9 +15042,6 @@ impl Default for DXGKMDT_OPM_SET_PROTECTION_LEVEL_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKMDT_OPM_SET_PROTECTION_LEVEL_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGKMDT_OPM_STANDARD_INFORMATION {
@@ -18044,9 +15055,6 @@ impl Default for DXGKMDT_OPM_STANDARD_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKMDT_OPM_STANDARD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18101,9 +15109,6 @@ impl Default for DXGKVGPU_ESCAPE_HEAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_HEAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGKVGPU_ESCAPE_INITIALIZE {
@@ -18114,9 +15119,6 @@ impl Default for DXGKVGPU_ESCAPE_INITIALIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_INITIALIZE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18130,9 +15132,6 @@ impl Default for DXGKVGPU_ESCAPE_PAUSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_PAUSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DXGKVGPU_ESCAPE_PAUSE_0 {
@@ -18144,9 +15143,6 @@ impl Default for DXGKVGPU_ESCAPE_PAUSE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_PAUSE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGKVGPU_ESCAPE_PAUSE_0_0 {
@@ -18156,9 +15152,6 @@ impl Default for DXGKVGPU_ESCAPE_PAUSE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_PAUSE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18170,9 +15163,6 @@ impl Default for DXGKVGPU_ESCAPE_POWERTRANSITIONCOMPLETE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_POWERTRANSITIONCOMPLETE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18186,9 +15176,6 @@ impl Default for DXGKVGPU_ESCAPE_READ_PCI_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_READ_PCI_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGKVGPU_ESCAPE_READ_VGPU_TYPE {
@@ -18199,9 +15186,6 @@ impl Default for DXGKVGPU_ESCAPE_READ_VGPU_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_READ_VGPU_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGKVGPU_ESCAPE_RELEASE {
@@ -18211,9 +15195,6 @@ impl Default for DXGKVGPU_ESCAPE_RELEASE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_RELEASE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18226,9 +15207,6 @@ impl Default for DXGKVGPU_ESCAPE_RESUME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_RESUME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18253,9 +15231,6 @@ impl Default for DXGKVGPU_ESCAPE_WRITE_PCI_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGKVGPU_ESCAPE_WRITE_PCI_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_ADAPTER_PERFDATA {
@@ -18274,9 +15249,6 @@ impl Default for DXGK_ADAPTER_PERFDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_ADAPTER_PERFDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_ADAPTER_PERFDATACAPS {
@@ -18291,9 +15263,6 @@ impl Default for DXGK_ADAPTER_PERFDATACAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_ADAPTER_PERFDATACAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_BACKLIGHT_INFO {
@@ -18305,9 +15274,6 @@ impl Default for DXGK_BACKLIGHT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_BACKLIGHT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18322,9 +15288,6 @@ impl Default for DXGK_BRIGHTNESS_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union DXGK_BRIGHTNESS_CAPS_0 {
@@ -18336,9 +15299,6 @@ impl Default for DXGK_BRIGHTNESS_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_BRIGHTNESS_CAPS_0_0 {
@@ -18348,9 +15308,6 @@ impl Default for DXGK_BRIGHTNESS_CAPS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18365,9 +15322,6 @@ impl Default for DXGK_BRIGHTNESS_GET_NIT_RANGES_OUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_GET_NIT_RANGES_OUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_BRIGHTNESS_GET_OUT {
@@ -18378,9 +15332,6 @@ impl Default for DXGK_BRIGHTNESS_GET_OUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_GET_OUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGK_BRIGHTNESS_MAXIMUM_NIT_RANGE_COUNT: u32 = 16u32;
 #[repr(C, packed(1))]
@@ -18394,9 +15345,6 @@ impl Default for DXGK_BRIGHTNESS_NIT_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_NIT_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18412,9 +15360,6 @@ impl Default for DXGK_BRIGHTNESS_SENSOR_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_SENSOR_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union DXGK_BRIGHTNESS_SENSOR_DATA_0 {
@@ -18426,9 +15371,6 @@ impl Default for DXGK_BRIGHTNESS_SENSOR_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_SENSOR_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_BRIGHTNESS_SENSOR_DATA_0_0 {
@@ -18438,9 +15380,6 @@ impl Default for DXGK_BRIGHTNESS_SENSOR_DATA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_SENSOR_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18452,9 +15391,6 @@ impl Default for DXGK_BRIGHTNESS_SENSOR_DATA_CHROMATICITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_SENSOR_DATA_CHROMATICITY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18468,9 +15404,6 @@ impl Default for DXGK_BRIGHTNESS_SET_IN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_SET_IN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DXGK_BRIGHTNESS_STATE {
@@ -18480,9 +15413,6 @@ impl Default for DXGK_BRIGHTNESS_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18495,9 +15425,6 @@ impl Default for DXGK_BRIGHTNESS_STATE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_STATE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_BRIGHTNESS_STATE_0_0 {
@@ -18507,9 +15434,6 @@ impl Default for DXGK_BRIGHTNESS_STATE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_BRIGHTNESS_STATE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18536,9 +15460,6 @@ impl Default for DXGK_DISPLAY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_DISPLAY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18591,9 +15512,6 @@ impl Default for DXGK_ESCAPE_GPUMMUCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_ESCAPE_GPUMMUCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DXGK_FAULT_ERROR_CODE {
@@ -18603,9 +15521,6 @@ impl Default for DXGK_FAULT_ERROR_CODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_FAULT_ERROR_CODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18618,9 +15533,6 @@ impl Default for DXGK_FAULT_ERROR_CODE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_FAULT_ERROR_CODE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_FAULT_ERROR_CODE_0_0 {
@@ -18631,9 +15543,6 @@ impl Default for DXGK_FAULT_ERROR_CODE_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_FAULT_ERROR_CODE_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_FAULT_ERROR_CODE_0_1 {
@@ -18643,9 +15552,6 @@ impl Default for DXGK_FAULT_ERROR_CODE_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_FAULT_ERROR_CODE_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18665,9 +15571,6 @@ impl Default for DXGK_GPUCLOCKDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_GPUCLOCKDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DXGK_GPUCLOCKDATA_FLAGS {
@@ -18677,9 +15580,6 @@ impl Default for DXGK_GPUCLOCKDATA_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_GPUCLOCKDATA_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18692,9 +15592,6 @@ impl Default for DXGK_GPUCLOCKDATA_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_GPUCLOCKDATA_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_GPUCLOCKDATA_FLAGS_0_0 {
@@ -18704,9 +15601,6 @@ impl Default for DXGK_GPUCLOCKDATA_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_GPUCLOCKDATA_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18718,9 +15612,6 @@ impl Default for DXGK_GPUVERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_GPUVERSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Power")]
@@ -18739,10 +15630,6 @@ impl Default for DXGK_GRAPHICSPOWER_REGISTER_INPUT_V_1_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Power")]
-impl windows_core::TypeKind for DXGK_GRAPHICSPOWER_REGISTER_INPUT_V_1_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Power")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18757,10 +15644,6 @@ impl Default for DXGK_GRAPHICSPOWER_REGISTER_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Power")]
-impl windows_core::TypeKind for DXGK_GRAPHICSPOWER_REGISTER_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGK_GRAPHICSPOWER_VERSION: u32 = 4098u32;
 pub const DXGK_GRAPHICSPOWER_VERSION_1_0: u32 = 4096u32;
@@ -18781,9 +15664,6 @@ impl Default for DXGK_MIRACAST_CHUNK_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_MIRACAST_CHUNK_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGK_MIRACAST_CHUNK_ID_0 {
@@ -18793,9 +15673,6 @@ impl Default for DXGK_MIRACAST_CHUNK_ID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_MIRACAST_CHUNK_ID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18809,9 +15686,6 @@ impl Default for DXGK_MIRACAST_CHUNK_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_MIRACAST_CHUNK_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18834,9 +15708,6 @@ impl Default for DXGK_MONITORLINKINFO_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_MONITORLINKINFO_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_MONITORLINKINFO_CAPABILITIES_0 {
@@ -18846,9 +15717,6 @@ impl Default for DXGK_MONITORLINKINFO_CAPABILITIES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_MONITORLINKINFO_CAPABILITIES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18861,9 +15729,6 @@ impl Default for DXGK_MONITORLINKINFO_USAGEHINTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_MONITORLINKINFO_USAGEHINTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_MONITORLINKINFO_USAGEHINTS_0 {
@@ -18873,9 +15738,6 @@ impl Default for DXGK_MONITORLINKINFO_USAGEHINTS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_MONITORLINKINFO_USAGEHINTS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18891,9 +15753,6 @@ impl Default for DXGK_NODEMETADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_NODEMETADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DXGK_NODEMETADATA_FLAGS {
@@ -18903,9 +15762,6 @@ impl Default for DXGK_NODEMETADATA_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_NODEMETADATA_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18918,9 +15774,6 @@ impl Default for DXGK_NODEMETADATA_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_NODEMETADATA_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DXGK_NODEMETADATA_FLAGS_0_0 {
@@ -18930,9 +15783,6 @@ impl Default for DXGK_NODEMETADATA_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_NODEMETADATA_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18949,9 +15799,6 @@ impl Default for DXGK_NODE_PERFDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_NODE_PERFDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGK_PAGE_FAULT_ADAPTER_RESET_REQUIRED: DXGK_PAGE_FAULT_FLAGS = DXGK_PAGE_FAULT_FLAGS(4i32);
 pub const DXGK_PAGE_FAULT_ENGINE_RESET_REQUIRED: DXGK_PAGE_FAULT_FLAGS = DXGK_PAGE_FAULT_FLAGS(8i32);
@@ -18975,9 +15822,6 @@ impl Default for DXGK_PTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_PTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DXGK_PTE_0 {
@@ -18989,9 +15833,6 @@ impl Default for DXGK_PTE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_PTE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGK_PTE_0_0 {
@@ -19001,9 +15842,6 @@ impl Default for DXGK_PTE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_PTE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -19015,9 +15853,6 @@ impl Default for DXGK_PTE_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGK_PTE_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -19047,9 +15882,6 @@ impl Default for DXGK_TARGETMODE_DETAIL_TIMING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_TARGETMODE_DETAIL_TIMING {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DxgkBacklightOptimizationDesktop: DXGK_BACKLIGHT_OPTIMIZATION_LEVEL = DXGK_BACKLIGHT_OPTIMIZATION_LEVEL(1i32);
 pub const DxgkBacklightOptimizationDimmed: DXGK_BACKLIGHT_OPTIMIZATION_LEVEL = DXGK_BACKLIGHT_OPTIMIZATION_LEVEL(3i32);
 pub const DxgkBacklightOptimizationDisable: DXGK_BACKLIGHT_OPTIMIZATION_LEVEL = DXGK_BACKLIGHT_OPTIMIZATION_LEVEL(0i32);
@@ -19065,9 +15897,6 @@ impl Default for GPUP_DRIVER_ESCAPE_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GPUP_DRIVER_ESCAPE_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GUID_DEVINTERFACE_GRAPHICSPOWER: windows_core::GUID = windows_core::GUID::from_u128(0xea5c6870_e93c_4588_bef1_fec42fc9429a);
 pub const HpdAwarenessAlwaysConnected: DXGK_CHILD_DEVICE_HPD_AWARENESS = DXGK_CHILD_DEVICE_HPD_AWARENESS(1i32);
@@ -19257,9 +16086,6 @@ impl Default for OUTPUTDUPL_CONTEXT_DEBUG_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OUTPUTDUPL_CONTEXT_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -19501,9 +16327,6 @@ impl Default for _NT_D3DLINEPATTERN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _NT_D3DLINEPATTERN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const _NT_D3DPMISCCAPS_FOGINFVF: i32 = 8192i32;
 pub const _NT_D3DPS_COLOROUT_MAX_V2_0: u32 = 4u32;

--- a/crates/libs/windows/src/Windows/Wdk/NetworkManagement/Ndis/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/NetworkManagement/Ndis/mod.rs
@@ -592,9 +592,6 @@ impl Default for BINARY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BINARY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BROADCAST_VC: u32 = 8u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -606,9 +603,6 @@ impl Default for BSSID_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BSSID_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CALL_PARAMETERS_CHANGED: u32 = 2u32;
 pub const CLOCK_NETWORK_DERIVED: u32 = 2u32;
@@ -650,9 +644,6 @@ impl Default for CO_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CO_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CO_ADDRESS_FAMILY {
@@ -664,9 +655,6 @@ impl Default for CO_ADDRESS_FAMILY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CO_ADDRESS_FAMILY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CO_ADDRESS_FAMILY_PROXY: u32 = 2147483648u32;
 #[repr(C)]
@@ -680,9 +668,6 @@ impl Default for CO_ADDRESS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CO_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub type CO_AF_REGISTER_NOTIFY_HANDLER = Option<unsafe extern "system" fn()>;
 #[repr(C)]
@@ -698,10 +683,6 @@ impl Default for CO_CALL_MANAGER_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for CO_CALL_MANAGER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -728,9 +709,6 @@ impl Default for CO_PVC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CO_PVC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CO_SAP {
@@ -742,9 +720,6 @@ impl Default for CO_SAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CO_SAP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CO_SEND_FLAG_SET_DISCARD_ELIBILITY: u32 = 1u32;
 #[repr(C)]
@@ -758,9 +733,6 @@ impl Default for CO_SPECIFIC_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CO_SPECIFIC_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTO_GENERIC_ERROR: u32 = 1u32;
 pub const CRYPTO_INVALID_PACKET_SYNTAX: u32 = 6u32;
@@ -799,9 +771,6 @@ impl Default for FILTERDBS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTERDBS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILTERDBS_0 {
@@ -813,9 +782,6 @@ impl Default for FILTERDBS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTERDBS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GEN_GET_NETCARD_TIME {
@@ -825,9 +791,6 @@ impl Default for GEN_GET_NETCARD_TIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GEN_GET_NETCARD_TIME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -839,9 +802,6 @@ impl Default for GEN_GET_TIME_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GEN_GET_TIME_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GUID_NDIS_NDK_CAPABILITIES: windows_core::GUID = windows_core::GUID::from_u128(0x7969ba4d_dd80_4bc7_b3e6_68043997e519);
 pub const GUID_NDIS_NDK_STATE: windows_core::GUID = windows_core::GUID::from_u128(0x530c69c9_2f51_49de_a1af_088d54ffa474);
@@ -896,9 +856,6 @@ impl Default for LOCK_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOCK_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MAXIMUM_IP_OPER_STATUS_ADDRESS_FAMILIES_SUPPORTED: u32 = 32u32;
 pub const MAX_HASHES: u32 = 4u32;
 #[repr(C)]
@@ -913,9 +870,6 @@ impl Default for MEDIA_SPECIFIC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEDIA_SPECIFIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub type MINIPORT_CO_ACTIVATE_VC = Option<unsafe extern "system" fn(miniportvccontext: *const core::ffi::c_void, callparameters: *mut CO_CALL_PARAMETERS) -> i32>;
 pub type MINIPORT_CO_CREATE_VC = Option<unsafe extern "system" fn(miniportadaptercontext: *const core::ffi::c_void, ndisvchandle: *const core::ffi::c_void, miniportvccontext: *mut *mut core::ffi::c_void) -> i32>;
@@ -942,9 +896,6 @@ impl Default for NDIS_802_11_AI_REQFI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_AI_REQFI {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_802_11_AI_REQFI_CAPABILITIES: u32 = 1u32;
 pub const NDIS_802_11_AI_REQFI_CURRENTAPADDRESS: u32 = 4u32;
 pub const NDIS_802_11_AI_REQFI_LISTENINTERVAL: u32 = 2u32;
@@ -959,9 +910,6 @@ impl Default for NDIS_802_11_AI_RESFI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_AI_RESFI {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_802_11_AI_RESFI_ASSOCIATIONID: u32 = 4u32;
 pub const NDIS_802_11_AI_RESFI_CAPABILITIES: u32 = 1u32;
@@ -984,9 +932,6 @@ impl Default for NDIS_802_11_ASSOCIATION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_ASSOCIATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_AUTHENTICATION_ENCRYPTION {
@@ -998,9 +943,6 @@ impl Default for NDIS_802_11_AUTHENTICATION_ENCRYPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_AUTHENTICATION_ENCRYPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_AUTHENTICATION_EVENT {
@@ -1011,9 +953,6 @@ impl Default for NDIS_802_11_AUTHENTICATION_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_AUTHENTICATION_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1029,9 +968,6 @@ impl Default for NDIS_802_11_AUTHENTICATION_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_AUTHENTICATION_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_802_11_AUTH_REQUEST_AUTH_FIELDS: u32 = 15u32;
 pub const NDIS_802_11_AUTH_REQUEST_GROUP_ERROR: u32 = 14u32;
@@ -1049,9 +985,6 @@ impl Default for NDIS_802_11_BSSID_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_BSSID_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_BSSID_LIST_EX {
@@ -1062,9 +995,6 @@ impl Default for NDIS_802_11_BSSID_LIST_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_BSSID_LIST_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1080,9 +1010,6 @@ impl Default for NDIS_802_11_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_CONFIGURATION {
@@ -1097,9 +1024,6 @@ impl Default for NDIS_802_11_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_CONFIGURATION_FH {
@@ -1113,9 +1037,6 @@ impl Default for NDIS_802_11_CONFIGURATION_FH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_CONFIGURATION_FH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_FIXED_IEs {
@@ -1127,9 +1048,6 @@ impl Default for NDIS_802_11_FIXED_IEs {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_FIXED_IEs {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1145,9 +1063,6 @@ impl Default for NDIS_802_11_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_802_11_LENGTH_RATES: u32 = 8u32;
 pub const NDIS_802_11_LENGTH_RATES_EX: u32 = 16u32;
@@ -1172,9 +1087,6 @@ impl Default for NDIS_802_11_NETWORK_TYPE_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_NETWORK_TYPE_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_NON_BCAST_SSID_LIST {
@@ -1185,9 +1097,6 @@ impl Default for NDIS_802_11_NON_BCAST_SSID_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_NON_BCAST_SSID_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1201,9 +1110,6 @@ impl Default for NDIS_802_11_PMKID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_PMKID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_PMKID_CANDIDATE_LIST {
@@ -1215,9 +1121,6 @@ impl Default for NDIS_802_11_PMKID_CANDIDATE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_PMKID_CANDIDATE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_802_11_PMKID_CANDIDATE_PREAUTH_ENABLED: u32 = 1u32;
 #[repr(transparent)]
@@ -1244,9 +1147,6 @@ impl Default for NDIS_802_11_REMOVE_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_REMOVE_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_SSID {
@@ -1257,9 +1157,6 @@ impl Default for NDIS_802_11_SSID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_SSID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1295,9 +1192,6 @@ impl Default for NDIS_802_11_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_STATUS_INDICATION {
@@ -1307,9 +1201,6 @@ impl Default for NDIS_802_11_STATUS_INDICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_STATUS_INDICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1326,9 +1217,6 @@ impl Default for NDIS_802_11_TEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_TEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NDIS_802_11_TEST_0 {
@@ -1339,9 +1227,6 @@ impl Default for NDIS_802_11_TEST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_TEST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1355,9 +1240,6 @@ impl Default for NDIS_802_11_VARIABLE_IEs {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_VARIABLE_IEs {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_WEP {
@@ -1370,9 +1252,6 @@ impl Default for NDIS_802_11_WEP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_WEP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1428,9 +1307,6 @@ impl Default for NDIS_CONFIGURATION_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_CONFIGURATION_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NDIS_CONFIGURATION_PARAMETER_0 {
@@ -1442,9 +1318,6 @@ impl Default for NDIS_CONFIGURATION_PARAMETER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_CONFIGURATION_PARAMETER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_CONFIG_FLAG_FILTER_INSTANCE_CONFIGURATION: u32 = 1u32;
 pub const NDIS_CO_CALL_MANAGER_OPTIONAL_HANDLERS_REVISION_1: u32 = 1u32;
@@ -1486,9 +1359,6 @@ impl Default for NDIS_CO_DEVICE_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_CO_DEVICE_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_CO_LINK_SPEED {
@@ -1499,9 +1369,6 @@ impl Default for NDIS_CO_LINK_SPEED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_CO_LINK_SPEED {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_CO_MAC_OPTION_DYNAMIC_LINK_SPEED: u32 = 1u32;
 pub const NDIS_DEFAULT_RECEIVE_FILTER_ID: u32 = 0u32;
@@ -1536,10 +1403,6 @@ impl Default for NDIS_DMA_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for NDIS_DMA_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_System_SystemServices")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1557,10 +1420,6 @@ impl Default for NDIS_DMA_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_System_SystemServices")]
-impl windows_core::TypeKind for NDIS_DMA_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_DRIVER_FLAGS_RESERVED: u32 = 8u32;
 pub const NDIS_ENCAPSULATED_PACKET_TASK_OFFLOAD_INNER_IPV4: u32 = 1u32;
@@ -1597,10 +1456,6 @@ impl Default for NDIS_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for NDIS_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1841,9 +1696,6 @@ impl Default for NDIS_GUID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_GUID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NDIS_GUID_0 {
@@ -1854,9 +1706,6 @@ impl Default for NDIS_GUID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_GUID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1871,9 +1720,6 @@ impl Default for NDIS_HARDWARE_CROSSTIMESTAMP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_HARDWARE_CROSSTIMESTAMP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_HARDWARE_CROSSTIMESTAMP_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -1922,9 +1768,6 @@ impl Default for NDIS_INTERRUPT_MODERATION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_INTERRUPT_MODERATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_INTERRUPT_MODERATION_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1938,9 +1781,6 @@ impl Default for NDIS_IPSEC_OFFLOAD_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_IPSEC_OFFLOAD_V1_1 {
@@ -1951,9 +1791,6 @@ impl Default for NDIS_IPSEC_OFFLOAD_V1_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_IPSEC_OFFLOAD_V1_2 {
@@ -1963,9 +1800,6 @@ impl Default for NDIS_IPSEC_OFFLOAD_V1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1980,9 +1814,6 @@ impl Default for NDIS_IPSEC_OFFLOAD_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_IPSEC_OFFLOAD_V2_ADD_SA_EX_REVISION_1: u32 = 1u32;
 pub const NDIS_IPSEC_OFFLOAD_V2_ADD_SA_REVISION_1: u32 = 1u32;
@@ -2002,10 +1833,6 @@ impl Default for NDIS_IP_OPER_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_IP_OPER_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_IP_OPER_STATE_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2020,10 +1847,6 @@ impl Default for NDIS_IP_OPER_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_IP_OPER_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2040,10 +1863,6 @@ impl Default for NDIS_IP_OPER_STATUS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_IP_OPER_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_IP_OPER_STATUS_INFO_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2055,9 +1874,6 @@ impl Default for NDIS_IRDA_PACKET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_IRDA_PACKET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_ISOLATION_NAME_MAX_STRING_SIZE: u32 = 127u32;
 pub const NDIS_ISOLATION_PARAMETERS_REVISION_1: u32 = 1u32;
@@ -2087,10 +1903,6 @@ impl Default for NDIS_LINK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_LINK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_LINK_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2102,9 +1914,6 @@ impl Default for NDIS_LINK_SPEED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_LINK_SPEED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2123,10 +1932,6 @@ impl Default for NDIS_LINK_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_LINK_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_LINK_STATE_DUPLEX_AUTO_NEGOTIATED: u32 = 4u32;
 pub const NDIS_LINK_STATE_PAUSE_FUNCTIONS_AUTO_NEGOTIATED: u32 = 8u32;
@@ -2226,10 +2031,6 @@ impl Default for NDIS_MINIPORT_TIMER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for NDIS_MINIPORT_TIMER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_MIN_API: u32 = 1024u32;
 pub const NDIS_MONITOR_CONFIG_REVISION_1: u32 = 1u32;
 pub const NDIS_MSIX_CONFIG_PARAMETERS_REVISION_1: u32 = 1u32;
@@ -2323,9 +2124,6 @@ impl Default for NDIS_OBJECT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_OBJECT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_OBJECT_REVISION_1: u32 = 1u32;
 pub const NDIS_OBJECT_TYPE_BIND_PARAMETERS: u32 = 134u32;
 pub const NDIS_OBJECT_TYPE_CLIENT_CHIMNEY_OFFLOAD_CHARACTERISTICS: u32 = 147u32;
@@ -2408,9 +2206,6 @@ impl Default for NDIS_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_OFFLOAD_ENCAPSULATION_REVISION_1: u32 = 1u32;
 pub const NDIS_OFFLOAD_FLAGS_GROUP_CHECKSUM_CAPABILITIES: u32 = 1u32;
 pub const NDIS_OFFLOAD_NOT_SUPPORTED: u32 = 0u32;
@@ -2435,9 +2230,6 @@ impl Default for NDIS_OFFLOAD_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_OFFLOAD_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_OFFLOAD_PARAMETERS_CONNECTION_OFFLOAD_DISABLED: u32 = 1u32;
 pub const NDIS_OFFLOAD_PARAMETERS_CONNECTION_OFFLOAD_ENABLED: u32 = 2u32;
@@ -2506,10 +2298,6 @@ impl Default for NDIS_OPER_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_OPER_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_OPER_STATE_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2520,9 +2308,6 @@ impl Default for NDIS_PACKET_8021Q_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_PACKET_8021Q_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2535,9 +2320,6 @@ impl Default for NDIS_PACKET_8021Q_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_PACKET_8021Q_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_PACKET_8021Q_INFO_0_0 {
@@ -2547,9 +2329,6 @@ impl Default for NDIS_PACKET_8021Q_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_PACKET_8021Q_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_PACKET_TYPE_ALL_FUNCTIONAL: u32 = 8192u32;
 pub const NDIS_PACKET_TYPE_ALL_LOCAL: u32 = 128u32;
@@ -2596,9 +2375,6 @@ impl Default for NDIS_PCI_DEVICE_CUSTOM_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_PCI_DEVICE_CUSTOM_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_PD_ACQUIRE_QUEUES_FLAG_DRAIN_NOTIFICATION: u32 = 1u32;
 pub const NDIS_PD_ACQUIRE_QUEUES_PARAMETERS_REVISION_1: u32 = 1u32;
@@ -2679,9 +2455,6 @@ impl Default for NDIS_PHYSICAL_ADDRESS_UNIT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_PHYSICAL_ADDRESS_UNIT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NDIS_PHYSICAL_MEDIUM(pub i32);
@@ -2703,9 +2476,6 @@ impl Default for NDIS_PM_PACKET_PATTERN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_PM_PACKET_PATTERN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_PM_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const NDIS_PM_PARAMETERS_REVISION_2: u32 = 2u32;
@@ -2742,9 +2512,6 @@ impl Default for NDIS_PM_WAKE_UP_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_PM_WAKE_UP_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_PM_WOL_BITMAP_PATTERN_ENABLED: u32 = 1u32;
 pub const NDIS_PM_WOL_BITMAP_PATTERN_SUPPORTED: u32 = 1u32;
 pub const NDIS_PM_WOL_EAPOL_REQUEST_ID_MESSAGE_ENABLED: u32 = 65536u32;
@@ -2774,9 +2541,6 @@ impl Default for NDIS_PNP_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_PNP_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_PNP_WAKE_UP_LINK_CHANGE: u32 = 4u32;
 pub const NDIS_PNP_WAKE_UP_MAGIC_PACKET: u32 = 1u32;
@@ -2816,10 +2580,6 @@ impl Default for NDIS_PORT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_PORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2836,10 +2596,6 @@ impl Default for NDIS_PORT_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_PORT_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_PORT_ARRAY_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2854,9 +2610,6 @@ impl Default for NDIS_PORT_AUTHENTICATION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_PORT_AUTHENTICATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_PORT_AUTHENTICATION_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -2885,10 +2638,6 @@ impl Default for NDIS_PORT_CHARACTERISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_PORT_CHARACTERISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_PORT_CHARACTERISTICS_REVISION_1: u32 = 1u32;
 pub const NDIS_PORT_CHAR_USE_DEFAULT_AUTH_SETTINGS: u32 = 1u32;
 #[repr(transparent)]
@@ -2914,10 +2663,6 @@ impl Default for NDIS_PORT_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_PORT_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_PORT_STATE_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -3086,9 +2831,6 @@ impl Default for NDIS_RECEIVE_HASH_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_RECEIVE_HASH_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_RECEIVE_HASH_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const NDIS_RECEIVE_QUEUE_ALLOCATION_COMPLETE_ARRAY_REVISION_1: u32 = 1u32;
 pub const NDIS_RECEIVE_QUEUE_ALLOCATION_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
@@ -3122,9 +2864,6 @@ impl Default for NDIS_RECEIVE_SCALE_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_RECEIVE_SCALE_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_RECEIVE_SCALE_CAPABILITIES_REVISION_1: u32 = 1u32;
 pub const NDIS_RECEIVE_SCALE_CAPABILITIES_REVISION_2: u32 = 2u32;
 pub const NDIS_RECEIVE_SCALE_CAPABILITIES_REVISION_3: u32 = 3u32;
@@ -3144,9 +2883,6 @@ impl Default for NDIS_RECEIVE_SCALE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_RECEIVE_SCALE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_RECEIVE_SCALE_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const NDIS_RECEIVE_SCALE_PARAMETERS_REVISION_2: u32 = 2u32;
@@ -3222,9 +2958,6 @@ impl Default for NDIS_RW_LOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_RW_LOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NDIS_RW_LOCK_0 {
@@ -3236,9 +2969,6 @@ impl Default for NDIS_RW_LOCK_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_RW_LOCK_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_RW_LOCK_0_0 {
@@ -3249,9 +2979,6 @@ impl Default for NDIS_RW_LOCK_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_RW_LOCK_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3265,9 +2992,6 @@ impl Default for NDIS_RW_LOCK_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_RW_LOCK_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_RW_LOCK_1_0 {
@@ -3280,9 +3004,6 @@ impl Default for NDIS_RW_LOCK_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_RW_LOCK_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NDIS_RW_LOCK_REFCOUNT {
@@ -3293,9 +3014,6 @@ impl Default for NDIS_RW_LOCK_REFCOUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_RW_LOCK_REFCOUNT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_SCATTER_GATHER_LIST_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const NDIS_SEND_COMPLETE_FLAGS_DISPATCH_LEVEL: u32 = 1u32;
@@ -3329,9 +3047,6 @@ impl Default for NDIS_SPIN_LOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_SPIN_LOCK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_SRIOV_BAR_RESOURCES_INFO_REVISION_1: u32 = 1u32;
 pub const NDIS_SRIOV_CAPABILITIES_REVISION_1: u32 = 1u32;
@@ -3409,9 +3124,6 @@ impl Default for NDIS_STATISTICS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_STATISTICS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_STATISTICS_INFO_REVISION_1: u32 = 1u32;
 pub const NDIS_STATISTICS_MULTICAST_BYTES_RCV_SUPPORTED: u32 = 8192u32;
 pub const NDIS_STATISTICS_MULTICAST_BYTES_XMIT_SUPPORTED: u32 = 128u32;
@@ -3435,9 +3147,6 @@ impl Default for NDIS_STATISTICS_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_STATISTICS_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_STATISTICS_VALUE_EX {
@@ -3450,9 +3159,6 @@ impl Default for NDIS_STATISTICS_VALUE_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_STATISTICS_VALUE_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_STATISTICS_XMIT_DISCARDS_SUPPORTED: u32 = 134217728u32;
 pub const NDIS_STATISTICS_XMIT_ERROR_SUPPORTED: u32 = 4u32;
@@ -3546,9 +3252,6 @@ impl Default for NDIS_TCP_CONNECTION_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_CONNECTION_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_TCP_CONNECTION_OFFLOAD_REVISION_1: u32 = 1u32;
 pub const NDIS_TCP_CONNECTION_OFFLOAD_REVISION_2: u32 = 2u32;
 #[repr(C)]
@@ -3564,9 +3267,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
@@ -3577,9 +3277,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3592,9 +3289,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
@@ -3605,9 +3299,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3620,9 +3311,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NDIS_TCP_IP_CHECKSUM_PACKET_INFO {
@@ -3632,9 +3320,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_PACKET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_PACKET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3648,9 +3333,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1 {
@@ -3661,9 +3343,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
@@ -3673,9 +3352,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_PACKET_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_TCP_LARGE_SEND_OFFLOAD_IPv4: u32 = 0u32;
 pub const NDIS_TCP_LARGE_SEND_OFFLOAD_IPv6: u32 = 1u32;
@@ -3688,9 +3364,6 @@ impl Default for NDIS_TCP_LARGE_SEND_OFFLOAD_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_LARGE_SEND_OFFLOAD_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3705,9 +3378,6 @@ impl Default for NDIS_TCP_LARGE_SEND_OFFLOAD_V1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_LARGE_SEND_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_TCP_LARGE_SEND_OFFLOAD_V1_TYPE: u32 = 0u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3719,9 +3389,6 @@ impl Default for NDIS_TCP_LARGE_SEND_OFFLOAD_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_LARGE_SEND_OFFLOAD_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3735,9 +3402,6 @@ impl Default for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_TCP_LARGE_SEND_OFFLOAD_V2_1 {
@@ -3750,9 +3414,6 @@ impl Default for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_TCP_LARGE_SEND_OFFLOAD_V2_TYPE: u32 = 1u32;
 pub const NDIS_TCP_RECV_SEG_COALESC_OFFLOAD_REVISION_1: u32 = 1u32;
@@ -3769,9 +3430,6 @@ impl Default for NDIS_TIMEOUT_DPC_REQUEST_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TIMEOUT_DPC_REQUEST_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_TIMEOUT_DPC_REQUEST_CAPABILITIES_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_System_Kernel"))]
@@ -3785,10 +3443,6 @@ impl Default for NDIS_TIMER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for NDIS_TIMER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_TIMER_CHARACTERISTICS_REVISION_1: u32 = 1u32;
 pub type NDIS_TIMER_FUNCTION = Option<unsafe extern "system" fn(systemspecific1: *const core::ffi::c_void, functioncontext: *const core::ffi::c_void, systemspecific2: *const core::ffi::c_void, systemspecific3: *const core::ffi::c_void)>;
@@ -3806,9 +3460,6 @@ impl Default for NDIS_TIMESTAMP_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TIMESTAMP_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_TIMESTAMP_CAPABILITIES_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -3834,9 +3485,6 @@ impl Default for NDIS_TIMESTAMP_CAPABILITY_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TIMESTAMP_CAPABILITY_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_UDP_SEGMENTATION_OFFLOAD_IPV4: u32 = 0u32;
 pub const NDIS_UDP_SEGMENTATION_OFFLOAD_IPV6: u32 = 1u32;
 #[repr(C)]
@@ -3851,9 +3499,6 @@ impl Default for NDIS_VAR_DATA_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_VAR_DATA_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WAN_FRAGMENT {
@@ -3864,9 +3509,6 @@ impl Default for NDIS_WAN_FRAGMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WAN_FRAGMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3892,9 +3534,6 @@ impl Default for NDIS_WAN_GET_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WAN_GET_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NDIS_WAN_HEADER_FORMAT(pub i32);
@@ -3908,9 +3547,6 @@ impl Default for NDIS_WAN_LINE_DOWN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WAN_LINE_DOWN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3931,9 +3567,6 @@ impl Default for NDIS_WAN_LINE_UP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WAN_LINE_UP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NDIS_WAN_MEDIUM_SUBTYPE(pub i32);
@@ -3947,9 +3580,6 @@ impl Default for NDIS_WAN_PROTOCOL_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WAN_PROTOCOL_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3976,9 +3606,6 @@ impl Default for NDIS_WLAN_BSSID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WLAN_BSSID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WLAN_BSSID_EX {
@@ -3999,9 +3626,6 @@ impl Default for NDIS_WLAN_BSSID_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WLAN_BSSID_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_WLAN_WAKE_ON_4WAY_HANDSHAKE_REQUEST_ENABLED: u32 = 8u32;
 pub const NDIS_WLAN_WAKE_ON_4WAY_HANDSHAKE_REQUEST_SUPPORTED: u32 = 8u32;
@@ -4028,10 +3652,6 @@ impl Default for NDIS_WMI_ENUM_ADAPTER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_WMI_ENUM_ADAPTER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_WMI_ENUM_ADAPTER_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4052,10 +3672,6 @@ impl Default for NDIS_WMI_EVENT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_WMI_EVENT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_WMI_EVENT_HEADER_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4068,9 +3684,6 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4086,9 +3699,6 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4107,9 +3717,6 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
@@ -4123,9 +3730,6 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4143,10 +3747,6 @@ impl Default for NDIS_WMI_METHOD_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_WMI_METHOD_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_WMI_METHOD_HEADER_REVISION_1: u32 = 1u32;
 pub const NDIS_WMI_OBJECT_TYPE_ENUM_ADAPTER: u32 = 4u32;
@@ -4169,9 +3769,6 @@ impl Default for NDIS_WMI_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_OUTPUT_INFO {
@@ -4184,9 +3781,6 @@ impl Default for NDIS_WMI_OUTPUT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_OUTPUT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_WMI_PM_ACTIVE_CAPABILITIES_REVISION_1: u32 = 1u32;
 pub const NDIS_WMI_PM_ADMIN_CONFIG_REVISION_1: u32 = 1u32;
@@ -4209,10 +3803,6 @@ impl Default for NDIS_WMI_SET_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for NDIS_WMI_SET_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_WMI_SET_HEADER_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4231,9 +3821,6 @@ impl Default for NDIS_WMI_TCP_CONNECTION_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_CONNECTION_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
@@ -4246,9 +3833,6 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4265,9 +3849,6 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
@@ -4283,9 +3864,6 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
@@ -4299,9 +3877,6 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4317,9 +3892,6 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1 {
@@ -4329,9 +3901,6 @@ impl Default for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4347,9 +3916,6 @@ impl Default for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2 {
@@ -4360,9 +3926,6 @@ impl Default for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4375,9 +3938,6 @@ impl Default for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4393,9 +3953,6 @@ impl Default for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WORK_ITEM {
@@ -4407,9 +3964,6 @@ impl Default for NDIS_WORK_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WORK_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -4439,9 +3993,6 @@ impl Default for NETWORK_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_ADDRESS_IP {
@@ -4453,9 +4004,6 @@ impl Default for NETWORK_ADDRESS_IP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETWORK_ADDRESS_IP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4470,9 +4018,6 @@ impl Default for NETWORK_ADDRESS_IP6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_ADDRESS_IP6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_ADDRESS_IPX {
@@ -4485,9 +4030,6 @@ impl Default for NETWORK_ADDRESS_IPX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_ADDRESS_IPX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_ADDRESS_LIST {
@@ -4499,9 +4041,6 @@ impl Default for NETWORK_ADDRESS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETWORK_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NET_BUFFER_LIST_POOL_FLAG_VERIFY: u32 = 1u32;
 pub const NET_BUFFER_LIST_POOL_PARAMETERS_REVISION_1: u32 = 1u32;
@@ -4792,9 +4331,6 @@ impl Default for OFFLOAD_ALGO_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OFFLOAD_ALGO_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct OFFLOAD_CONF_ALGO(pub i32);
@@ -4826,9 +4362,6 @@ impl Default for OFFLOAD_IPSEC_ADD_SA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OFFLOAD_IPSEC_ADD_SA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OFFLOAD_IPSEC_ADD_UDPESP_SA {
@@ -4855,9 +4388,6 @@ impl Default for OFFLOAD_IPSEC_ADD_UDPESP_SA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OFFLOAD_IPSEC_ADD_UDPESP_SA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OFFLOAD_IPSEC_CONF_3_DES: OFFLOAD_CONF_ALGO = OFFLOAD_CONF_ALGO(3i32);
 pub const OFFLOAD_IPSEC_CONF_DES: OFFLOAD_CONF_ALGO = OFFLOAD_CONF_ALGO(1i32);
 pub const OFFLOAD_IPSEC_CONF_MAX: OFFLOAD_CONF_ALGO = OFFLOAD_CONF_ALGO(4i32);
@@ -4873,9 +4403,6 @@ impl Default for OFFLOAD_IPSEC_DELETE_SA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OFFLOAD_IPSEC_DELETE_SA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OFFLOAD_IPSEC_DELETE_UDPESP_SA {
@@ -4886,9 +4413,6 @@ impl Default for OFFLOAD_IPSEC_DELETE_UDPESP_SA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OFFLOAD_IPSEC_DELETE_UDPESP_SA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OFFLOAD_IPSEC_INTEGRITY_MAX: OFFLOAD_INTEGRITY_ALGO = OFFLOAD_INTEGRITY_ALGO(3i32);
 pub const OFFLOAD_IPSEC_INTEGRITY_MD5: OFFLOAD_INTEGRITY_ALGO = OFFLOAD_INTEGRITY_ALGO(1i32);
@@ -4904,9 +4428,6 @@ impl Default for OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_IKE: UDP_ENCAP_TYPE = UDP_ENCAP_TYPE(0i32);
 pub const OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_OTHER: UDP_ENCAP_TYPE = UDP_ENCAP_TYPE(1i32);
@@ -4928,9 +4449,6 @@ impl Default for OFFLOAD_SECURITY_ASSOCIATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OFFLOAD_SECURITY_ASSOCIATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OID_1394_LOCAL_NODE_INFO: u32 = 201392385u32;
 pub const OID_1394_VC_INFO: u32 = 201392386u32;
@@ -5723,9 +5241,6 @@ impl Default for PMKID_CANDIDATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PMKID_CANDIDATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type PNDIS_TIMER_FUNCTION = Option<unsafe extern "system" fn()>;
 pub type PROTCOL_CO_AF_REGISTER_NOTIFY = Option<unsafe extern "system" fn()>;
 pub type PROTOCOL_CL_ADD_PARTY_COMPLETE = Option<unsafe extern "system" fn(status: i32, protocolpartycontext: *const core::ffi::c_void, ndispartyhandle: *const core::ffi::c_void, callparameters: *const CO_CALL_PARAMETERS)>;
@@ -5775,9 +5290,6 @@ impl Default for REFERENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFERENCE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RESERVE_RESOURCES_VC: u32 = 64u32;
 pub const ROUND_DOWN_FLOW: u32 = 128u32;
 pub const ROUND_UP_FLOW: u32 = 256u32;
@@ -5802,9 +5314,6 @@ impl Default for TRANSPORT_HEADER_OFFSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSPORT_HEADER_OFFSET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRUNCATED_HASH_LEN: u32 = 12u32;
 #[repr(transparent)]
@@ -5833,9 +5342,6 @@ impl Default for VAR_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VAR_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WAN_PROTOCOL_KEEPS_STATS: u32 = 1u32;
 pub type W_CO_ACTIVATE_VC_HANDLER = Option<unsafe extern "system" fn() -> i32>;

--- a/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/Minifilters/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/Minifilters/mod.rs
@@ -1726,10 +1726,6 @@ impl Default for FLT_CALLBACK_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_CALLBACK_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -1743,10 +1739,6 @@ impl Default for FLT_CALLBACK_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_CALLBACK_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1759,10 +1751,6 @@ impl Default for FLT_CALLBACK_DATA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_CALLBACK_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1783,10 +1771,6 @@ impl Default for FLT_CALLBACK_DATA_QUEUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_CALLBACK_DATA_QUEUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1811,10 +1795,6 @@ impl Default for FLT_CONTEXT_REGISTRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for FLT_CONTEXT_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FLT_CREATEFILE_TARGET_ECP_CONTEXT {
@@ -1827,9 +1807,6 @@ impl Default for FLT_CREATEFILE_TARGET_ECP_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLT_CREATEFILE_TARGET_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLT_FILE_CONTEXT: u32 = 4u32;
 pub const FLT_FILE_NAME_ALLOW_QUERY_ON_REPARSE: u32 = 67108864u32;
@@ -1852,9 +1829,6 @@ impl Default for FLT_FILE_NAME_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLT_FILE_NAME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLT_FILE_NAME_NORMALIZED: u32 = 1u32;
 pub const FLT_FILE_NAME_OPENED: u32 = 2u32;
@@ -1889,10 +1863,6 @@ impl Default for FLT_IO_PARAMETER_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_IO_PARAMETER_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FLT_MAX_DEVICE_REPARSE_ATTEMPTS: u32 = 64u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1903,9 +1873,6 @@ impl Default for FLT_NAME_CONTROL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLT_NAME_CONTROL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1922,10 +1889,6 @@ impl Default for FLT_OPERATION_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_OPERATION_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -1971,10 +1934,6 @@ impl Default for FLT_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1987,10 +1946,6 @@ impl Default for FLT_PARAMETERS_22 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_22 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2008,10 +1963,6 @@ impl Default for FLT_PARAMETERS_21 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_21 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2028,10 +1979,6 @@ impl Default for FLT_PARAMETERS_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2047,10 +1994,6 @@ impl Default for FLT_PARAMETERS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2070,10 +2013,6 @@ impl Default for FLT_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -2090,10 +2029,6 @@ impl Default for FLT_PARAMETERS_13 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_13 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2109,10 +2044,6 @@ impl Default for FLT_PARAMETERS_13_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_13_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2126,10 +2057,6 @@ impl Default for FLT_PARAMETERS_13_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_13_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2148,10 +2075,6 @@ impl Default for FLT_PARAMETERS_13_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_13_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2167,10 +2090,6 @@ impl Default for FLT_PARAMETERS_13_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_13_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2189,10 +2108,6 @@ impl Default for FLT_PARAMETERS_13_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_13_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -2206,10 +2121,6 @@ impl Default for FLT_PARAMETERS_11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_11 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2228,10 +2139,6 @@ impl Default for FLT_PARAMETERS_11_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_11_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2248,10 +2155,6 @@ impl Default for FLT_PARAMETERS_11_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_11_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2270,10 +2173,6 @@ impl Default for FLT_PARAMETERS_11_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_11_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -2288,10 +2187,6 @@ impl Default for FLT_PARAMETERS_25 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_25 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2309,10 +2204,6 @@ impl Default for FLT_PARAMETERS_12 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_12 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2328,10 +2219,6 @@ impl Default for FLT_PARAMETERS_12_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_12_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2345,10 +2232,6 @@ impl Default for FLT_PARAMETERS_12_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_12_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2367,10 +2250,6 @@ impl Default for FLT_PARAMETERS_12_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_12_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2388,10 +2267,6 @@ impl Default for FLT_PARAMETERS_12_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_12_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2404,10 +2279,6 @@ impl Default for FLT_PARAMETERS_12_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_12_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2426,10 +2297,6 @@ impl Default for FLT_PARAMETERS_14 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_14 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2441,10 +2308,6 @@ impl Default for FLT_PARAMETERS_28 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_28 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2461,10 +2324,6 @@ impl Default for FLT_PARAMETERS_27 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_27 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -2478,10 +2337,6 @@ impl Default for FLT_PARAMETERS_30 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_30 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2493,10 +2348,6 @@ impl Default for FLT_PARAMETERS_31 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_31 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2510,10 +2361,6 @@ impl Default for FLT_PARAMETERS_26 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_26 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2531,10 +2378,6 @@ impl Default for FLT_PARAMETERS_32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2557,10 +2400,6 @@ impl Default for FLT_PARAMETERS_20 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2572,10 +2411,6 @@ impl Default for FLT_PARAMETERS_20_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2589,10 +2424,6 @@ impl Default for FLT_PARAMETERS_20_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2604,10 +2435,6 @@ impl Default for FLT_PARAMETERS_20_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2622,10 +2449,6 @@ impl Default for FLT_PARAMETERS_20_8 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20_8 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2637,10 +2460,6 @@ impl Default for FLT_PARAMETERS_20_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2658,10 +2477,6 @@ impl Default for FLT_PARAMETERS_20_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2677,10 +2492,6 @@ impl Default for FLT_PARAMETERS_20_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2692,10 +2503,6 @@ impl Default for FLT_PARAMETERS_20_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2709,10 +2516,6 @@ impl Default for FLT_PARAMETERS_20_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2728,10 +2531,6 @@ impl Default for FLT_PARAMETERS_20_9 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_20_9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -2746,10 +2545,6 @@ impl Default for FLT_PARAMETERS_29 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_29 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2768,10 +2563,6 @@ impl Default for FLT_PARAMETERS_7 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2785,10 +2576,6 @@ impl Default for FLT_PARAMETERS_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2804,10 +2591,6 @@ impl Default for FLT_PARAMETERS_24 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_24 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2826,10 +2609,6 @@ impl Default for FLT_PARAMETERS_18 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_18 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2845,10 +2624,6 @@ impl Default for FLT_PARAMETERS_15 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_15 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2862,10 +2637,6 @@ impl Default for FLT_PARAMETERS_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_9 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2883,10 +2654,6 @@ impl Default for FLT_PARAMETERS_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2898,10 +2665,6 @@ impl Default for FLT_PARAMETERS_23 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_23 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2916,10 +2679,6 @@ impl Default for FLT_PARAMETERS_8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_8 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2937,10 +2696,6 @@ impl Default for FLT_PARAMETERS_6 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -2955,10 +2710,6 @@ impl Default for FLT_PARAMETERS_6_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_6_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2971,10 +2722,6 @@ impl Default for FLT_PARAMETERS_6_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_6_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -2990,10 +2737,6 @@ impl Default for FLT_PARAMETERS_19 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_19 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3006,10 +2749,6 @@ impl Default for FLT_PARAMETERS_16 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_16 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -3024,10 +2763,6 @@ impl Default for FLT_PARAMETERS_10 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_10 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -3044,10 +2779,6 @@ impl Default for FLT_PARAMETERS_17 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_17 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -3063,10 +2794,6 @@ impl Default for FLT_PARAMETERS_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_PARAMETERS_4 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLT_PORT_CONNECT: u32 = 1u32;
 #[repr(transparent)]
@@ -3115,10 +2842,6 @@ impl Default for FLT_REGISTRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_Storage_InstallableFileSystems", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FLT_REGISTRATION_VERSION: u32 = 515u32;
 pub const FLT_REGISTRATION_VERSION_0200: u32 = 512u32;
 pub const FLT_REGISTRATION_VERSION_0201: u32 = 513u32;
@@ -3139,9 +2862,6 @@ impl Default for FLT_RELATED_CONTEXTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLT_RELATED_CONTEXTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FLT_RELATED_CONTEXTS_EX {
@@ -3157,9 +2877,6 @@ impl Default for FLT_RELATED_CONTEXTS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLT_RELATED_CONTEXTS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -3178,10 +2895,6 @@ impl Default for FLT_RELATED_OBJECTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FLT_RELATED_OBJECTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLT_SECTION_CONTEXT: u32 = 64u32;
 pub const FLT_SET_CONTEXT_KEEP_IF_EXISTS: FLT_SET_CONTEXT_OPERATION = FLT_SET_CONTEXT_OPERATION(1i32);
@@ -3204,9 +2917,6 @@ impl Default for FLT_TAG_DATA_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FLT_TAG_DATA_BUFFER_0 {
@@ -3220,9 +2930,6 @@ impl Default for FLT_TAG_DATA_BUFFER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FLT_TAG_DATA_BUFFER_0_3 {
@@ -3234,9 +2941,6 @@ impl Default for FLT_TAG_DATA_BUFFER_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FLT_TAG_DATA_BUFFER_0_2 {
@@ -3246,9 +2950,6 @@ impl Default for FLT_TAG_DATA_BUFFER_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3264,9 +2965,6 @@ impl Default for FLT_TAG_DATA_BUFFER_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FLT_TAG_DATA_BUFFER_0_0 {
@@ -3281,9 +2979,6 @@ impl Default for FLT_TAG_DATA_BUFFER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLT_TAG_DATA_BUFFER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLT_TRANSACTION_CONTEXT: u32 = 32u32;
 pub const FLT_VALID_FILE_NAME_FLAGS: u32 = 4278190080u32;
@@ -3307,9 +3002,6 @@ impl Default for FLT_VOLUME_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLT_VOLUME_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GUID_ECP_FLT_CREATEFILE_TARGET: windows_core::GUID = windows_core::GUID::from_u128(0xce08041d_f411_447f_b70d_ccee45c23fac);
 pub const IRP_MJ_ACQUIRE_FOR_CC_FLUSH: u16 = 65531u16;

--- a/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/Storage/FileSystem/mod.rs
@@ -4677,9 +4677,6 @@ impl Default for ACE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[cfg(feature = "Win32_System_Memory")]
 pub type ALLOCATE_VIRTUAL_MEMORY_EX_CALLBACK = Option<unsafe extern "system" fn(callbackcontext: super::super::super::Win32::Foundation::HANDLE, processhandle: super::super::super::Win32::Foundation::HANDLE, baseaddress: *mut *mut core::ffi::c_void, regionsize: *mut usize, allocationtype: u32, pageprotection: u32, extendedparameters: *mut super::super::super::Win32::System::Memory::MEM_EXTENDED_PARAMETER, extendedparametercount: u32) -> super::super::super::Win32::Foundation::NTSTATUS>;
 #[repr(C)]
@@ -4709,9 +4706,6 @@ impl Default for ATOMIC_CREATE_ECP_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATOMIC_CREATE_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ATOMIC_CREATE_ECP_IN_FLAG_BEST_EFFORT: u32 = 256u32;
 pub const ATOMIC_CREATE_ECP_IN_FLAG_EOF_SPECIFIED: u32 = 4u32;
@@ -4771,9 +4765,6 @@ impl Default for BASE_MCB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BASE_MCB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BOOT_AREA_INFO {
@@ -4785,9 +4776,6 @@ impl Default for BOOT_AREA_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BOOT_AREA_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BOOT_AREA_INFO_0 {
@@ -4797,9 +4785,6 @@ impl Default for BOOT_AREA_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BOOT_AREA_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4814,9 +4799,6 @@ impl Default for CACHE_MANAGER_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CACHE_MANAGER_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CACHE_MANAGER_CALLBACKS_EX {
@@ -4828,9 +4810,6 @@ impl Default for CACHE_MANAGER_CALLBACKS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CACHE_MANAGER_CALLBACKS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CACHE_MANAGER_CALLBACKS_EX_V1: u32 = 1u32;
 #[repr(C)]
@@ -4846,9 +4825,6 @@ impl Default for CACHE_MANAGER_CALLBACK_FUNCTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CACHE_MANAGER_CALLBACK_FUNCTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy)]
@@ -4861,10 +4837,6 @@ impl Default for CACHE_UNINITIALIZE_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for CACHE_UNINITIALIZE_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CACHE_USE_DIRECT_ACCESS_MAPPING: u32 = 1u32;
 pub const CACHE_VALID_FLAGS: u32 = 1u32;
@@ -4887,10 +4859,6 @@ impl Default for CC_ASYNC_READ_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for CC_ASYNC_READ_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CC_DISABLE_DIRTY_PAGE_TRACKING: u32 = 8u32;
 pub const CC_DISABLE_READ_AHEAD: u32 = 2u32;
 pub const CC_DISABLE_UNMAP_BEHIND: u32 = 32u32;
@@ -4908,9 +4876,6 @@ impl Default for CC_ERROR_CALLBACK_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CC_ERROR_CALLBACK_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CC_FILE_SIZES {
@@ -4922,9 +4887,6 @@ impl Default for CC_FILE_SIZES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CC_FILE_SIZES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CC_FLUSH_AND_PURGE_GATHER_DIRTY_BITS: u32 = 2u32;
 pub const CC_FLUSH_AND_PURGE_NO_PURGE: u32 = 1u32;
@@ -4945,9 +4907,6 @@ impl Default for COMPRESSED_DATA_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMPRESSED_DATA_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const COMPRESSION_ENGINE_MASK: u32 = 65280u32;
 pub const COMPRESSION_ENGINE_MAX: u32 = 512u32;
 pub const COMPRESSION_FORMAT_MASK: u32 = 255u32;
@@ -4962,9 +4921,6 @@ impl Default for CONTAINER_ROOT_INFO_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONTAINER_ROOT_INFO_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONTAINER_ROOT_INFO_OUTPUT {
@@ -4976,9 +4932,6 @@ impl Default for CONTAINER_ROOT_INFO_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONTAINER_ROOT_INFO_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONTAINER_VOLUME_STATE {
@@ -4988,9 +4941,6 @@ impl Default for CONTAINER_VOLUME_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONTAINER_VOLUME_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -5004,10 +4954,6 @@ impl Default for COPY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for COPY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5030,9 +4976,6 @@ impl Default for CPTABLEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CPTABLEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5047,10 +4990,6 @@ impl Default for CREATE_REDIRECTION_ECP_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CREATE_REDIRECTION_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CREATE_REDIRECTION_FLAGS_SERVICED_FROM_LAYER: u32 = 1u32;
 pub const CREATE_REDIRECTION_FLAGS_SERVICED_FROM_REGISTERED_LAYER: u32 = 4u32;
@@ -5067,9 +5006,6 @@ impl Default for CREATE_USN_JOURNAL_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_USN_JOURNAL_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5088,9 +5024,6 @@ impl Default for CSV_DOWN_LEVEL_OPEN_ECP_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSV_DOWN_LEVEL_OPEN_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CSV_QUERY_FILE_REVISION_ECP_CONTEXT {
@@ -5101,9 +5034,6 @@ impl Default for CSV_QUERY_FILE_REVISION_ECP_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CSV_QUERY_FILE_REVISION_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -5118,10 +5048,6 @@ impl Default for CSV_QUERY_FILE_REVISION_ECP_CONTEXT_FILE_ID_128 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CSV_QUERY_FILE_REVISION_ECP_CONTEXT_FILE_ID_128 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CSV_SET_HANDLE_PROPERTIES_ECP_CONTEXT {
@@ -5133,9 +5059,6 @@ impl Default for CSV_SET_HANDLE_PROPERTIES_ECP_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CSV_SET_HANDLE_PROPERTIES_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CSV_SET_HANDLE_PROPERTIES_ECP_CONTEXT_FLAGS_VALID_ONLY_IF_CSV_COORDINATOR: u32 = 1u32;
 pub const ChangeDataControlArea: FSRTL_CHANGE_BACKING_TYPE = FSRTL_CHANGE_BACKING_TYPE(0i32);
@@ -5188,9 +5111,6 @@ impl Default for DUAL_OPLOCK_KEY_ECP_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DUAL_OPLOCK_KEY_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DUPLICATE_CLUSTER_DATA {
@@ -5203,9 +5123,6 @@ impl Default for DUPLICATE_CLUSTER_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DUPLICATE_CLUSTER_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DfsLinkTrackingInformation: LINK_TRACKING_INFORMATION_TYPE = LINK_TRACKING_INFORMATION_TYPE(1i32);
 pub const EA_NAME_NETWORK_OPEN_ECP_INTEGRITY: windows_core::PCSTR = windows_core::s!("ECP{c584edbf-00df-4d28-00b8-8435baca8911e8}-INTEGRITY");
@@ -5223,9 +5140,6 @@ impl Default for ECP_OPEN_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ECP_OPEN_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ECP_OPEN_PARAMETERS_FLAG_FAIL_ON_CASE_SENSITIVE_DIR: u32 = 16u32;
 pub const ECP_OPEN_PARAMETERS_FLAG_IGNORE_DIR_CASE_SENSITIVITY: u32 = 8u32;
@@ -5248,10 +5162,6 @@ impl Default for EOF_WAIT_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for EOF_WAIT_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EVENT_INCREMENT: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5264,9 +5174,6 @@ impl Default for EXTENT_READ_CACHE_INFO_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXTENT_READ_CACHE_INFO_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EqualTo: FSRTL_COMPARISON_RESULT = FSRTL_COMPARISON_RESULT(0i32);
 #[repr(transparent)]
@@ -5281,9 +5188,6 @@ impl Default for FILE_ACCESS_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ACCESS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_ACTION_ADDED_STREAM: u32 = 6u32;
 pub const FILE_ACTION_ID_NOT_TUNNELLED: u32 = 10u32;
@@ -5301,9 +5205,6 @@ impl Default for FILE_ALIGNMENT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_ALIGNMENT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_ALLOCATION_INFORMATION {
@@ -5313,9 +5214,6 @@ impl Default for FILE_ALLOCATION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ALLOCATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5335,9 +5233,6 @@ impl Default for FILE_ALL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_ALL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_BASIC_INFORMATION {
@@ -5351,9 +5246,6 @@ impl Default for FILE_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5378,9 +5270,6 @@ impl Default for FILE_BOTH_DIR_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_BOTH_DIR_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_CASE_SENSITIVE_INFORMATION {
@@ -5390,9 +5279,6 @@ impl Default for FILE_CASE_SENSITIVE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_CASE_SENSITIVE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_CLEANUP_FILE_DELETED: u32 = 4u32;
 pub const FILE_CLEANUP_FILE_REMAINS: u32 = 2u32;
@@ -5413,9 +5299,6 @@ impl Default for FILE_COMPLETION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_COMPLETION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_COMPRESSION_INFORMATION {
@@ -5430,9 +5313,6 @@ impl Default for FILE_COMPRESSION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_COMPRESSION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_CONTAINS_EXTENDED_CREATE_INFORMATION: NTCREATEFILE_CREATE_OPTIONS = NTCREATEFILE_CREATE_OPTIONS(268435456u32);
 pub const FILE_CREATE: NTCREATEFILE_CREATE_DISPOSITION = NTCREATEFILE_CREATE_DISPOSITION(2u32);
@@ -5459,9 +5339,6 @@ impl Default for FILE_DIRECTORY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_DIRECTORY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_DISALLOW_EXCLUSIVE: NTCREATEFILE_CREATE_OPTIONS = NTCREATEFILE_CREATE_OPTIONS(131072u32);
 pub const FILE_DISPOSITION_DELETE: FILE_DISPOSITION_INFORMATION_EX_FLAGS = FILE_DISPOSITION_INFORMATION_EX_FLAGS(1u32);
 pub const FILE_DISPOSITION_DO_NOT_DELETE: FILE_DISPOSITION_INFORMATION_EX_FLAGS = FILE_DISPOSITION_INFORMATION_EX_FLAGS(0u32);
@@ -5477,9 +5354,6 @@ impl Default for FILE_DISPOSITION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_DISPOSITION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_DISPOSITION_INFORMATION_EX {
@@ -5489,9 +5363,6 @@ impl Default for FILE_DISPOSITION_INFORMATION_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_DISPOSITION_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5507,9 +5378,6 @@ impl Default for FILE_EA_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_EA_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_EA_TYPE_ASCII: u32 = 65533u32;
 pub const FILE_EA_TYPE_ASN1: u32 = 65501u32;
@@ -5534,9 +5402,6 @@ impl Default for FILE_END_OF_FILE_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_END_OF_FILE_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_FS_ATTRIBUTE_INFORMATION {
@@ -5549,9 +5414,6 @@ impl Default for FILE_FS_ATTRIBUTE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_FS_ATTRIBUTE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5568,9 +5430,6 @@ impl Default for FILE_FS_CONTROL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_FS_CONTROL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_FS_DATA_COPY_INFORMATION {
@@ -5580,9 +5439,6 @@ impl Default for FILE_FS_DATA_COPY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_FS_DATA_COPY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5595,9 +5451,6 @@ impl Default for FILE_FS_DRIVER_PATH_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_FS_DRIVER_PATH_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5615,9 +5468,6 @@ impl Default for FILE_FS_SECTOR_SIZE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_FS_SECTOR_SIZE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_FS_VOLUME_FLAGS_INFORMATION {
@@ -5627,9 +5477,6 @@ impl Default for FILE_FS_VOLUME_FLAGS_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_FS_VOLUME_FLAGS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5652,9 +5499,6 @@ impl Default for FILE_FULL_DIR_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_FULL_DIR_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_FULL_EA_INFORMATION {
@@ -5669,9 +5513,6 @@ impl Default for FILE_FULL_EA_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_FULL_EA_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_GET_EA_INFORMATION {
@@ -5683,9 +5524,6 @@ impl Default for FILE_GET_EA_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_GET_EA_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -5700,10 +5538,6 @@ impl Default for FILE_GET_QUOTA_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FILE_GET_QUOTA_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5728,9 +5562,6 @@ impl Default for FILE_ID_BOTH_DIR_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ID_BOTH_DIR_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -5759,10 +5590,6 @@ impl Default for FILE_ID_EXTD_BOTH_DIR_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for FILE_ID_EXTD_BOTH_DIR_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5788,10 +5615,6 @@ impl Default for FILE_ID_EXTD_DIR_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for FILE_ID_EXTD_DIR_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_ID_FULL_DIR_INFORMATION {
@@ -5813,9 +5636,6 @@ impl Default for FILE_ID_FULL_DIR_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ID_FULL_DIR_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5840,9 +5660,6 @@ impl Default for FILE_ID_GLOBAL_TX_DIR_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_ID_GLOBAL_TX_DIR_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_ID_GLOBAL_TX_DIR_INFO_FLAG_VISIBLE_OUTSIDE_TX: u32 = 4u32;
 pub const FILE_ID_GLOBAL_TX_DIR_INFO_FLAG_VISIBLE_TO_TX: u32 = 2u32;
 pub const FILE_ID_GLOBAL_TX_DIR_INFO_FLAG_WRITELOCKED: u32 = 1u32;
@@ -5858,10 +5675,6 @@ impl Default for FILE_ID_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for FILE_ID_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5879,9 +5692,6 @@ impl Default for FILE_INFORMATION_DEFINITION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_INFORMATION_DEFINITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_INTERNAL_INFORMATION {
@@ -5892,9 +5702,6 @@ impl Default for FILE_INTERNAL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_INTERNAL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_KNOWN_FOLDER_INFORMATION {
@@ -5904,9 +5711,6 @@ impl Default for FILE_KNOWN_FOLDER_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_KNOWN_FOLDER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5925,10 +5729,6 @@ impl Default for FILE_LINKS_FULL_ID_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for FILE_LINKS_FULL_ID_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_LINKS_INFORMATION {
@@ -5940,9 +5740,6 @@ impl Default for FILE_LINKS_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_LINKS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -5959,10 +5756,6 @@ impl Default for FILE_LINK_ENTRY_FULL_ID_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for FILE_LINK_ENTRY_FULL_ID_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_LINK_ENTRY_INFORMATION {
@@ -5975,9 +5768,6 @@ impl Default for FILE_LINK_ENTRY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_LINK_ENTRY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_LINK_FORCE_RESIZE_SOURCE_SR: u32 = 256u32;
 pub const FILE_LINK_FORCE_RESIZE_SR: u32 = 384u32;
@@ -5996,9 +5786,6 @@ impl Default for FILE_LINK_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_LINK_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILE_LINK_INFORMATION_0 {
@@ -6009,9 +5796,6 @@ impl Default for FILE_LINK_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_LINK_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_LINK_NO_DECREASE_AVAILABLE_SPACE: u32 = 32u32;
 pub const FILE_LINK_NO_INCREASE_AVAILABLE_SPACE: u32 = 16u32;
@@ -6038,10 +5822,6 @@ impl Default for FILE_LOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FILE_LOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6060,10 +5840,6 @@ impl Default for FILE_LOCK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FILE_LOCK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_MAILSLOT_QUERY_INFORMATION {
@@ -6078,9 +5854,6 @@ impl Default for FILE_MAILSLOT_QUERY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_MAILSLOT_QUERY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_MAILSLOT_SET_INFORMATION {
@@ -6091,9 +5864,6 @@ impl Default for FILE_MAILSLOT_SET_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_MAILSLOT_SET_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_MODE_INFORMATION {
@@ -6103,9 +5873,6 @@ impl Default for FILE_MODE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_MODE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6120,9 +5887,6 @@ impl Default for FILE_MOVE_CLUSTER_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_MOVE_CLUSTER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_NAMES_INFORMATION {
@@ -6136,9 +5900,6 @@ impl Default for FILE_NAMES_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_NAMES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_NAME_INFORMATION {
@@ -6149,9 +5910,6 @@ impl Default for FILE_NAME_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_NAME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_NEED_EA: u32 = 128u32;
 #[repr(C)]
@@ -6170,9 +5928,6 @@ impl Default for FILE_NETWORK_OPEN_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_NETWORK_OPEN_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_NETWORK_PHYSICAL_NAME_INFORMATION {
@@ -6183,9 +5938,6 @@ impl Default for FILE_NETWORK_PHYSICAL_NAME_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_NETWORK_PHYSICAL_NAME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_NON_DIRECTORY_FILE: NTCREATEFILE_CREATE_OPTIONS = NTCREATEFILE_CREATE_OPTIONS(64u32);
 pub const FILE_NOTIFY_CHANGE_EA: u32 = 128u32;
@@ -6209,9 +5961,6 @@ impl Default for FILE_OBJECTID_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_OBJECTID_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILE_OBJECTID_INFORMATION_0 {
@@ -6222,9 +5971,6 @@ impl Default for FILE_OBJECTID_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_OBJECTID_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6237,9 +5983,6 @@ impl Default for FILE_OBJECTID_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_OBJECTID_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_OPBATCH_BREAK_UNDERWAY: u32 = 9u32;
 pub const FILE_OPEN: NTCREATEFILE_CREATE_DISPOSITION = NTCREATEFILE_CREATE_DISPOSITION(1u32);
@@ -6266,9 +6009,6 @@ impl Default for FILE_PIPE_ASSIGN_EVENT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_PIPE_ASSIGN_EVENT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_PIPE_BYTE_STREAM_MODE: u32 = 0u32;
 pub const FILE_PIPE_BYTE_STREAM_TYPE: u32 = 0u32;
 pub const FILE_PIPE_CLIENT_END: u32 = 0u32;
@@ -6283,9 +6023,6 @@ impl Default for FILE_PIPE_CLIENT_PROCESS_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_PIPE_CLIENT_PROCESS_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_PIPE_CLIENT_PROCESS_BUFFER_EX {
@@ -6299,9 +6036,6 @@ impl Default for FILE_PIPE_CLIENT_PROCESS_BUFFER_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_PIPE_CLIENT_PROCESS_BUFFER_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_PIPE_CLIENT_PROCESS_BUFFER_V2 {
@@ -6312,9 +6046,6 @@ impl Default for FILE_PIPE_CLIENT_PROCESS_BUFFER_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_PIPE_CLIENT_PROCESS_BUFFER_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_PIPE_CLOSING_STATE: u32 = 4u32;
 pub const FILE_PIPE_COMPLETE_OPERATION: u32 = 1u32;
@@ -6334,9 +6065,6 @@ impl Default for FILE_PIPE_CREATE_SYMLINK_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_PIPE_CREATE_SYMLINK_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_PIPE_DELETE_SYMLINK_INPUT {
@@ -6347,9 +6075,6 @@ impl Default for FILE_PIPE_DELETE_SYMLINK_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_PIPE_DELETE_SYMLINK_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_PIPE_DISCONNECTED_STATE: u32 = 1u32;
 #[repr(C)]
@@ -6366,9 +6091,6 @@ impl Default for FILE_PIPE_EVENT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_PIPE_EVENT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_PIPE_FULL_DUPLEX: u32 = 2u32;
 pub const FILE_PIPE_INBOUND: u32 = 0u32;
 #[repr(C)]
@@ -6381,9 +6103,6 @@ impl Default for FILE_PIPE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_PIPE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_PIPE_LISTENING_STATE: u32 = 2u32;
 #[repr(C)]
@@ -6405,9 +6124,6 @@ impl Default for FILE_PIPE_LOCAL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_PIPE_LOCAL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_PIPE_MESSAGE_MODE: u32 = 1u32;
 pub const FILE_PIPE_MESSAGE_TYPE: u32 = 1u32;
 pub const FILE_PIPE_OUTBOUND: u32 = 1u32;
@@ -6425,9 +6141,6 @@ impl Default for FILE_PIPE_PEEK_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_PIPE_PEEK_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_PIPE_QUEUE_OPERATION: u32 = 0u32;
 pub const FILE_PIPE_READ_DATA: u32 = 0u32;
 pub const FILE_PIPE_REJECT_REMOTE_CLIENTS: u32 = 2u32;
@@ -6442,9 +6155,6 @@ impl Default for FILE_PIPE_REMOTE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_PIPE_REMOTE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_PIPE_SERVER_END: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6455,9 +6165,6 @@ impl Default for FILE_PIPE_SILO_ARRIVAL_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_PIPE_SILO_ARRIVAL_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_PIPE_SYMLINK_FLAG_GLOBAL: u32 = 1u32;
 pub const FILE_PIPE_SYMLINK_FLAG_RELATIVE: u32 = 2u32;
@@ -6475,9 +6182,6 @@ impl Default for FILE_PIPE_WAIT_FOR_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_PIPE_WAIT_FOR_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_PIPE_WRITE_SPACE: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6488,9 +6192,6 @@ impl Default for FILE_POSITION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_POSITION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -6509,10 +6210,6 @@ impl Default for FILE_QUOTA_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FILE_QUOTA_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_RANDOM_ACCESS: NTCREATEFILE_CREATE_OPTIONS = NTCREATEFILE_CREATE_OPTIONS(2048u32);
 #[repr(C)]
@@ -6534,9 +6231,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_REMOTE_PROTOCOL_INFORMATION_0 {
@@ -6546,9 +6240,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6561,9 +6252,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFORMATION_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFORMATION_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_REMOTE_PROTOCOL_INFORMATION_1_0 {
@@ -6575,9 +6263,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFORMATION_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFORMATION_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_REMOTE_PROTOCOL_INFORMATION_1_0_0 {
@@ -6587,9 +6272,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFORMATION_1_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFORMATION_1_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6604,9 +6286,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFORMATION_1_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFORMATION_1_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_RENAME_FORCE_RESIZE_SOURCE_SR: u32 = 256u32;
 pub const FILE_RENAME_FORCE_RESIZE_SR: u32 = 384u32;
@@ -6625,9 +6304,6 @@ impl Default for FILE_RENAME_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_RENAME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILE_RENAME_INFORMATION_0 {
@@ -6638,9 +6314,6 @@ impl Default for FILE_RENAME_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_RENAME_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_RENAME_NO_DECREASE_AVAILABLE_SPACE: u32 = 32u32;
 pub const FILE_RENAME_NO_INCREASE_AVAILABLE_SPACE: u32 = 16u32;
@@ -6660,9 +6333,6 @@ impl Default for FILE_REPARSE_POINT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_REPARSE_POINT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_RESERVE_OPFILTER: NTCREATEFILE_CREATE_OPTIONS = NTCREATEFILE_CREATE_OPTIONS(1048576u32);
 pub const FILE_SEQUENTIAL_ONLY: NTCREATEFILE_CREATE_OPTIONS = NTCREATEFILE_CREATE_OPTIONS(4u32);
 pub const FILE_SESSION_AWARE: NTCREATEFILE_CREATE_OPTIONS = NTCREATEFILE_CREATE_OPTIONS(262144u32);
@@ -6680,9 +6350,6 @@ impl Default for FILE_STANDARD_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_STANDARD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_STANDARD_LINK_INFORMATION {
@@ -6695,9 +6362,6 @@ impl Default for FILE_STANDARD_LINK_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_STANDARD_LINK_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6718,9 +6382,6 @@ impl Default for FILE_STAT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_STAT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6748,9 +6409,6 @@ impl Default for FILE_STAT_LX_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_STAT_LX_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Ioctl")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6762,10 +6420,6 @@ impl Default for FILE_STORAGE_RESERVE_ID_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Ioctl")]
-impl windows_core::TypeKind for FILE_STORAGE_RESERVE_ID_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6780,9 +6434,6 @@ impl Default for FILE_STREAM_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_STREAM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_SUPERSEDE: NTCREATEFILE_CREATE_DISPOSITION = NTCREATEFILE_CREATE_DISPOSITION(0u32);
 pub const FILE_SYNCHRONOUS_IO_ALERT: NTCREATEFILE_CREATE_OPTIONS = NTCREATEFILE_CREATE_OPTIONS(16u32);
@@ -6800,9 +6451,6 @@ impl Default for FILE_TIMESTAMPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_TIMESTAMPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_TRACKING_INFORMATION {
@@ -6814,9 +6462,6 @@ impl Default for FILE_TRACKING_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_TRACKING_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_VC_CONTENT_INDEX_DISABLED: u32 = 8u32;
 pub const FILE_VC_LOG_QUOTA_LIMIT: u32 = 32u32;
@@ -6841,9 +6486,6 @@ impl Default for FILE_VOLUME_NAME_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_VOLUME_NAME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_WRITE_THROUGH: NTCREATEFILE_CREATE_OPTIONS = NTCREATEFILE_CREATE_OPTIONS(2u32);
 pub const FLAGS_DELAY_REASONS_BITMAP_SCANNED: u32 = 2u32;
 pub const FLAGS_DELAY_REASONS_LOG_FILE_FULL: u32 = 1u32;
@@ -6864,9 +6506,6 @@ impl Default for FSCTL_GHOST_FILE_EXTENTS_INPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSCTL_GHOST_FILE_EXTENTS_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSCTL_LMR_GET_LINK_TRACKING_INFORMATION: u32 = 1310952u32;
 pub const FSCTL_LMR_SET_LINK_TRACKING_INFORMATION: u32 = 1310956u32;
@@ -6908,9 +6547,6 @@ impl Default for FSCTL_QUERY_GHOSTED_FILE_EXTENTS_INPUT_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSCTL_QUERY_GHOSTED_FILE_EXTENTS_INPUT_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSCTL_QUERY_GHOSTED_FILE_EXTENTS_OUTPUT {
@@ -6923,9 +6559,6 @@ impl Default for FSCTL_QUERY_GHOSTED_FILE_EXTENTS_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSCTL_QUERY_GHOSTED_FILE_EXTENTS_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSCTL_QUERY_VOLUME_NUMA_INFO_OUTPUT {
@@ -6935,9 +6568,6 @@ impl Default for FSCTL_QUERY_VOLUME_NUMA_INFO_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSCTL_QUERY_VOLUME_NUMA_INFO_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6949,9 +6579,6 @@ impl Default for FSCTL_UNMAP_SPACE_INPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSCTL_UNMAP_SPACE_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSCTL_UNMAP_SPACE_OUTPUT {
@@ -6961,9 +6588,6 @@ impl Default for FSCTL_UNMAP_SPACE_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSCTL_UNMAP_SPACE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSRTL_ADD_TC_CASE_SENSITIVE: u32 = 1u32;
 pub const FSRTL_ADD_TC_KEY_BY_SHORT_NAME: u32 = 2u32;
@@ -6986,10 +6610,6 @@ impl Default for FSRTL_ADVANCED_FCB_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for FSRTL_ADVANCED_FCB_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy)]
@@ -7002,10 +6622,6 @@ impl Default for FSRTL_ADVANCED_FCB_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for FSRTL_ADVANCED_FCB_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSRTL_ALLOCATE_ECPLIST_FLAG_CHARGE_QUOTA: u32 = 1u32;
 pub const FSRTL_ALLOCATE_ECP_FLAG_CHARGE_QUOTA: u32 = 1u32;
@@ -7024,10 +6640,6 @@ impl Default for FSRTL_AUXILIARY_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for FSRTL_AUXILIARY_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSRTL_AUXILIARY_FLAG_DEALLOCATE: u32 = 1u32;
 pub const FSRTL_CC_FLUSH_ERROR_FLAG_NO_HARD_ERROR: u32 = 1u32;
@@ -7056,10 +6668,6 @@ impl Default for FSRTL_COMMON_FCB_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for FSRTL_COMMON_FCB_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7098,9 +6706,6 @@ impl Default for FSRTL_MUP_PROVIDER_INFO_LEVEL_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSRTL_MUP_PROVIDER_INFO_LEVEL_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSRTL_MUP_PROVIDER_INFO_LEVEL_2 {
@@ -7111,9 +6716,6 @@ impl Default for FSRTL_MUP_PROVIDER_INFO_LEVEL_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSRTL_MUP_PROVIDER_INFO_LEVEL_2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSRTL_NTFS_LEGAL: u32 = 4u32;
 pub const FSRTL_OLE_LEGAL: u32 = 16u32;
@@ -7131,10 +6733,6 @@ impl Default for FSRTL_PER_FILEOBJECT_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for FSRTL_PER_FILEOBJECT_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7150,10 +6748,6 @@ impl Default for FSRTL_PER_FILE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for FSRTL_PER_FILE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7168,10 +6762,6 @@ impl Default for FSRTL_PER_STREAM_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for FSRTL_PER_STREAM_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSRTL_UNC_HARDENING_CAPABILITIES_INTEGRITY: u32 = 2u32;
 pub const FSRTL_UNC_HARDENING_CAPABILITIES_MUTUAL_AUTH: u32 = 1u32;
@@ -7193,9 +6783,6 @@ impl Default for FSRTL_UNC_PROVIDER_REGISTRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSRTL_UNC_PROVIDER_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FSRTL_UNC_PROVIDER_REGISTRATION_0 {
@@ -7207,9 +6794,6 @@ impl Default for FSRTL_UNC_PROVIDER_REGISTRATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSRTL_UNC_PROVIDER_REGISTRATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSRTL_UNC_PROVIDER_REGISTRATION_0_0 {
@@ -7219,9 +6803,6 @@ impl Default for FSRTL_UNC_PROVIDER_REGISTRATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSRTL_UNC_PROVIDER_REGISTRATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7234,9 +6815,6 @@ impl Default for FSRTL_UNC_PROVIDER_REGISTRATION_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSRTL_UNC_PROVIDER_REGISTRATION_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSRTL_UNC_PROVIDER_REGISTRATION_1_0 {
@@ -7246,9 +6824,6 @@ impl Default for FSRTL_UNC_PROVIDER_REGISTRATION_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSRTL_UNC_PROVIDER_REGISTRATION_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSRTL_UNC_REGISTRATION_CURRENT_VERSION: u32 = 513u32;
 pub const FSRTL_UNC_REGISTRATION_VERSION_0200: u32 = 512u32;
@@ -7282,9 +6857,6 @@ impl Default for FS_BPIO_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FS_BPIO_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Ioctl")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7299,10 +6871,6 @@ impl Default for FS_BPIO_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Ioctl")]
-impl windows_core::TypeKind for FS_BPIO_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FS_FILTER_ACQUIRE_FOR_CC_FLUSH: u16 = 65531u16;
 pub const FS_FILTER_ACQUIRE_FOR_MOD_WRITE: u16 = 65533u16;
@@ -7334,10 +6902,6 @@ impl Default for FS_FILTER_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -7355,10 +6919,6 @@ impl Default for FS_FILTER_CALLBACK_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_CALLBACK_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -7375,10 +6935,6 @@ impl Default for FS_FILTER_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7391,10 +6947,6 @@ impl Default for FS_FILTER_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -7412,10 +6964,6 @@ impl Default for FS_FILTER_PARAMETERS_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_PARAMETERS_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7431,10 +6979,6 @@ impl Default for FS_FILTER_PARAMETERS_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_PARAMETERS_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -7452,10 +6996,6 @@ impl Default for FS_FILTER_PARAMETERS_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_PARAMETERS_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7467,10 +7007,6 @@ impl Default for FS_FILTER_PARAMETERS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FS_FILTER_PARAMETERS_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FS_FILTER_QUERY_OPEN: u16 = 65529u16;
 pub const FS_FILTER_RELEASE_FOR_CC_FLUSH: u16 = 65530u16;
@@ -7491,9 +7027,6 @@ impl Default for FS_FILTER_SECTION_SYNC_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FS_FILTER_SECTION_SYNC_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FS_FILTER_SECTION_SYNC_SUPPORTS_ASYNC_PARALLEL_IO: u32 = 1u32;
 pub const FS_FILTER_SECTION_SYNC_SUPPORTS_DIRECT_MAP_DATA: u32 = 2u32;
@@ -7628,9 +7161,6 @@ impl Default for GENERATE_NAME_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GENERATE_NAME_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GHOSTED_FILE_EXTENT {
@@ -7645,9 +7175,6 @@ impl Default for GHOSTED_FILE_EXTENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GHOSTED_FILE_EXTENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GUID_ECP_ATOMIC_CREATE: windows_core::GUID = windows_core::GUID::from_u128(0x4720bd83_52ac_4104_a130_d1ec6a8cc8e5);
 pub const GUID_ECP_CLOUDFILES_ATTRIBUTION: windows_core::GUID = windows_core::GUID::from_u128(0x2932ff52_8378_4fc1_8edb_6bdc8f602709);
@@ -7726,10 +7253,6 @@ impl Default for IO_CREATE_STREAM_FILE_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_CREATE_STREAM_FILE_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IO_CREATE_STREAM_FILE_RAISE_ON_ERROR: u32 = 1u32;
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -7743,10 +7266,6 @@ impl Default for IO_DEVICE_HINT_ECP_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_DEVICE_HINT_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IO_DISK_INCREMENT: u32 = 1u32;
 pub const IO_FILE_OBJECT_NON_PAGED_POOL_CHARGE: u32 = 64u32;
@@ -7773,10 +7292,6 @@ impl Default for IO_PRIORITY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_PRIORITY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IO_REPARSE_TAG_ACRONIS_HSM_0: i32 = 96i32;
 pub const IO_REPARSE_TAG_ACRONIS_HSM_1: i32 = 97i32;
@@ -7894,9 +7409,6 @@ impl Default for IO_STOP_ON_SYMLINK_FILTER_ECP_v0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_STOP_ON_SYMLINK_FILTER_ECP_v0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_STOP_ON_SYMLINK_FILTER_ECP_v0_0 {
@@ -7907,9 +7419,6 @@ impl Default for IO_STOP_ON_SYMLINK_FILTER_ECP_v0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_STOP_ON_SYMLINK_FILTER_ECP_v0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -7927,10 +7436,6 @@ impl Default for KAPC_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KAPC_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -7944,10 +7449,6 @@ impl Default for KAPC_STATE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KAPC_STATE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7959,10 +7460,6 @@ impl Default for KAPC_STATE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KAPC_STATE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -7977,10 +7474,6 @@ impl Default for KAPC_STATE_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KAPC_STATE_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7992,10 +7485,6 @@ impl Default for KAPC_STATE_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KAPC_STATE_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KnownFolderDesktop: FILE_KNOWN_FOLDER_TYPE = FILE_KNOWN_FOLDER_TYPE(1i32);
 pub const KnownFolderDocuments: FILE_KNOWN_FOLDER_TYPE = FILE_KNOWN_FOLDER_TYPE(2i32);
@@ -8019,10 +7508,6 @@ impl Default for LARGE_MCB {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for LARGE_MCB {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LCN_CHECKSUM_VALID: _LCN_WEAK_REFERENCE_STATE = _LCN_WEAK_REFERENCE_STATE(2i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8037,9 +7522,6 @@ impl Default for LCN_WEAK_REFERENCE_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LCN_WEAK_REFERENCE_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LCN_WEAK_REFERENCE_CREATE_INPUT_BUFFER {
@@ -8053,9 +7535,6 @@ impl Default for LCN_WEAK_REFERENCE_CREATE_INPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LCN_WEAK_REFERENCE_CREATE_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LCN_WEAK_REFERENCE_VALID: _LCN_WEAK_REFERENCE_STATE = _LCN_WEAK_REFERENCE_STATE(1i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8067,9 +7546,6 @@ impl Default for LINK_TRACKING_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINK_TRACKING_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8102,10 +7578,6 @@ impl Default for MCB {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for MCB {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCB_FLAG_RAISE_ON_ALLOCATION_FAILURE: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8121,9 +7593,6 @@ impl Default for MEMORY_RANGE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEMORY_RANGE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFT_ENUM_DATA {
@@ -8137,9 +7606,6 @@ impl Default for MFT_ENUM_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFT_ENUM_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8161,9 +7627,6 @@ impl Default for MM_PREFETCH_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MM_PREFETCH_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MM_PREFETCH_FLAGS_0 {
@@ -8173,9 +7636,6 @@ impl Default for MM_PREFETCH_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MM_PREFETCH_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8192,10 +7652,6 @@ impl Default for MSV1_0_ENUMUSERS_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Authentication_Identity")]
-impl windows_core::TypeKind for MSV1_0_ENUMUSERS_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Authentication_Identity")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8210,10 +7666,6 @@ impl Default for MSV1_0_ENUMUSERS_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Authentication_Identity")]
-impl windows_core::TypeKind for MSV1_0_ENUMUSERS_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Authentication_Identity")]
@@ -8234,10 +7686,6 @@ impl Default for MSV1_0_GETCHALLENRESP_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Authentication_Identity")]
-impl windows_core::TypeKind for MSV1_0_GETCHALLENRESP_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Authentication_Identity")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8253,10 +7701,6 @@ impl Default for MSV1_0_GETCHALLENRESP_REQUEST_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Authentication_Identity")]
-impl windows_core::TypeKind for MSV1_0_GETCHALLENRESP_REQUEST_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Security_Authentication_Identity", feature = "Win32_System_Kernel"))]
@@ -8276,10 +7720,6 @@ impl Default for MSV1_0_GETCHALLENRESP_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Security_Authentication_Identity", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for MSV1_0_GETCHALLENRESP_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Authentication_Identity")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8292,10 +7732,6 @@ impl Default for MSV1_0_GETUSERINFO_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Authentication_Identity")]
-impl windows_core::TypeKind for MSV1_0_GETUSERINFO_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Authentication_Identity")]
@@ -8314,10 +7750,6 @@ impl Default for MSV1_0_GETUSERINFO_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Authentication_Identity")]
-impl windows_core::TypeKind for MSV1_0_GETUSERINFO_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Authentication_Identity")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8329,10 +7761,6 @@ impl Default for MSV1_0_LM20_CHALLENGE_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Authentication_Identity")]
-impl windows_core::TypeKind for MSV1_0_LM20_CHALLENGE_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Authentication_Identity")]
@@ -8346,10 +7774,6 @@ impl Default for MSV1_0_LM20_CHALLENGE_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Authentication_Identity")]
-impl windows_core::TypeKind for MSV1_0_LM20_CHALLENGE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MemoryBasicInformation: MEMORY_INFORMATION_CLASS = MEMORY_INFORMATION_CLASS(0i32);
 pub const MemoryType64KPage: RTL_MEMORY_TYPE = RTL_MEMORY_TYPE(2i32);
@@ -8384,9 +7808,6 @@ impl Default for NETWORK_APP_INSTANCE_ECP_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_APP_INSTANCE_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_APP_INSTANCE_VERSION_ECP_CONTEXT {
@@ -8400,9 +7821,6 @@ impl Default for NETWORK_APP_INSTANCE_VERSION_ECP_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_APP_INSTANCE_VERSION_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_OPEN_ECP_CONTEXT {
@@ -8415,9 +7833,6 @@ impl Default for NETWORK_OPEN_ECP_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_OPEN_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_OPEN_ECP_CONTEXT_0 {
@@ -8428,9 +7843,6 @@ impl Default for NETWORK_OPEN_ECP_CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETWORK_OPEN_ECP_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8444,9 +7856,6 @@ impl Default for NETWORK_OPEN_ECP_CONTEXT_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_OPEN_ECP_CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_OPEN_ECP_CONTEXT_0_1 {
@@ -8458,9 +7867,6 @@ impl Default for NETWORK_OPEN_ECP_CONTEXT_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETWORK_OPEN_ECP_CONTEXT_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8474,9 +7880,6 @@ impl Default for NETWORK_OPEN_ECP_CONTEXT_V0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_OPEN_ECP_CONTEXT_V0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_OPEN_ECP_CONTEXT_V0_0 {
@@ -8487,9 +7890,6 @@ impl Default for NETWORK_OPEN_ECP_CONTEXT_V0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETWORK_OPEN_ECP_CONTEXT_V0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8502,9 +7902,6 @@ impl Default for NETWORK_OPEN_ECP_CONTEXT_V0_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_OPEN_ECP_CONTEXT_V0_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_OPEN_ECP_CONTEXT_V0_0_1 {
@@ -8515,9 +7912,6 @@ impl Default for NETWORK_OPEN_ECP_CONTEXT_V0_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETWORK_OPEN_ECP_CONTEXT_V0_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NETWORK_OPEN_ECP_IN_FLAG_DISABLE_HANDLE_COLLAPSING: u32 = 1u32;
 pub const NETWORK_OPEN_ECP_IN_FLAG_DISABLE_HANDLE_DURABILITY: u32 = 2u32;
@@ -8545,10 +7939,6 @@ impl Default for NFS_OPEN_ECP_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for NFS_OPEN_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NLSTABLEINFO {
@@ -8561,9 +7951,6 @@ impl Default for NLSTABLEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NLSTABLEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NO_8DOT3_NAME_PRESENT: u32 = 1u32;
 #[repr(transparent)]
@@ -8628,10 +8015,6 @@ impl Default for OPEN_REPARSE_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for OPEN_REPARSE_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8648,10 +8031,6 @@ impl Default for OPEN_REPARSE_LIST_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for OPEN_REPARSE_LIST_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPEN_REPARSE_POINT_OVERRIDE_CREATE_OPTION: u32 = 64u32;
 pub const OPEN_REPARSE_POINT_REPARSE_ALWAYS: u32 = 126u32;
@@ -8692,9 +8071,6 @@ impl Default for OPLOCK_KEY_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPLOCK_KEY_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OPLOCK_KEY_ECP_CONTEXT {
@@ -8705,9 +8081,6 @@ impl Default for OPLOCK_KEY_ECP_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPLOCK_KEY_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPLOCK_NOTIFY_BREAK_WAIT_INTERIM_TIMEOUT: OPLOCK_NOTIFY_REASON = OPLOCK_NOTIFY_REASON(0i32);
 pub const OPLOCK_NOTIFY_BREAK_WAIT_TERMINATED: OPLOCK_NOTIFY_REASON = OPLOCK_NOTIFY_REASON(1i32);
@@ -8725,10 +8098,6 @@ impl Default for OPLOCK_NOTIFY_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for OPLOCK_NOTIFY_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8771,9 +8140,6 @@ impl Default for PHYSICAL_EXTENTS_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_EXTENTS_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PHYSICAL_MEMORY_DESCRIPTOR {
@@ -8786,9 +8152,6 @@ impl Default for PHYSICAL_MEMORY_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_MEMORY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PHYSICAL_MEMORY_RUN {
@@ -8799,9 +8162,6 @@ impl Default for PHYSICAL_MEMORY_RUN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PHYSICAL_MEMORY_RUN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PIN_CALLER_TRACKS_DIRTY_DATA: u32 = 32u32;
 pub const PIN_EXCLUSIVE: u32 = 2u32;
@@ -8835,9 +8195,6 @@ impl Default for PREFETCH_OPEN_ECP_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PREFETCH_OPEN_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8851,10 +8208,6 @@ impl Default for PREFIX_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for PREFIX_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
@@ -8871,10 +8224,6 @@ impl Default for PREFIX_TABLE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for PREFIX_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PRELEASE_FROM_LAZY_WRITE = Option<unsafe extern "system" fn(context: *const core::ffi::c_void)>;
 pub type PRELEASE_FROM_READ_AHEAD = Option<unsafe extern "system" fn(context: *const core::ffi::c_void)>;
@@ -8899,9 +8248,6 @@ impl Default for PUBLIC_BCB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PUBLIC_BCB {
-    type TypeKind = windows_core::CopyType;
-}
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type PUNLOCK_ROUTINE = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, filelockinfo: *const FILE_LOCK_INFO)>;
 pub const PURGE_WITH_ACTIVE_VIEWS: u32 = 8u32;
@@ -8919,10 +8265,6 @@ impl Default for QUERY_BAD_RANGES_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Ioctl")]
-impl windows_core::TypeKind for QUERY_BAD_RANGES_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const QUERY_DIRECT_ACCESS_DATA_EXTENTS: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8937,9 +8279,6 @@ impl Default for QUERY_DIRECT_ACCESS_EXTENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUERY_DIRECT_ACCESS_EXTENTS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const QUERY_DIRECT_ACCESS_IMAGE_EXTENTS: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8951,9 +8290,6 @@ impl Default for QUERY_ON_CREATE_EA_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUERY_ON_CREATE_EA_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8971,9 +8307,6 @@ impl Default for QUERY_ON_CREATE_ECP_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUERY_ON_CREATE_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QUERY_ON_CREATE_FILE_LX_INFORMATION {
@@ -8989,9 +8322,6 @@ impl Default for QUERY_ON_CREATE_FILE_LX_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUERY_ON_CREATE_FILE_LX_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9012,9 +8342,6 @@ impl Default for QUERY_ON_CREATE_FILE_STAT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUERY_ON_CREATE_FILE_STAT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9028,10 +8355,6 @@ impl Default for QUERY_PATH_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security"))]
-impl windows_core::TypeKind for QUERY_PATH_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security"))]
@@ -9052,10 +8375,6 @@ impl Default for QUERY_PATH_REQUEST_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security"))]
-impl windows_core::TypeKind for QUERY_PATH_REQUEST_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QUERY_PATH_RESPONSE {
@@ -9065,9 +8384,6 @@ impl Default for QUERY_PATH_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUERY_PATH_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub type QUERY_VIRTUAL_MEMORY_CALLBACK = Option<unsafe extern "system" fn(callbackcontext: super::super::super::Win32::Foundation::HANDLE, processhandle: super::super::super::Win32::Foundation::HANDLE, baseaddress: *const core::ffi::c_void, memoryinformationclass: HEAP_MEMORY_INFO_CLASS, memoryinformation: *mut core::ffi::c_void, memoryinformationlength: usize, returnlength: *mut usize) -> super::super::super::Win32::Foundation::NTSTATUS>;
 pub const QoCFileEaInformation: u32 = 4u32;
@@ -9086,9 +8402,6 @@ impl Default for READ_AHEAD_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for READ_AHEAD_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_Storage_FileSystem", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -9103,10 +8416,6 @@ impl Default for READ_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_System_SystemServices", feature = "Win32_Security", feature = "Win32_Storage_FileSystem", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for READ_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9124,9 +8433,6 @@ impl Default for READ_USN_JOURNAL_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for READ_USN_JOURNAL_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9153,9 +8459,6 @@ impl Default for REFS_DEALLOCATE_RANGES_INPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_DEALLOCATE_RANGES_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REFS_DEALLOCATE_RANGES_INPUT_BUFFER_EX {
@@ -9171,9 +8474,6 @@ impl Default for REFS_DEALLOCATE_RANGES_INPUT_BUFFER_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_DEALLOCATE_RANGES_INPUT_BUFFER_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REFS_DEALLOCATE_RANGES_RANGE {
@@ -9184,9 +8484,6 @@ impl Default for REFS_DEALLOCATE_RANGES_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REFS_DEALLOCATE_RANGES_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9207,9 +8504,6 @@ impl Default for REFS_QUERY_VOLUME_COMPRESSION_INFO_OUTPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_QUERY_VOLUME_COMPRESSION_INFO_OUTPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REFS_QUERY_VOLUME_DEDUP_INFO_OUTPUT_BUFFER {
@@ -9219,9 +8513,6 @@ impl Default for REFS_QUERY_VOLUME_DEDUP_INFO_OUTPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REFS_QUERY_VOLUME_DEDUP_INFO_OUTPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9234,9 +8525,6 @@ impl Default for REFS_REMOVE_HARDLINK_BACKPOINTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REFS_REMOVE_HARDLINK_BACKPOINTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9257,9 +8545,6 @@ impl Default for REFS_SET_VOLUME_COMPRESSION_INFO_INPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_SET_VOLUME_COMPRESSION_INFO_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REFS_SET_VOLUME_DEDUP_INFO_INPUT_BUFFER {
@@ -9269,9 +8554,6 @@ impl Default for REFS_SET_VOLUME_DEDUP_INFO_INPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REFS_SET_VOLUME_DEDUP_INFO_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9285,9 +8567,6 @@ impl Default for REFS_STREAM_EXTENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REFS_STREAM_EXTENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REFS_STREAM_EXTENT_PROPERTY_CRC32: _REFS_STREAM_EXTENT_PROPERTIES = _REFS_STREAM_EXTENT_PROPERTIES(128i32);
 pub const REFS_STREAM_EXTENT_PROPERTY_CRC64: _REFS_STREAM_EXTENT_PROPERTIES = _REFS_STREAM_EXTENT_PROPERTIES(256i32);
@@ -9309,9 +8588,6 @@ impl Default for REFS_STREAM_SNAPSHOT_LIST_OUTPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_STREAM_SNAPSHOT_LIST_OUTPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REFS_STREAM_SNAPSHOT_LIST_OUTPUT_BUFFER_ENTRY {
@@ -9328,9 +8604,6 @@ impl Default for REFS_STREAM_SNAPSHOT_LIST_OUTPUT_BUFFER_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_STREAM_SNAPSHOT_LIST_OUTPUT_BUFFER_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REFS_STREAM_SNAPSHOT_MANAGEMENT_INPUT_BUFFER {
@@ -9344,9 +8617,6 @@ impl Default for REFS_STREAM_SNAPSHOT_MANAGEMENT_INPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REFS_STREAM_SNAPSHOT_MANAGEMENT_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9371,9 +8641,6 @@ impl Default for REFS_STREAM_SNAPSHOT_QUERY_DELTAS_INPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_STREAM_SNAPSHOT_QUERY_DELTAS_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REFS_STREAM_SNAPSHOT_QUERY_DELTAS_OUTPUT_BUFFER {
@@ -9386,9 +8653,6 @@ impl Default for REFS_STREAM_SNAPSHOT_QUERY_DELTAS_OUTPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_STREAM_SNAPSHOT_QUERY_DELTAS_OUTPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REFS_VOLUME_COUNTER_INFO_INPUT_BUFFER {
@@ -9398,9 +8662,6 @@ impl Default for REFS_VOLUME_COUNTER_INFO_INPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REFS_VOLUME_COUNTER_INFO_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9427,9 +8688,6 @@ impl Default for REFS_VOLUME_DATA_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_VOLUME_DATA_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REMOTE_LINK_TRACKING_INFORMATION {
@@ -9441,9 +8699,6 @@ impl Default for REMOTE_LINK_TRACKING_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REMOTE_LINK_TRACKING_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REMOTE_PROTOCOL_FLAG_INTEGRITY: u32 = 16u32;
 pub const REMOTE_PROTOCOL_FLAG_LOOPBACK: u32 = 1u32;
@@ -9465,9 +8720,6 @@ impl Default for REPARSE_DATA_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPARSE_DATA_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union REPARSE_DATA_BUFFER_0 {
@@ -9480,9 +8732,6 @@ impl Default for REPARSE_DATA_BUFFER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPARSE_DATA_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPARSE_DATA_BUFFER_0_2 {
@@ -9492,9 +8741,6 @@ impl Default for REPARSE_DATA_BUFFER_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REPARSE_DATA_BUFFER_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9510,9 +8756,6 @@ impl Default for REPARSE_DATA_BUFFER_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPARSE_DATA_BUFFER_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPARSE_DATA_BUFFER_0_0 {
@@ -9527,9 +8770,6 @@ impl Default for REPARSE_DATA_BUFFER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REPARSE_DATA_BUFFER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -9547,10 +8787,6 @@ impl Default for REPARSE_DATA_BUFFER_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for REPARSE_DATA_BUFFER_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
@@ -9564,10 +8800,6 @@ impl Default for REPARSE_DATA_BUFFER_EX_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for REPARSE_DATA_BUFFER_EX_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const REPARSE_DATA_EX_FLAG_GIVEN_TAG_OR_NONE: u32 = 1u32;
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -9579,9 +8811,6 @@ impl Default for REPARSE_INDEX_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REPARSE_INDEX_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9595,9 +8824,6 @@ impl Default for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER_0 {
@@ -9609,9 +8835,6 @@ impl Default for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RETURN_NON_NT_USER_SESSION_KEY: u32 = 8u32;
 pub const RETURN_PRIMARY_LOGON_DOMAINNAME: u32 = 4u32;
@@ -9627,9 +8850,6 @@ impl Default for RKF_BYPASS_ECP_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RKF_BYPASS_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RPI_SMB2_SERVERCAP_DFS: u32 = 1u32;
 pub const RPI_SMB2_SERVERCAP_DIRECTORY_LEASING: u32 = 32u32;
@@ -9669,9 +8889,6 @@ impl Default for RTL_HEAP_MEMORY_LIMIT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_HEAP_MEMORY_LIMIT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RTL_HEAP_MEMORY_LIMIT_INFO {
@@ -9682,9 +8899,6 @@ impl Default for RTL_HEAP_MEMORY_LIMIT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTL_HEAP_MEMORY_LIMIT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9705,9 +8919,6 @@ impl Default for RTL_HEAP_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTL_HEAP_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9730,9 +8941,6 @@ impl Default for RTL_NLS_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_NLS_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type RTL_REALLOCATE_STRING_ROUTINE = Option<unsafe extern "system" fn(numberofbytes: usize, buffer: *const core::ffi::c_void) -> *mut core::ffi::c_void>;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9748,9 +8956,6 @@ impl Default for RTL_SEGMENT_HEAP_MEMORY_SOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_SEGMENT_HEAP_MEMORY_SOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RTL_SEGMENT_HEAP_MEMORY_SOURCE_0 {
@@ -9761,9 +8966,6 @@ impl Default for RTL_SEGMENT_HEAP_MEMORY_SOURCE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTL_SEGMENT_HEAP_MEMORY_SOURCE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9779,9 +8981,6 @@ impl Default for RTL_SEGMENT_HEAP_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_SEGMENT_HEAP_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RTL_SEGMENT_HEAP_VA_CALLBACKS {
@@ -9794,9 +8993,6 @@ impl Default for RTL_SEGMENT_HEAP_VA_CALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTL_SEGMENT_HEAP_VA_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RTL_SYSTEM_VOLUME_INFORMATION_FOLDER: windows_core::PCWSTR = windows_core::w!("System Volume Information");
 pub const SECURITY_ANONYMOUS_LOGON_RID: i32 = 7i32;
@@ -9817,10 +9013,6 @@ impl Default for SECURITY_CLIENT_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SECURITY_CLIENT_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Authentication_Identity")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9834,10 +9026,6 @@ impl Default for SEC_APPLICATION_PROTOCOLS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Authentication_Identity")]
-impl windows_core::TypeKind for SEC_APPLICATION_PROTOCOLS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_DTLS_MTU {
@@ -9848,9 +9036,6 @@ impl Default for SEC_DTLS_MTU {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_DTLS_MTU {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_FLAGS {
@@ -9860,9 +9045,6 @@ impl Default for SEC_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9877,9 +9059,6 @@ impl Default for SEC_NEGOTIATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_NEGOTIATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_PRESHAREDKEY {
@@ -9891,9 +9070,6 @@ impl Default for SEC_PRESHAREDKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_PRESHAREDKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_SRTP_MASTER_KEY_IDENTIFIER {
@@ -9904,9 +9080,6 @@ impl Default for SEC_SRTP_MASTER_KEY_IDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_SRTP_MASTER_KEY_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SEGMENT_HEAP_FLG_USE_PAGE_HEAP: u32 = 1u32;
 pub const SEGMENT_HEAP_PARAMETERS_VERSION: u32 = 3u32;
@@ -9921,9 +9094,6 @@ impl Default for SET_CACHED_RUNS_STATE_INPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SET_CACHED_RUNS_STATE_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SET_PURGE_FAILURE_MODE_DISABLED: u32 = 2u32;
 #[repr(C)]
@@ -9948,10 +9118,6 @@ impl Default for SE_AUDIT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SE_AUDIT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10042,10 +9208,6 @@ impl Default for SE_EXPORTS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SE_EXPORTS {
-    type TypeKind = windows_core::CopyType;
-}
 pub type SE_LOGON_SESSION_TERMINATED_ROUTINE = Option<unsafe extern "system" fn(logonid: *const super::super::super::Win32::Foundation::LUID) -> super::super::super::Win32::Foundation::NTSTATUS>;
 #[cfg(feature = "Wdk_Foundation")]
 pub type SE_LOGON_SESSION_TERMINATED_ROUTINE_EX = Option<unsafe extern "system" fn(logonid: *const super::super::super::Win32::Foundation::LUID, pserversilo: super::super::Foundation::PESILO, context: *const core::ffi::c_void) -> super::super::super::Win32::Foundation::NTSTATUS>;
@@ -10072,10 +9234,6 @@ impl Default for SRV_OPEN_ECP_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for SRV_OPEN_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SRV_OPEN_ECP_CONTEXT_VERSION_2: u32 = 2u32;
 pub const SUPPORTED_FS_FEATURES_BYPASS_IO: u32 = 8u32;
 pub const SUPPORTED_FS_FEATURES_OFFLOAD_READ: u32 = 1u32;
@@ -10098,9 +9256,6 @@ impl Default for SYSTEM_PROCESS_TRUST_LABEL_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_PROCESS_TRUST_LABEL_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecBuffer {
@@ -10112,9 +9267,6 @@ impl Default for SecBuffer {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecBuffer {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10128,9 +9280,6 @@ impl Default for SecBufferDesc {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecBufferDesc {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecHandle {
@@ -10141,9 +9290,6 @@ impl Default for SecHandle {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecHandle {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SharedVirtualDiskCDPSnapshotsSupported: SharedVirtualDiskSupportType = SharedVirtualDiskSupportType(7i32);
 #[repr(transparent)]
@@ -10207,10 +9353,6 @@ impl Default for TUNNEL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for TUNNEL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10225,10 +9367,6 @@ impl Default for UNICODE_PREFIX_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for UNICODE_PREFIX_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
@@ -10246,10 +9384,6 @@ impl Default for UNICODE_PREFIX_TABLE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for UNICODE_PREFIX_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UNINITIALIZE_CACHE_MAPS: u32 = 1u32;
 pub const USE_PRIMARY_PASSWORD: u32 = 1u32;
@@ -10271,9 +9405,6 @@ impl Default for USN_JOURNAL_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USN_JOURNAL_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10298,9 +9429,6 @@ impl Default for USN_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USN_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VACB_MAPPING_GRANULARITY: u32 = 262144u32;
 pub const VACB_OFFSET_SHIFT: u32 = 18u32;
 pub const VALID_INHERIT_FLAGS: u32 = 31u32;
@@ -10314,9 +9442,6 @@ impl Default for VCN_RANGE_INPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VCN_RANGE_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10409,9 +9534,6 @@ impl Default for VOLUME_REFS_INFO_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUME_REFS_INFO_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VmPrefetchInformation: VIRTUAL_MEMORY_INFORMATION_CLASS = VIRTUAL_MEMORY_INFORMATION_CLASS(0i32);
 pub const WCIFS_REDIRECTION_FLAGS_CREATE_SERVICED_FROM_LAYER: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Wdk/System/Registry/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/System/Registry/mod.rs
@@ -319,9 +319,6 @@ impl Default for KEY_VALUE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEY_VALUE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KEY_VALUE_INFORMATION_CLASS(pub i32);
@@ -369,9 +366,6 @@ impl Default for REG_ENUMERATE_KEY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_ENUMERATE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_ENUMERATE_VALUE_KEY_INFORMATION {
@@ -390,9 +384,6 @@ impl Default for REG_ENUMERATE_VALUE_KEY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_ENUMERATE_VALUE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_QUERY_KEY_INFORMATION {
@@ -409,9 +400,6 @@ impl Default for REG_QUERY_KEY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_QUERY_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -431,9 +419,6 @@ impl Default for REG_QUERY_MULTIPLE_VALUE_KEY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_QUERY_MULTIPLE_VALUE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_QUERY_VALUE_KEY_INFORMATION {
@@ -452,9 +437,6 @@ impl Default for REG_QUERY_VALUE_KEY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_QUERY_VALUE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_SET_INFORMATION_KEY_INFORMATION {
@@ -470,7 +452,4 @@ impl Default for REG_SET_INFORMATION_KEY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_SET_INFORMATION_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Wdk/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Wdk/System/SystemServices/mod.rs
@@ -6892,9 +6892,6 @@ impl Default for ACPI_DEBUGGING_DEVICE_IN_USE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACPI_DEBUGGING_DEVICE_IN_USE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6918,10 +6915,6 @@ impl Default for ACPI_INTERFACE_STANDARD {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for ACPI_INTERFACE_STANDARD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACPI_INTERFACE_STANDARD2 {
@@ -6943,9 +6936,6 @@ impl Default for ACPI_INTERFACE_STANDARD2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACPI_INTERFACE_STANDARD2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ADAPTER_INFO_API_BYPASS: u32 = 2u32;
 pub const ADAPTER_INFO_SYNCHRONOUS_CALLBACK: u32 = 1u32;
 #[repr(C)]
@@ -6965,9 +6955,6 @@ impl Default for AGP_TARGET_BUS_INTERFACE_STANDARD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AGP_TARGET_BUS_INTERFACE_STANDARD {
-    type TypeKind = windows_core::CopyType;
-}
 #[cfg(feature = "Wdk_Foundation")]
 pub type ALLOCATE_FUNCTION = Option<unsafe extern "system" fn(pooltype: super::super::Foundation::POOL_TYPE, numberofbytes: usize, tag: u32) -> *mut core::ffi::c_void>;
 pub const ALLOC_DATA_PRAGMA: u32 = 1u32;
@@ -6986,9 +6973,6 @@ impl Default for AMD_L1_CACHE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMD_L1_CACHE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMD_L1_CACHE_INFO_0 {
@@ -7002,9 +6986,6 @@ impl Default for AMD_L1_CACHE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMD_L1_CACHE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AMD_L2_CACHE_INFO {
@@ -7015,9 +6996,6 @@ impl Default for AMD_L2_CACHE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMD_L2_CACHE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7031,9 +7009,6 @@ impl Default for AMD_L2_CACHE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMD_L2_CACHE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AMD_L3_CACHE_INFO {
@@ -7044,9 +7019,6 @@ impl Default for AMD_L3_CACHE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMD_L3_CACHE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7059,9 +7031,6 @@ impl Default for AMD_L3_CACHE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMD_L3_CACHE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ANY_SIZE: u32 = 1u32;
 pub const APC_LEVEL: u32 = 1u32;
@@ -7080,10 +7049,6 @@ impl Default for ARBITER_ADD_RESERVED_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for ARBITER_ADD_RESERVED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7095,10 +7060,6 @@ impl Default for ARBITER_BOOT_ALLOCATION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for ARBITER_BOOT_ALLOCATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -7113,10 +7074,6 @@ impl Default for ARBITER_CONFLICT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for ARBITER_CONFLICT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ARBITER_FLAG_BOOT_CONFIG: u32 = 1u32;
 pub const ARBITER_FLAG_OTHER_ENUM: u32 = 4u32;
@@ -7138,10 +7095,6 @@ impl Default for ARBITER_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for ARBITER_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -7167,10 +7120,6 @@ impl Default for ARBITER_LIST_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for ARBITER_LIST_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -7182,10 +7131,6 @@ impl Default for ARBITER_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for ARBITER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -7205,10 +7150,6 @@ impl Default for ARBITER_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for ARBITER_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ARBITER_PARTIAL: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7219,9 +7160,6 @@ impl Default for ARBITER_QUERY_ALLOCATED_RESOURCES_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ARBITER_QUERY_ALLOCATED_RESOURCES_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -7234,10 +7172,6 @@ impl Default for ARBITER_QUERY_ARBITRATE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for ARBITER_QUERY_ARBITRATE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -7253,10 +7187,6 @@ impl Default for ARBITER_QUERY_CONFLICT_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for ARBITER_QUERY_CONFLICT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7278,10 +7208,6 @@ impl Default for ARBITER_RETEST_ALLOCATION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for ARBITER_RETEST_ALLOCATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7295,10 +7221,6 @@ impl Default for ARBITER_TEST_ALLOCATION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for ARBITER_TEST_ALLOCATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -7323,10 +7245,6 @@ impl Default for ARM64_NT_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for ARM64_NT_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 #[derive(Clone, Copy)]
@@ -7339,10 +7257,6 @@ impl Default for ARM64_NT_CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for ARM64_NT_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -7385,10 +7299,6 @@ impl Default for ARM64_NT_CONTEXT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for ARM64_NT_CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ARM64_PCR_RESERVED_MASK: u32 = 4095u32;
 pub const ARM_PROCESSOR_ERROR_SECTION_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xe19e3d16_bc11_11e4_9caa_c2051d5d46b0);
@@ -7453,9 +7363,6 @@ impl Default for BDCB_IMAGE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDCB_IMAGE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDCB_STATUS_UPDATE_CONTEXT {
@@ -7465,9 +7372,6 @@ impl Default for BDCB_STATUS_UPDATE_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDCB_STATUS_UPDATE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7486,9 +7390,6 @@ impl Default for BOOTDISK_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BOOTDISK_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BOOTDISK_INFORMATION_EX {
@@ -7506,9 +7407,6 @@ impl Default for BOOTDISK_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BOOTDISK_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct BOOTDISK_INFORMATION_LITE {
@@ -7519,9 +7417,6 @@ impl Default for BOOTDISK_INFORMATION_LITE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BOOTDISK_INFORMATION_LITE {
-    type TypeKind = windows_core::CopyType;
 }
 pub type BOOT_DRIVER_CALLBACK_FUNCTION = Option<unsafe extern "system" fn(callbackcontext: *const core::ffi::c_void, classification: BDCB_CALLBACK_TYPE, imageinformation: *mut BDCB_IMAGE_INFORMATION)>;
 pub const BOOT_NOTIFY_TYPE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x3d61a466_ab40_409a_a698_f362d464b38f);
@@ -7552,10 +7447,6 @@ impl Default for BUS_INTERFACE_STANDARD {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for BUS_INTERFACE_STANDARD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BUS_QUERY_ID_TYPE(pub i32);
@@ -7574,9 +7465,6 @@ impl Default for BUS_RESOURCE_UPDATE_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BUS_RESOURCE_UPDATE_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union BUS_SPECIFIC_RESET_FLAGS {
@@ -7588,9 +7476,6 @@ impl Default for BUS_SPECIFIC_RESET_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BUS_SPECIFIC_RESET_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BUS_SPECIFIC_RESET_FLAGS_0 {
@@ -7600,9 +7485,6 @@ impl Default for BUS_SPECIFIC_RESET_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BUS_SPECIFIC_RESET_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BackgroundWorkQueue: WORK_QUEUE_TYPE = WORK_QUEUE_TYPE(4i32);
 pub const BdCbClassificationEnd: BDCB_CLASSIFICATION = BDCB_CLASSIFICATION(4i32);
@@ -7653,10 +7535,6 @@ impl Default for CLFS_MGMT_CLIENT_REGISTRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_Storage_FileSystem", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for CLFS_MGMT_CLIENT_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLFS_SCAN_BACKWARD: u8 = 4u8;
 pub const CLFS_SCAN_BUFFERED: u8 = 32u8;
 pub const CLFS_SCAN_CLOSE: u8 = 8u8;
@@ -7682,10 +7560,6 @@ impl Default for CMC_DRIVER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for CMC_DRIVER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CMC_NOTIFY_TYPE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x2dce8bb1_bdd7_450e_b9ad_9cf4ebd4f890);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7700,9 +7574,6 @@ impl Default for CM_COMPONENT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_COMPONENT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_DISK_GEOMETRY_DEVICE_DATA {
@@ -7715,9 +7586,6 @@ impl Default for CM_DISK_GEOMETRY_DEVICE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_DISK_GEOMETRY_DEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7741,9 +7609,6 @@ impl Default for CM_EISA_FUNCTION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_EISA_FUNCTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct CM_EISA_SLOT_INFORMATION {
@@ -7760,9 +7625,6 @@ impl Default for CM_EISA_SLOT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_EISA_SLOT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7791,9 +7653,6 @@ impl Default for CM_FLOPPY_DEVICE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_FLOPPY_DEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CM_FULL_RESOURCE_DESCRIPTOR {
@@ -7805,9 +7664,6 @@ impl Default for CM_FULL_RESOURCE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_FULL_RESOURCE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7823,9 +7679,6 @@ impl Default for CM_INT13_DRIVE_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_INT13_DRIVE_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_KEYBOARD_DEVICE_DATA {
@@ -7840,9 +7693,6 @@ impl Default for CM_KEYBOARD_DEVICE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_KEYBOARD_DEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct CM_MCA_POS_DATA {
@@ -7856,9 +7706,6 @@ impl Default for CM_MCA_POS_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_MCA_POS_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7896,9 +7743,6 @@ impl Default for CM_MONITOR_DEVICE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_MONITOR_DEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR {
@@ -7911,9 +7755,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7938,9 +7779,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
@@ -7952,9 +7790,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_8 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7971,9 +7806,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_13 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
@@ -7983,9 +7815,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7998,9 +7827,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_9 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8017,9 +7843,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_5 {
@@ -8032,9 +7855,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
@@ -8045,9 +7865,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8061,9 +7878,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10 {
@@ -8074,9 +7888,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_10 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -8089,9 +7900,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_11 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12 {
@@ -8102,9 +7910,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_12 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -8117,9 +7922,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
@@ -8129,9 +7931,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8143,9 +7942,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8160,9 +7956,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_1 {
@@ -8175,9 +7968,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_3_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
@@ -8188,9 +7978,6 @@ impl Default for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_DESCRIPTOR_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8204,9 +7991,6 @@ impl Default for CM_PARTIAL_RESOURCE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PARTIAL_RESOURCE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8224,9 +8008,6 @@ impl Default for CM_PCCARD_DEVICE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PCCARD_DEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct CM_PNP_BIOS_DEVICE_NODE {
@@ -8240,9 +8021,6 @@ impl Default for CM_PNP_BIOS_DEVICE_NODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_PNP_BIOS_DEVICE_NODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8266,9 +8044,6 @@ impl Default for CM_PNP_BIOS_INSTALLATION_CHECK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_PNP_BIOS_INSTALLATION_CHECK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Power")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8287,10 +8062,6 @@ impl Default for CM_POWER_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Power")]
-impl windows_core::TypeKind for CM_POWER_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CM_RESOURCE_CONNECTION_CLASS_FUNCTION_CONFIG: u32 = 3u32;
 pub const CM_RESOURCE_CONNECTION_CLASS_GPIO: u32 = 1u32;
@@ -8326,9 +8097,6 @@ impl Default for CM_RESOURCE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_RESOURCE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CM_RESOURCE_MEMORY_24: u32 = 16u32;
 pub const CM_RESOURCE_MEMORY_BAR: u32 = 128u32;
@@ -8368,9 +8136,6 @@ impl Default for CM_ROM_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_ROM_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_SCSI_DEVICE_DATA {
@@ -8383,9 +8148,6 @@ impl Default for CM_SCSI_DEVICE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_SCSI_DEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_SERIAL_DEVICE_DATA {
@@ -8397,9 +8159,6 @@ impl Default for CM_SERIAL_DEVICE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_SERIAL_DEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CM_SERVICE_MEASURED_BOOT_LOAD: u32 = 32u32;
 #[repr(transparent)]
@@ -8418,9 +8177,6 @@ impl Default for CM_SONIC_DEVICE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_SONIC_DEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_VIDEO_DEVICE_DATA {
@@ -8432,9 +8188,6 @@ impl Default for CM_VIDEO_DEVICE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_VIDEO_DEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8455,9 +8208,6 @@ impl Default for CONFIGURATION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONFIGURATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8485,10 +8235,6 @@ impl Default for CONTROLLER_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for CONTROLLER_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct COUNTED_REASON_CONTEXT {
@@ -8501,9 +8247,6 @@ impl Default for COUNTED_REASON_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COUNTED_REASON_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union COUNTED_REASON_CONTEXT_0 {
@@ -8514,9 +8257,6 @@ impl Default for COUNTED_REASON_CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COUNTED_REASON_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8530,9 +8270,6 @@ impl Default for COUNTED_REASON_CONTEXT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COUNTED_REASON_CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CP15_PCR_RESERVED_MASK: u32 = 4095u32;
 pub const CPER_EMPTY_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000);
@@ -8549,10 +8286,6 @@ impl Default for CPE_DRIVER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for CPE_DRIVER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CPE_NOTIFY_TYPE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x4e292f96_d843_4a55_a8c2_d481f27ebeee);
 pub const CP_GET_ERROR: u32 = 2u32;
@@ -8573,9 +8306,6 @@ impl Default for CRASHDUMP_FUNCTIONS_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRASHDUMP_FUNCTIONS_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CREATE_FILE_TYPE(pub i32);
@@ -8590,9 +8320,6 @@ impl Default for CREATE_USER_PROCESS_ECP_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_USER_PROCESS_ECP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CardPresent: PCI_EXPRESS_CARD_PRESENCE = PCI_EXPRESS_CARD_PRESENCE(1i32);
 pub const CbusConfiguration: BUS_DATA_TYPE = BUS_DATA_TYPE(3i32);
@@ -8667,9 +8394,6 @@ impl Default for D3COLD_AUX_POWER_AND_TIMING_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3COLD_AUX_POWER_AND_TIMING_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3COLD_LAST_TRANSITION_STATUS(pub i32);
@@ -8694,9 +8418,6 @@ impl Default for D3COLD_SUPPORT_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3COLD_SUPPORT_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3COLD_SUPPORT_INTERFACE_VERSION: u32 = 1u32;
 pub const DBG_DEVICE_FLAG_BARS_MAPPED: u32 = 2u32;
@@ -8724,9 +8445,6 @@ impl Default for DEBUGGING_DEVICE_IN_USE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUGGING_DEVICE_IN_USE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEBUGGING_DEVICE_IN_USE_0 {
@@ -8738,9 +8456,6 @@ impl Default for DEBUGGING_DEVICE_IN_USE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUGGING_DEVICE_IN_USE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DEBUGGING_DEVICE_IN_USE_INFORMATION {
@@ -8751,9 +8466,6 @@ impl Default for DEBUGGING_DEVICE_IN_USE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUGGING_DEVICE_IN_USE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8769,9 +8481,6 @@ impl Default for DEBUG_DEVICE_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_DEVICE_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEBUG_DEVICE_ADDRESS_0 {
@@ -8783,9 +8492,6 @@ impl Default for DEBUG_DEVICE_ADDRESS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_DEVICE_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_DEVICE_ADDRESS_0_0 {
@@ -8796,9 +8502,6 @@ impl Default for DEBUG_DEVICE_ADDRESS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_DEVICE_ADDRESS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8833,9 +8536,6 @@ impl Default for DEBUG_DEVICE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_DEVICE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEBUG_DEVICE_DESCRIPTOR_0 {
@@ -8847,9 +8547,6 @@ impl Default for DEBUG_DEVICE_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_DEVICE_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_DEVICE_DESCRIPTOR_0_0 {
@@ -8859,9 +8556,6 @@ impl Default for DEBUG_DEVICE_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_DEVICE_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8873,9 +8567,6 @@ impl Default for DEBUG_EFI_IOMMU_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_EFI_IOMMU_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8892,9 +8583,6 @@ impl Default for DEBUG_MEMORY_REQUIREMENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_MEMORY_REQUIREMENTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_TRANSPORT_DATA {
@@ -8909,9 +8597,6 @@ impl Default for DEBUG_TRANSPORT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_TRANSPORT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEFAULT_DEVICE_DRIVER_CREATOR_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x57217c8d_5e66_44fb_8033_9b74cacedf5b);
 pub type DEVICE_BUS_SPECIFIC_RESET_HANDLER = Option<unsafe extern "system" fn(interfacecontext: *const core::ffi::c_void, bustype: *const windows_core::GUID, resettypeselected: DEVICE_BUS_SPECIFIC_RESET_TYPE, flags: *const BUS_SPECIFIC_RESET_FLAGS, resetparameters: *const core::ffi::c_void) -> super::super::super::Win32::Foundation::NTSTATUS>;
 #[repr(C)]
@@ -8925,9 +8610,6 @@ impl Default for DEVICE_BUS_SPECIFIC_RESET_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_BUS_SPECIFIC_RESET_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVICE_BUS_SPECIFIC_RESET_TYPE {
@@ -8940,9 +8622,6 @@ impl Default for DEVICE_BUS_SPECIFIC_RESET_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_BUS_SPECIFIC_RESET_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_BUS_SPECIFIC_RESET_TYPE_1 {
@@ -8953,9 +8632,6 @@ impl Default for DEVICE_BUS_SPECIFIC_RESET_TYPE_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_BUS_SPECIFIC_RESET_TYPE_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
@@ -8965,9 +8641,6 @@ impl Default for DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_BUS_SPECIFIC_RESET_TYPE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Power")]
@@ -8990,10 +8663,6 @@ impl Default for DEVICE_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Power")]
-impl windows_core::TypeKind for DEVICE_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub type DEVICE_CHANGE_COMPLETE_CALLBACK = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void)>;
 #[repr(C)]
@@ -9025,9 +8694,6 @@ impl Default for DEVICE_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEVICE_DESCRIPTION_VERSION: u32 = 0u32;
 pub const DEVICE_DESCRIPTION_VERSION1: u32 = 1u32;
 pub const DEVICE_DESCRIPTION_VERSION2: u32 = 2u32;
@@ -9047,9 +8713,6 @@ impl Default for DEVICE_FAULT_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_FAULT_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_FLAGS {
@@ -9059,9 +8722,6 @@ impl Default for DEVICE_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9080,9 +8740,6 @@ impl Default for DEVICE_INTERFACE_CHANGE_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_INTERFACE_CHANGE_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEVICE_INTERFACE_INCLUDE_NONACTIVE: u32 = 1u32;
 pub type DEVICE_QUERY_BUS_SPECIFIC_RESET_HANDLER = Option<unsafe extern "system" fn(interfacecontext: *const core::ffi::c_void, resetinfocount: *mut u32, resetinfosupported: *mut DEVICE_BUS_SPECIFIC_RESET_INFO) -> super::super::super::Win32::Foundation::NTSTATUS>;
 #[repr(transparent)]
@@ -9100,10 +8757,6 @@ impl Default for DEVICE_RELATIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for DEVICE_RELATIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9133,9 +8786,6 @@ impl Default for DEVICE_RESET_INTERFACE_STANDARD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_RESET_INTERFACE_STANDARD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEVICE_RESET_INTERFACE_VERSION: u32 = 1u32;
 pub const DEVICE_RESET_INTERFACE_VERSION_1: u32 = 1u32;
 pub const DEVICE_RESET_INTERFACE_VERSION_2: u32 = 2u32;
@@ -9151,9 +8801,6 @@ impl Default for DEVICE_RESET_STATUS_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_RESET_STATUS_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_RESET_STATUS_FLAGS_0 {
@@ -9163,9 +8810,6 @@ impl Default for DEVICE_RESET_STATUS_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_RESET_STATUS_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9197,9 +8841,6 @@ impl Default for DISK_SIGNATURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_SIGNATURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISK_SIGNATURE_0 {
@@ -9211,9 +8852,6 @@ impl Default for DISK_SIGNATURE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_SIGNATURE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_SIGNATURE_0_1 {
@@ -9223,9 +8861,6 @@ impl Default for DISK_SIGNATURE_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_SIGNATURE_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9237,9 +8872,6 @@ impl Default for DISK_SIGNATURE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_SIGNATURE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DISPATCH_LEVEL: u32 = 2u32;
 pub const DMAV3_TRANFER_WIDTH_128: u32 = 4u32;
@@ -9262,10 +8894,6 @@ impl Default for DMA_ADAPTER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for DMA_ADAPTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DMA_ADAPTER_INFO {
@@ -9276,9 +8904,6 @@ impl Default for DMA_ADAPTER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_ADAPTER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9291,9 +8916,6 @@ impl Default for DMA_ADAPTER_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_ADAPTER_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMA_ADAPTER_INFO_CRASHDUMP {
@@ -9305,9 +8927,6 @@ impl Default for DMA_ADAPTER_INFO_CRASHDUMP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_ADAPTER_INFO_CRASHDUMP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9323,9 +8942,6 @@ impl Default for DMA_ADAPTER_INFO_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_ADAPTER_INFO_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DMA_ADAPTER_INFO_VERSION1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9337,9 +8953,6 @@ impl Default for DMA_COMMON_BUFFER_EXTENDED_CONFIGURATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_COMMON_BUFFER_EXTENDED_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9354,9 +8967,6 @@ impl Default for DMA_COMMON_BUFFER_EXTENDED_CONFIGURATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_COMMON_BUFFER_EXTENDED_CONFIGURATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMA_COMMON_BUFFER_EXTENDED_CONFIGURATION_0_0 {
@@ -9368,9 +8978,6 @@ impl Default for DMA_COMMON_BUFFER_EXTENDED_CONFIGURATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_COMMON_BUFFER_EXTENDED_CONFIGURATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMA_COMMON_BUFFER_EXTENDED_CONFIGURATION_0_1 {
@@ -9381,9 +8988,6 @@ impl Default for DMA_COMMON_BUFFER_EXTENDED_CONFIGURATION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_COMMON_BUFFER_EXTENDED_CONFIGURATION_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9406,9 +9010,6 @@ impl Default for DMA_CONFIGURATION_BYTE0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_CONFIGURATION_BYTE0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMA_CONFIGURATION_BYTE1 {
@@ -9418,9 +9019,6 @@ impl Default for DMA_CONFIGURATION_BYTE1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_CONFIGURATION_BYTE1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMA_FAIL_ON_BOUNCE: u32 = 4u32;
 #[repr(C)]
@@ -9446,9 +9044,6 @@ impl Default for DMA_IOMMU_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_IOMMU_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DMA_IOMMU_INTERFACE_EX {
@@ -9461,9 +9056,6 @@ impl Default for DMA_IOMMU_INTERFACE_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_IOMMU_INTERFACE_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DMA_IOMMU_INTERFACE_EX_0 {
@@ -9474,9 +9066,6 @@ impl Default for DMA_IOMMU_INTERFACE_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_IOMMU_INTERFACE_EX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMA_IOMMU_INTERFACE_EX_VERSION: u32 = 1u32;
 pub const DMA_IOMMU_INTERFACE_EX_VERSION_1: u32 = 1u32;
@@ -9504,9 +9093,6 @@ impl Default for DMA_IOMMU_INTERFACE_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_IOMMU_INTERFACE_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9538,9 +9124,6 @@ impl Default for DMA_IOMMU_INTERFACE_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_IOMMU_INTERFACE_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMA_IOMMU_INTERFACE_VERSION: u32 = 1u32;
 pub const DMA_IOMMU_INTERFACE_VERSION_1: u32 = 1u32;
@@ -9595,10 +9178,6 @@ impl Default for DMA_OPERATIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for DMA_OPERATIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DMA_SPEED(pub i32);
@@ -9616,9 +9195,6 @@ impl Default for DMA_TRANSFER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_TRANSFER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DMA_TRANSFER_INFO_0 {
@@ -9629,9 +9205,6 @@ impl Default for DMA_TRANSFER_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_TRANSFER_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9645,9 +9218,6 @@ impl Default for DMA_TRANSFER_INFO_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_TRANSFER_INFO_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMA_TRANSFER_INFO_V2 {
@@ -9660,9 +9230,6 @@ impl Default for DMA_TRANSFER_INFO_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_TRANSFER_INFO_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMA_TRANSFER_INFO_VERSION1: u32 = 1u32;
 pub const DMA_TRANSFER_INFO_VERSION2: u32 = 2u32;
@@ -9682,9 +9249,6 @@ impl Default for DOMAIN_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOMAIN_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DOMAIN_CONFIGURATION_0 {
@@ -9695,9 +9259,6 @@ impl Default for DOMAIN_CONFIGURATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOMAIN_CONFIGURATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9719,9 +9280,6 @@ impl Default for DOMAIN_CONFIGURATION_ARM64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOMAIN_CONFIGURATION_ARM64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOMAIN_CONFIGURATION_X64 {
@@ -9732,9 +9290,6 @@ impl Default for DOMAIN_CONFIGURATION_X64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOMAIN_CONFIGURATION_X64 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DPC_NORMAL: u32 = 0u32;
 pub const DPC_THREADED: u32 = 1u32;
@@ -9751,9 +9306,6 @@ impl Default for DPC_WATCHDOG_GLOBAL_TRIAGE_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DPC_WATCHDOG_GLOBAL_TRIAGE_BLOCK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DPC_WATCHDOG_GLOBAL_TRIAGE_BLOCK_REVISION_1: u32 = 1u32;
 pub const DPC_WATCHDOG_GLOBAL_TRIAGE_BLOCK_SIGNATURE: u32 = 2931740382u32;
@@ -9782,9 +9334,6 @@ impl Default for DRIVER_VERIFIER_THUNK_PAIRS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVER_VERIFIER_THUNK_PAIRS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRIVER_VERIFIER_TRACK_POOL_ALLOCATIONS: u32 = 8u32;
 pub const DRS_LEVEL: u32 = 14u32;
@@ -9883,9 +9432,6 @@ impl Default for EFI_ACPI_RAS_SIGNAL_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EFI_ACPI_RAS_SIGNAL_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EFLAG_SIGN: u32 = 32768u32;
 pub const EFLAG_ZERO: u32 = 16384u32;
 #[repr(C)]
@@ -9898,9 +9444,6 @@ impl Default for EISA_DMA_CONFIGURATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EISA_DMA_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EISA_EMPTY_SLOT: u32 = 131u32;
 pub const EISA_FREE_FORM_DATA: u32 = 64u32;
@@ -9926,9 +9469,6 @@ impl Default for EISA_IRQ_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EISA_IRQ_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EISA_IRQ_DESCRIPTOR {
@@ -9938,9 +9478,6 @@ impl Default for EISA_IRQ_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EISA_IRQ_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -9956,9 +9493,6 @@ impl Default for EISA_MEMORY_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EISA_MEMORY_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EISA_MEMORY_TYPE {
@@ -9968,9 +9502,6 @@ impl Default for EISA_MEMORY_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EISA_MEMORY_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EISA_MEMORY_TYPE_RAM: u32 = 1u32;
 pub const EISA_MORE_ENTRIES: u32 = 128u32;
@@ -9985,9 +9516,6 @@ impl Default for EISA_PORT_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EISA_PORT_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EISA_PORT_DESCRIPTOR {
@@ -9997,9 +9525,6 @@ impl Default for EISA_PORT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EISA_PORT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EISA_SYSTEM_MEMORY: u32 = 0u32;
 pub type ENABLE_VIRTUALIZATION = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, numvfs: u16, enablevfmigration: super::super::super::Win32::Foundation::BOOLEAN, enablemigrationinterrupt: super::super::super::Win32::Foundation::BOOLEAN, enablevirtualization: super::super::super::Win32::Foundation::BOOLEAN) -> super::super::super::Win32::Foundation::NTSTATUS>;
@@ -10063,9 +9588,6 @@ impl Default for ETW_TRACE_SESSION_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ETW_TRACE_SESSION_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EVENT_QUERY_STATE: u32 = 1u32;
 pub const EXCEPTION_ALIGNMENT_CHECK: u32 = 17u32;
 pub const EXCEPTION_BOUND_CHECK: u32 = 5u32;
@@ -10103,9 +9625,6 @@ impl Default for EXTENDED_CREATE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXTENDED_CREATE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXTENDED_CREATE_INFORMATION_32 {
@@ -10117,9 +9636,6 @@ impl Default for EXTENDED_CREATE_INFORMATION_32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXTENDED_CREATE_INFORMATION_32 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EXTINT_NOTIFY_TYPE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xfe84086e_b557_43cf_ac1b_17982e078470);
 #[cfg(feature = "Wdk_Foundation")]
@@ -10137,9 +9653,6 @@ impl Default for EXT_DELETE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXT_DELETE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub type EX_CALLBACK_FUNCTION = Option<unsafe extern "system" fn(callbackcontext: *const core::ffi::c_void, argument1: *const core::ffi::c_void, argument2: *const core::ffi::c_void) -> super::super::super::Win32::Foundation::NTSTATUS>;
 pub const EX_CARR_ALLOCATE_NONPAGED_POOL: u32 = 1u32;
@@ -10167,9 +9680,6 @@ impl Default for EX_RUNDOWN_REF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EX_RUNDOWN_REF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EX_RUNDOWN_REF_0 {
@@ -10180,9 +9690,6 @@ impl Default for EX_RUNDOWN_REF_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EX_RUNDOWN_REF_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EX_TIMER_HIGH_RESOLUTION: u32 = 4u32;
 pub const EX_TIMER_NO_WAKE: u32 = 8u32;
@@ -10213,10 +9720,6 @@ impl Default for FAULT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FAULT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -10229,10 +9732,6 @@ impl Default for FAULT_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FAULT_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10255,10 +9754,6 @@ impl Default for FAULT_INFORMATION_ARM64 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for FAULT_INFORMATION_ARM64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAULT_INFORMATION_ARM64_FLAGS {
@@ -10268,9 +9763,6 @@ impl Default for FAULT_INFORMATION_ARM64_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAULT_INFORMATION_ARM64_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10290,9 +9782,6 @@ impl Default for FAULT_INFORMATION_X64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAULT_INFORMATION_X64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAULT_INFORMATION_X64_FLAGS {
@@ -10302,9 +9791,6 @@ impl Default for FAULT_INFORMATION_X64_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAULT_INFORMATION_X64_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_128_BYTE_ALIGNMENT: u32 = 127u32;
 pub const FILE_256_BYTE_ALIGNMENT: u32 = 255u32;
@@ -10321,9 +9807,6 @@ impl Default for FILE_ATTRIBUTE_TAG_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ATTRIBUTE_TAG_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_ATTRIBUTE_VALID_FLAGS: u32 = 32695u32;
 pub const FILE_ATTRIBUTE_VALID_KERNEL_SET_FLAGS: u32 = 5910951u32;
@@ -10357,9 +9840,6 @@ impl Default for FILE_END_OF_FILE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_END_OF_FILE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_FLOPPY_DISKETTE: u32 = 4u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10371,9 +9851,6 @@ impl Default for FILE_FS_DEVICE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_FS_DEVICE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10388,9 +9865,6 @@ impl Default for FILE_FS_FULL_SIZE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_FS_FULL_SIZE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10414,9 +9888,6 @@ impl Default for FILE_FS_FULL_SIZE_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_FS_FULL_SIZE_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_FS_LABEL_INFORMATION {
@@ -10427,9 +9898,6 @@ impl Default for FILE_FS_LABEL_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_FS_LABEL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10443,9 +9911,6 @@ impl Default for FILE_FS_METADATA_SIZE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_FS_METADATA_SIZE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_FS_OBJECTID_INFORMATION {
@@ -10456,9 +9921,6 @@ impl Default for FILE_FS_OBJECTID_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_FS_OBJECTID_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10472,9 +9934,6 @@ impl Default for FILE_FS_SIZE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_FS_SIZE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10490,9 +9949,6 @@ impl Default for FILE_FS_VOLUME_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_FS_VOLUME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_IOSTATUSBLOCK_RANGE_INFORMATION {
@@ -10504,9 +9960,6 @@ impl Default for FILE_IOSTATUSBLOCK_RANGE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_IOSTATUSBLOCK_RANGE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_IO_COMPLETION_NOTIFICATION_INFORMATION {
@@ -10516,9 +9969,6 @@ impl Default for FILE_IO_COMPLETION_NOTIFICATION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_IO_COMPLETION_NOTIFICATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
@@ -10531,10 +9981,6 @@ impl Default for FILE_IO_PRIORITY_HINT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for FILE_IO_PRIORITY_HINT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
@@ -10549,10 +9995,6 @@ impl Default for FILE_IO_PRIORITY_HINT_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for FILE_IO_PRIORITY_HINT_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_IS_REMOTE_DEVICE_INFORMATION {
@@ -10562,9 +10004,6 @@ impl Default for FILE_IS_REMOTE_DEVICE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_IS_REMOTE_DEVICE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_LONG_ALIGNMENT: u32 = 3u32;
 #[repr(C)]
@@ -10578,9 +10017,6 @@ impl Default for FILE_MEMORY_PARTITION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_MEMORY_PARTITION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILE_MEMORY_PARTITION_INFORMATION_0 {
@@ -10591,9 +10027,6 @@ impl Default for FILE_MEMORY_PARTITION_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_MEMORY_PARTITION_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10606,9 +10039,6 @@ impl Default for FILE_MEMORY_PARTITION_INFORMATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_MEMORY_PARTITION_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_NUMA_NODE_INFORMATION {
@@ -10618,9 +10048,6 @@ impl Default for FILE_NUMA_NODE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_NUMA_NODE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_OCTA_ALIGNMENT: u32 = 15u32;
 pub const FILE_PORTABLE_DEVICE: u32 = 262144u32;
@@ -10634,9 +10061,6 @@ impl Default for FILE_PROCESS_IDS_USING_FILE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_PROCESS_IDS_USING_FILE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_QUAD_ALIGNMENT: u32 = 7u32;
 pub const FILE_QUERY_INDEX_SPECIFIED: u32 = 4u32;
@@ -10663,9 +10087,6 @@ impl Default for FILE_SFIO_RESERVE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_SFIO_RESERVE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_SFIO_VOLUME_INFORMATION {
@@ -10677,9 +10098,6 @@ impl Default for FILE_SFIO_VOLUME_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_SFIO_VOLUME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_SHARE_VALID_FLAGS: u32 = 7u32;
 pub const FILE_SKIP_SET_USER_EVENT_ON_FAST_IO: u32 = 4u32;
@@ -10699,9 +10117,6 @@ impl Default for FILE_STANDARD_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_STANDARD_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_USE_FILE_POINTER_POSITION: u32 = 4294967294u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10712,9 +10127,6 @@ impl Default for FILE_VALID_DATA_LENGTH_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_VALID_DATA_LENGTH_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_VALID_EXTENDED_OPTION_FLAGS: u32 = 268435456u32;
 pub const FILE_VIRTUAL_VOLUME: u32 = 64u32;
@@ -10740,9 +10152,6 @@ impl Default for FLOATING_SAVE_AREA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLOATING_SAVE_AREA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLUSH_MULTIPLE_MAXIMUM: u32 = 32u32;
 pub const FM_LOCK_BIT: u32 = 1u32;
@@ -10828,9 +10237,6 @@ impl Default for FPGA_CONTROL_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FPGA_CONTROL_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type FPGA_CONTROL_LINK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, enable: super::super::super::Win32::Foundation::BOOLEAN) -> super::super::super::Win32::Foundation::NTSTATUS>;
 pub type FREE_FUNCTION = Option<unsafe extern "system" fn(buffer: *const core::ffi::c_void)>;
 #[repr(C)]
@@ -10844,9 +10250,6 @@ impl Default for FUNCTION_LEVEL_DEVICE_RESET_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FUNCTION_LEVEL_DEVICE_RESET_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub type FWMI_NOTIFICATION_CALLBACK = Option<unsafe extern "system" fn(wnode: *mut core::ffi::c_void, context: *mut core::ffi::c_void)>;
 pub const FailControl: NPEM_CONTROL_STANDARD_CONTROL_BIT = NPEM_CONTROL_STANDARD_CONTROL_BIT(4i32);
@@ -10917,9 +10320,6 @@ impl Default for HAL_AMLI_BAD_IO_ADDRESS_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HAL_AMLI_BAD_IO_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HAL_APIC_DESTINATION_MODE(pub i32);
@@ -10936,9 +10336,6 @@ impl Default for HAL_BUS_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HAL_BUS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10951,10 +10348,6 @@ impl Default for HAL_CALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for HAL_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Ioctl", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -10990,10 +10383,6 @@ impl Default for HAL_DISPATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Ioctl", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for HAL_DISPATCH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HAL_DISPATCH_VERSION: u32 = 5u32;
 #[repr(transparent)]
@@ -11039,9 +10428,6 @@ impl Default for HAL_ERROR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HAL_ERROR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HAL_MASK_UNMASK_FLAGS_NONE: u32 = 0u32;
 pub const HAL_MASK_UNMASK_FLAGS_SERVICING_COMPLETE: u32 = 2u32;
 pub const HAL_MASK_UNMASK_FLAGS_SERVICING_DEFERRED: u32 = 1u32;
@@ -11056,9 +10442,6 @@ impl Default for HAL_MCA_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HAL_MCA_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HAL_MCA_RECORD: MCA_EXCEPTION_TYPE = MCA_EXCEPTION_TYPE(1i32);
 pub const HAL_MCE_RECORD: MCA_EXCEPTION_TYPE = MCA_EXCEPTION_TYPE(0i32);
@@ -11077,9 +10460,6 @@ impl Default for HAL_PLATFORM_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HAL_PLATFORM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HAL_POWER_INFORMATION {
@@ -11089,9 +10469,6 @@ impl Default for HAL_POWER_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HAL_POWER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11103,9 +10480,6 @@ impl Default for HAL_PROCESSOR_FEATURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HAL_PROCESSOR_FEATURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HAL_PROCESSOR_SPEED_INFORMATION {
@@ -11115,9 +10489,6 @@ impl Default for HAL_PROCESSOR_SPEED_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HAL_PROCESSOR_SPEED_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11136,9 +10507,6 @@ impl Default for HARDWARE_COUNTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HARDWARE_COUNTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11160,9 +10528,6 @@ impl Default for HWPROFILE_CHANGE_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HWPROFILE_CHANGE_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HalAcpiAuditInformation: HAL_QUERY_INFORMATION_CLASS = HAL_QUERY_INFORMATION_CLASS(26i32);
 pub const HalCallbackInformation: HAL_QUERY_INFORMATION_CLASS = HAL_QUERY_INFORMATION_CLASS(5i32);
@@ -11269,9 +10634,6 @@ impl Default for IMAGE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_INFO_0 {
@@ -11283,9 +10645,6 @@ impl Default for IMAGE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_INFO_0_0 {
@@ -11295,9 +10654,6 @@ impl Default for IMAGE_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -11313,10 +10669,6 @@ impl Default for IMAGE_INFO_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IMAGE_INFO_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INITIAL_PRIVILEGE_COUNT: u32 = 3u32;
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -11331,10 +10683,6 @@ impl Default for INITIAL_PRIVILEGE_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for INITIAL_PRIVILEGE_SET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INIT_NOTIFY_TYPE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xcc5263e8_9308_454a_89d0_340bd39bc98e);
 pub const INJECT_ERRTYPE_MEMORY_CORRECTABLE: u32 = 8u32;
@@ -11359,9 +10707,6 @@ impl Default for INPUT_MAPPING_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INPUT_MAPPING_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INTEL_CACHE_INFO_EAX {
@@ -11373,9 +10718,6 @@ impl Default for INTEL_CACHE_INFO_EAX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTEL_CACHE_INFO_EAX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTEL_CACHE_INFO_EAX_0 {
@@ -11385,9 +10727,6 @@ impl Default for INTEL_CACHE_INFO_EAX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTEL_CACHE_INFO_EAX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11400,9 +10739,6 @@ impl Default for INTEL_CACHE_INFO_EBX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTEL_CACHE_INFO_EBX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTEL_CACHE_INFO_EBX_0 {
@@ -11412,9 +10748,6 @@ impl Default for INTEL_CACHE_INFO_EBX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTEL_CACHE_INFO_EBX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11432,9 +10765,6 @@ impl Default for INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11464,10 +10794,6 @@ impl Default for IOMMU_DEVICE_CREATION_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for IOMMU_DEVICE_CREATION_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -11481,10 +10807,6 @@ impl Default for IOMMU_DEVICE_CREATION_CONFIGURATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for IOMMU_DEVICE_CREATION_CONFIGURATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IOMMU_DEVICE_CREATION_CONFIGURATION_ACPI {
@@ -11495,9 +10817,6 @@ impl Default for IOMMU_DEVICE_CREATION_CONFIGURATION_ACPI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IOMMU_DEVICE_CREATION_CONFIGURATION_ACPI {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11519,9 +10838,6 @@ impl Default for IOMMU_DMA_DOMAIN_CREATION_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOMMU_DMA_DOMAIN_CREATION_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IOMMU_DMA_DOMAIN_CREATION_FLAGS_0 {
@@ -11531,9 +10847,6 @@ impl Default for IOMMU_DMA_DOMAIN_CREATION_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IOMMU_DMA_DOMAIN_CREATION_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11549,9 +10862,6 @@ impl Default for IOMMU_DMA_LOGICAL_ADDRESS_TOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOMMU_DMA_LOGICAL_ADDRESS_TOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IOMMU_DMA_LOGICAL_ADDRESS_TOKEN_MAPPED_SEGMENT {
@@ -11564,9 +10874,6 @@ impl Default for IOMMU_DMA_LOGICAL_ADDRESS_TOKEN_MAPPED_SEGMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOMMU_DMA_LOGICAL_ADDRESS_TOKEN_MAPPED_SEGMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IOMMU_DMA_LOGICAL_ALLOCATOR_CONFIG {
@@ -11578,9 +10885,6 @@ impl Default for IOMMU_DMA_LOGICAL_ALLOCATOR_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOMMU_DMA_LOGICAL_ALLOCATOR_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IOMMU_DMA_LOGICAL_ALLOCATOR_CONFIG_0 {
@@ -11591,9 +10895,6 @@ impl Default for IOMMU_DMA_LOGICAL_ALLOCATOR_CONFIG_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOMMU_DMA_LOGICAL_ALLOCATOR_CONFIG_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IOMMU_DMA_LOGICAL_ALLOCATOR_CONFIG_0_0 {
@@ -11603,9 +10904,6 @@ impl Default for IOMMU_DMA_LOGICAL_ALLOCATOR_CONFIG_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IOMMU_DMA_LOGICAL_ALLOCATOR_CONFIG_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11622,9 +10920,6 @@ impl Default for IOMMU_DMA_RESERVED_REGION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IOMMU_DMA_RESERVED_REGION {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type IOMMU_DOMAIN_ATTACH_DEVICE = Option<unsafe extern "system" fn(domain: *const super::super::Foundation::IOMMU_DMA_DOMAIN, physicaldeviceobject: *const super::super::Foundation::DEVICE_OBJECT, inputmappingidbase: u32, mappingcount: u32) -> super::super::super::Win32::Foundation::NTSTATUS>;
@@ -11658,9 +10953,6 @@ impl Default for IOMMU_INTERFACE_STATE_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOMMU_INTERFACE_STATE_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type IOMMU_INTERFACE_STATE_CHANGE_CALLBACK = Option<unsafe extern "system" fn(statechange: *const IOMMU_INTERFACE_STATE_CHANGE, context: *const core::ffi::c_void)>;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11673,9 +10965,6 @@ impl Default for IOMMU_INTERFACE_STATE_CHANGE_FIELDS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOMMU_INTERFACE_STATE_CHANGE_FIELDS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IOMMU_INTERFACE_STATE_CHANGE_FIELDS_0 {
@@ -11685,9 +10974,6 @@ impl Default for IOMMU_INTERFACE_STATE_CHANGE_FIELDS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IOMMU_INTERFACE_STATE_CHANGE_FIELDS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Wdk_Foundation")]
 pub type IOMMU_MAP_IDENTITY_RANGE = Option<unsafe extern "system" fn(domain: *const super::super::Foundation::IOMMU_DMA_DOMAIN, permissions: u32, mdl: *const super::super::Foundation::MDL) -> super::super::super::Win32::Foundation::NTSTATUS>;
@@ -11710,10 +10996,6 @@ impl Default for IOMMU_MAP_PHYSICAL_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IOMMU_MAP_PHYSICAL_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
@@ -11728,10 +11010,6 @@ impl Default for IOMMU_MAP_PHYSICAL_ADDRESS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IOMMU_MAP_PHYSICAL_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11745,10 +11023,6 @@ impl Default for IOMMU_MAP_PHYSICAL_ADDRESS_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IOMMU_MAP_PHYSICAL_ADDRESS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11760,10 +11034,6 @@ impl Default for IOMMU_MAP_PHYSICAL_ADDRESS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IOMMU_MAP_PHYSICAL_ADDRESS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
@@ -11777,10 +11047,6 @@ impl Default for IOMMU_MAP_PHYSICAL_ADDRESS_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IOMMU_MAP_PHYSICAL_ADDRESS_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11830,9 +11096,6 @@ impl Default for IO_ATTRIBUTION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_ATTRIBUTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IO_ATTRIBUTION_INFORMATION_0 {
@@ -11844,9 +11107,6 @@ impl Default for IO_ATTRIBUTION_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_ATTRIBUTION_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_ATTRIBUTION_INFORMATION_0_0 {
@@ -11856,9 +11116,6 @@ impl Default for IO_ATTRIBUTION_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_ATTRIBUTION_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IO_ATTRIBUTION_INFO_V1: u32 = 1u32;
 pub const IO_CHECK_CREATE_PARAMETERS: u32 = 512u32;
@@ -11898,10 +11155,6 @@ impl Default for IO_CONNECT_INTERRUPT_FULLY_SPECIFIED_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_CONNECT_INTERRUPT_FULLY_SPECIFIED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11919,10 +11172,6 @@ impl Default for IO_CONNECT_INTERRUPT_LINE_BASED_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_CONNECT_INTERRUPT_LINE_BASED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -11943,10 +11192,6 @@ impl Default for IO_CONNECT_INTERRUPT_MESSAGE_BASED_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_CONNECT_INTERRUPT_MESSAGE_BASED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -11961,10 +11206,6 @@ impl Default for IO_CONNECT_INTERRUPT_MESSAGE_BASED_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_CONNECT_INTERRUPT_MESSAGE_BASED_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -11977,10 +11218,6 @@ impl Default for IO_CONNECT_INTERRUPT_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_CONNECT_INTERRUPT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -11995,10 +11232,6 @@ impl Default for IO_CONNECT_INTERRUPT_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_CONNECT_INTERRUPT_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12026,10 +11259,6 @@ impl Default for IO_CSQ {
     }
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_CSQ {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type IO_CSQ_ACQUIRE_LOCK = Option<unsafe extern "system" fn(csq: *const IO_CSQ, irql: *mut u8)>;
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type IO_CSQ_COMPLETE_CANCELED_IRP = Option<unsafe extern "system" fn(csq: *const IO_CSQ, irp: *const super::super::Foundation::IRP)>;
@@ -12052,10 +11281,6 @@ impl Default for IO_CSQ_IRP_CONTEXT {
     }
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_CSQ_IRP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type IO_CSQ_PEEK_NEXT_IRP = Option<unsafe extern "system" fn(csq: *const IO_CSQ, irp: *const super::super::Foundation::IRP, peekcontext: *const core::ffi::c_void) -> *mut super::super::Foundation::IRP>;
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type IO_CSQ_RELEASE_LOCK = Option<unsafe extern "system" fn(csq: *const IO_CSQ, irql: u8)>;
@@ -12074,10 +11299,6 @@ impl Default for IO_DISCONNECT_INTERRUPT_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_DISCONNECT_INTERRUPT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
@@ -12091,10 +11312,6 @@ impl Default for IO_DISCONNECT_INTERRUPT_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_DISCONNECT_INTERRUPT_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type IO_DPC_ROUTINE = Option<unsafe extern "system" fn(dpc: *const super::super::Foundation::KDPC, deviceobject: *const super::super::Foundation::DEVICE_OBJECT, irp: *mut super::super::Foundation::IRP, context: *const core::ffi::c_void)>;
@@ -12114,10 +11331,6 @@ impl Default for IO_DRIVER_CREATE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_DRIVER_CREATE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_ERROR_LOG_MESSAGE {
@@ -12132,9 +11345,6 @@ impl Default for IO_ERROR_LOG_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_ERROR_LOG_MESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12158,9 +11368,6 @@ impl Default for IO_ERROR_LOG_PACKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_ERROR_LOG_PACKET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12173,10 +11380,6 @@ impl Default for IO_FOEXT_SHADOW_FILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for IO_FOEXT_SHADOW_FILE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
@@ -12192,10 +11395,6 @@ impl Default for IO_FOEXT_SILO_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_FOEXT_SILO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
@@ -12209,10 +11408,6 @@ impl Default for IO_FOEXT_SILO_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_FOEXT_SILO_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12224,10 +11419,6 @@ impl Default for IO_FOEXT_SILO_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_FOEXT_SILO_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IO_FORCE_ACCESS_CHECK: u32 = 1u32;
 pub const IO_IGNORE_SHARE_ACCESS_CHECK: u32 = 2048u32;
@@ -12244,10 +11435,6 @@ impl Default for IO_INTERRUPT_MESSAGE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_INTERRUPT_MESSAGE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
@@ -12267,10 +11454,6 @@ impl Default for IO_INTERRUPT_MESSAGE_INFO_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_INTERRUPT_MESSAGE_INFO_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IO_KEYBOARD_INCREMENT: u32 = 6u32;
 pub const IO_MOUSE_INCREMENT: u32 = 6u32;
@@ -12300,10 +11483,6 @@ impl Default for IO_REMOVE_LOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for IO_REMOVE_LOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy)]
@@ -12318,10 +11497,6 @@ impl Default for IO_REMOVE_LOCK_COMMON_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for IO_REMOVE_LOCK_COMMON_BLOCK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
@@ -12344,10 +11519,6 @@ impl Default for IO_REMOVE_LOCK_DBG_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for IO_REMOVE_LOCK_DBG_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IO_REPARSE: u32 = 0u32;
 pub const IO_REPARSE_GLOBAL: u32 = 2u32;
 #[repr(C)]
@@ -12363,10 +11534,6 @@ impl Default for IO_REPORT_INTERRUPT_ACTIVE_STATE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_REPORT_INTERRUPT_ACTIVE_STATE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
@@ -12380,10 +11547,6 @@ impl Default for IO_REPORT_INTERRUPT_ACTIVE_STATE_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for IO_REPORT_INTERRUPT_ACTIVE_STATE_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IO_RESOURCE_ALTERNATIVE: u32 = 8u32;
 pub const IO_RESOURCE_DEFAULT: u32 = 2u32;
@@ -12402,9 +11565,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -12428,9 +11588,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_RESOURCE_DESCRIPTOR_0_7 {
@@ -12444,9 +11601,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_RESOURCE_DESCRIPTOR_0_8 {
@@ -12458,9 +11612,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_8 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12477,9 +11628,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_12 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_12 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_RESOURCE_DESCRIPTOR_0_6 {
@@ -12489,9 +11637,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12506,9 +11651,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_RESOURCE_DESCRIPTOR_0_3 {
@@ -12519,9 +11661,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12535,9 +11674,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12553,9 +11689,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_RESOURCE_DESCRIPTOR_0_9 {
@@ -12568,9 +11701,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_9 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12585,9 +11715,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_10 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_10 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_RESOURCE_DESCRIPTOR_0_11 {
@@ -12600,9 +11727,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_11 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12617,9 +11741,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_RESOURCE_DESCRIPTOR_0_0 {
@@ -12633,9 +11754,6 @@ impl Default for IO_RESOURCE_DESCRIPTOR_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_RESOURCE_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IO_RESOURCE_LIST {
@@ -12648,9 +11766,6 @@ impl Default for IO_RESOURCE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_RESOURCE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IO_RESOURCE_PREFERRED: u32 = 1u32;
 #[repr(C)]
@@ -12669,9 +11784,6 @@ impl Default for IO_RESOURCE_REQUIREMENTS_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_RESOURCE_REQUIREMENTS_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IO_SERIAL_INCREMENT: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12683,9 +11795,6 @@ impl Default for IO_SESSION_CONNECT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_SESSION_CONNECT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12711,9 +11820,6 @@ impl Default for IO_SESSION_STATE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_SESSION_STATE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IO_SESSION_STATE_LOGOFF_EVENT: u32 = 32u32;
 pub const IO_SESSION_STATE_LOGON_EVENT: u32 = 16u32;
 #[repr(C)]
@@ -12729,9 +11835,6 @@ impl Default for IO_SESSION_STATE_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_SESSION_STATE_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IO_SESSION_STATE_TERMINATION_EVENT: u32 = 2u32;
 pub const IO_SESSION_STATE_VALID_EVENT_MASK: u32 = 63u32;
@@ -12752,9 +11855,6 @@ impl Default for IO_STATUS_BLOCK32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_STATUS_BLOCK32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IO_STATUS_BLOCK64 {
@@ -12766,9 +11866,6 @@ impl Default for IO_STATUS_BLOCK64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_STATUS_BLOCK64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IO_STATUS_BLOCK64_0 {
@@ -12779,9 +11876,6 @@ impl Default for IO_STATUS_BLOCK64_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_STATUS_BLOCK64_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type IO_TIMER_ROUTINE = Option<unsafe extern "system" fn(deviceobject: *const super::super::Foundation::DEVICE_OBJECT, context: *const core::ffi::c_void)>;
@@ -13028,9 +12122,6 @@ impl Default for KADDRESS_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KADDRESS_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KADDRESS_RANGE_DESCRIPTOR {
@@ -13041,9 +12132,6 @@ impl Default for KADDRESS_RANGE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KADDRESS_RANGE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -13070,10 +12158,6 @@ impl Default for KAPC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KAPC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KBUGCHECK_ADD_PAGES {
@@ -13087,9 +12171,6 @@ impl Default for KBUGCHECK_ADD_PAGES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KBUGCHECK_ADD_PAGES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13115,10 +12196,6 @@ impl Default for KBUGCHECK_CALLBACK_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KBUGCHECK_CALLBACK_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 pub type KBUGCHECK_CALLBACK_ROUTINE = Option<unsafe extern "system" fn(buffer: *mut core::ffi::c_void, length: u32)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13132,9 +12209,6 @@ impl Default for KBUGCHECK_DUMP_IO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KBUGCHECK_DUMP_IO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13157,10 +12231,6 @@ impl Default for KBUGCHECK_REASON_CALLBACK_RECORD {
     }
 }
 #[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KBUGCHECK_REASON_CALLBACK_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_System_Kernel")]
 pub type KBUGCHECK_REASON_CALLBACK_ROUTINE = Option<unsafe extern "system" fn(reason: KBUGCHECK_CALLBACK_REASON, record: *const KBUGCHECK_REASON_CALLBACK_RECORD, reasonspecificdata: *mut core::ffi::c_void, reasonspecificdatalength: u32)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13176,9 +12246,6 @@ impl Default for KBUGCHECK_REMOVE_PAGES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KBUGCHECK_REMOVE_PAGES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KBUGCHECK_SECONDARY_DUMP_DATA {
@@ -13193,9 +12260,6 @@ impl Default for KBUGCHECK_SECONDARY_DUMP_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KBUGCHECK_SECONDARY_DUMP_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13220,9 +12284,6 @@ impl Default for KBUGCHECK_SECONDARY_DUMP_DATA_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KBUGCHECK_SECONDARY_DUMP_DATA_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13241,10 +12302,6 @@ impl Default for KBUGCHECK_TRIAGE_DUMP_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KBUGCHECK_TRIAGE_DUMP_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KB_ADD_PAGES_FLAG_ADDITIONAL_RANGES_EXIST: u32 = 2147483648u32;
 pub const KB_ADD_PAGES_FLAG_PHYSICAL_ADDRESS: u32 = 2u32;
@@ -13271,10 +12328,6 @@ impl Default for KDEVICE_QUEUE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KDEVICE_QUEUE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KDPC_IMPORTANCE(pub i32);
@@ -13291,9 +12344,6 @@ impl Default for KDPC_WATCHDOG_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KDPC_WATCHDOG_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13321,9 +12371,6 @@ impl Default for KERNEL_SOFT_RESTART_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERNEL_SOFT_RESTART_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KERNEL_SOFT_RESTART_NOTIFICATION_VERSION: u32 = 1u32;
 pub const KERNEL_STACK_SIZE: u32 = 12288u32;
 #[repr(C)]
@@ -13339,9 +12386,6 @@ impl Default for KERNEL_USER_TIMES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERNEL_USER_TIMES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEY_BASIC_INFORMATION {
@@ -13354,9 +12398,6 @@ impl Default for KEY_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13375,9 +12416,6 @@ impl Default for KEY_CACHED_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEY_CACHED_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEY_CONTROL_FLAGS_INFORMATION {
@@ -13387,9 +12425,6 @@ impl Default for KEY_CONTROL_FLAGS_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_CONTROL_FLAGS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13411,9 +12446,6 @@ impl Default for KEY_FULL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEY_FULL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEY_LAYER_INFORMATION {
@@ -13423,9 +12455,6 @@ impl Default for KEY_LAYER_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_LAYER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13437,9 +12466,6 @@ impl Default for KEY_NAME_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_NAME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13456,9 +12482,6 @@ impl Default for KEY_NODE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEY_NODE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEY_SET_VIRTUALIZATION_INFORMATION {
@@ -13469,9 +12492,6 @@ impl Default for KEY_SET_VIRTUALIZATION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEY_SET_VIRTUALIZATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEY_TRUST_INFORMATION {
@@ -13481,9 +12501,6 @@ impl Default for KEY_TRUST_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_TRUST_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13497,9 +12514,6 @@ impl Default for KEY_VALUE_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_VALUE_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13516,9 +12530,6 @@ impl Default for KEY_VALUE_FULL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEY_VALUE_FULL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEY_VALUE_LAYER_INFORMATION {
@@ -13528,9 +12539,6 @@ impl Default for KEY_VALUE_LAYER_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_VALUE_LAYER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13545,9 +12553,6 @@ impl Default for KEY_VALUE_PARTIAL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEY_VALUE_PARTIAL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEY_VALUE_PARTIAL_INFORMATION_ALIGN64 {
@@ -13560,9 +12565,6 @@ impl Default for KEY_VALUE_PARTIAL_INFORMATION_ALIGN64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEY_VALUE_PARTIAL_INFORMATION_ALIGN64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEY_VIRTUALIZATION_INFORMATION {
@@ -13572,9 +12574,6 @@ impl Default for KEY_VIRTUALIZATION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_VIRTUALIZATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13586,9 +12585,6 @@ impl Default for KEY_WOW64_FLAGS_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEY_WOW64_FLAGS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEY_WRITE_TIME_INFORMATION {
@@ -13598,9 +12594,6 @@ impl Default for KEY_WRITE_TIME_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_WRITE_TIME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KE_MAX_TRIAGE_DUMP_DATA_MEMORY_SIZE: u32 = 33554432u32;
 pub const KE_PROCESSOR_CHANGE_ADD_EXISTING: u32 = 1u32;
@@ -13618,10 +12611,6 @@ impl Default for KE_PROCESSOR_CHANGE_NOTIFY_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KE_PROCESSOR_CHANGE_NOTIFY_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13643,9 +12632,6 @@ impl Default for KFLOATING_SAVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KFLOATING_SAVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy)]
@@ -13657,10 +12643,6 @@ impl Default for KGATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KGATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13681,9 +12663,6 @@ impl Default for KLOCK_QUEUE_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KLOCK_QUEUE_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type KMESSAGE_SERVICE_ROUTINE = Option<unsafe extern "system" fn(interrupt: *const isize, servicecontext: *const core::ffi::c_void, messageid: u32) -> super::super::super::Win32::Foundation::BOOLEAN>;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13701,10 +12680,6 @@ impl Default for KSEMAPHORE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KSEMAPHORE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type KSERVICE_ROUTINE = Option<unsafe extern "system" fn(interrupt: *const isize, servicecontext: *const core::ffi::c_void) -> super::super::super::Win32::Foundation::BOOLEAN>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13716,9 +12691,6 @@ impl Default for KSPIN_LOCK_QUEUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPIN_LOCK_QUEUE {
-    type TypeKind = windows_core::CopyType;
 }
 pub type KSTART_ROUTINE = Option<unsafe extern "system" fn(startcontext: *const core::ffi::c_void)>;
 pub type KSYNCHRONIZE_ROUTINE = Option<unsafe extern "system" fn(synchronizecontext: *const core::ffi::c_void) -> super::super::super::Win32::Foundation::BOOLEAN>;
@@ -13733,9 +12705,6 @@ impl Default for KSYSTEM_TIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSYSTEM_TIME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
@@ -13752,10 +12721,6 @@ impl Default for KTIMER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KTIMER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -13775,10 +12740,6 @@ impl Default for KTRIAGE_DUMP_DATA_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KTRIAGE_DUMP_DATA_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KUMS_UCH_VOLATILE_BIT: u32 = 0u32;
 #[repr(C)]
@@ -13872,10 +12833,6 @@ impl Default for KUSER_SHARED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KUSER_SHARED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy)]
@@ -13889,10 +12846,6 @@ impl Default for KUSER_SHARED_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KUSER_SHARED_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13905,10 +12858,6 @@ impl Default for KUSER_SHARED_DATA_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KUSER_SHARED_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy)]
@@ -13920,10 +12869,6 @@ impl Default for KUSER_SHARED_DATA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KUSER_SHARED_DATA_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
@@ -13938,10 +12883,6 @@ impl Default for KUSER_SHARED_DATA_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KUSER_SHARED_DATA_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13953,10 +12894,6 @@ impl Default for KUSER_SHARED_DATA_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KUSER_SHARED_DATA_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
@@ -13972,10 +12909,6 @@ impl Default for KUSER_SHARED_DATA_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KUSER_SHARED_DATA_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13988,10 +12921,6 @@ impl Default for KUSER_SHARED_DATA_3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KUSER_SHARED_DATA_3_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
@@ -14006,10 +12935,6 @@ impl Default for KUSER_SHARED_DATA_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KUSER_SHARED_DATA_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14023,10 +12948,6 @@ impl Default for KUSER_SHARED_DATA_4_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for KUSER_SHARED_DATA_4_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KWAIT_CHAIN {
@@ -14036,9 +12957,6 @@ impl Default for KWAIT_CHAIN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KWAIT_CHAIN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14108,9 +13026,6 @@ impl Default for LEGACY_BUS_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LEGACY_BUS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LINK_SHARE_ACCESS {
@@ -14122,9 +13037,6 @@ impl Default for LINK_SHARE_ACCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINK_SHARE_ACCESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14139,9 +13051,6 @@ impl Default for LOADER_PARTITION_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOADER_PARTITION_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union LOADER_PARTITION_INFORMATION_EX_0 {
@@ -14152,9 +13061,6 @@ impl Default for LOADER_PARTITION_INFORMATION_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LOADER_PARTITION_INFORMATION_EX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14204,9 +13110,6 @@ impl Default for MAILSLOT_CREATE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MAILSLOT_CREATE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MAP_REGISTER_ENTRY {
@@ -14217,9 +13120,6 @@ impl Default for MAP_REGISTER_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MAP_REGISTER_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MAXIMUM_DEBUG_BARS: u32 = 6u32;
 pub const MAXIMUM_FILENAME_LENGTH: u32 = 256u32;
@@ -14239,10 +13139,6 @@ impl Default for MCA_DRIVER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for MCA_DRIVER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MCA_EXCEPTION {
@@ -14261,9 +13157,6 @@ impl Default for MCA_EXCEPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCA_EXCEPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MCA_EXCEPTION_0 {
@@ -14274,9 +13167,6 @@ impl Default for MCA_EXCEPTION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCA_EXCEPTION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14292,9 +13182,6 @@ impl Default for MCA_EXCEPTION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCA_EXCEPTION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MCA_EXCEPTION_0_1 {
@@ -14305,9 +13192,6 @@ impl Default for MCA_EXCEPTION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCA_EXCEPTION_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14325,9 +13209,6 @@ impl Default for MCG_CAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCG_CAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCG_CAP_0 {
@@ -14337,9 +13218,6 @@ impl Default for MCG_CAP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCG_CAP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -14352,9 +13230,6 @@ impl Default for MCG_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCG_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCG_STATUS_0 {
@@ -14365,9 +13240,6 @@ impl Default for MCG_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCG_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14380,9 +13252,6 @@ impl Default for MCI_ADDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_ADDR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MCI_ADDR_0 {
@@ -14393,9 +13262,6 @@ impl Default for MCI_ADDR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_ADDR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14408,9 +13274,6 @@ impl Default for MCI_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MCI_STATS_0 {
@@ -14422,9 +13285,6 @@ impl Default for MCI_STATS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_STATS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -14439,9 +13299,6 @@ impl Default for MCI_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_STATUS_AMD_BITS {
@@ -14451,9 +13308,6 @@ impl Default for MCI_STATUS_AMD_BITS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_STATUS_AMD_BITS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -14465,9 +13319,6 @@ impl Default for MCI_STATUS_BITS_COMMON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_STATUS_BITS_COMMON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_STATUS_INTEL_BITS {
@@ -14477,9 +13328,6 @@ impl Default for MCI_STATUS_INTEL_BITS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_STATUS_INTEL_BITS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MDL_ALLOCATED_FIXED_SIZE: u32 = 8u32;
 pub const MDL_DESCRIBES_AWE: u32 = 1024u32;
@@ -14507,9 +13355,6 @@ impl Default for MEMORY_PARTITION_DEDICATED_MEMORY_OPEN_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEMORY_PARTITION_DEDICATED_MEMORY_OPEN_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MEM_COMMIT: u32 = 4096u32;
 pub const MEM_DECOMMIT: u32 = 16384u32;
@@ -14552,9 +13397,6 @@ impl Default for MM_COPY_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MM_COPY_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MM_COPY_ADDRESS_0 {
@@ -14565,9 +13407,6 @@ impl Default for MM_COPY_ADDRESS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MM_COPY_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MM_COPY_MEMORY_PHYSICAL: u32 = 1u32;
 pub const MM_COPY_MEMORY_VIRTUAL: u32 = 2u32;
@@ -14598,9 +13437,6 @@ impl Default for MM_PHYSICAL_ADDRESS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MM_PHYSICAL_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MM_PROTECT_DRIVER_SECTION_ALLOW_UNLOAD: u32 = 1u32;
 pub const MM_PROTECT_DRIVER_SECTION_VALID_FLAGS: u32 = 1u32;
@@ -14640,9 +13476,6 @@ impl Default for MU_TELEMETRY_SECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MU_TELEMETRY_SECTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MU_TELEMETRY_SECTION_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x85183a8b_9c41_429c_939c_5c3c087ca280);
 pub const MapPhysicalAddressTypeContiguousRange: IOMMU_MAP_PHYSICAL_ADDRESS_TYPE = IOMMU_MAP_PHYSICAL_ADDRESS_TYPE(1i32);
@@ -14784,9 +13617,6 @@ impl Default for NAMED_PIPE_CREATE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NAMED_PIPE_CREATE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NEC98x86: ALTERNATIVE_ARCHITECTURE_TYPE = ALTERNATIVE_ARCHITECTURE_TYPE(1i32);
 pub type NMI_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, handled: super::super::super::Win32::Foundation::BOOLEAN) -> super::super::super::Win32::Foundation::BOOLEAN>;
 pub const NMI_NOTIFY_TYPE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x5bad89ff_b7e6_42c9_814a_cf2485d6e98a);
@@ -14802,9 +13632,6 @@ impl Default for NPEM_CAPABILITY_STANDARD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NPEM_CAPABILITY_STANDARD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NPEM_CAPABILITY_STANDARD_0 {
@@ -14814,9 +13641,6 @@ impl Default for NPEM_CAPABILITY_STANDARD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NPEM_CAPABILITY_STANDARD_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type NPEM_CONTROL_ENABLE_DISABLE = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, enablenpem: super::super::super::Win32::Foundation::BOOLEAN) -> super::super::super::Win32::Foundation::NTSTATUS>;
 #[repr(C)]
@@ -14836,9 +13660,6 @@ impl Default for NPEM_CONTROL_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NPEM_CONTROL_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NPEM_CONTROL_INTERFACE_CURRENT_VERSION: u32 = 2u32;
 pub const NPEM_CONTROL_INTERFACE_VERSION1: u32 = 1u32;
@@ -14868,9 +13689,6 @@ impl Default for NT_TIB32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NT_TIB32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NT_TIB32_0 {
@@ -14881,9 +13699,6 @@ impl Default for NT_TIB32_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NT_TIB32_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NX_SUPPORT_POLICY_ALWAYSOFF: u32 = 0u32;
 pub const NX_SUPPORT_POLICY_ALWAYSON: u32 = 1u32;
@@ -14910,9 +13725,6 @@ impl Default for OBJECT_HANDLE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OBJECT_HANDLE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OBJECT_TYPE_CREATE: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
@@ -14929,10 +13741,6 @@ impl Default for OB_CALLBACK_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for OB_CALLBACK_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OB_FLT_REGISTRATION_VERSION: u32 = 256u32;
 pub const OB_FLT_REGISTRATION_VERSION_0100: u32 = 256u32;
@@ -14953,10 +13761,6 @@ impl Default for OB_OPERATION_REGISTRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for OB_OPERATION_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OB_POST_CREATE_HANDLE_INFORMATION {
@@ -14967,9 +13771,6 @@ impl Default for OB_POST_CREATE_HANDLE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OB_POST_CREATE_HANDLE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OB_POST_DUPLICATE_HANDLE_INFORMATION {
@@ -14979,9 +13780,6 @@ impl Default for OB_POST_DUPLICATE_HANDLE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OB_POST_DUPLICATE_HANDLE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
@@ -15001,10 +13799,6 @@ impl Default for OB_POST_OPERATION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for OB_POST_OPERATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
@@ -15018,10 +13812,6 @@ impl Default for OB_POST_OPERATION_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for OB_POST_OPERATION_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15034,10 +13824,6 @@ impl Default for OB_POST_OPERATION_INFORMATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for OB_POST_OPERATION_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union OB_POST_OPERATION_PARAMETERS {
@@ -15048,9 +13834,6 @@ impl Default for OB_POST_OPERATION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OB_POST_OPERATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -15067,9 +13850,6 @@ impl Default for OB_PRE_CREATE_HANDLE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OB_PRE_CREATE_HANDLE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OB_PRE_DUPLICATE_HANDLE_INFORMATION {
@@ -15082,9 +13862,6 @@ impl Default for OB_PRE_DUPLICATE_HANDLE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OB_PRE_DUPLICATE_HANDLE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
@@ -15103,10 +13880,6 @@ impl Default for OB_PRE_OPERATION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for OB_PRE_OPERATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
@@ -15120,10 +13893,6 @@ impl Default for OB_PRE_OPERATION_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for OB_PRE_OPERATION_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15136,10 +13905,6 @@ impl Default for OB_PRE_OPERATION_INFORMATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for OB_PRE_OPERATION_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union OB_PRE_OPERATION_PARAMETERS {
@@ -15150,9 +13915,6 @@ impl Default for OB_PRE_OPERATION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OB_PRE_OPERATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPLOCK_KEY_FLAG_PARENT_KEY: u32 = 1u32;
 pub const OPLOCK_KEY_FLAG_TARGET_KEY: u32 = 2u32;
@@ -15192,9 +13954,6 @@ impl Default for PAGE_PRIORITY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PAGE_PRIORITY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PAGE_READONLY: u32 = 2u32;
 pub const PAGE_READWRITE: u32 = 4u32;
@@ -15269,9 +14028,6 @@ impl Default for PCIBUSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCIBUSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCIBus: INTERFACE_TYPE = INTERFACE_TYPE(5i32);
 pub const PCIConfiguration: BUS_DATA_TYPE = BUS_DATA_TYPE(4i32);
 pub const PCIEXPRESS_ERROR_SECTION_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xd995e954_bbc1_430f_ad91_b44dcb3c6f35);
@@ -15306,9 +14062,6 @@ impl Default for PCIX_BRIDGE_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCIX_BRIDGE_CAPABILITY_1 {
@@ -15320,9 +14073,6 @@ impl Default for PCIX_BRIDGE_CAPABILITY_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCIX_BRIDGE_CAPABILITY_1_0 {
@@ -15332,9 +14082,6 @@ impl Default for PCIX_BRIDGE_CAPABILITY_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -15347,9 +14094,6 @@ impl Default for PCIX_BRIDGE_CAPABILITY_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCIX_BRIDGE_CAPABILITY_2_0 {
@@ -15359,9 +14103,6 @@ impl Default for PCIX_BRIDGE_CAPABILITY_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -15374,9 +14115,6 @@ impl Default for PCIX_BRIDGE_CAPABILITY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCIX_BRIDGE_CAPABILITY_0_0 {
@@ -15386,9 +14124,6 @@ impl Default for PCIX_BRIDGE_CAPABILITY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCIX_BRIDGE_CAPABILITY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCIX_MODE1_100MHZ: u32 = 2u32;
 pub const PCIX_MODE1_133MHZ: u32 = 3u32;
@@ -15429,9 +14164,6 @@ impl Default for PCI_ADVANCED_FEATURES_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_ADVANCED_FEATURES_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_ADVANCED_FEATURES_CAPABILITY_0 {
@@ -15443,9 +14175,6 @@ impl Default for PCI_ADVANCED_FEATURES_CAPABILITY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_ADVANCED_FEATURES_CAPABILITY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_ADVANCED_FEATURES_CAPABILITY_0_0 {
@@ -15455,9 +14184,6 @@ impl Default for PCI_ADVANCED_FEATURES_CAPABILITY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_ADVANCED_FEATURES_CAPABILITY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -15470,9 +14196,6 @@ impl Default for PCI_ADVANCED_FEATURES_CAPABILITY_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_ADVANCED_FEATURES_CAPABILITY_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_ADVANCED_FEATURES_CAPABILITY_1_0 {
@@ -15482,9 +14205,6 @@ impl Default for PCI_ADVANCED_FEATURES_CAPABILITY_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_ADVANCED_FEATURES_CAPABILITY_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -15497,9 +14217,6 @@ impl Default for PCI_ADVANCED_FEATURES_CAPABILITY_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_ADVANCED_FEATURES_CAPABILITY_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_ADVANCED_FEATURES_CAPABILITY_2_0 {
@@ -15510,9 +14227,6 @@ impl Default for PCI_ADVANCED_FEATURES_CAPABILITY_2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_ADVANCED_FEATURES_CAPABILITY_2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_AGP_APERTURE_PAGE_SIZE {
@@ -15522,9 +14236,6 @@ impl Default for PCI_AGP_APERTURE_PAGE_SIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_AGP_APERTURE_PAGE_SIZE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15539,9 +14250,6 @@ impl Default for PCI_AGP_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_AGP_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_AGP_CAPABILITY_1 {
@@ -15551,9 +14259,6 @@ impl Default for PCI_AGP_CAPABILITY_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_AGP_CAPABILITY_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15565,9 +14270,6 @@ impl Default for PCI_AGP_CAPABILITY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_AGP_CAPABILITY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_AGP_CONTROL {
@@ -15577,9 +14279,6 @@ impl Default for PCI_AGP_CONTROL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_AGP_CONTROL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15597,9 +14296,6 @@ impl Default for PCI_AGP_EXTENDED_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_AGP_EXTENDED_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_AGP_ISOCH_COMMAND {
@@ -15610,9 +14306,6 @@ impl Default for PCI_AGP_ISOCH_COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_AGP_ISOCH_COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_AGP_ISOCH_STATUS {
@@ -15622,9 +14315,6 @@ impl Default for PCI_AGP_ISOCH_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_AGP_ISOCH_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_AGP_RATE_1X: u32 = 1u32;
 pub const PCI_AGP_RATE_2X: u32 = 2u32;
@@ -15644,9 +14334,6 @@ impl Default for PCI_ATS_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_ATS_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_ATS_INTERFACE_VERSION: u32 = 1u32;
 pub const PCI_BRIDGE_TYPE: u32 = 1u32;
@@ -15671,9 +14358,6 @@ impl Default for PCI_BUS_INTERFACE_STANDARD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_BUS_INTERFACE_STANDARD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_BUS_INTERFACE_STANDARD_VERSION: u32 = 2u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -15688,9 +14372,6 @@ impl Default for PCI_CAPABILITIES_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_CAPABILITIES_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_CAPABILITY_ID_ADVANCED_FEATURES: u32 = 19u32;
 pub const PCI_CAPABILITY_ID_AGP: u32 = 2u32;
@@ -15743,9 +14424,6 @@ impl Default for PCI_COMMON_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_COMMON_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PCI_COMMON_HEADER {
@@ -15768,9 +14446,6 @@ impl Default for PCI_COMMON_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_COMMON_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_COMMON_HEADER_0 {
@@ -15782,9 +14457,6 @@ impl Default for PCI_COMMON_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_COMMON_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15806,9 +14478,6 @@ impl Default for PCI_COMMON_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_COMMON_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15841,9 +14510,6 @@ impl Default for PCI_COMMON_HEADER_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_COMMON_HEADER_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_COMMON_HEADER_0_2 {
@@ -15865,9 +14531,6 @@ impl Default for PCI_COMMON_HEADER_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_COMMON_HEADER_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_COMMON_HEADER_0_2_0 {
@@ -15878,9 +14541,6 @@ impl Default for PCI_COMMON_HEADER_0_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_COMMON_HEADER_0_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_DATA_VERSION: u32 = 1u32;
 #[repr(C)]
@@ -15894,9 +14554,6 @@ impl Default for PCI_DEBUGGING_DEVICE_IN_USE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_DEBUGGING_DEVICE_IN_USE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -15920,9 +14577,6 @@ impl Default for PCI_DEVICE_PRESENCE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_DEVICE_PRESENCE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_DEVICE_PRESENT_INTERFACE {
@@ -15938,9 +14592,6 @@ impl Default for PCI_DEVICE_PRESENT_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_DEVICE_PRESENT_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_DEVICE_PRESENT_INTERFACE_VERSION: u32 = 1u32;
 pub const PCI_DEVICE_TYPE: u32 = 0u32;
@@ -15970,9 +14621,6 @@ impl Default for PCI_EXPRESS_ACS_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ACS_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_ACS_CAPABILITY_REGISTER {
@@ -15984,9 +14632,6 @@ impl Default for PCI_EXPRESS_ACS_CAPABILITY_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ACS_CAPABILITY_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ACS_CAPABILITY_REGISTER_0 {
@@ -15996,9 +14641,6 @@ impl Default for PCI_EXPRESS_ACS_CAPABILITY_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ACS_CAPABILITY_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16011,9 +14653,6 @@ impl Default for PCI_EXPRESS_ACS_CONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ACS_CONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ACS_CONTROL_0 {
@@ -16023,9 +14662,6 @@ impl Default for PCI_EXPRESS_ACS_CONTROL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ACS_CONTROL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_ADVANCED_ERROR_REPORTING_CAP_ID: u32 = 1u32;
 #[repr(C)]
@@ -16039,9 +14675,6 @@ impl Default for PCI_EXPRESS_AER_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_AER_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_AER_CAPABILITIES_0 {
@@ -16051,9 +14684,6 @@ impl Default for PCI_EXPRESS_AER_CAPABILITIES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_AER_CAPABILITIES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16077,9 +14707,6 @@ impl Default for PCI_EXPRESS_AER_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_AER_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ARI_CAPABILITY {
@@ -16092,9 +14719,6 @@ impl Default for PCI_EXPRESS_ARI_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ARI_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ARI_CAPABILITY_REGISTER {
@@ -16104,9 +14728,6 @@ impl Default for PCI_EXPRESS_ARI_CAPABILITY_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ARI_CAPABILITY_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_ARI_CAP_ID: u32 = 14u32;
 #[repr(C)]
@@ -16118,9 +14739,6 @@ impl Default for PCI_EXPRESS_ARI_CONTROL_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ARI_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -16140,9 +14758,6 @@ impl Default for PCI_EXPRESS_ATS_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ATS_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ATS_CAPABILITY_REGISTER {
@@ -16152,9 +14767,6 @@ impl Default for PCI_EXPRESS_ATS_CAPABILITY_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ATS_CAPABILITY_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_ATS_CAP_ID: u32 = 15u32;
 #[repr(C)]
@@ -16168,9 +14780,6 @@ impl Default for PCI_EXPRESS_ATS_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ATS_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ATS_CONTROL_REGISTER_0 {
@@ -16180,9 +14789,6 @@ impl Default for PCI_EXPRESS_ATS_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ATS_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16206,9 +14812,6 @@ impl Default for PCI_EXPRESS_BRIDGE_AER_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_BRIDGE_AER_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_CAPABILITIES_REGISTER {
@@ -16220,9 +14823,6 @@ impl Default for PCI_EXPRESS_CAPABILITIES_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CAPABILITIES_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CAPABILITIES_REGISTER_0 {
@@ -16232,9 +14832,6 @@ impl Default for PCI_EXPRESS_CAPABILITIES_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_CAPABILITIES_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16265,9 +14862,6 @@ impl Default for PCI_EXPRESS_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PCI_EXPRESS_CARD_PRESENCE(pub i32);
@@ -16283,9 +14877,6 @@ impl Default for PCI_EXPRESS_CORRECTABLE_ERROR_MASK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CORRECTABLE_ERROR_MASK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CORRECTABLE_ERROR_MASK_0 {
@@ -16295,9 +14886,6 @@ impl Default for PCI_EXPRESS_CORRECTABLE_ERROR_MASK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_CORRECTABLE_ERROR_MASK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16310,9 +14898,6 @@ impl Default for PCI_EXPRESS_CORRECTABLE_ERROR_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CORRECTABLE_ERROR_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CORRECTABLE_ERROR_STATUS_0 {
@@ -16322,9 +14907,6 @@ impl Default for PCI_EXPRESS_CORRECTABLE_ERROR_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_CORRECTABLE_ERROR_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16339,9 +14921,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_CXL_DVSEC_CAPABILITY_REGISTER_V11 {
@@ -16353,9 +14932,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_CAPABILITY_REGISTER_V11 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_CAPABILITY_REGISTER_V11 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CXL_DVSEC_CAPABILITY_REGISTER_V11_0 {
@@ -16365,9 +14941,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_CAPABILITY_REGISTER_V11_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_CAPABILITY_REGISTER_V11_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16396,9 +14969,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_CAPABILITY_V11 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_CAPABILITY_V11 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_CXL_DVSEC_CONTROL_REGISTER {
@@ -16410,9 +14980,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CXL_DVSEC_CONTROL_REGISTER_0 {
@@ -16422,9 +14989,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16437,9 +15001,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_LOCK_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_LOCK_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CXL_DVSEC_LOCK_REGISTER_0 {
@@ -16450,9 +15011,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_LOCK_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_LOCK_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CXL_DVSEC_RANGE_BASE_HIGH_REGISTER {
@@ -16462,9 +15020,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_RANGE_BASE_HIGH_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_RANGE_BASE_HIGH_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16477,9 +15032,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_RANGE_BASE_LOW_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_RANGE_BASE_LOW_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CXL_DVSEC_RANGE_BASE_LOW_REGISTER_0 {
@@ -16490,9 +15042,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_RANGE_BASE_LOW_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_RANGE_BASE_LOW_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CXL_DVSEC_RANGE_SIZE_HIGH_REGISTER {
@@ -16502,9 +15051,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_RANGE_SIZE_HIGH_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_RANGE_SIZE_HIGH_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16517,9 +15063,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_RANGE_SIZE_LOW_REGISTER_V11 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_RANGE_SIZE_LOW_REGISTER_V11 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CXL_DVSEC_RANGE_SIZE_LOW_REGISTER_V11_0 {
@@ -16529,9 +15072,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_RANGE_SIZE_LOW_REGISTER_V11_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_RANGE_SIZE_LOW_REGISTER_V11_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16544,9 +15084,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_STATUS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_CXL_DVSEC_STATUS_REGISTER_0 {
@@ -16556,9 +15093,6 @@ impl Default for PCI_EXPRESS_CXL_DVSEC_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_CXL_DVSEC_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16573,9 +15107,6 @@ impl Default for PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_CAP_ID: u32 = 35u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16588,9 +15119,6 @@ impl Default for PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_1_0 {
@@ -16600,9 +15128,6 @@ impl Default for PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16615,9 +15140,6 @@ impl Default for PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_2_0 {
@@ -16627,9 +15149,6 @@ impl Default for PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DESIGNATED_VENDOR_SPECIFIC_HEADER_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16642,9 +15161,6 @@ impl Default for PCI_EXPRESS_DEVICE_CAPABILITIES_2_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_CAPABILITIES_2_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DEVICE_CAPABILITIES_2_REGISTER_0 {
@@ -16654,9 +15170,6 @@ impl Default for PCI_EXPRESS_DEVICE_CAPABILITIES_2_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_CAPABILITIES_2_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16669,9 +15182,6 @@ impl Default for PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER_0 {
@@ -16681,9 +15191,6 @@ impl Default for PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_CAPABILITIES_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16696,9 +15203,6 @@ impl Default for PCI_EXPRESS_DEVICE_CONTROL_2_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_CONTROL_2_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DEVICE_CONTROL_2_REGISTER_0 {
@@ -16708,9 +15212,6 @@ impl Default for PCI_EXPRESS_DEVICE_CONTROL_2_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_CONTROL_2_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16724,9 +15225,6 @@ impl Default for PCI_EXPRESS_DEVICE_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DEVICE_CONTROL_REGISTER_0 {
@@ -16737,9 +15235,6 @@ impl Default for PCI_EXPRESS_DEVICE_CONTROL_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DEVICE_CONTROL_REGISTER_1 {
@@ -16749,9 +15244,6 @@ impl Default for PCI_EXPRESS_DEVICE_CONTROL_REGISTER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_CONTROL_REGISTER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_DEVICE_SERIAL_NUMBER_CAP_ID: u32 = 3u32;
 #[repr(C)]
@@ -16765,9 +15257,6 @@ impl Default for PCI_EXPRESS_DEVICE_STATUS_2_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_STATUS_2_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DEVICE_STATUS_2_REGISTER_0 {
@@ -16777,9 +15266,6 @@ impl Default for PCI_EXPRESS_DEVICE_STATUS_2_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_STATUS_2_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16792,9 +15278,6 @@ impl Default for PCI_EXPRESS_DEVICE_STATUS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DEVICE_STATUS_REGISTER_0 {
@@ -16804,9 +15287,6 @@ impl Default for PCI_EXPRESS_DEVICE_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DEVICE_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -16834,9 +15314,6 @@ impl Default for PCI_EXPRESS_DPC_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_DPC_CAPS_REGISTER {
@@ -16848,9 +15325,6 @@ impl Default for PCI_EXPRESS_DPC_CAPS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_CAPS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DPC_CAPS_REGISTER_0 {
@@ -16860,9 +15334,6 @@ impl Default for PCI_EXPRESS_DPC_CAPS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_CAPS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_DPC_CAP_ID: u32 = 29u32;
 #[repr(C)]
@@ -16876,9 +15347,6 @@ impl Default for PCI_EXPRESS_DPC_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DPC_CONTROL_REGISTER_0 {
@@ -16888,9 +15356,6 @@ impl Default for PCI_EXPRESS_DPC_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16903,9 +15368,6 @@ impl Default for PCI_EXPRESS_DPC_ERROR_SOURCE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_ERROR_SOURCE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DPC_ERROR_SOURCE_ID_0 {
@@ -16915,9 +15377,6 @@ impl Default for PCI_EXPRESS_DPC_ERROR_SOURCE_ID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_ERROR_SOURCE_ID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16930,9 +15389,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_EXCEPTION_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_EXCEPTION_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DPC_RP_PIO_EXCEPTION_REGISTER_0 {
@@ -16942,9 +15398,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_EXCEPTION_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_EXCEPTION_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16956,9 +15409,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_HEADERLOG_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_HEADERLOG_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_DPC_RP_PIO_IMPSPECLOG_REGISTER {
@@ -16968,9 +15418,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_IMPSPECLOG_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_IMPSPECLOG_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16983,9 +15430,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_MASK_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_MASK_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DPC_RP_PIO_MASK_REGISTER_0 {
@@ -16995,9 +15439,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_MASK_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_MASK_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17010,9 +15451,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_SEVERITY_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_SEVERITY_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DPC_RP_PIO_SEVERITY_REGISTER_0 {
@@ -17022,9 +15460,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_SEVERITY_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_SEVERITY_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17037,9 +15472,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_STATUS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DPC_RP_PIO_STATUS_REGISTER_0 {
@@ -17049,9 +15481,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17064,9 +15493,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_SYSERR_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_SYSERR_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DPC_RP_PIO_SYSERR_REGISTER_0 {
@@ -17077,9 +15503,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_SYSERR_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_SYSERR_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DPC_RP_PIO_TLPPREFIXLOG_REGISTER {
@@ -17089,9 +15512,6 @@ impl Default for PCI_EXPRESS_DPC_RP_PIO_TLPPREFIXLOG_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_RP_PIO_TLPPREFIXLOG_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17104,9 +15524,6 @@ impl Default for PCI_EXPRESS_DPC_STATUS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_DPC_STATUS_REGISTER_0 {
@@ -17116,9 +15533,6 @@ impl Default for PCI_EXPRESS_DPC_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_DPC_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -17130,9 +15544,6 @@ impl Default for PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ENHANCED_CAPABILITY_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PCI_EXPRESS_ENTER_LINK_QUIESCENT_MODE = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void) -> super::super::super::Win32::Foundation::NTSTATUS>;
 #[repr(C)]
@@ -17146,9 +15557,6 @@ impl Default for PCI_EXPRESS_ERROR_SOURCE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ERROR_SOURCE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ERROR_SOURCE_ID_0 {
@@ -17160,9 +15568,6 @@ impl Default for PCI_EXPRESS_ERROR_SOURCE_ID_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ERROR_SOURCE_ID_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_EVENT_COLLECTOR_ENDPOINT_ASSOCIATION_CAPABILITY {
@@ -17173,9 +15578,6 @@ impl Default for PCI_EXPRESS_EVENT_COLLECTOR_ENDPOINT_ASSOCIATION_CAPABILITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_EVENT_COLLECTOR_ENDPOINT_ASSOCIATION_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PCI_EXPRESS_EXIT_LINK_QUIESCENT_MODE = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void) -> super::super::super::Win32::Foundation::NTSTATUS>;
 pub const PCI_EXPRESS_FRS_QUEUEING_CAP_ID: u32 = 33u32;
@@ -17199,9 +15601,6 @@ impl Default for PCI_EXPRESS_L1_PM_SS_CAPABILITIES_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_L1_PM_SS_CAPABILITIES_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_L1_PM_SS_CAPABILITIES_REGISTER_0 {
@@ -17211,9 +15610,6 @@ impl Default for PCI_EXPRESS_L1_PM_SS_CAPABILITIES_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_L1_PM_SS_CAPABILITIES_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17228,9 +15624,6 @@ impl Default for PCI_EXPRESS_L1_PM_SS_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_L1_PM_SS_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_EXPRESS_L1_PM_SS_CAP_ID: u32 = 30u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17243,9 +15636,6 @@ impl Default for PCI_EXPRESS_L1_PM_SS_CONTROL_1_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_L1_PM_SS_CONTROL_1_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_L1_PM_SS_CONTROL_1_REGISTER_0 {
@@ -17255,9 +15645,6 @@ impl Default for PCI_EXPRESS_L1_PM_SS_CONTROL_1_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_L1_PM_SS_CONTROL_1_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17270,9 +15657,6 @@ impl Default for PCI_EXPRESS_L1_PM_SS_CONTROL_2_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_L1_PM_SS_CONTROL_2_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_L1_PM_SS_CONTROL_2_REGISTER_0 {
@@ -17283,9 +15667,6 @@ impl Default for PCI_EXPRESS_L1_PM_SS_CONTROL_2_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_L1_PM_SS_CONTROL_2_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_LANE_ERROR_STATUS {
@@ -17295,9 +15676,6 @@ impl Default for PCI_EXPRESS_LANE_ERROR_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_LANE_ERROR_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17310,9 +15688,6 @@ impl Default for PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER_0 {
@@ -17322,9 +15697,6 @@ impl Default for PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CAPABILITIES_2_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17337,9 +15709,6 @@ impl Default for PCI_EXPRESS_LINK_CAPABILITIES_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CAPABILITIES_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_LINK_CAPABILITIES_REGISTER_0 {
@@ -17350,9 +15719,6 @@ impl Default for PCI_EXPRESS_LINK_CAPABILITIES_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CAPABILITIES_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PCI_EXPRESS_LINK_CONTROL3 {
@@ -17362,9 +15728,6 @@ impl Default for PCI_EXPRESS_LINK_CONTROL3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CONTROL3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17377,9 +15740,6 @@ impl Default for PCI_EXPRESS_LINK_CONTROL3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CONTROL3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_LINK_CONTROL3_0_0 {
@@ -17389,9 +15749,6 @@ impl Default for PCI_EXPRESS_LINK_CONTROL3_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CONTROL3_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17404,9 +15761,6 @@ impl Default for PCI_EXPRESS_LINK_CONTROL_2_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CONTROL_2_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_LINK_CONTROL_2_REGISTER_0 {
@@ -17416,9 +15770,6 @@ impl Default for PCI_EXPRESS_LINK_CONTROL_2_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CONTROL_2_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17431,9 +15782,6 @@ impl Default for PCI_EXPRESS_LINK_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_LINK_CONTROL_REGISTER_0 {
@@ -17443,9 +15791,6 @@ impl Default for PCI_EXPRESS_LINK_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -17463,9 +15808,6 @@ impl Default for PCI_EXPRESS_LINK_QUIESCENT_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_QUIESCENT_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_EXPRESS_LINK_QUIESCENT_INTERFACE_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17478,9 +15820,6 @@ impl Default for PCI_EXPRESS_LINK_STATUS_2_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_STATUS_2_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_LINK_STATUS_2_REGISTER_0 {
@@ -17490,9 +15829,6 @@ impl Default for PCI_EXPRESS_LINK_STATUS_2_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_STATUS_2_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17505,9 +15841,6 @@ impl Default for PCI_EXPRESS_LINK_STATUS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_LINK_STATUS_REGISTER_0 {
@@ -17517,9 +15850,6 @@ impl Default for PCI_EXPRESS_LINK_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_LINK_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17536,9 +15866,6 @@ impl Default for PCI_EXPRESS_LTR_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LTR_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_EXPRESS_LTR_CAP_ID: u32 = 24u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17551,9 +15878,6 @@ impl Default for PCI_EXPRESS_LTR_MAX_LATENCY_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_LTR_MAX_LATENCY_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_LTR_MAX_LATENCY_REGISTER_0 {
@@ -17563,9 +15887,6 @@ impl Default for PCI_EXPRESS_LTR_MAX_LATENCY_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_LTR_MAX_LATENCY_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17590,9 +15911,6 @@ impl Default for PCI_EXPRESS_NPEM_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_NPEM_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_NPEM_CAPABILITY_REGISTER {
@@ -17604,9 +15922,6 @@ impl Default for PCI_EXPRESS_NPEM_CAPABILITY_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_NPEM_CAPABILITY_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_NPEM_CAPABILITY_REGISTER_0 {
@@ -17616,9 +15931,6 @@ impl Default for PCI_EXPRESS_NPEM_CAPABILITY_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_NPEM_CAPABILITY_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_NPEM_CAP_ID: u32 = 41u32;
 #[repr(C)]
@@ -17632,9 +15944,6 @@ impl Default for PCI_EXPRESS_NPEM_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_NPEM_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_NPEM_CONTROL_REGISTER_0 {
@@ -17644,9 +15953,6 @@ impl Default for PCI_EXPRESS_NPEM_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_NPEM_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17659,9 +15965,6 @@ impl Default for PCI_EXPRESS_NPEM_STATUS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_NPEM_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_NPEM_STATUS_REGISTER_0 {
@@ -17671,9 +15974,6 @@ impl Default for PCI_EXPRESS_NPEM_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_NPEM_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_PAGE_REQUEST_CAP_ID: u32 = 19u32;
 #[repr(C)]
@@ -17688,9 +15988,6 @@ impl Default for PCI_EXPRESS_PASID_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_PASID_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_PASID_CAPABILITY_REGISTER {
@@ -17702,9 +15999,6 @@ impl Default for PCI_EXPRESS_PASID_CAPABILITY_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_PASID_CAPABILITY_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_PASID_CAPABILITY_REGISTER_0 {
@@ -17714,9 +16008,6 @@ impl Default for PCI_EXPRESS_PASID_CAPABILITY_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_PASID_CAPABILITY_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_PASID_CAP_ID: u32 = 27u32;
 #[repr(C)]
@@ -17730,9 +16021,6 @@ impl Default for PCI_EXPRESS_PASID_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_PASID_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_PASID_CONTROL_REGISTER_0 {
@@ -17742,9 +16030,6 @@ impl Default for PCI_EXPRESS_PASID_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_PASID_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17757,9 +16042,6 @@ impl Default for PCI_EXPRESS_PME_REQUESTOR_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_PME_REQUESTOR_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_PME_REQUESTOR_ID_0 {
@@ -17769,9 +16051,6 @@ impl Default for PCI_EXPRESS_PME_REQUESTOR_ID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_PME_REQUESTOR_ID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_PMUX_CAP_ID: u32 = 26u32;
 pub const PCI_EXPRESS_POWER_BUDGETING_CAP_ID: u32 = 4u32;
@@ -17792,9 +16071,6 @@ impl Default for PCI_EXPRESS_PRI_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_PRI_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_PRI_CONTROL_REGISTER {
@@ -17806,9 +16082,6 @@ impl Default for PCI_EXPRESS_PRI_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_PRI_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_PRI_CONTROL_REGISTER_0 {
@@ -17818,9 +16091,6 @@ impl Default for PCI_EXPRESS_PRI_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_PRI_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17833,9 +16103,6 @@ impl Default for PCI_EXPRESS_PRI_STATUS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_PRI_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_PRI_STATUS_REGISTER_0 {
@@ -17845,9 +16112,6 @@ impl Default for PCI_EXPRESS_PRI_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_PRI_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -17861,9 +16125,6 @@ impl Default for PCI_EXPRESS_PTM_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_PTM_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_PTM_CAPABILITY_REGISTER {
@@ -17875,9 +16136,6 @@ impl Default for PCI_EXPRESS_PTM_CAPABILITY_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_PTM_CAPABILITY_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_PTM_CAPABILITY_REGISTER_0 {
@@ -17887,9 +16145,6 @@ impl Default for PCI_EXPRESS_PTM_CAPABILITY_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_PTM_CAPABILITY_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_PTM_CAP_ID: u32 = 31u32;
 #[repr(C)]
@@ -17903,9 +16158,6 @@ impl Default for PCI_EXPRESS_PTM_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_PTM_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_PTM_CONTROL_REGISTER_0 {
@@ -17915,9 +16167,6 @@ impl Default for PCI_EXPRESS_PTM_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_PTM_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17939,9 +16188,6 @@ impl Default for PCI_EXPRESS_RESIZABLE_BAR_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_RESIZABLE_BAR_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_RESIZABLE_BAR_CAPABILITY_REGISTER {
@@ -17953,9 +16199,6 @@ impl Default for PCI_EXPRESS_RESIZABLE_BAR_CAPABILITY_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_RESIZABLE_BAR_CAPABILITY_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_RESIZABLE_BAR_CAPABILITY_REGISTER_0 {
@@ -17965,9 +16208,6 @@ impl Default for PCI_EXPRESS_RESIZABLE_BAR_CAPABILITY_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_RESIZABLE_BAR_CAPABILITY_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_RESIZABLE_BAR_CAP_ID: u32 = 21u32;
 #[repr(C)]
@@ -17981,9 +16221,6 @@ impl Default for PCI_EXPRESS_RESIZABLE_BAR_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_RESIZABLE_BAR_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_RESIZABLE_BAR_CONTROL_REGISTER_0 {
@@ -17993,9 +16230,6 @@ impl Default for PCI_EXPRESS_RESIZABLE_BAR_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_RESIZABLE_BAR_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18007,9 +16241,6 @@ impl Default for PCI_EXPRESS_RESIZABLE_BAR_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_RESIZABLE_BAR_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18031,9 +16262,6 @@ impl Default for PCI_EXPRESS_ROOTPORT_AER_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ROOTPORT_AER_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER {
@@ -18045,9 +16273,6 @@ impl Default for PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER_0 {
@@ -18057,9 +16282,6 @@ impl Default for PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_CAPABILITIES_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18072,9 +16294,6 @@ impl Default for PCI_EXPRESS_ROOT_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ROOT_CONTROL_REGISTER_0 {
@@ -18084,9 +16303,6 @@ impl Default for PCI_EXPRESS_ROOT_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18099,9 +16315,6 @@ impl Default for PCI_EXPRESS_ROOT_ERROR_COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_ERROR_COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ROOT_ERROR_COMMAND_0 {
@@ -18111,9 +16324,6 @@ impl Default for PCI_EXPRESS_ROOT_ERROR_COMMAND_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_ERROR_COMMAND_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18126,9 +16336,6 @@ impl Default for PCI_EXPRESS_ROOT_ERROR_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_ERROR_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ROOT_ERROR_STATUS_0 {
@@ -18138,9 +16345,6 @@ impl Default for PCI_EXPRESS_ROOT_ERROR_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_ERROR_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18158,9 +16362,6 @@ impl Default for PCI_EXPRESS_ROOT_PORT_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_PORT_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_EXPRESS_ROOT_PORT_INTERFACE_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18173,9 +16374,6 @@ impl Default for PCI_EXPRESS_ROOT_STATUS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_ROOT_STATUS_REGISTER_0 {
@@ -18185,9 +16383,6 @@ impl Default for PCI_EXPRESS_ROOT_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_ROOT_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18201,9 +16396,6 @@ impl Default for PCI_EXPRESS_SECONDARY_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SECONDARY_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_EXPRESS_SECONDARY_PCI_EXPRESS_CAP_ID: u32 = 25u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18216,9 +16408,6 @@ impl Default for PCI_EXPRESS_SEC_AER_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SEC_AER_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SEC_AER_CAPABILITIES_0 {
@@ -18228,9 +16417,6 @@ impl Default for PCI_EXPRESS_SEC_AER_CAPABILITIES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SEC_AER_CAPABILITIES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18243,9 +16429,6 @@ impl Default for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK_0 {
@@ -18255,9 +16438,6 @@ impl Default for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_MASK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18270,9 +16450,6 @@ impl Default for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY_0 {
@@ -18282,9 +16459,6 @@ impl Default for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_SEVERITY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18297,9 +16471,6 @@ impl Default for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS_0 {
@@ -18309,9 +16480,6 @@ impl Default for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SEC_UNCORRECTABLE_ERROR_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18325,9 +16493,6 @@ impl Default for PCI_EXPRESS_SERIAL_NUMBER_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SERIAL_NUMBER_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_EXPRESS_SINGLE_ROOT_IO_VIRTUALIZATION_CAP_ID: u32 = 16u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18340,9 +16505,6 @@ impl Default for PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER_0 {
@@ -18352,9 +16514,6 @@ impl Default for PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SLOT_CAPABILITIES_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18367,9 +16526,6 @@ impl Default for PCI_EXPRESS_SLOT_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SLOT_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SLOT_CONTROL_REGISTER_0 {
@@ -18379,9 +16535,6 @@ impl Default for PCI_EXPRESS_SLOT_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SLOT_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18394,9 +16547,6 @@ impl Default for PCI_EXPRESS_SLOT_STATUS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SLOT_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SLOT_STATUS_REGISTER_0 {
@@ -18406,9 +16556,6 @@ impl Default for PCI_EXPRESS_SLOT_STATUS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SLOT_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18436,9 +16583,6 @@ impl Default for PCI_EXPRESS_SRIOV_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SRIOV_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_SRIOV_CAPS {
@@ -18450,9 +16594,6 @@ impl Default for PCI_EXPRESS_SRIOV_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SRIOV_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SRIOV_CAPS_0 {
@@ -18462,9 +16603,6 @@ impl Default for PCI_EXPRESS_SRIOV_CAPS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SRIOV_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18477,9 +16615,6 @@ impl Default for PCI_EXPRESS_SRIOV_CONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SRIOV_CONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SRIOV_CONTROL_0 {
@@ -18489,9 +16624,6 @@ impl Default for PCI_EXPRESS_SRIOV_CONTROL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SRIOV_CONTROL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18504,9 +16636,6 @@ impl Default for PCI_EXPRESS_SRIOV_MIGRATION_STATE_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SRIOV_MIGRATION_STATE_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SRIOV_MIGRATION_STATE_ARRAY_0 {
@@ -18516,9 +16645,6 @@ impl Default for PCI_EXPRESS_SRIOV_MIGRATION_STATE_ARRAY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SRIOV_MIGRATION_STATE_ARRAY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18531,9 +16657,6 @@ impl Default for PCI_EXPRESS_SRIOV_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_SRIOV_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_SRIOV_STATUS_0 {
@@ -18543,9 +16666,6 @@ impl Default for PCI_EXPRESS_SRIOV_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_SRIOV_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18559,9 +16679,6 @@ impl Default for PCI_EXPRESS_TPH_REQUESTER_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_TPH_REQUESTER_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_EXPRESS_TPH_REQUESTER_CAPABILITY_REGISTER {
@@ -18573,9 +16690,6 @@ impl Default for PCI_EXPRESS_TPH_REQUESTER_CAPABILITY_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_TPH_REQUESTER_CAPABILITY_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_TPH_REQUESTER_CAPABILITY_REGISTER_0 {
@@ -18585,9 +16699,6 @@ impl Default for PCI_EXPRESS_TPH_REQUESTER_CAPABILITY_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_TPH_REQUESTER_CAPABILITY_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_TPH_REQUESTER_CAP_ID: u32 = 23u32;
 #[repr(C)]
@@ -18601,9 +16712,6 @@ impl Default for PCI_EXPRESS_TPH_REQUESTER_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_TPH_REQUESTER_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_TPH_REQUESTER_CONTROL_REGISTER_0 {
@@ -18613,9 +16721,6 @@ impl Default for PCI_EXPRESS_TPH_REQUESTER_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_TPH_REQUESTER_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_TPH_ST_LOCATION_MSIX_TABLE: u32 = 2u32;
 pub const PCI_EXPRESS_TPH_ST_LOCATION_NONE: u32 = 0u32;
@@ -18632,9 +16737,6 @@ impl Default for PCI_EXPRESS_TPH_ST_TABLE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_TPH_ST_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_TPH_ST_TABLE_ENTRY_0 {
@@ -18644,9 +16746,6 @@ impl Default for PCI_EXPRESS_TPH_ST_TABLE_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_TPH_ST_TABLE_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18659,9 +16758,6 @@ impl Default for PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK_0 {
@@ -18671,9 +16767,6 @@ impl Default for PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_UNCORRECTABLE_ERROR_MASK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18686,9 +16779,6 @@ impl Default for PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY_0 {
@@ -18698,9 +16788,6 @@ impl Default for PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_UNCORRECTABLE_ERROR_SEVERITY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18713,9 +16800,6 @@ impl Default for PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS_0 {
@@ -18725,9 +16809,6 @@ impl Default for PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_UNCORRECTABLE_ERROR_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_VC_AND_MFVC_CAP_ID: u32 = 9u32;
 #[repr(C)]
@@ -18741,9 +16822,6 @@ impl Default for PCI_EXPRESS_VENDOR_SPECIFIC_CAPABILITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_VENDOR_SPECIFIC_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_VENDOR_SPECIFIC_CAP_ID: u32 = 11u32;
 #[repr(C)]
@@ -18760,9 +16838,6 @@ impl Default for PCI_EXPRESS_VIRTUAL_CHANNEL_CAPABILITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_EXPRESS_VIRTUAL_CHANNEL_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_EXPRESS_VIRTUAL_CHANNEL_CAP_ID: u32 = 2u32;
 pub type PCI_EXPRESS_WAKE_CONTROL = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, enablewake: super::super::super::Win32::Foundation::BOOLEAN)>;
@@ -18784,9 +16859,6 @@ impl Default for PCI_FIRMWARE_BUS_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FIRMWARE_BUS_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_FIRMWARE_BUS_CAPS_0 {
@@ -18796,9 +16868,6 @@ impl Default for PCI_FIRMWARE_BUS_CAPS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_FIRMWARE_BUS_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18813,9 +16882,6 @@ impl Default for PCI_FIRMWARE_BUS_CAPS_RETURN_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FIRMWARE_BUS_CAPS_RETURN_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_FPB_CAPABILITIES_REGISTER {
@@ -18827,9 +16893,6 @@ impl Default for PCI_FPB_CAPABILITIES_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FPB_CAPABILITIES_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_FPB_CAPABILITIES_REGISTER_0 {
@@ -18839,9 +16902,6 @@ impl Default for PCI_FPB_CAPABILITIES_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_FPB_CAPABILITIES_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18861,9 +16921,6 @@ impl Default for PCI_FPB_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FPB_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_FPB_CAPABILITY_HEADER {
@@ -18874,9 +16931,6 @@ impl Default for PCI_FPB_CAPABILITY_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_FPB_CAPABILITY_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18889,9 +16943,6 @@ impl Default for PCI_FPB_MEM_HIGH_VECTOR_CONTROL1_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FPB_MEM_HIGH_VECTOR_CONTROL1_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_FPB_MEM_HIGH_VECTOR_CONTROL1_REGISTER_0 {
@@ -18902,9 +16953,6 @@ impl Default for PCI_FPB_MEM_HIGH_VECTOR_CONTROL1_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FPB_MEM_HIGH_VECTOR_CONTROL1_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_FPB_MEM_HIGH_VECTOR_CONTROL2_REGISTER {
@@ -18914,9 +16962,6 @@ impl Default for PCI_FPB_MEM_HIGH_VECTOR_CONTROL2_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_FPB_MEM_HIGH_VECTOR_CONTROL2_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18929,9 +16974,6 @@ impl Default for PCI_FPB_MEM_LOW_VECTOR_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FPB_MEM_LOW_VECTOR_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_FPB_MEM_LOW_VECTOR_CONTROL_REGISTER_0 {
@@ -18941,9 +16983,6 @@ impl Default for PCI_FPB_MEM_LOW_VECTOR_CONTROL_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_FPB_MEM_LOW_VECTOR_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18956,9 +16995,6 @@ impl Default for PCI_FPB_RID_VECTOR_CONTROL1_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FPB_RID_VECTOR_CONTROL1_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_FPB_RID_VECTOR_CONTROL1_REGISTER_0 {
@@ -18968,9 +17004,6 @@ impl Default for PCI_FPB_RID_VECTOR_CONTROL1_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_FPB_RID_VECTOR_CONTROL1_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -18983,9 +17016,6 @@ impl Default for PCI_FPB_RID_VECTOR_CONTROL2_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FPB_RID_VECTOR_CONTROL2_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_FPB_RID_VECTOR_CONTROL2_REGISTER_0 {
@@ -18995,9 +17025,6 @@ impl Default for PCI_FPB_RID_VECTOR_CONTROL2_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_FPB_RID_VECTOR_CONTROL2_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -19010,9 +17037,6 @@ impl Default for PCI_FPB_VECTOR_ACCESS_CONTROL_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FPB_VECTOR_ACCESS_CONTROL_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_FPB_VECTOR_ACCESS_CONTROL_REGISTER_0 {
@@ -19023,9 +17047,6 @@ impl Default for PCI_FPB_VECTOR_ACCESS_CONTROL_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_FPB_VECTOR_ACCESS_CONTROL_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_FPB_VECTOR_ACCESS_DATA_REGISTER {
@@ -19035,9 +17056,6 @@ impl Default for PCI_FPB_VECTOR_ACCESS_DATA_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_FPB_VECTOR_ACCESS_DATA_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -19074,9 +17092,6 @@ impl Default for PCI_MSIX_TABLE_CONFIG_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_MSIX_TABLE_CONFIG_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_MSIX_TABLE_CONFIG_INTERFACE_VERSION: u32 = 1u32;
 pub const PCI_MULTIFUNCTION: u32 = 128u32;
 pub type PCI_PIN_TO_LINE = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, pcidata: *const PCI_COMMON_CONFIG)>;
@@ -19091,9 +17106,6 @@ impl Default for PCI_PMC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_PMC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_PMC_0 {
@@ -19103,9 +17115,6 @@ impl Default for PCI_PMC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_PMC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -19117,9 +17126,6 @@ impl Default for PCI_PMCSR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_PMCSR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_PMCSR_BSE {
@@ -19129,9 +17135,6 @@ impl Default for PCI_PMCSR_BSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_PMCSR_BSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -19147,9 +17150,6 @@ impl Default for PCI_PM_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_PM_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_PM_CAPABILITY_2 {
@@ -19160,9 +17160,6 @@ impl Default for PCI_PM_CAPABILITY_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_PM_CAPABILITY_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -19175,9 +17172,6 @@ impl Default for PCI_PM_CAPABILITY_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_PM_CAPABILITY_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_PM_CAPABILITY_0 {
@@ -19188,9 +17182,6 @@ impl Default for PCI_PM_CAPABILITY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_PM_CAPABILITY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PCI_PREPARE_MULTISTAGE_RESUME = Option<unsafe extern "system" fn(context: *const core::ffi::c_void)>;
 pub const PCI_PROGRAMMING_INTERFACE_MSC_NVM_EXPRESS: u32 = 2u32;
@@ -19213,9 +17204,6 @@ impl Default for PCI_ROOT_BUS_HARDWARE_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_ROOT_BUS_HARDWARE_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_ROOT_BUS_HARDWARE_CAPABILITY_0 {
@@ -19230,9 +17218,6 @@ impl Default for PCI_ROOT_BUS_HARDWARE_CAPABILITY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_ROOT_BUS_HARDWARE_CAPABILITY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PCI_ROOT_BUS_OSC_CONTROL_FIELD {
@@ -19242,9 +17227,6 @@ impl Default for PCI_ROOT_BUS_OSC_CONTROL_FIELD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_ROOT_BUS_OSC_CONTROL_FIELD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -19257,9 +17239,6 @@ impl Default for PCI_ROOT_BUS_OSC_CONTROL_FIELD_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_ROOT_BUS_OSC_CONTROL_FIELD_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_ROOT_BUS_OSC_CONTROL_FIELD_0_0 {
@@ -19269,9 +17248,6 @@ impl Default for PCI_ROOT_BUS_OSC_CONTROL_FIELD_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_ROOT_BUS_OSC_CONTROL_FIELD_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_ROOT_BUS_OSC_METHOD_CAPABILITY_REVISION: u32 = 1u32;
 #[repr(C)]
@@ -19284,9 +17260,6 @@ impl Default for PCI_ROOT_BUS_OSC_SUPPORT_FIELD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_ROOT_BUS_OSC_SUPPORT_FIELD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_ROOT_BUS_OSC_SUPPORT_FIELD_0 {
@@ -19298,9 +17271,6 @@ impl Default for PCI_ROOT_BUS_OSC_SUPPORT_FIELD_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_ROOT_BUS_OSC_SUPPORT_FIELD_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_ROOT_BUS_OSC_SUPPORT_FIELD_0_0 {
@@ -19310,9 +17280,6 @@ impl Default for PCI_ROOT_BUS_OSC_SUPPORT_FIELD_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_ROOT_BUS_OSC_SUPPORT_FIELD_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_SECURITY_DIRECT_TRANSLATED_P2P: u32 = 4u32;
 pub const PCI_SECURITY_ENHANCED: u32 = 2u32;
@@ -19333,9 +17300,6 @@ impl Default for PCI_SECURITY_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_SECURITY_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_SECURITY_INTERFACE2 {
@@ -19353,9 +17317,6 @@ impl Default for PCI_SECURITY_INTERFACE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_SECURITY_INTERFACE2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_SECURITY_INTERFACE_VERSION: u32 = 1u32;
 pub const PCI_SECURITY_INTERFACE_VERSION2: u32 = 2u32;
 pub const PCI_SECURITY_SRIOV_DIRECT_TRANSLATED_P2P: u32 = 262144u32;
@@ -19369,9 +17330,6 @@ impl Default for PCI_SEGMENT_BUS_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_SEGMENT_BUS_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_SEGMENT_BUS_NUMBER_0 {
@@ -19383,9 +17341,6 @@ impl Default for PCI_SEGMENT_BUS_NUMBER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_SEGMENT_BUS_NUMBER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_SEGMENT_BUS_NUMBER_0_0 {
@@ -19395,9 +17350,6 @@ impl Default for PCI_SEGMENT_BUS_NUMBER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_SEGMENT_BUS_NUMBER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PCI_SET_ACS = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, enablesourcevalidation: PCI_ACS_BIT, enabletranslationblocking: PCI_ACS_BIT, enablep2prequestredirect: PCI_ACS_BIT, enablecompletionredirect: PCI_ACS_BIT, enableupstreamforwarding: PCI_ACS_BIT, enableegresscontrol: PCI_ACS_BIT, enabledirecttranslatedp2p: PCI_ACS_BIT) -> super::super::super::Win32::Foundation::NTSTATUS>;
 pub type PCI_SET_ACS2 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, scenariostomodify: u32, scenariostate: u32) -> super::super::super::Win32::Foundation::NTSTATUS>;
@@ -19412,9 +17364,6 @@ impl Default for PCI_SLOT_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_SLOT_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_SLOT_NUMBER_0 {
@@ -19426,9 +17375,6 @@ impl Default for PCI_SLOT_NUMBER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_SLOT_NUMBER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_SLOT_NUMBER_0_0 {
@@ -19438,9 +17384,6 @@ impl Default for PCI_SLOT_NUMBER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_SLOT_NUMBER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCI_STATUS_66MHZ_CAPABLE: u32 = 32u32;
 pub const PCI_STATUS_CAPABILITIES_LIST: u32 = 16u32;
@@ -19553,9 +17496,6 @@ impl Default for PCI_SUBSYSTEM_IDS_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_SUBSYSTEM_IDS_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_TYPE0_ADDRESSES: u32 = 6u32;
 pub const PCI_TYPE1_ADDRESSES: u32 = 2u32;
 pub const PCI_TYPE2_ADDRESSES: u32 = 5u32;
@@ -19581,9 +17521,6 @@ impl Default for PCI_VENDOR_SPECIFIC_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_VENDOR_SPECIFIC_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_VIRTUALIZATION_INTERFACE {
@@ -19604,9 +17541,6 @@ impl Default for PCI_VIRTUALIZATION_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_VIRTUALIZATION_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCI_WHICHSPACE_CONFIG: u32 = 0u32;
 pub const PCI_WHICHSPACE_ROM: u32 = 1382638416u32;
 #[repr(C)]
@@ -19621,9 +17555,6 @@ impl Default for PCI_X_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_X_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PCI_X_CAPABILITY_0 {
@@ -19635,9 +17566,6 @@ impl Default for PCI_X_CAPABILITY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_X_CAPABILITY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_X_CAPABILITY_0_0 {
@@ -19647,9 +17575,6 @@ impl Default for PCI_X_CAPABILITY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_X_CAPABILITY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -19662,9 +17587,6 @@ impl Default for PCI_X_CAPABILITY_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCI_X_CAPABILITY_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCI_X_CAPABILITY_1_0 {
@@ -19674,9 +17596,6 @@ impl Default for PCI_X_CAPABILITY_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCI_X_CAPABILITY_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCIe_NOTIFY_TYPE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xcf93c01f_1a16_4dfc_b8bc_9c4daf67c104);
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_Storage_FileSystem", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -19721,10 +17640,6 @@ impl Default for PCW_CALLBACK_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for PCW_CALLBACK_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PCW_CALLBACK_TYPE(pub i32);
@@ -19741,9 +17656,6 @@ impl Default for PCW_COUNTER_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCW_COUNTER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PCW_COUNTER_INFORMATION {
@@ -19754,9 +17666,6 @@ impl Default for PCW_COUNTER_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCW_COUNTER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCW_CURRENT_VERSION: u32 = 512u32;
 #[repr(C)]
@@ -19769,9 +17678,6 @@ impl Default for PCW_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCW_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
@@ -19789,10 +17695,6 @@ impl Default for PCW_MASK_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for PCW_MASK_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -19812,9 +17714,6 @@ impl Default for PCW_REGISTRATION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCW_REGISTRATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PCW_VERSION_1: u32 = 256u32;
 pub const PCW_VERSION_2: u32 = 512u32;
@@ -19949,9 +17848,6 @@ impl Default for PHYSICAL_COUNTER_EVENT_BUFFER_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_COUNTER_EVENT_BUFFER_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PHYSICAL_COUNTER_RESOURCE_DESCRIPTOR {
@@ -19963,9 +17859,6 @@ impl Default for PHYSICAL_COUNTER_RESOURCE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PHYSICAL_COUNTER_RESOURCE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -19981,9 +17874,6 @@ impl Default for PHYSICAL_COUNTER_RESOURCE_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_COUNTER_RESOURCE_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PHYSICAL_COUNTER_RESOURCE_DESCRIPTOR_0_0 {
@@ -19994,9 +17884,6 @@ impl Default for PHYSICAL_COUNTER_RESOURCE_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PHYSICAL_COUNTER_RESOURCE_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -20012,9 +17899,6 @@ impl Default for PHYSICAL_COUNTER_RESOURCE_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_COUNTER_RESOURCE_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PHYSICAL_MEMORY_RANGE {
@@ -20025,9 +17909,6 @@ impl Default for PHYSICAL_MEMORY_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PHYSICAL_MEMORY_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type PINITIALIZE_DMA_TRANSFER_CONTEXT = Option<unsafe extern "system" fn(dmaadapter: *const DMA_ADAPTER, dmatransfercontext: *mut core::ffi::c_void) -> super::super::super::Win32::Foundation::NTSTATUS>;
@@ -20105,9 +17986,6 @@ impl Default for PLUGPLAY_NOTIFICATION_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PLUGPLAY_NOTIFICATION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PLUGPLAY_PROPERTY_PERSISTENT: u32 = 1u32;
 pub const PLUGPLAY_REGKEY_CURRENT_HWPROFILE: u32 = 4u32;
 pub const PLUGPLAY_REGKEY_DEVICE: u32 = 1u32;
@@ -20136,9 +18014,6 @@ impl Default for PM_DISPATCH_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PM_DISPATCH_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type PNMI_CALLBACK = Option<unsafe extern "system" fn() -> super::super::super::Win32::Foundation::BOOLEAN>;
 pub const PNPBus: INTERFACE_TYPE = INTERFACE_TYPE(15i32);
 pub type PNPEM_CONTROL_ENABLE_DISABLE = Option<unsafe extern "system" fn() -> super::super::super::Win32::Foundation::NTSTATUS>;
@@ -20159,9 +18034,6 @@ impl Default for PNP_BUS_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PNP_BUS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PNP_DEVICE_ASSIGNED_TO_GUEST: u32 = 256u32;
 pub const PNP_DEVICE_DISABLED: u32 = 1u32;
@@ -20187,9 +18059,6 @@ impl Default for PNP_EXTENDED_ADDRESS_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PNP_EXTENDED_ADDRESS_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PNP_EXTENDED_ADDRESS_INTERFACE_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20205,9 +18074,6 @@ impl Default for PNP_LOCATION_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PNP_LOCATION_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20231,9 +18097,6 @@ impl Default for PNP_REPLACE_DRIVER_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PNP_REPLACE_DRIVER_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PNP_REPLACE_DRIVER_INTERFACE_VERSION: u32 = 1u32;
 pub const PNP_REPLACE_HARDWARE_MEMORY_MIRRORING: u32 = 4u32;
 pub const PNP_REPLACE_HARDWARE_PAGE_COPY: u32 = 8u32;
@@ -20251,9 +18114,6 @@ impl Default for PNP_REPLACE_MEMORY_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PNP_REPLACE_MEMORY_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PNP_REPLACE_MEMORY_LIST_0 {
@@ -20264,9 +18124,6 @@ impl Default for PNP_REPLACE_MEMORY_LIST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PNP_REPLACE_MEMORY_LIST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PNP_REPLACE_MEMORY_SUPPORTED: u32 = 1u32;
 #[repr(C)]
@@ -20287,9 +18144,6 @@ impl Default for PNP_REPLACE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PNP_REPLACE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PNP_REPLACE_PARAMETERS_VERSION: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20305,9 +18159,6 @@ impl Default for PNP_REPLACE_PROCESSOR_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PNP_REPLACE_PROCESSOR_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PNP_REPLACE_PROCESSOR_LIST_V1 {
@@ -20320,9 +18171,6 @@ impl Default for PNP_REPLACE_PROCESSOR_LIST_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PNP_REPLACE_PROCESSOR_LIST_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PNP_REPLACE_PROCESSOR_SUPPORTED: u32 = 2u32;
 pub type PNTFS_DEREF_EXPORTED_SECURITY_DESCRIPTOR = Option<unsafe extern "system" fn()>;
@@ -20348,9 +18196,6 @@ impl Default for POOLED_USAGE_AND_LIMITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POOLED_USAGE_AND_LIMITS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const POOL_COLD_ALLOCATION: u32 = 256u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20361,9 +18206,6 @@ impl Default for POOL_CREATE_EXTENDED_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POOL_CREATE_EXTENDED_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POOL_CREATE_FLG_SECURE_POOL: u32 = 1u32;
 pub const POOL_CREATE_FLG_USE_GLOBAL_POOL: u32 = 2u32;
@@ -20379,9 +18221,6 @@ impl Default for POOL_EXTENDED_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POOL_EXTENDED_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POOL_EXTENDED_PARAMETER_0 {
@@ -20391,9 +18230,6 @@ impl Default for POOL_EXTENDED_PARAMETER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POOL_EXTENDED_PARAMETER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -20408,9 +18244,6 @@ impl Default for POOL_EXTENDED_PARAMETER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POOL_EXTENDED_PARAMETER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POOL_EXTENDED_PARAMETER_REQUIRED_FIELD_BITS: u32 = 1u32;
 #[repr(transparent)]
@@ -20429,9 +18262,6 @@ impl Default for POOL_EXTENDED_PARAMS_SECURE_POOL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POOL_EXTENDED_PARAMS_SECURE_POOL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POOL_NX_ALLOCATION: u32 = 512u32;
 pub const POOL_NX_OPTIN_AUTO: u32 = 1u32;
@@ -20453,9 +18283,6 @@ impl Default for POWER_MONITOR_INVOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POWER_MONITOR_INVOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct POWER_MONITOR_REQUEST_REASON(pub i32);
@@ -20471,9 +18298,6 @@ impl Default for POWER_PLATFORM_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_PLATFORM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -20493,9 +18317,6 @@ impl Default for POWER_SEQUENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POWER_SEQUENCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POWER_SESSION_CONNECT {
@@ -20506,9 +18327,6 @@ impl Default for POWER_SESSION_CONNECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_SESSION_CONNECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20521,9 +18339,6 @@ impl Default for POWER_SESSION_RIT_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POWER_SESSION_RIT_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POWER_SESSION_TIMEOUTS {
@@ -20534,9 +18349,6 @@ impl Default for POWER_SESSION_TIMEOUTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_SESSION_TIMEOUTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20549,9 +18361,6 @@ impl Default for POWER_SESSION_WINLOGON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_SESSION_WINLOGON {
-    type TypeKind = windows_core::CopyType;
 }
 pub type POWER_SETTING_CALLBACK = Option<unsafe extern "system" fn(settingguid: *const windows_core::GUID, value: *const core::ffi::c_void, valuelength: u32, context: *mut core::ffi::c_void) -> super::super::super::Win32::Foundation::NTSTATUS>;
 pub const POWER_SETTING_VALUE_VERSION: u32 = 1u32;
@@ -20567,10 +18376,6 @@ impl Default for POWER_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Power")]
-impl windows_core::TypeKind for POWER_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -20591,9 +18396,6 @@ impl Default for POWER_THROTTLING_PROCESS_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POWER_THROTTLING_PROCESS_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const POWER_THROTTLING_THREAD_CURRENT_VERSION: u32 = 1u32;
 pub const POWER_THROTTLING_THREAD_EXECUTION_SPEED: u32 = 1u32;
 #[repr(C)]
@@ -20607,9 +18409,6 @@ impl Default for POWER_THROTTLING_THREAD_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_THROTTLING_THREAD_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POWER_THROTTLING_THREAD_VALID_FLAGS: u32 = 1u32;
 #[repr(transparent)]
@@ -20632,9 +18431,6 @@ impl Default for PO_FX_COMPONENT_IDLE_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PO_FX_COMPONENT_IDLE_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type PO_FX_COMPONENT_IDLE_STATE_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, component: u32, state: u32)>;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -20646,9 +18442,6 @@ impl Default for PO_FX_COMPONENT_PERF_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PO_FX_COMPONENT_PERF_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -20664,9 +18457,6 @@ impl Default for PO_FX_COMPONENT_PERF_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PO_FX_COMPONENT_PERF_SET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PO_FX_COMPONENT_PERF_SET_0 {
@@ -20677,9 +18467,6 @@ impl Default for PO_FX_COMPONENT_PERF_SET_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PO_FX_COMPONENT_PERF_SET_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20692,9 +18479,6 @@ impl Default for PO_FX_COMPONENT_PERF_SET_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PO_FX_COMPONENT_PERF_SET_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PO_FX_COMPONENT_PERF_SET_0_1 {
@@ -20705,9 +18489,6 @@ impl Default for PO_FX_COMPONENT_PERF_SET_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PO_FX_COMPONENT_PERF_SET_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PO_FX_COMPONENT_PERF_STATE_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, component: u32, succeeded: super::super::super::Win32::Foundation::BOOLEAN, requestcontext: *const core::ffi::c_void)>;
 #[repr(C)]
@@ -20722,9 +18503,6 @@ impl Default for PO_FX_COMPONENT_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PO_FX_COMPONENT_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20741,9 +18519,6 @@ impl Default for PO_FX_COMPONENT_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PO_FX_COMPONENT_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PO_FX_DEVICE_POWER_NOT_REQUIRED_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void)>;
 pub type PO_FX_DEVICE_POWER_REQUIRED_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void)>;
@@ -20766,9 +18541,6 @@ impl Default for PO_FX_DEVICE_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PO_FX_DEVICE_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PO_FX_DEVICE_V2 {
@@ -20788,9 +18560,6 @@ impl Default for PO_FX_DEVICE_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PO_FX_DEVICE_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20815,9 +18584,6 @@ impl Default for PO_FX_DEVICE_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PO_FX_DEVICE_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PO_FX_DIRECTED_FX_DEFAULT_IDLE_TIMEOUT: u32 = 0u32;
 pub type PO_FX_DIRECTED_POWER_DOWN_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, flags: u32)>;
 pub type PO_FX_DIRECTED_POWER_UP_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, flags: u32)>;
@@ -20839,9 +18605,6 @@ impl Default for PO_FX_PERF_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PO_FX_PERF_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PO_FX_PERF_STATE_CHANGE {
@@ -20853,9 +18616,6 @@ impl Default for PO_FX_PERF_STATE_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PO_FX_PERF_STATE_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PO_FX_PERF_STATE_CHANGE_0 {
@@ -20866,9 +18626,6 @@ impl Default for PO_FX_PERF_STATE_CHANGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PO_FX_PERF_STATE_CHANGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -20974,9 +18731,6 @@ impl Default for PROCESS_ACCESS_TOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_ACCESS_TOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_DEVICEMAP_INFORMATION {
@@ -20986,9 +18740,6 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -21001,9 +18752,6 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_DEVICEMAP_INFORMATION_0_1 {
@@ -21015,9 +18763,6 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_DEVICEMAP_INFORMATION_0_0 {
@@ -21027,9 +18772,6 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -21042,9 +18784,6 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROCESS_DEVICEMAP_INFORMATION_EX_0 {
@@ -21055,9 +18794,6 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_EX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21070,9 +18806,6 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION_EX_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_EX_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
@@ -21082,9 +18815,6 @@ impl Default for PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_DEVICEMAP_INFORMATION_EX_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21096,9 +18826,6 @@ impl Default for PROCESS_EXCEPTION_PORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_EXCEPTION_PORT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROCESS_EXCEPTION_PORT_ALL_STATE_BITS: u32 = 3u32;
 #[repr(C)]
@@ -21115,10 +18842,6 @@ impl Default for PROCESS_EXTENDED_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
-impl windows_core::TypeKind for PROCESS_EXTENDED_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
 #[derive(Clone, Copy)]
@@ -21132,10 +18855,6 @@ impl Default for PROCESS_EXTENDED_BASIC_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
-impl windows_core::TypeKind for PROCESS_EXTENDED_BASIC_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21147,10 +18866,6 @@ impl Default for PROCESS_EXTENDED_BASIC_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Kernel", feature = "Win32_System_Threading"))]
-impl windows_core::TypeKind for PROCESS_EXTENDED_BASIC_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROCESS_HANDLE_EXCEPTIONS_ENABLED: u32 = 1u32;
 pub const PROCESS_HANDLE_RAISE_UM_EXCEPTION_ON_INVALID_HANDLE_CLOSE_DISABLED: u32 = 0u32;
@@ -21165,9 +18880,6 @@ impl Default for PROCESS_HANDLE_TRACING_ENABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_HANDLE_TRACING_ENABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_HANDLE_TRACING_ENABLE_EX {
@@ -21178,9 +18890,6 @@ impl Default for PROCESS_HANDLE_TRACING_ENABLE_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_HANDLE_TRACING_ENABLE_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_WindowsProgramming")]
@@ -21197,10 +18906,6 @@ impl Default for PROCESS_HANDLE_TRACING_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_WindowsProgramming")]
-impl windows_core::TypeKind for PROCESS_HANDLE_TRACING_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PROCESS_HANDLE_TRACING_MAX_STACKS: u32 = 16u32;
 #[repr(C)]
 #[cfg(feature = "Win32_System_WindowsProgramming")]
@@ -21216,10 +18921,6 @@ impl Default for PROCESS_HANDLE_TRACING_QUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_WindowsProgramming")]
-impl windows_core::TypeKind for PROCESS_HANDLE_TRACING_QUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_KEEPALIVE_COUNT_INFORMATION {
@@ -21230,9 +18931,6 @@ impl Default for PROCESS_KEEPALIVE_COUNT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_KEEPALIVE_COUNT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROCESS_LUID_DOSDEVICES_ONLY: u32 = 1u32;
 #[repr(C)]
@@ -21245,9 +18943,6 @@ impl Default for PROCESS_MEMBERSHIP_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MEMBERSHIP_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_REVOKE_FILE_HANDLES_INFORMATION {
@@ -21258,9 +18953,6 @@ impl Default for PROCESS_REVOKE_FILE_HANDLES_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_REVOKE_FILE_HANDLES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_SESSION_INFORMATION {
@@ -21270,9 +18962,6 @@ impl Default for PROCESS_SESSION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_SESSION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21285,9 +18974,6 @@ impl Default for PROCESS_SYSCALL_PROVIDER_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_SYSCALL_PROVIDER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_WS_WATCH_INFORMATION {
@@ -21298,9 +18984,6 @@ impl Default for PROCESS_WS_WATCH_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_WS_WATCH_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROFILE_LEVEL: u32 = 27u32;
 pub const PROTECTED_POOL: u32 = 0u32;
@@ -21369,10 +19052,6 @@ impl Default for PS_CREATE_NOTIFY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power", feature = "Win32_System_WindowsProgramming"))]
-impl windows_core::TypeKind for PS_CREATE_NOTIFY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power", feature = "Win32_System_WindowsProgramming"))]
 #[derive(Clone, Copy)]
@@ -21386,10 +19065,6 @@ impl Default for PS_CREATE_NOTIFY_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power", feature = "Win32_System_WindowsProgramming"))]
-impl windows_core::TypeKind for PS_CREATE_NOTIFY_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power", feature = "Win32_System_WindowsProgramming"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21401,10 +19076,6 @@ impl Default for PS_CREATE_NOTIFY_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power", feature = "Win32_System_WindowsProgramming"))]
-impl windows_core::TypeKind for PS_CREATE_NOTIFY_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PS_IMAGE_NOTIFY_CONFLICTING_ARCHITECTURE: u32 = 1u32;
 pub const PS_INVALID_SILO_CONTEXT_SLOT: u32 = 4294967295u32;
@@ -21430,9 +19101,6 @@ impl Default for PTM_CONTROL_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PTM_CONTROL_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PTM_DEVICE_DISABLE = Option<unsafe extern "system" fn(context: *const core::ffi::c_void) -> super::super::super::Win32::Foundation::NTSTATUS>;
 pub type PTM_DEVICE_ENABLE = Option<unsafe extern "system" fn(context: *const core::ffi::c_void) -> super::super::super::Win32::Foundation::NTSTATUS>;
@@ -21600,9 +19268,6 @@ impl Default for REENUMERATE_SELF_INTERFACE_STANDARD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REENUMERATE_SELF_INTERFACE_STANDARD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_CALLBACK_CONTEXT_CLEANUP_INFORMATION {
@@ -21614,9 +19279,6 @@ impl Default for REG_CALLBACK_CONTEXT_CLEANUP_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_CALLBACK_CONTEXT_CLEANUP_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21641,9 +19303,6 @@ impl Default for REG_CREATE_KEY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_CREATE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21673,9 +19332,6 @@ impl Default for REG_CREATE_KEY_INFORMATION_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_CREATE_KEY_INFORMATION_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_DELETE_KEY_INFORMATION {
@@ -21688,9 +19344,6 @@ impl Default for REG_DELETE_KEY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_DELETE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21706,9 +19359,6 @@ impl Default for REG_DELETE_VALUE_KEY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_DELETE_VALUE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_KEY_HANDLE_CLOSE_INFORMATION {
@@ -21721,9 +19371,6 @@ impl Default for REG_KEY_HANDLE_CLOSE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_KEY_HANDLE_CLOSE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21744,9 +19391,6 @@ impl Default for REG_LOAD_KEY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_LOAD_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21769,9 +19413,6 @@ impl Default for REG_LOAD_KEY_INFORMATION_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_LOAD_KEY_INFORMATION_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct REG_NOTIFY_CLASS(pub i32);
@@ -21786,9 +19427,6 @@ impl Default for REG_POST_CREATE_KEY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_POST_CREATE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21806,9 +19444,6 @@ impl Default for REG_POST_OPERATION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_POST_OPERATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_PRE_CREATE_KEY_INFORMATION {
@@ -21818,9 +19453,6 @@ impl Default for REG_PRE_CREATE_KEY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_PRE_CREATE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
@@ -21840,10 +19472,6 @@ impl Default for REG_QUERY_KEY_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for REG_QUERY_KEY_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21862,10 +19490,6 @@ impl Default for REG_QUERY_KEY_SECURITY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for REG_QUERY_KEY_SECURITY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_RENAME_KEY_INFORMATION {
@@ -21879,9 +19503,6 @@ impl Default for REG_RENAME_KEY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_RENAME_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21898,9 +19519,6 @@ impl Default for REG_REPLACE_KEY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_REPLACE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_RESTORE_KEY_INFORMATION {
@@ -21916,9 +19534,6 @@ impl Default for REG_RESTORE_KEY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_RESTORE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_SAVE_KEY_INFORMATION {
@@ -21933,9 +19548,6 @@ impl Default for REG_SAVE_KEY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_SAVE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21953,9 +19565,6 @@ impl Default for REG_SAVE_MERGED_KEY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_SAVE_MERGED_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21972,10 +19581,6 @@ impl Default for REG_SET_KEY_SECURITY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for REG_SET_KEY_SECURITY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21995,9 +19600,6 @@ impl Default for REG_SET_VALUE_KEY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_SET_VALUE_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REG_UNLOAD_KEY_INFORMATION {
@@ -22011,9 +19613,6 @@ impl Default for REG_UNLOAD_KEY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REG_UNLOAD_KEY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 pub type REQUEST_POWER_COMPLETE = Option<unsafe extern "system" fn(deviceobject: *const super::super::Foundation::DEVICE_OBJECT, minorfunction: u8, powerstate: POWER_STATE, context: *const core::ffi::c_void, iostatus: *const super::super::super::Win32::System::IO::IO_STATUS_BLOCK)>;
@@ -22031,10 +19630,6 @@ impl Default for RESOURCE_HASH_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for RESOURCE_HASH_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RESOURCE_HASH_TABLE_SIZE: u32 = 64u32;
 #[repr(C)]
@@ -22058,10 +19653,6 @@ impl Default for RESOURCE_PERFORMANCE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for RESOURCE_PERFORMANCE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -22096,9 +19687,6 @@ impl Default for RTL_AVL_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_AVL_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RTL_BALANCED_LINKS {
@@ -22113,9 +19701,6 @@ impl Default for RTL_BALANCED_LINKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_BALANCED_LINKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RTL_BITMAP {
@@ -22127,9 +19712,6 @@ impl Default for RTL_BITMAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_BITMAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RTL_BITMAP_RUN {
@@ -22140,9 +19722,6 @@ impl Default for RTL_BITMAP_RUN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTL_BITMAP_RUN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -22162,9 +19741,6 @@ impl Default for RTL_DYNAMIC_HASH_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_DYNAMIC_HASH_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -22179,10 +19755,6 @@ impl Default for RTL_DYNAMIC_HASH_TABLE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for RTL_DYNAMIC_HASH_TABLE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -22195,10 +19767,6 @@ impl Default for RTL_DYNAMIC_HASH_TABLE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for RTL_DYNAMIC_HASH_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -22214,10 +19782,6 @@ impl Default for RTL_DYNAMIC_HASH_TABLE_ENUMERATOR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for RTL_DYNAMIC_HASH_TABLE_ENUMERATOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -22230,10 +19794,6 @@ impl Default for RTL_DYNAMIC_HASH_TABLE_ENUMERATOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for RTL_DYNAMIC_HASH_TABLE_ENUMERATOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
 pub type RTL_GENERIC_ALLOCATE_ROUTINE = Option<unsafe extern "system" fn(table: *const RTL_GENERIC_TABLE, bytesize: u32) -> *mut core::ffi::c_void>;
@@ -22264,10 +19824,6 @@ impl Default for RTL_GENERIC_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for RTL_GENERIC_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RTL_GUID_STRING_SIZE: u32 = 38u32;
 pub const RTL_HASH_ALLOCATED_HEADER: u32 = 1u32;
 pub const RTL_HASH_RESERVED_SIGNATURE: u32 = 0u32;
@@ -22294,9 +19850,6 @@ impl Default for RTL_QUERY_REGISTRY_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTL_QUERY_REGISTRY_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RTL_QUERY_REGISTRY_TOPKEY: u32 = 2u32;
 pub const RTL_QUERY_REGISTRY_TYPECHECK: u32 = 256u32;
@@ -22410,9 +19963,6 @@ impl Default for SCATTER_GATHER_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCATTER_GATHER_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCATTER_GATHER_LIST {
@@ -22425,9 +19975,6 @@ impl Default for SCATTER_GATHER_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCATTER_GATHER_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCI_NOTIFY_TYPE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xe9d59197_94ee_4a4f_8ad8_9b7d8bd93d2e);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -22439,9 +19986,6 @@ impl Default for SDEV_IDENTIFIER_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SDEV_IDENTIFIER_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SDEV_IDENTIFIER_INTERFACE_VERSION: u32 = 1u32;
 pub const SEA_NOTIFY_TYPE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x9a78788a_bbe8_11e4_809e_67611e5d46b0);
@@ -22465,10 +20009,6 @@ impl Default for SECURE_DRIVER_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for SECURE_DRIVER_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECURE_DRIVER_INTERFACE_VERSION: u32 = 1u32;
 #[cfg(feature = "Wdk_Foundation")]
@@ -22579,9 +20119,6 @@ impl Default for SHARE_ACCESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHARE_ACCESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SHORT_LEAST_SIGNIFICANT_BIT: u32 = 0u32;
 pub const SHORT_MOST_SIGNIFICANT_BIT: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -22595,9 +20132,6 @@ impl Default for SIGNAL_REG_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIGNAL_REG_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 pub type SILO_CONTEXT_CLEANUP_CALLBACK = Option<unsafe extern "system" fn(silocontext: *const core::ffi::c_void)>;
 #[cfg(feature = "Wdk_Foundation")]
@@ -22620,10 +20154,6 @@ impl Default for SILO_MONITOR_REGISTRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for SILO_MONITOR_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Wdk_Foundation")]
 #[derive(Clone, Copy)]
@@ -22636,10 +20166,6 @@ impl Default for SILO_MONITOR_REGISTRATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Wdk_Foundation")]
-impl windows_core::TypeKind for SILO_MONITOR_REGISTRATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SILO_MONITOR_REGISTRATION_VERSION: u32 = 1u32;
 #[cfg(feature = "Wdk_Foundation")]
@@ -22694,9 +20220,6 @@ impl Default for SOC_SUBSYSTEM_FAILURE_DETAILS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOC_SUBSYSTEM_FAILURE_DETAILS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SOC_SUBSYSTEM_TYPE(pub i32);
@@ -22739,9 +20262,6 @@ impl Default for SYSTEM_FIRMWARE_TABLE_HANDLER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_FIRMWARE_TABLE_HANDLER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_FIRMWARE_TABLE_INFORMATION {
@@ -22756,9 +20276,6 @@ impl Default for SYSTEM_FIRMWARE_TABLE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_FIRMWARE_TABLE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SYSTEM_POWER_CONDITION(pub i32);
@@ -22772,9 +20289,6 @@ impl Default for SYSTEM_POWER_STATE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_POWER_STATE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SYSTEM_POWER_STATE_CONTEXT_0 {
@@ -22786,9 +20300,6 @@ impl Default for SYSTEM_POWER_STATE_CONTEXT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_POWER_STATE_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_POWER_STATE_CONTEXT_0_0 {
@@ -22798,9 +20309,6 @@ impl Default for SYSTEM_POWER_STATE_CONTEXT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_POWER_STATE_CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ScsiAdapter: CONFIGURATION_TYPE = CONFIGURATION_TYPE(10i32);
 pub const SeImageTypeDriver: SE_IMAGE_TYPE = SE_IMAGE_TYPE(1i32);
@@ -22852,10 +20360,6 @@ impl Default for TARGET_DEVICE_REMOVAL_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for TARGET_DEVICE_REMOVAL_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const THREAD_ALERT: u32 = 4u32;
 pub const THREAD_CSWITCH_PMU_DISABLE: u32 = 0u32;
 pub const THREAD_CSWITCH_PMU_ENABLE: u32 = 1u32;
@@ -22879,9 +20383,6 @@ impl Default for TIMER_SET_COALESCABLE_TIMER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TIMER_SET_COALESCABLE_TIMER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TIMER_TOLERABLE_DELAY_BITS: u32 = 6u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -22899,9 +20400,6 @@ impl Default for TIME_FIELDS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TIME_FIELDS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -22925,10 +20423,6 @@ impl Default for TRANSLATOR_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for TRANSLATOR_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TREE_CONNECT_NO_CLIENT_BUFFERING: u32 = 8u32;
 pub const TREE_CONNECT_WRITE_THROUGH: u32 = 2u32;
 pub const TXF_MINIVERSION_DEFAULT_VIEW: u32 = 65534u32;
@@ -22943,9 +20437,6 @@ impl Default for TXN_PARAMETER_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXN_PARAMETER_BLOCK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TableEmptyTree: TABLE_SEARCH_RESULT = TABLE_SEARCH_RESULT(0i32);
 pub const TableFoundNode: TABLE_SEARCH_RESULT = TABLE_SEARCH_RESULT(1i32);
@@ -22992,9 +20483,6 @@ impl Default for VIRTUAL_CHANNEL_CAPABILITIES1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_CHANNEL_CAPABILITIES1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_CHANNEL_CAPABILITIES1_0 {
@@ -23004,9 +20492,6 @@ impl Default for VIRTUAL_CHANNEL_CAPABILITIES1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_CHANNEL_CAPABILITIES1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -23019,9 +20504,6 @@ impl Default for VIRTUAL_CHANNEL_CAPABILITIES2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_CHANNEL_CAPABILITIES2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_CHANNEL_CAPABILITIES2_0 {
@@ -23031,9 +20513,6 @@ impl Default for VIRTUAL_CHANNEL_CAPABILITIES2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_CHANNEL_CAPABILITIES2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -23046,9 +20525,6 @@ impl Default for VIRTUAL_CHANNEL_CONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_CHANNEL_CONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_CHANNEL_CONTROL_0 {
@@ -23058,9 +20534,6 @@ impl Default for VIRTUAL_CHANNEL_CONTROL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_CHANNEL_CONTROL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -23073,9 +20546,6 @@ impl Default for VIRTUAL_CHANNEL_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_CHANNEL_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_CHANNEL_STATUS_0 {
@@ -23085,9 +20555,6 @@ impl Default for VIRTUAL_CHANNEL_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_CHANNEL_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -23102,9 +20569,6 @@ impl Default for VIRTUAL_RESOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_RESOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIRTUAL_RESOURCE_CAPABILITY {
@@ -23116,9 +20580,6 @@ impl Default for VIRTUAL_RESOURCE_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_RESOURCE_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_RESOURCE_CAPABILITY_0 {
@@ -23128,9 +20589,6 @@ impl Default for VIRTUAL_RESOURCE_CAPABILITY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_RESOURCE_CAPABILITY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -23143,9 +20601,6 @@ impl Default for VIRTUAL_RESOURCE_CONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_RESOURCE_CONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_RESOURCE_CONTROL_0 {
@@ -23155,9 +20610,6 @@ impl Default for VIRTUAL_RESOURCE_CONTROL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_RESOURCE_CONTROL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -23170,9 +20622,6 @@ impl Default for VIRTUAL_RESOURCE_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_RESOURCE_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_RESOURCE_STATUS_0 {
@@ -23182,9 +20631,6 @@ impl Default for VIRTUAL_RESOURCE_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_RESOURCE_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VMEBus: INTERFACE_TYPE = INTERFACE_TYPE(6i32);
 pub const VMEConfiguration: BUS_DATA_TYPE = BUS_DATA_TYPE(5i32);
@@ -23208,9 +20654,6 @@ impl Default for VM_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VM_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VM_COUNTERS_EX {
@@ -23232,9 +20675,6 @@ impl Default for VM_COUNTERS_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VM_COUNTERS_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VM_COUNTERS_EX2 {
@@ -23246,9 +20686,6 @@ impl Default for VM_COUNTERS_EX2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VM_COUNTERS_EX2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VPB_DIRECT_WRITES_ALLOWED: u32 = 32u32;
 pub const VPB_DISMOUNTING: u32 = 128u32;
@@ -23277,10 +20714,6 @@ impl Default for WAIT_CONTEXT_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for WAIT_CONTEXT_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy)]
@@ -23293,10 +20726,6 @@ impl Default for WAIT_CONTEXT_BLOCK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for WAIT_CONTEXT_BLOCK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
@@ -23312,10 +20741,6 @@ impl Default for WAIT_CONTEXT_BLOCK_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Wdk_Foundation", feature = "Wdk_Storage_FileSystem", feature = "Win32_Security", feature = "Win32_System_IO", feature = "Win32_System_Kernel", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for WAIT_CONTEXT_BLOCK_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WCS_RAS_REGISTER_NAME_MAX_LENGTH: u32 = 32u32;
 pub const WDM_MAJORVERSION: u32 = 6u32;
 pub const WDM_MINORVERSION: u32 = 0u32;
@@ -23330,9 +20755,6 @@ impl Default for WHEA128A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA128A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEAP_ACPI_TIMEOUT_EVENT {
@@ -23344,9 +20766,6 @@ impl Default for WHEAP_ACPI_TIMEOUT_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_ACPI_TIMEOUT_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -23363,10 +20782,6 @@ impl Default for WHEAP_ADD_REMOVE_ERROR_SOURCE_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEAP_ADD_REMOVE_ERROR_SOURCE_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_ATTEMPT_RECOVERY_EVENT {
@@ -23380,9 +20795,6 @@ impl Default for WHEAP_ATTEMPT_RECOVERY_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_ATTEMPT_RECOVERY_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -23399,10 +20811,6 @@ impl Default for WHEAP_BAD_HEST_NOTIFY_DATA_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEAP_BAD_HEST_NOTIFY_DATA_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_CLEARED_POISON_EVENT {
@@ -23414,9 +20822,6 @@ impl Default for WHEAP_CLEARED_POISON_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_CLEARED_POISON_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEAP_CMCI_IMPLEMENTED_EVENT {
@@ -23427,9 +20832,6 @@ impl Default for WHEAP_CMCI_IMPLEMENTED_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_CMCI_IMPLEMENTED_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -23445,9 +20847,6 @@ impl Default for WHEAP_CMCI_INITERR_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_CMCI_INITERR_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_CMCI_RESTART_EVENT {
@@ -23462,9 +20861,6 @@ impl Default for WHEAP_CMCI_RESTART_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_CMCI_RESTART_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_CREATE_GENERIC_RECORD_EVENT {
@@ -23477,9 +20873,6 @@ impl Default for WHEAP_CREATE_GENERIC_RECORD_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_CREATE_GENERIC_RECORD_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -23494,10 +20887,6 @@ impl Default for WHEAP_DEFERRED_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for WHEAP_DEFERRED_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEAP_DEVICE_DRV_EVENT {
@@ -23508,9 +20897,6 @@ impl Default for WHEAP_DEVICE_DRV_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_DEVICE_DRV_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -23527,9 +20913,6 @@ impl Default for WHEAP_DPC_ERROR_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_DPC_ERROR_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -23548,10 +20931,6 @@ impl Default for WHEAP_DROPPED_CORRECTED_ERROR_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEAP_DROPPED_CORRECTED_ERROR_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEAP_EDPC_ENABLED_EVENT {
@@ -23563,9 +20942,6 @@ impl Default for WHEAP_EDPC_ENABLED_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_EDPC_ENABLED_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -23579,9 +20955,6 @@ impl Default for WHEAP_ERROR_CLEARED_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_ERROR_CLEARED_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_ERROR_RECORD_EVENT {
@@ -23592,9 +20965,6 @@ impl Default for WHEAP_ERROR_RECORD_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_ERROR_RECORD_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -23608,9 +20978,6 @@ impl Default for WHEAP_ERR_SRC_ARRAY_INVALID_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_ERR_SRC_ARRAY_INVALID_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -23626,10 +20993,6 @@ impl Default for WHEAP_ERR_SRC_INVALID_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEAP_ERR_SRC_INVALID_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_FOUND_ERROR_IN_BANK_EVENT {
@@ -23644,9 +21007,6 @@ impl Default for WHEAP_FOUND_ERROR_IN_BANK_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_FOUND_ERROR_IN_BANK_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_GENERIC_ERR_MEM_MAP_EVENT {
@@ -23660,9 +21020,6 @@ impl Default for WHEAP_GENERIC_ERR_MEM_MAP_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_GENERIC_ERR_MEM_MAP_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEAP_OSC_IMPLEMENTED {
@@ -23674,9 +21031,6 @@ impl Default for WHEAP_OSC_IMPLEMENTED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_OSC_IMPLEMENTED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -23696,9 +21050,6 @@ impl Default for WHEAP_PCIE_CONFIG_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_PCIE_CONFIG_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -23720,9 +21071,6 @@ impl Default for WHEAP_PCIE_OVERRIDE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_PCIE_OVERRIDE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_PCIE_READ_OVERRIDES_ERR {
@@ -23734,9 +21082,6 @@ impl Default for WHEAP_PCIE_READ_OVERRIDES_ERR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_PCIE_READ_OVERRIDES_ERR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -23750,9 +21095,6 @@ impl Default for WHEAP_PFA_MEMORY_OFFLINED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_PFA_MEMORY_OFFLINED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -23771,9 +21113,6 @@ impl Default for WHEAP_PFA_MEMORY_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_PFA_MEMORY_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_PFA_MEMORY_REMOVE_MONITOR {
@@ -23788,9 +21127,6 @@ impl Default for WHEAP_PFA_MEMORY_REMOVE_MONITOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_PFA_MEMORY_REMOVE_MONITOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHEAP_PFA_OFFLINE_DECISION_TYPE(pub i32);
@@ -23804,9 +21140,6 @@ impl Default for WHEAP_PLUGIN_DEFECT_LIST_CORRUPT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_PLUGIN_DEFECT_LIST_CORRUPT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEAP_PLUGIN_DEFECT_LIST_FULL_EVENT {
@@ -23816,9 +21149,6 @@ impl Default for WHEAP_PLUGIN_DEFECT_LIST_FULL_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_PLUGIN_DEFECT_LIST_FULL_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -23830,9 +21160,6 @@ impl Default for WHEAP_PLUGIN_DEFECT_LIST_UEFI_VAR_FAILED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_PLUGIN_DEFECT_LIST_UEFI_VAR_FAILED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEAP_PLUGIN_PFA_EVENT {
@@ -23843,9 +21170,6 @@ impl Default for WHEAP_PLUGIN_PFA_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_PLUGIN_PFA_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -23869,9 +21193,6 @@ impl Default for WHEAP_PROCESS_EINJ_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_PROCESS_EINJ_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_PROCESS_HEST_EVENT {
@@ -23894,9 +21215,6 @@ impl Default for WHEAP_PROCESS_HEST_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_PROCESS_HEST_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_PSHED_INJECT_ERROR {
@@ -23915,9 +21233,6 @@ impl Default for WHEAP_PSHED_INJECT_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_PSHED_INJECT_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_PSHED_PLUGIN_REGISTER {
@@ -23932,9 +21247,6 @@ impl Default for WHEAP_PSHED_PLUGIN_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_PSHED_PLUGIN_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_ROW_FAILURE_EVENT {
@@ -23946,9 +21258,6 @@ impl Default for WHEAP_ROW_FAILURE_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_ROW_FAILURE_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -23966,9 +21275,6 @@ impl Default for WHEAP_SPURIOUS_AER_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEAP_SPURIOUS_AER_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 #[derive(Clone, Copy)]
@@ -23982,10 +21288,6 @@ impl Default for WHEAP_STARTED_REPORT_HW_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEAP_STARTED_REPORT_HW_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEAP_STUCK_ERROR_EVENT {
@@ -23998,9 +21300,6 @@ impl Default for WHEAP_STUCK_ERROR_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEAP_STUCK_ERROR_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24019,9 +21318,6 @@ impl Default for WHEA_ACPI_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ACPI_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24042,9 +21338,6 @@ impl Default for WHEA_AMD_EXTENDED_REGISTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_AMD_EXTENDED_REGISTERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_AMD_EXT_REG_NUM: u32 = 10u32;
 #[repr(C, packed(1))]
@@ -24072,9 +21365,6 @@ impl Default for WHEA_ARMV8_AARCH32_GPRS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARMV8_AARCH32_GPRS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARMV8_AARCH64_EL3_CSR {
@@ -24093,9 +21383,6 @@ impl Default for WHEA_ARMV8_AARCH64_EL3_CSR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ARMV8_AARCH64_EL3_CSR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24138,9 +21425,6 @@ impl Default for WHEA_ARMV8_AARCH64_GPRS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARMV8_AARCH64_GPRS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_AARCH32_EL1_CSR {
@@ -24174,9 +21458,6 @@ impl Default for WHEA_ARM_AARCH32_EL1_CSR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_AARCH32_EL1_CSR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_AARCH32_EL2_CSR {
@@ -24202,9 +21483,6 @@ impl Default for WHEA_ARM_AARCH32_EL2_CSR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_AARCH32_EL2_CSR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_AARCH32_SECURE_CSR {
@@ -24215,9 +21493,6 @@ impl Default for WHEA_ARM_AARCH32_SECURE_CSR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ARM_AARCH32_SECURE_CSR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24245,9 +21520,6 @@ impl Default for WHEA_ARM_AARCH64_EL1_CSR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_AARCH64_EL1_CSR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_AARCH64_EL2_CSR {
@@ -24272,9 +21544,6 @@ impl Default for WHEA_ARM_AARCH64_EL2_CSR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_AARCH64_EL2_CSR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_BUS_ERROR {
@@ -24291,9 +21560,6 @@ impl Default for WHEA_ARM_BUS_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_BUS_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_ARM_BUS_ERROR_VALID_BITS {
@@ -24305,9 +21571,6 @@ impl Default for WHEA_ARM_BUS_ERROR_VALID_BITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_BUS_ERROR_VALID_BITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_BUS_ERROR_VALID_BITS_0 {
@@ -24317,9 +21580,6 @@ impl Default for WHEA_ARM_BUS_ERROR_VALID_BITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ARM_BUS_ERROR_VALID_BITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24334,9 +21594,6 @@ impl Default for WHEA_ARM_CACHE_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_CACHE_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_ARM_CACHE_ERROR_VALID_BITS {
@@ -24348,9 +21605,6 @@ impl Default for WHEA_ARM_CACHE_ERROR_VALID_BITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_CACHE_ERROR_VALID_BITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_CACHE_ERROR_VALID_BITS_0 {
@@ -24360,9 +21614,6 @@ impl Default for WHEA_ARM_CACHE_ERROR_VALID_BITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ARM_CACHE_ERROR_VALID_BITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24374,9 +21625,6 @@ impl Default for WHEA_ARM_MISC_CSR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ARM_MISC_CSR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24391,9 +21639,6 @@ impl Default for WHEA_ARM_PROCESSOR_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_PROCESSOR_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_PROCESSOR_ERROR_CONTEXT_INFORMATION_HEADER {
@@ -24407,9 +21652,6 @@ impl Default for WHEA_ARM_PROCESSOR_ERROR_CONTEXT_INFORMATION_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_PROCESSOR_ERROR_CONTEXT_INFORMATION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_ARM_PROCESSOR_ERROR_CONTEXT_INFORMATION_HEADER_FLAGS {
@@ -24421,9 +21663,6 @@ impl Default for WHEA_ARM_PROCESSOR_ERROR_CONTEXT_INFORMATION_HEADER_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_PROCESSOR_ERROR_CONTEXT_INFORMATION_HEADER_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_PROCESSOR_ERROR_CONTEXT_INFORMATION_HEADER_FLAGS_0 {
@@ -24433,9 +21672,6 @@ impl Default for WHEA_ARM_PROCESSOR_ERROR_CONTEXT_INFORMATION_HEADER_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ARM_PROCESSOR_ERROR_CONTEXT_INFORMATION_HEADER_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24455,9 +21691,6 @@ impl Default for WHEA_ARM_PROCESSOR_ERROR_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_PROCESSOR_ERROR_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_ARM_PROCESSOR_ERROR_INFORMATION_VALID_BITS {
@@ -24469,9 +21702,6 @@ impl Default for WHEA_ARM_PROCESSOR_ERROR_INFORMATION_VALID_BITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_PROCESSOR_ERROR_INFORMATION_VALID_BITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_PROCESSOR_ERROR_INFORMATION_VALID_BITS_0 {
@@ -24481,9 +21711,6 @@ impl Default for WHEA_ARM_PROCESSOR_ERROR_INFORMATION_VALID_BITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ARM_PROCESSOR_ERROR_INFORMATION_VALID_BITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24505,9 +21732,6 @@ impl Default for WHEA_ARM_PROCESSOR_ERROR_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_PROCESSOR_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_ARM_PROCESSOR_ERROR_SECTION_VALID_BITS {
@@ -24519,9 +21743,6 @@ impl Default for WHEA_ARM_PROCESSOR_ERROR_SECTION_VALID_BITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_PROCESSOR_ERROR_SECTION_VALID_BITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_PROCESSOR_ERROR_SECTION_VALID_BITS_0 {
@@ -24531,9 +21752,6 @@ impl Default for WHEA_ARM_PROCESSOR_ERROR_SECTION_VALID_BITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ARM_PROCESSOR_ERROR_SECTION_VALID_BITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24548,9 +21766,6 @@ impl Default for WHEA_ARM_TLB_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_TLB_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_ARM_TLB_ERROR_VALID_BITS {
@@ -24562,9 +21777,6 @@ impl Default for WHEA_ARM_TLB_ERROR_VALID_BITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ARM_TLB_ERROR_VALID_BITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ARM_TLB_ERROR_VALID_BITS_0 {
@@ -24574,9 +21786,6 @@ impl Default for WHEA_ARM_TLB_ERROR_VALID_BITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ARM_TLB_ERROR_VALID_BITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -24590,9 +21799,6 @@ impl Default for WHEA_AZCC_ROOT_BUS_ERR_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_AZCC_ROOT_BUS_ERR_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_AZCC_ROOT_BUS_LIST_EVENT {
@@ -24604,9 +21810,6 @@ impl Default for WHEA_AZCC_ROOT_BUS_LIST_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_AZCC_ROOT_BUS_LIST_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24621,9 +21824,6 @@ impl Default for WHEA_AZCC_SET_POISON_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_AZCC_SET_POISON_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -24646,9 +21846,6 @@ impl Default for WHEA_ERROR_INJECTION_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_INJECTION_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHEA_ERROR_INJECTION_CAPABILITIES_0 {
@@ -24658,9 +21855,6 @@ impl Default for WHEA_ERROR_INJECTION_CAPABILITIES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_INJECTION_CAPABILITIES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_ERROR_LOG_ENTRY_VERSION: u32 = 1u32;
 #[repr(transparent)]
@@ -24677,9 +21871,6 @@ impl Default for WHEA_ERROR_PACKET_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_PACKET_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ERROR_PACKET_FLAGS_0 {
@@ -24689,9 +21880,6 @@ impl Default for WHEA_ERROR_PACKET_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_PACKET_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_ERROR_PACKET_SECTION_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xe71254e9_c1b9_4940_ab76_909703a4320f);
 #[repr(C, packed(1))]
@@ -24722,10 +21910,6 @@ impl Default for WHEA_ERROR_PACKET_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEA_ERROR_PACKET_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 #[derive(Clone, Copy)]
@@ -24743,10 +21927,6 @@ impl Default for WHEA_ERROR_PACKET_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEA_ERROR_PACKET_V1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_ERROR_PACKET_V1_VERSION: u32 = 2u32;
 #[repr(C, packed(1))]
@@ -24776,10 +21956,6 @@ impl Default for WHEA_ERROR_PACKET_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEA_ERROR_PACKET_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WHEA_ERROR_PACKET_V2_VERSION: u32 = 3u32;
 pub const WHEA_ERROR_PACKET_VERSION: u32 = 3u32;
 pub const WHEA_ERROR_PKT_VERSION: u32 = 3u32;
@@ -24793,9 +21969,6 @@ impl Default for WHEA_ERROR_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_RECORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_ERROR_RECORD_FLAGS_DEVICE_DRIVER: u32 = 8u32;
 pub const WHEA_ERROR_RECORD_FLAGS_PREVIOUSERROR: u32 = 2u32;
@@ -24826,9 +21999,6 @@ impl Default for WHEA_ERROR_RECORD_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHEA_ERROR_RECORD_HEADER_0 {
@@ -24839,9 +22009,6 @@ impl Default for WHEA_ERROR_RECORD_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24854,9 +22021,6 @@ impl Default for WHEA_ERROR_RECORD_HEADER_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_ERROR_RECORD_HEADER_FLAGS {
@@ -24868,9 +22032,6 @@ impl Default for WHEA_ERROR_RECORD_HEADER_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_HEADER_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ERROR_RECORD_HEADER_FLAGS_0 {
@@ -24880,9 +22041,6 @@ impl Default for WHEA_ERROR_RECORD_HEADER_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_HEADER_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -24895,9 +22053,6 @@ impl Default for WHEA_ERROR_RECORD_HEADER_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_HEADER_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ERROR_RECORD_HEADER_VALIDBITS_0 {
@@ -24907,9 +22062,6 @@ impl Default for WHEA_ERROR_RECORD_HEADER_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_HEADER_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_ERROR_RECORD_REVISION: u32 = 528u32;
 #[repr(C, packed(1))]
@@ -24931,9 +22083,6 @@ impl Default for WHEA_ERROR_RECORD_SECTION_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_SECTION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_FLAGS {
@@ -24945,9 +22094,6 @@ impl Default for WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_FLAGS_0 {
@@ -24957,9 +22103,6 @@ impl Default for WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_REVISION: u32 = 768u32;
 #[repr(C)]
@@ -24973,9 +22116,6 @@ impl Default for WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_VALIDBITS_0 {
@@ -24985,9 +22125,6 @@ impl Default for WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_RECORD_SECTION_DESCRIPTOR_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_ERROR_RECORD_SIGNATURE_END: u32 = 4294967295u32;
 pub const WHEA_ERROR_RECORD_VALID_PARTITIONID: u32 = 4u32;
@@ -25009,9 +22146,6 @@ impl Default for WHEA_ERROR_RECOVERY_INFO_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_RECOVERY_INFO_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHEA_ERROR_SEVERITY(pub i32);
@@ -25031,9 +22165,6 @@ impl Default for WHEA_ERROR_SOURCE_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_SOURCE_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WHEA_ERROR_SOURCE_CORRECT = Option<unsafe extern "system" fn() -> super::super::super::Win32::Foundation::NTSTATUS>;
 pub type WHEA_ERROR_SOURCE_CREATE_RECORD = Option<unsafe extern "system" fn() -> super::super::super::Win32::Foundation::NTSTATUS>;
 pub type WHEA_ERROR_SOURCE_INITIALIZE = Option<unsafe extern "system" fn() -> super::super::super::Win32::Foundation::NTSTATUS>;
@@ -25052,10 +22183,6 @@ impl Default for WHEA_ERROR_SOURCE_OVERRIDE_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEA_ERROR_SOURCE_OVERRIDE_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WHEA_ERROR_SOURCE_RECOVER = Option<unsafe extern "system" fn() -> super::super::super::Win32::Foundation::NTSTATUS>;
 pub type WHEA_ERROR_SOURCE_UNINITIALIZE = Option<unsafe extern "system" fn()>;
 #[repr(C, packed(1))]
@@ -25069,9 +22196,6 @@ impl Default for WHEA_ERROR_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ERROR_STATUS_0 {
@@ -25081,9 +22205,6 @@ impl Default for WHEA_ERROR_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_ERROR_TEXT_LEN: u32 = 32u32;
 #[repr(transparent)]
@@ -25101,9 +22222,6 @@ impl Default for WHEA_ETW_OVERFLOW_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ETW_OVERFLOW_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEA_EVENT_LOG_ENTRY {
@@ -25113,9 +22231,6 @@ impl Default for WHEA_EVENT_LOG_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_EVENT_LOG_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25128,9 +22243,6 @@ impl Default for WHEA_EVENT_LOG_ENTRY_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_EVENT_LOG_ENTRY_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_EVENT_LOG_ENTRY_FLAGS_0 {
@@ -25140,9 +22252,6 @@ impl Default for WHEA_EVENT_LOG_ENTRY_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_EVENT_LOG_ENTRY_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25161,9 +22270,6 @@ impl Default for WHEA_EVENT_LOG_ENTRY_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_EVENT_LOG_ENTRY_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHEA_EVENT_LOG_ENTRY_ID(pub i32);
@@ -25180,9 +22286,6 @@ impl Default for WHEA_FAILED_ADD_DEFECT_LIST_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_FAILED_ADD_DEFECT_LIST_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_FIRMWARE_ERROR_RECORD_REFERENCE {
@@ -25194,9 +22297,6 @@ impl Default for WHEA_FIRMWARE_ERROR_RECORD_REFERENCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_FIRMWARE_ERROR_RECORD_REFERENCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_FIRMWARE_RECORD_TYPE_IPFSAL: u32 = 0u32;
 pub const WHEA_GENERIC_ENTRY_TEXT_LEN: u32 = 20u32;
@@ -25217,9 +22317,6 @@ impl Default for WHEA_GENERIC_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_GENERIC_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_GENERIC_ERROR_BLOCKSTATUS {
@@ -25231,9 +22328,6 @@ impl Default for WHEA_GENERIC_ERROR_BLOCKSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_GENERIC_ERROR_BLOCKSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_GENERIC_ERROR_BLOCKSTATUS_0 {
@@ -25243,9 +22337,6 @@ impl Default for WHEA_GENERIC_ERROR_BLOCKSTATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_GENERIC_ERROR_BLOCKSTATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25264,9 +22355,6 @@ impl Default for WHEA_GENERIC_ERROR_DATA_ENTRY_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_GENERIC_ERROR_DATA_ENTRY_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25287,9 +22375,6 @@ impl Default for WHEA_GENERIC_ERROR_DATA_ENTRY_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_GENERIC_ERROR_DATA_ENTRY_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WHEA_INVALID_ERR_SRC_ID: u32 = 0u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -25302,9 +22387,6 @@ impl Default for WHEA_IN_USE_PAGE_NOTIFY_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_IN_USE_PAGE_NOTIFY_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHEA_IN_USE_PAGE_NOTIFY_FLAGS_0 {
@@ -25314,9 +22396,6 @@ impl Default for WHEA_IN_USE_PAGE_NOTIFY_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_IN_USE_PAGE_NOTIFY_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_IN_USE_PAGE_NOTIFY_FLAG_NOTIFYALL: u32 = 64u32;
 pub const WHEA_IN_USE_PAGE_NOTIFY_FLAG_PAGEOFFLINED: u32 = 128u32;
@@ -25349,9 +22428,6 @@ impl Default for WHEA_MEMORY_CORRECTABLE_ERROR_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_MEMORY_CORRECTABLE_ERROR_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_MEMORY_CORRECTABLE_ERROR_HEADER {
@@ -25362,9 +22438,6 @@ impl Default for WHEA_MEMORY_CORRECTABLE_ERROR_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_MEMORY_CORRECTABLE_ERROR_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -25377,9 +22450,6 @@ impl Default for WHEA_MEMORY_CORRECTABLE_ERROR_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_MEMORY_CORRECTABLE_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_MEMORY_CORRECTABLE_ERROR_SECTION_VALIDBITS {
@@ -25391,9 +22461,6 @@ impl Default for WHEA_MEMORY_CORRECTABLE_ERROR_SECTION_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_MEMORY_CORRECTABLE_ERROR_SECTION_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_MEMORY_CORRECTABLE_ERROR_SECTION_VALIDBITS_0 {
@@ -25403,9 +22470,6 @@ impl Default for WHEA_MEMORY_CORRECTABLE_ERROR_SECTION_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_MEMORY_CORRECTABLE_ERROR_SECTION_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25436,9 +22500,6 @@ impl Default for WHEA_MEMORY_ERROR_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_MEMORY_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_MEMORY_ERROR_SECTION_VALIDBITS {
@@ -25450,9 +22511,6 @@ impl Default for WHEA_MEMORY_ERROR_SECTION_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_MEMORY_ERROR_SECTION_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_MEMORY_ERROR_SECTION_VALIDBITS_0 {
@@ -25462,9 +22520,6 @@ impl Default for WHEA_MEMORY_ERROR_SECTION_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_MEMORY_ERROR_SECTION_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25476,9 +22531,6 @@ impl Default for WHEA_MEMORY_THROTTLE_SUMMARY_FAILED_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_MEMORY_THROTTLE_SUMMARY_FAILED_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_MSCHECK_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x48ab7f57_dc34_4f6c_a7d3_b0b5b0a74314);
 #[repr(C, packed(1))]
@@ -25493,9 +22545,6 @@ impl Default for WHEA_MSR_DUMP_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_MSR_DUMP_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEA_NMI_ERROR_SECTION {
@@ -25506,9 +22555,6 @@ impl Default for WHEA_NMI_ERROR_SECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_NMI_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25521,9 +22567,6 @@ impl Default for WHEA_NMI_ERROR_SECTION_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_NMI_ERROR_SECTION_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_NMI_ERROR_SECTION_FLAGS_0 {
@@ -25533,9 +22576,6 @@ impl Default for WHEA_NMI_ERROR_SECTION_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_NMI_ERROR_SECTION_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25547,9 +22587,6 @@ impl Default for WHEA_OFFLINE_DONE_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_OFFLINE_DONE_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -25568,9 +22605,6 @@ impl Default for WHEA_PACKET_LOG_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PACKET_LOG_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_PCIEXPRESS_BRIDGE_CONTROL_STATUS {
@@ -25581,9 +22615,6 @@ impl Default for WHEA_PCIEXPRESS_BRIDGE_CONTROL_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIEXPRESS_BRIDGE_CONTROL_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25596,9 +22627,6 @@ impl Default for WHEA_PCIEXPRESS_BRIDGE_CONTROL_STATUS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIEXPRESS_BRIDGE_CONTROL_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_PCIEXPRESS_COMMAND_STATUS {
@@ -25610,9 +22638,6 @@ impl Default for WHEA_PCIEXPRESS_COMMAND_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIEXPRESS_COMMAND_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PCIEXPRESS_COMMAND_STATUS_0 {
@@ -25623,9 +22648,6 @@ impl Default for WHEA_PCIEXPRESS_COMMAND_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIEXPRESS_COMMAND_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25640,9 +22662,6 @@ impl Default for WHEA_PCIEXPRESS_DEVICE_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIEXPRESS_DEVICE_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -25666,9 +22685,6 @@ impl Default for WHEA_PCIEXPRESS_ERROR_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIEXPRESS_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_PCIEXPRESS_ERROR_SECTION_VALIDBITS {
@@ -25680,9 +22696,6 @@ impl Default for WHEA_PCIEXPRESS_ERROR_SECTION_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIEXPRESS_ERROR_SECTION_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PCIEXPRESS_ERROR_SECTION_VALIDBITS_0 {
@@ -25692,9 +22705,6 @@ impl Default for WHEA_PCIEXPRESS_ERROR_SECTION_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIEXPRESS_ERROR_SECTION_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25707,9 +22717,6 @@ impl Default for WHEA_PCIEXPRESS_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIEXPRESS_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PCIEXPRESS_VERSION_0 {
@@ -25721,9 +22728,6 @@ impl Default for WHEA_PCIEXPRESS_VERSION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIEXPRESS_VERSION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25738,9 +22742,6 @@ impl Default for WHEA_PCIE_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIE_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PCIE_CORRECTABLE_ERROR_DEVICES {
@@ -25754,9 +22755,6 @@ impl Default for WHEA_PCIE_CORRECTABLE_ERROR_DEVICES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIE_CORRECTABLE_ERROR_DEVICES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_PCIE_CORRECTABLE_ERROR_DEVICES_VALIDBITS {
@@ -25768,9 +22766,6 @@ impl Default for WHEA_PCIE_CORRECTABLE_ERROR_DEVICES_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIE_CORRECTABLE_ERROR_DEVICES_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PCIE_CORRECTABLE_ERROR_DEVICES_VALIDBITS_0 {
@@ -25780,9 +22775,6 @@ impl Default for WHEA_PCIE_CORRECTABLE_ERROR_DEVICES_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIE_CORRECTABLE_ERROR_DEVICES_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -25794,9 +22786,6 @@ impl Default for WHEA_PCIE_CORRECTABLE_ERROR_SECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIE_CORRECTABLE_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_PCIE_CORRECTABLE_ERROR_SECTION_COUNT_SIZE: u32 = 32u32;
 #[repr(C, packed(1))]
@@ -25810,9 +22799,6 @@ impl Default for WHEA_PCIE_CORRECTABLE_ERROR_SECTION_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIE_CORRECTABLE_ERROR_SECTION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_PCIXBUS_COMMAND {
@@ -25824,9 +22810,6 @@ impl Default for WHEA_PCIXBUS_COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIXBUS_COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PCIXBUS_COMMAND_0 {
@@ -25836,9 +22819,6 @@ impl Default for WHEA_PCIXBUS_COMMAND_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIXBUS_COMMAND_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25860,9 +22840,6 @@ impl Default for WHEA_PCIXBUS_ERROR_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIXBUS_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_PCIXBUS_ERROR_SECTION_VALIDBITS {
@@ -25874,9 +22851,6 @@ impl Default for WHEA_PCIXBUS_ERROR_SECTION_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIXBUS_ERROR_SECTION_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PCIXBUS_ERROR_SECTION_VALIDBITS_0 {
@@ -25886,9 +22860,6 @@ impl Default for WHEA_PCIXBUS_ERROR_SECTION_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIXBUS_ERROR_SECTION_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25901,9 +22872,6 @@ impl Default for WHEA_PCIXBUS_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIXBUS_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHEA_PCIXBUS_ID_0 {
@@ -25914,9 +22882,6 @@ impl Default for WHEA_PCIXBUS_ID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIXBUS_ID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25933,9 +22898,6 @@ impl Default for WHEA_PCIXDEVICE_ERROR_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIXDEVICE_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_PCIXDEVICE_ERROR_SECTION_VALIDBITS {
@@ -25947,9 +22909,6 @@ impl Default for WHEA_PCIXDEVICE_ERROR_SECTION_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIXDEVICE_ERROR_SECTION_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PCIXDEVICE_ERROR_SECTION_VALIDBITS_0 {
@@ -25959,9 +22918,6 @@ impl Default for WHEA_PCIXDEVICE_ERROR_SECTION_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIXDEVICE_ERROR_SECTION_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -25977,9 +22933,6 @@ impl Default for WHEA_PCIXDEVICE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCIXDEVICE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PCIXDEVICE_REGISTER_PAIR {
@@ -25990,9 +22943,6 @@ impl Default for WHEA_PCIXDEVICE_REGISTER_PAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCIXDEVICE_REGISTER_PAIR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -26005,9 +22955,6 @@ impl Default for WHEA_PCI_RECOVERY_SECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCI_RECOVERY_SECTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -26026,9 +22973,6 @@ impl Default for WHEA_PERSISTENCE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PERSISTENCE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PERSISTENCE_INFO_0 {
@@ -26038,9 +22982,6 @@ impl Default for WHEA_PERSISTENCE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PERSISTENCE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -26063,9 +23004,6 @@ impl Default for WHEA_PMEM_ERROR_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PMEM_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WHEA_PMEM_ERROR_SECTION_LOCATION_INFO_SIZE: u32 = 64u32;
 pub const WHEA_PMEM_ERROR_SECTION_MAX_PAGES: u32 = 50u32;
 #[repr(C, packed(1))]
@@ -26079,9 +23017,6 @@ impl Default for WHEA_PMEM_ERROR_SECTION_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PMEM_ERROR_SECTION_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PMEM_ERROR_SECTION_VALIDBITS_0 {
@@ -26091,9 +23026,6 @@ impl Default for WHEA_PMEM_ERROR_SECTION_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PMEM_ERROR_SECTION_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -26107,9 +23039,6 @@ impl Default for WHEA_PMEM_PAGE_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PMEM_PAGE_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_PROCESSOR_FAMILY_INFO {
@@ -26121,9 +23050,6 @@ impl Default for WHEA_PROCESSOR_FAMILY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PROCESSOR_FAMILY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PROCESSOR_FAMILY_INFO_0 {
@@ -26134,9 +23060,6 @@ impl Default for WHEA_PROCESSOR_FAMILY_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PROCESSOR_FAMILY_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -26162,9 +23085,6 @@ impl Default for WHEA_PROCESSOR_GENERIC_ERROR_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PROCESSOR_GENERIC_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_PROCESSOR_GENERIC_ERROR_SECTION_VALIDBITS {
@@ -26176,9 +23096,6 @@ impl Default for WHEA_PROCESSOR_GENERIC_ERROR_SECTION_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PROCESSOR_GENERIC_ERROR_SECTION_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PROCESSOR_GENERIC_ERROR_SECTION_VALIDBITS_0 {
@@ -26188,9 +23105,6 @@ impl Default for WHEA_PROCESSOR_GENERIC_ERROR_SECTION_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PROCESSOR_GENERIC_ERROR_SECTION_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -26203,9 +23117,6 @@ impl Default for WHEA_PSHED_PI_CPU_BUSES_INIT_FAILED_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PSHED_PI_CPU_BUSES_INIT_FAILED_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEA_PSHED_PI_TRACE_EVENT {
@@ -26216,9 +23127,6 @@ impl Default for WHEA_PSHED_PI_TRACE_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PSHED_PI_TRACE_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -26246,10 +23154,6 @@ impl Default for WHEA_PSHED_PLUGIN_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEA_PSHED_PLUGIN_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PSHED_PLUGIN_DIMM_MISMATCH {
@@ -26269,9 +23173,6 @@ impl Default for WHEA_PSHED_PLUGIN_DIMM_MISMATCH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PSHED_PLUGIN_DIMM_MISMATCH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHEA_PSHED_PLUGIN_ENABLE_NOTIFY_ERRORS(pub i32);
@@ -26286,9 +23187,6 @@ impl Default for WHEA_PSHED_PLUGIN_ENABLE_NOTIFY_FAILED_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PSHED_PLUGIN_ENABLE_NOTIFY_FAILED_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEA_PSHED_PLUGIN_HEARTBEAT {
@@ -26298,9 +23196,6 @@ impl Default for WHEA_PSHED_PLUGIN_HEARTBEAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PSHED_PLUGIN_HEARTBEAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -26312,9 +23207,6 @@ impl Default for WHEA_PSHED_PLUGIN_INIT_FAILED_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PSHED_PLUGIN_INIT_FAILED_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -26329,9 +23221,6 @@ impl Default for WHEA_PSHED_PLUGIN_LOAD_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PSHED_PLUGIN_LOAD_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PSHED_PLUGIN_PLATFORM_SUPPORT_EVENT {
@@ -26343,9 +23232,6 @@ impl Default for WHEA_PSHED_PLUGIN_PLATFORM_SUPPORT_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PSHED_PLUGIN_PLATFORM_SUPPORT_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -26363,10 +23249,6 @@ impl Default for WHEA_PSHED_PLUGIN_REGISTRATION_PACKET_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEA_PSHED_PLUGIN_REGISTRATION_PACKET_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -26386,10 +23268,6 @@ impl Default for WHEA_PSHED_PLUGIN_REGISTRATION_PACKET_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for WHEA_PSHED_PLUGIN_REGISTRATION_PACKET_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PSHED_PLUGIN_UNLOAD_EVENT {
@@ -26400,9 +23278,6 @@ impl Default for WHEA_PSHED_PLUGIN_UNLOAD_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PSHED_PLUGIN_UNLOAD_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -26419,9 +23294,6 @@ impl Default for WHEA_RECOVERY_ACTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_RECOVERY_ACTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_RECOVERY_ACTION_0 {
@@ -26432,9 +23304,6 @@ impl Default for WHEA_RECOVERY_ACTION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_RECOVERY_ACTION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -26449,9 +23318,6 @@ impl Default for WHEA_RECOVERY_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_RECOVERY_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHEA_RECOVERY_CONTEXT_0 {
@@ -26462,9 +23328,6 @@ impl Default for WHEA_RECOVERY_CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_RECOVERY_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -26481,9 +23344,6 @@ impl Default for WHEA_RECOVERY_CONTEXT_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_RECOVERY_CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHEA_RECOVERY_CONTEXT_0_1 {
@@ -26493,9 +23353,6 @@ impl Default for WHEA_RECOVERY_CONTEXT_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_RECOVERY_CONTEXT_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -26516,9 +23373,6 @@ impl Default for WHEA_REGISTER_KEY_NOTIFICATION_FAILED_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_REGISTER_KEY_NOTIFICATION_FAILED_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHEA_REPORT_HW_ERROR_DEVICE_DRIVER_FLAGS {
@@ -26530,9 +23384,6 @@ impl Default for WHEA_REPORT_HW_ERROR_DEVICE_DRIVER_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_REPORT_HW_ERROR_DEVICE_DRIVER_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHEA_REPORT_HW_ERROR_DEVICE_DRIVER_FLAGS_0 {
@@ -26542,9 +23393,6 @@ impl Default for WHEA_REPORT_HW_ERROR_DEVICE_DRIVER_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_REPORT_HW_ERROR_DEVICE_DRIVER_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -26557,9 +23405,6 @@ impl Default for WHEA_REVISION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_REVISION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHEA_REVISION_0 {
@@ -26570,9 +23415,6 @@ impl Default for WHEA_REVISION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_REVISION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -26586,9 +23428,6 @@ impl Default for WHEA_SEA_SECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_SEA_SECTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_SECTION_DESCRIPTOR_FLAGS_CONTAINMENTWRN: u32 = 2u32;
 pub const WHEA_SECTION_DESCRIPTOR_FLAGS_FRU_TEXT_BY_PLUGIN: u32 = 128u32;
@@ -26610,9 +23449,6 @@ impl Default for WHEA_SEI_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_SEI_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_SEL_BUGCHECK_PROGRESS {
@@ -26624,9 +23460,6 @@ impl Default for WHEA_SEL_BUGCHECK_PROGRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_SEL_BUGCHECK_PROGRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -26640,9 +23473,6 @@ impl Default for WHEA_SEL_BUGCHECK_RECOVERY_STATUS_MULTIPLE_BUGCHECK_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_SEL_BUGCHECK_RECOVERY_STATUS_MULTIPLE_BUGCHECK_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -26658,9 +23488,6 @@ impl Default for WHEA_SEL_BUGCHECK_RECOVERY_STATUS_PHASE1_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_SEL_BUGCHECK_RECOVERY_STATUS_PHASE1_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHEA_SEL_BUGCHECK_RECOVERY_STATUS_PHASE1_EVENT_0 {
@@ -26671,9 +23498,6 @@ impl Default for WHEA_SEL_BUGCHECK_RECOVERY_STATUS_PHASE1_EVENT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_SEL_BUGCHECK_RECOVERY_STATUS_PHASE1_EVENT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_SEL_BUGCHECK_RECOVERY_STATUS_PHASE1_VERSION: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -26688,9 +23512,6 @@ impl Default for WHEA_SEL_BUGCHECK_RECOVERY_STATUS_PHASE2_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_SEL_BUGCHECK_RECOVERY_STATUS_PHASE2_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEA_SEL_BUGCHECK_RECOVERY_STATUS_START_EVENT {
@@ -26701,9 +23522,6 @@ impl Default for WHEA_SEL_BUGCHECK_RECOVERY_STATUS_START_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_SEL_BUGCHECK_RECOVERY_STATUS_START_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub type WHEA_SIGNAL_HANDLER_OVERRIDE_CALLBACK = Option<unsafe extern "system" fn() -> super::super::super::Win32::Foundation::BOOLEAN>;
 #[repr(C, packed(1))]
@@ -26720,9 +23538,6 @@ impl Default for WHEA_SRAR_DETAIL_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_SRAR_DETAIL_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_SRAS_TABLE_ENTRIES_EVENT {
@@ -26736,9 +23551,6 @@ impl Default for WHEA_SRAS_TABLE_ENTRIES_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_SRAS_TABLE_ENTRIES_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEA_SRAS_TABLE_ERROR {
@@ -26748,9 +23560,6 @@ impl Default for WHEA_SRAS_TABLE_ERROR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_SRAS_TABLE_ERROR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -26762,9 +23571,6 @@ impl Default for WHEA_SRAS_TABLE_NOT_FOUND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_SRAS_TABLE_NOT_FOUND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHEA_THROTTLE_ADD_ERR_SRC_FAILED_EVENT {
@@ -26774,9 +23580,6 @@ impl Default for WHEA_THROTTLE_ADD_ERR_SRC_FAILED_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_THROTTLE_ADD_ERR_SRC_FAILED_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -26790,9 +23593,6 @@ impl Default for WHEA_THROTTLE_MEMORY_ADD_OR_REMOVE_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_THROTTLE_MEMORY_ADD_OR_REMOVE_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -26808,9 +23608,6 @@ impl Default for WHEA_THROTTLE_PCIE_ADD_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_THROTTLE_PCIE_ADD_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_THROTTLE_PCIE_REMOVE_EVENT {
@@ -26823,9 +23620,6 @@ impl Default for WHEA_THROTTLE_PCIE_REMOVE_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_THROTTLE_PCIE_REMOVE_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_THROTTLE_REGISTRY_CORRUPT_EVENT {
@@ -26837,9 +23631,6 @@ impl Default for WHEA_THROTTLE_REGISTRY_CORRUPT_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_THROTTLE_REGISTRY_CORRUPT_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_THROTTLE_REG_DATA_IGNORED_EVENT {
@@ -26850,9 +23641,6 @@ impl Default for WHEA_THROTTLE_REG_DATA_IGNORED_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_THROTTLE_REG_DATA_IGNORED_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -26868,9 +23656,6 @@ impl Default for WHEA_TIMESTAMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_TIMESTAMP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_TIMESTAMP_0 {
@@ -26880,9 +23665,6 @@ impl Default for WHEA_TIMESTAMP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_TIMESTAMP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_TLBCHECK_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xfc06b535_5e1f_4562_9f25_0a3b9adb63c3);
 pub const WHEA_WRITE_FLAG_DUMMY: u32 = 1u32;
@@ -26930,9 +23712,6 @@ impl Default for WHEA_X64_REGISTER_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_X64_REGISTER_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_X86_REGISTER_STATE {
@@ -26967,9 +23746,6 @@ impl Default for WHEA_X86_REGISTER_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_X86_REGISTER_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_XPF_BUS_CHECK {
@@ -26981,9 +23757,6 @@ impl Default for WHEA_XPF_BUS_CHECK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_BUS_CHECK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_XPF_BUS_CHECK_0 {
@@ -26993,9 +23766,6 @@ impl Default for WHEA_XPF_BUS_CHECK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_XPF_BUS_CHECK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -27008,9 +23778,6 @@ impl Default for WHEA_XPF_CACHE_CHECK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_CACHE_CHECK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_XPF_CACHE_CHECK_0 {
@@ -27020,9 +23787,6 @@ impl Default for WHEA_XPF_CACHE_CHECK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_XPF_CACHE_CHECK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -27036,9 +23800,6 @@ impl Default for WHEA_XPF_CONTEXT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_XPF_CONTEXT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_XPF_MCA_EXTREG_MAX_COUNT: u32 = 24u32;
 #[repr(C, packed(1))]
@@ -27065,9 +23826,6 @@ impl Default for WHEA_XPF_MCA_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_MCA_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_XPF_MCA_SECTION_0 {
@@ -27078,9 +23836,6 @@ impl Default for WHEA_XPF_MCA_SECTION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_XPF_MCA_SECTION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_XPF_MCA_SECTION_VERSION: u32 = 3u32;
 pub const WHEA_XPF_MCA_SECTION_VERSION_2: u32 = 2u32;
@@ -27096,9 +23851,6 @@ impl Default for WHEA_XPF_MS_CHECK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_MS_CHECK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_XPF_MS_CHECK_0 {
@@ -27108,9 +23860,6 @@ impl Default for WHEA_XPF_MS_CHECK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_XPF_MS_CHECK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -27125,9 +23874,6 @@ impl Default for WHEA_XPF_PROCESSOR_ERROR_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_PROCESSOR_ERROR_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_XPF_PROCESSOR_ERROR_SECTION_VALIDBITS {
@@ -27139,9 +23885,6 @@ impl Default for WHEA_XPF_PROCESSOR_ERROR_SECTION_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_PROCESSOR_ERROR_SECTION_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_XPF_PROCESSOR_ERROR_SECTION_VALIDBITS_0 {
@@ -27151,9 +23894,6 @@ impl Default for WHEA_XPF_PROCESSOR_ERROR_SECTION_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_XPF_PROCESSOR_ERROR_SECTION_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -27171,9 +23911,6 @@ impl Default for WHEA_XPF_PROCINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_PROCINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_XPF_PROCINFO_0 {
@@ -27188,9 +23925,6 @@ impl Default for WHEA_XPF_PROCINFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_PROCINFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_XPF_PROCINFO_VALIDBITS {
@@ -27202,9 +23936,6 @@ impl Default for WHEA_XPF_PROCINFO_VALIDBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_PROCINFO_VALIDBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_XPF_PROCINFO_VALIDBITS_0 {
@@ -27214,9 +23945,6 @@ impl Default for WHEA_XPF_PROCINFO_VALIDBITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_XPF_PROCINFO_VALIDBITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -27229,9 +23957,6 @@ impl Default for WHEA_XPF_TLB_CHECK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_TLB_CHECK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_XPF_TLB_CHECK_0 {
@@ -27241,9 +23966,6 @@ impl Default for WHEA_XPF_TLB_CHECK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_XPF_TLB_CHECK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMIREGISTER: u32 = 0u32;
 pub const WMIREG_ACTION_BLOCK_IRPS: u32 = 5u32;
@@ -27545,9 +24267,6 @@ impl Default for XPF_RECOVERY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XPF_RECOVERY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct XPF_RECOVERY_INFO_1 {
@@ -27558,9 +24277,6 @@ impl Default for XPF_RECOVERY_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XPF_RECOVERY_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct XPF_RECOVERY_INFO_0 {
@@ -27570,9 +24286,6 @@ impl Default for XPF_RECOVERY_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XPF_RECOVERY_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XPF_TLB_CHECK_OPERATION_DATAREAD: u32 = 3u32;
 pub const XPF_TLB_CHECK_OPERATION_DATAWRITE: u32 = 4u32;
@@ -27611,10 +24324,6 @@ impl Default for XSAVE_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for XSAVE_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -27633,10 +24342,6 @@ impl Default for XSTATE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for XSTATE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 #[derive(Clone, Copy)]
@@ -27648,10 +24353,6 @@ impl Default for XSTATE_SAVE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for XSTATE_SAVE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -27665,10 +24366,6 @@ impl Default for XSTATE_SAVE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for XSTATE_SAVE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -27688,10 +24385,6 @@ impl Default for XSTATE_SAVE_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for XSTATE_SAVE_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -27707,10 +24400,6 @@ impl Default for ZONE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for ZONE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -27724,10 +24413,6 @@ impl Default for ZONE_SEGMENT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for ZONE_SEGMENT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _EXT_SET_PARAMETERS_V0 {
@@ -27739,9 +24424,6 @@ impl Default for _EXT_SET_PARAMETERS_V0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _EXT_SET_PARAMETERS_V0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const _STRSAFE_USE_SECURE_CRT: u32 = 0u32;
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
@@ -30,9 +30,6 @@ impl Default for DML_ACTIVATION_CELU_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_CELU_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_ELU_OPERATOR_DESC {
@@ -45,9 +42,6 @@ impl Default for DML_ACTIVATION_ELU_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_ELU_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_HARDMAX_OPERATOR_DESC {
@@ -58,9 +52,6 @@ impl Default for DML_ACTIVATION_HARDMAX_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ACTIVATION_HARDMAX_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -75,9 +66,6 @@ impl Default for DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_HARD_SIGMOID_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_IDENTITY_OPERATOR_DESC {
@@ -88,9 +76,6 @@ impl Default for DML_ACTIVATION_IDENTITY_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ACTIVATION_IDENTITY_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -103,9 +88,6 @@ impl Default for DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ACTIVATION_LEAKY_RELU_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -120,9 +102,6 @@ impl Default for DML_ACTIVATION_LINEAR_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_LINEAR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC {
@@ -133,9 +112,6 @@ impl Default for DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ACTIVATION_LOG_SOFTMAX_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -148,9 +124,6 @@ impl Default for DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ACTIVATION_PARAMETERIZED_RELU_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -165,9 +138,6 @@ impl Default for DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_PARAMETRIC_SOFTPLUS_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC {
@@ -180,9 +150,6 @@ impl Default for DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_RELU_GRAD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_RELU_OPERATOR_DESC {
@@ -193,9 +160,6 @@ impl Default for DML_ACTIVATION_RELU_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ACTIVATION_RELU_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -210,9 +174,6 @@ impl Default for DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_SCALED_ELU_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC {
@@ -225,9 +186,6 @@ impl Default for DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ACTIVATION_SCALED_TANH_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -242,9 +200,6 @@ impl Default for DML_ACTIVATION_SHRINK_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_SHRINK_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_SIGMOID_OPERATOR_DESC {
@@ -256,9 +211,6 @@ impl Default for DML_ACTIVATION_SIGMOID_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_SIGMOID_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_SOFTMAX_OPERATOR_DESC {
@@ -269,9 +221,6 @@ impl Default for DML_ACTIVATION_SOFTMAX_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ACTIVATION_SOFTMAX_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -285,9 +234,6 @@ impl Default for DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_SOFTPLUS_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC {
@@ -298,9 +244,6 @@ impl Default for DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ACTIVATION_SOFTSIGN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -313,9 +256,6 @@ impl Default for DML_ACTIVATION_TANH_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ACTIVATION_TANH_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC {
@@ -327,9 +267,6 @@ impl Default for DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ACTIVATION_THRESHOLDED_RELU_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -352,9 +289,6 @@ impl Default for DML_ADAM_OPTIMIZER_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ADAM_OPTIMIZER_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ARGMAX_OPERATOR_DESC {
@@ -369,9 +303,6 @@ impl Default for DML_ARGMAX_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ARGMAX_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ARGMIN_OPERATOR_DESC {
@@ -385,9 +316,6 @@ impl Default for DML_ARGMIN_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ARGMIN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -406,9 +334,6 @@ impl Default for DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_AVERAGE_POOLING_GRAD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_AVERAGE_POOLING_OPERATOR_DESC {
@@ -425,9 +350,6 @@ impl Default for DML_AVERAGE_POOLING_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_AVERAGE_POOLING_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -452,9 +374,6 @@ impl Default for DML_BATCH_NORMALIZATION_GRAD_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_BATCH_NORMALIZATION_GRAD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_BATCH_NORMALIZATION_OPERATOR_DESC {
@@ -473,9 +392,6 @@ impl Default for DML_BATCH_NORMALIZATION_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_BATCH_NORMALIZATION_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_BINDING_DESC {
@@ -486,9 +402,6 @@ impl Default for DML_BINDING_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_BINDING_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -501,9 +414,6 @@ impl Default for DML_BINDING_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_BINDING_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -519,10 +429,6 @@ impl Default for DML_BINDING_TABLE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for DML_BINDING_TABLE_DESC {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -543,10 +449,6 @@ impl Default for DML_BUFFER_ARRAY_BINDING {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for DML_BUFFER_ARRAY_BINDING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -560,10 +462,6 @@ impl Default for DML_BUFFER_BINDING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for DML_BUFFER_BINDING {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -581,9 +479,6 @@ impl Default for DML_BUFFER_TENSOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_BUFFER_TENSOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_CAST_OPERATOR_DESC {
@@ -594,9 +489,6 @@ impl Default for DML_CAST_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_CAST_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -622,9 +514,6 @@ impl Default for DML_CONVOLUTION_INTEGER_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_CONVOLUTION_INTEGER_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -653,9 +542,6 @@ impl Default for DML_CONVOLUTION_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_CONVOLUTION_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -709,9 +595,6 @@ impl Default for DML_CUMULATIVE_PRODUCT_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_CUMULATIVE_PRODUCT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_CUMULATIVE_SUMMATION_OPERATOR_DESC {
@@ -725,9 +608,6 @@ impl Default for DML_CUMULATIVE_SUMMATION_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_CUMULATIVE_SUMMATION_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -747,9 +627,6 @@ impl Default for DML_DEPTH_TO_SPACE1_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_DEPTH_TO_SPACE1_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_DEPTH_TO_SPACE_OPERATOR_DESC {
@@ -762,9 +639,6 @@ impl Default for DML_DEPTH_TO_SPACE_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_DEPTH_TO_SPACE_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_DIAGONAL_MATRIX_OPERATOR_DESC {
@@ -776,9 +650,6 @@ impl Default for DML_DIAGONAL_MATRIX_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_DIAGONAL_MATRIX_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -793,9 +664,6 @@ impl Default for DML_DYNAMIC_QUANTIZE_LINEAR_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_DYNAMIC_QUANTIZE_LINEAR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_ABS_OPERATOR_DESC {
@@ -807,9 +675,6 @@ impl Default for DML_ELEMENT_WISE_ABS_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ABS_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -823,9 +688,6 @@ impl Default for DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ACOSH_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_ACOS_OPERATOR_DESC {
@@ -837,9 +699,6 @@ impl Default for DML_ELEMENT_WISE_ACOS_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ACOS_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -854,9 +713,6 @@ impl Default for DML_ELEMENT_WISE_ADD1_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ADD1_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_ADD_OPERATOR_DESC {
@@ -868,9 +724,6 @@ impl Default for DML_ELEMENT_WISE_ADD_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ADD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -884,9 +737,6 @@ impl Default for DML_ELEMENT_WISE_ASINH_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ASINH_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_ASIN_OPERATOR_DESC {
@@ -898,9 +748,6 @@ impl Default for DML_ELEMENT_WISE_ASIN_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ASIN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -914,9 +761,6 @@ impl Default for DML_ELEMENT_WISE_ATANH_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ATANH_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_ATAN_OPERATOR_DESC {
@@ -928,9 +772,6 @@ impl Default for DML_ELEMENT_WISE_ATAN_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ATAN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -944,9 +785,6 @@ impl Default for DML_ELEMENT_WISE_ATAN_YX_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ATAN_YX_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC {
@@ -959,9 +797,6 @@ impl Default for DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_BIT_AND_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC {
@@ -973,9 +808,6 @@ impl Default for DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_BIT_COUNT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC {
@@ -986,9 +818,6 @@ impl Default for DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_BIT_NOT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1002,9 +831,6 @@ impl Default for DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_BIT_OR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC {
@@ -1016,9 +842,6 @@ impl Default for DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_BIT_SHIFT_LEFT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1032,9 +855,6 @@ impl Default for DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_BIT_SHIFT_RIGHT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC {
@@ -1047,9 +867,6 @@ impl Default for DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_BIT_XOR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_CEIL_OPERATOR_DESC {
@@ -1061,9 +878,6 @@ impl Default for DML_ELEMENT_WISE_CEIL_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_CEIL_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1079,9 +893,6 @@ impl Default for DML_ELEMENT_WISE_CLIP_GRAD_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_CLIP_GRAD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_CLIP_OPERATOR_DESC {
@@ -1096,9 +907,6 @@ impl Default for DML_ELEMENT_WISE_CLIP_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_CLIP_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC {
@@ -1112,9 +920,6 @@ impl Default for DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_CONSTANT_POW_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_COSH_OPERATOR_DESC {
@@ -1127,9 +932,6 @@ impl Default for DML_ELEMENT_WISE_COSH_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_COSH_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_COS_OPERATOR_DESC {
@@ -1141,9 +943,6 @@ impl Default for DML_ELEMENT_WISE_COS_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_COS_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1158,9 +957,6 @@ impl Default for DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_DEQUANTIZE_LINEAR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_DIFFERENCE_SQUARE_OPERATOR_DESC {
@@ -1172,9 +968,6 @@ impl Default for DML_ELEMENT_WISE_DIFFERENCE_SQUARE_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_DIFFERENCE_SQUARE_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1188,9 +981,6 @@ impl Default for DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_DIVIDE_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_ERF_OPERATOR_DESC {
@@ -1202,9 +992,6 @@ impl Default for DML_ELEMENT_WISE_ERF_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ERF_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1218,9 +1005,6 @@ impl Default for DML_ELEMENT_WISE_EXP_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_EXP_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC {
@@ -1233,9 +1017,6 @@ impl Default for DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_FLOOR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC {
@@ -1247,9 +1028,6 @@ impl Default for DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_IDENTITY_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1264,9 +1042,6 @@ impl Default for DML_ELEMENT_WISE_IF_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_IF_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC {
@@ -1279,9 +1054,6 @@ impl Default for DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_IS_INFINITY_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC {
@@ -1292,9 +1064,6 @@ impl Default for DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_IS_NAN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1308,9 +1077,6 @@ impl Default for DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_LOGICAL_AND_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC {
@@ -1322,9 +1088,6 @@ impl Default for DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_LOGICAL_EQUALS_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1338,9 +1101,6 @@ impl Default for DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC {
@@ -1352,9 +1112,6 @@ impl Default for DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_LOGICAL_GREATER_THAN_OR_EQUAL_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1368,9 +1125,6 @@ impl Default for DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC {
@@ -1383,9 +1137,6 @@ impl Default for DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_LOGICAL_LESS_THAN_OR_EQUAL_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC {
@@ -1396,9 +1147,6 @@ impl Default for DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_LOGICAL_NOT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1412,9 +1160,6 @@ impl Default for DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_LOGICAL_OR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC {
@@ -1426,9 +1171,6 @@ impl Default for DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_LOGICAL_XOR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1442,9 +1184,6 @@ impl Default for DML_ELEMENT_WISE_LOG_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_LOG_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_MAX_OPERATOR_DESC {
@@ -1456,9 +1195,6 @@ impl Default for DML_ELEMENT_WISE_MAX_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_MAX_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1472,9 +1208,6 @@ impl Default for DML_ELEMENT_WISE_MEAN_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_MEAN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_MIN_OPERATOR_DESC {
@@ -1486,9 +1219,6 @@ impl Default for DML_ELEMENT_WISE_MIN_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_MIN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1502,9 +1232,6 @@ impl Default for DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_MODULUS_FLOOR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC {
@@ -1516,9 +1243,6 @@ impl Default for DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_MODULUS_TRUNCATE_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1532,9 +1256,6 @@ impl Default for DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_MULTIPLY_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_POW_OPERATOR_DESC {
@@ -1547,9 +1268,6 @@ impl Default for DML_ELEMENT_WISE_POW_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_POW_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1569,9 +1287,6 @@ impl Default for DML_ELEMENT_WISE_QUANTIZED_LINEAR_ADD_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_QUANTIZED_LINEAR_ADD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC {
@@ -1585,9 +1300,6 @@ impl Default for DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_QUANTIZE_LINEAR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_RECIP_OPERATOR_DESC {
@@ -1599,9 +1311,6 @@ impl Default for DML_ELEMENT_WISE_RECIP_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_RECIP_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1615,9 +1324,6 @@ impl Default for DML_ELEMENT_WISE_ROUND_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_ROUND_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_SIGN_OPERATOR_DESC {
@@ -1628,9 +1334,6 @@ impl Default for DML_ELEMENT_WISE_SIGN_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_SIGN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1644,9 +1347,6 @@ impl Default for DML_ELEMENT_WISE_SINH_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_SINH_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_SIN_OPERATOR_DESC {
@@ -1658,9 +1358,6 @@ impl Default for DML_ELEMENT_WISE_SIN_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_SIN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1674,9 +1371,6 @@ impl Default for DML_ELEMENT_WISE_SQRT_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_SQRT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC {
@@ -1688,9 +1382,6 @@ impl Default for DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_SUBTRACT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1704,9 +1395,6 @@ impl Default for DML_ELEMENT_WISE_TANH_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ELEMENT_WISE_TANH_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ELEMENT_WISE_TAN_OPERATOR_DESC {
@@ -1718,9 +1406,6 @@ impl Default for DML_ELEMENT_WISE_TAN_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_TAN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1734,9 +1419,6 @@ impl Default for DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ELEMENT_WISE_THRESHOLD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1791,9 +1473,6 @@ impl Default for DML_FEATURE_DATA_FEATURE_LEVELS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_FEATURE_DATA_FEATURE_LEVELS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORT {
@@ -1803,9 +1482,6 @@ impl Default for DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_FEATURE_DATA_TENSOR_DATA_TYPE_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DML_FEATURE_FEATURE_LEVELS: DML_FEATURE = DML_FEATURE(1i32);
 #[repr(transparent)]
@@ -1830,9 +1506,6 @@ impl Default for DML_FEATURE_QUERY_FEATURE_LEVELS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_FEATURE_QUERY_FEATURE_LEVELS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORT {
@@ -1842,9 +1515,6 @@ impl Default for DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_FEATURE_QUERY_TENSOR_DATA_TYPE_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DML_FEATURE_TENSOR_DATA_TYPE_SUPPORT: DML_FEATURE = DML_FEATURE(0i32);
 #[repr(C)]
@@ -1859,9 +1529,6 @@ impl Default for DML_FILL_VALUE_CONSTANT_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_FILL_VALUE_CONSTANT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC {
@@ -1875,9 +1542,6 @@ impl Default for DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_FILL_VALUE_SEQUENCE_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_GATHER_ELEMENTS_OPERATOR_DESC {
@@ -1890,9 +1554,6 @@ impl Default for DML_GATHER_ELEMENTS_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_GATHER_ELEMENTS_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1909,9 +1570,6 @@ impl Default for DML_GATHER_ND1_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_GATHER_ND1_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_GATHER_ND_OPERATOR_DESC {
@@ -1926,9 +1584,6 @@ impl Default for DML_GATHER_ND_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_GATHER_ND_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_GATHER_OPERATOR_DESC {
@@ -1942,9 +1597,6 @@ impl Default for DML_GATHER_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_GATHER_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1963,9 +1615,6 @@ impl Default for DML_GEMM_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_GEMM_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1986,9 +1635,6 @@ impl Default for DML_GRAPH_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_GRAPH_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_GRAPH_EDGE_DESC {
@@ -1999,9 +1645,6 @@ impl Default for DML_GRAPH_EDGE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_GRAPH_EDGE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2020,9 +1663,6 @@ impl Default for DML_GRAPH_NODE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_GRAPH_NODE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2050,9 +1690,6 @@ impl Default for DML_GRU_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_GRU_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_INPUT_GRAPH_EDGE_DESC {
@@ -2065,9 +1702,6 @@ impl Default for DML_INPUT_GRAPH_EDGE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_INPUT_GRAPH_EDGE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2082,9 +1716,6 @@ impl Default for DML_INTERMEDIATE_GRAPH_EDGE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_INTERMEDIATE_GRAPH_EDGE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2110,9 +1741,6 @@ impl Default for DML_JOIN_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_JOIN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_LOCAL_RESPONSE_NORMALIZATION_GRAD_OPERATOR_DESC {
@@ -2130,9 +1758,6 @@ impl Default for DML_LOCAL_RESPONSE_NORMALIZATION_GRAD_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_LOCAL_RESPONSE_NORMALIZATION_GRAD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC {
@@ -2149,9 +1774,6 @@ impl Default for DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_LOCAL_RESPONSE_NORMALIZATION_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_LP_NORMALIZATION_OPERATOR_DESC {
@@ -2165,9 +1787,6 @@ impl Default for DML_LP_NORMALIZATION_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_LP_NORMALIZATION_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2185,9 +1804,6 @@ impl Default for DML_LP_POOLING_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_LP_POOLING_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2215,9 +1831,6 @@ impl Default for DML_LSTM_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_LSTM_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC {
@@ -2231,9 +1844,6 @@ impl Default for DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_MATRIX_MULTIPLY_INTEGER_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2257,9 +1867,6 @@ impl Default for DML_MAX_POOLING1_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_MAX_POOLING1_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_MAX_POOLING2_OPERATOR_DESC {
@@ -2277,9 +1884,6 @@ impl Default for DML_MAX_POOLING2_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_MAX_POOLING2_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2299,9 +1903,6 @@ impl Default for DML_MAX_POOLING_GRAD_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_MAX_POOLING_GRAD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_MAX_POOLING_OPERATOR_DESC {
@@ -2318,9 +1919,6 @@ impl Default for DML_MAX_POOLING_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_MAX_POOLING_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_MAX_UNPOOLING_OPERATOR_DESC {
@@ -2332,9 +1930,6 @@ impl Default for DML_MAX_UNPOOLING_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_MAX_UNPOOLING_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2354,9 +1949,6 @@ impl Default for DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_MEAN_VARIANCE_NORMALIZATION1_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC {
@@ -2374,9 +1966,6 @@ impl Default for DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_MEAN_VARIANCE_NORMALIZATION_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DML_MINIMUM_BUFFER_TENSOR_ALIGNMENT: u32 = 16u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2390,9 +1979,6 @@ impl Default for DML_NONZERO_COORDINATES_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_NONZERO_COORDINATES_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ONE_HOT_OPERATOR_DESC {
@@ -2405,9 +1991,6 @@ impl Default for DML_ONE_HOT_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ONE_HOT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DML_OPERATOR_ACTIVATION_CELU: DML_OPERATOR_TYPE = DML_OPERATOR_TYPE(128i32);
 pub const DML_OPERATOR_ACTIVATION_ELU: DML_OPERATOR_TYPE = DML_OPERATOR_TYPE(35i32);
@@ -2454,9 +2037,6 @@ impl Default for DML_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DML_OPERATOR_DIAGONAL_MATRIX: DML_OPERATOR_TYPE = DML_OPERATOR_TYPE(93i32);
 pub const DML_OPERATOR_DYNAMIC_QUANTIZE_LINEAR: DML_OPERATOR_TYPE = DML_OPERATOR_TYPE(148i32);
@@ -2540,9 +2120,6 @@ impl Default for DML_OPERATOR_GRAPH_NODE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_OPERATOR_GRAPH_NODE_DESC {
-    type TypeKind = windows_core::CloneType;
-}
 pub const DML_OPERATOR_GRU: DML_OPERATOR_TYPE = DML_OPERATOR_TYPE(78i32);
 pub const DML_OPERATOR_INVALID: DML_OPERATOR_TYPE = DML_OPERATOR_TYPE(0i32);
 pub const DML_OPERATOR_JOIN: DML_OPERATOR_TYPE = DML_OPERATOR_TYPE(63i32);
@@ -2604,9 +2181,6 @@ impl Default for DML_OUTPUT_GRAPH_EDGE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_OUTPUT_GRAPH_EDGE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DML_PADDING_MODE(pub i32);
@@ -2629,9 +2203,6 @@ impl Default for DML_PADDING_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_PADDING_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DML_PERSISTENT_BUFFER_ALIGNMENT: u32 = 256u32;
 #[repr(C)]
@@ -2659,9 +2230,6 @@ impl Default for DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_QUANTIZED_LINEAR_CONVOLUTION_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC {
@@ -2680,9 +2248,6 @@ impl Default for DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_QUANTIZED_LINEAR_MATRIX_MULTIPLY_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_RANDOM_GENERATOR_OPERATOR_DESC {
@@ -2695,9 +2260,6 @@ impl Default for DML_RANDOM_GENERATOR_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_RANDOM_GENERATOR_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2738,9 +2300,6 @@ impl Default for DML_REDUCE_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_REDUCE_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_RESAMPLE1_OPERATOR_DESC {
@@ -2756,9 +2315,6 @@ impl Default for DML_RESAMPLE1_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_RESAMPLE1_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2776,9 +2332,6 @@ impl Default for DML_RESAMPLE_GRAD_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_RESAMPLE_GRAD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_RESAMPLE_OPERATOR_DESC {
@@ -2793,9 +2346,6 @@ impl Default for DML_RESAMPLE_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_RESAMPLE_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_REVERSE_SUBSEQUENCES_OPERATOR_DESC {
@@ -2808,9 +2358,6 @@ impl Default for DML_REVERSE_SUBSEQUENCES_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_REVERSE_SUBSEQUENCES_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2831,9 +2378,6 @@ impl Default for DML_RNN_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_RNN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2858,9 +2402,6 @@ impl Default for DML_ROI_ALIGN1_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ROI_ALIGN1_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ROI_ALIGN_OPERATOR_DESC {
@@ -2881,9 +2422,6 @@ impl Default for DML_ROI_ALIGN_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_ROI_ALIGN_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_ROI_POOLING_OPERATOR_DESC {
@@ -2897,9 +2435,6 @@ impl Default for DML_ROI_POOLING_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_ROI_POOLING_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2927,9 +2462,6 @@ impl Default for DML_SCALAR_UNION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_SCALAR_UNION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_SCALE_BIAS {
@@ -2940,9 +2472,6 @@ impl Default for DML_SCALE_BIAS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_SCALE_BIAS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2959,9 +2488,6 @@ impl Default for DML_SCATTER_ND_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_SCATTER_ND_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_SCATTER_OPERATOR_DESC {
@@ -2976,9 +2502,6 @@ impl Default for DML_SCATTER_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_SCATTER_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_SIZE_2D {
@@ -2989,9 +2512,6 @@ impl Default for DML_SIZE_2D {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_SIZE_2D {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3008,9 +2528,6 @@ impl Default for DML_SLICE1_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_SLICE1_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_SLICE_GRAD_OPERATOR_DESC {
@@ -3025,9 +2542,6 @@ impl Default for DML_SLICE_GRAD_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_SLICE_GRAD_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3044,9 +2558,6 @@ impl Default for DML_SLICE_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_SLICE_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_SPACE_TO_DEPTH1_OPERATOR_DESC {
@@ -3060,9 +2571,6 @@ impl Default for DML_SPACE_TO_DEPTH1_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_SPACE_TO_DEPTH1_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_SPACE_TO_DEPTH_OPERATOR_DESC {
@@ -3074,9 +2582,6 @@ impl Default for DML_SPACE_TO_DEPTH_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_SPACE_TO_DEPTH_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3090,9 +2595,6 @@ impl Default for DML_SPLIT_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_SPLIT_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DML_TARGET_VERSION: u32 = 20480u32;
 pub const DML_TEMPORARY_BUFFER_ALIGNMENT: u32 = 256u32;
@@ -3121,9 +2623,6 @@ impl Default for DML_TENSOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_TENSOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DML_TENSOR_DIMENSION_COUNT_MAX: u32 = 5u32;
 pub const DML_TENSOR_DIMENSION_COUNT_MAX1: u32 = 8u32;
@@ -3183,9 +2682,6 @@ impl Default for DML_TILE_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_TILE_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_TOP_K1_OPERATOR_DESC {
@@ -3201,9 +2697,6 @@ impl Default for DML_TOP_K1_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_TOP_K1_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_TOP_K_OPERATOR_DESC {
@@ -3218,9 +2711,6 @@ impl Default for DML_TOP_K_OPERATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DML_TOP_K_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DML_UPSAMPLE_2D_OPERATOR_DESC {
@@ -3233,9 +2723,6 @@ impl Default for DML_UPSAMPLE_2D_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_UPSAMPLE_2D_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3250,9 +2737,6 @@ impl Default for DML_VALUE_SCALE_2D_OPERATOR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DML_VALUE_SCALE_2D_OPERATOR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IDMLBindingTable, IDMLBindingTable_Vtbl, 0x29c687dc_de74_4e3b_ab00_1168f2fc3cfc);
 impl core::ops::Deref for IDMLBindingTable {

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
@@ -1193,9 +1193,6 @@ impl Default for MLOperatorAttribute {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MLOperatorAttribute {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MLOperatorAttributeNameValue {
@@ -1209,9 +1206,6 @@ impl Default for MLOperatorAttributeNameValue {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MLOperatorAttributeNameValue {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MLOperatorAttributeNameValue_0 {
@@ -1224,9 +1218,6 @@ impl Default for MLOperatorAttributeNameValue_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MLOperatorAttributeNameValue_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1251,9 +1242,6 @@ impl Default for MLOperatorEdgeDescription {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MLOperatorEdgeDescription {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MLOperatorEdgeDescription_0 {
@@ -1264,9 +1252,6 @@ impl Default for MLOperatorEdgeDescription_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MLOperatorEdgeDescription_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1286,9 +1271,6 @@ impl Default for MLOperatorEdgeTypeConstraint {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MLOperatorEdgeTypeConstraint {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1316,9 +1298,6 @@ impl Default for MLOperatorKernelDescription {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MLOperatorKernelDescription {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1422,9 +1401,6 @@ impl Default for MLOperatorSchemaDescription {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MLOperatorSchemaDescription {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MLOperatorSchemaEdgeDescription {
@@ -1437,9 +1413,6 @@ impl Default for MLOperatorSchemaEdgeDescription {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MLOperatorSchemaEdgeDescription {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MLOperatorSchemaEdgeDescription_0 {
@@ -1451,9 +1424,6 @@ impl Default for MLOperatorSchemaEdgeDescription_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MLOperatorSchemaEdgeDescription_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1472,9 +1442,6 @@ impl Default for MLOperatorSetId {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MLOperatorSetId {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1516,10 +1483,6 @@ impl Default for WINML_BINDING_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for WINML_BINDING_DESC {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub union WINML_BINDING_DESC_0 {
@@ -1540,10 +1503,6 @@ impl Default for WINML_BINDING_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for WINML_BINDING_DESC_0 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const WINML_BINDING_IMAGE: WINML_BINDING_TYPE = WINML_BINDING_TYPE(4i32);
 pub const WINML_BINDING_MAP: WINML_BINDING_TYPE = WINML_BINDING_TYPE(3i32);
@@ -1576,9 +1535,6 @@ impl Default for WINML_IMAGE_BINDING_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINML_IMAGE_BINDING_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINML_IMAGE_VARIABLE_DESC {
@@ -1590,9 +1546,6 @@ impl Default for WINML_IMAGE_VARIABLE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINML_IMAGE_VARIABLE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1608,9 +1561,6 @@ impl Default for WINML_MAP_BINDING_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINML_MAP_BINDING_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINML_MAP_BINDING_DESC_0 {
@@ -1621,9 +1571,6 @@ impl Default for WINML_MAP_BINDING_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINML_MAP_BINDING_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1638,9 +1585,6 @@ impl Default for WINML_MAP_BINDING_DESC_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINML_MAP_BINDING_DESC_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINML_MAP_VARIABLE_DESC {
@@ -1651,9 +1595,6 @@ impl Default for WINML_MAP_VARIABLE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINML_MAP_VARIABLE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1669,9 +1610,6 @@ impl Default for WINML_MODEL_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINML_MODEL_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -1686,10 +1624,6 @@ impl Default for WINML_RESOURCE_BINDING_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for WINML_RESOURCE_BINDING_DESC {
-    type TypeKind = windows_core::CloneType;
 }
 pub const WINML_RUNTIME_CNTK: WINML_RUNTIME_TYPE = WINML_RUNTIME_TYPE(0i32);
 #[repr(transparent)]
@@ -1707,9 +1641,6 @@ impl Default for WINML_SEQUENCE_BINDING_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINML_SEQUENCE_BINDING_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINML_SEQUENCE_BINDING_DESC_0 {
@@ -1723,9 +1654,6 @@ impl Default for WINML_SEQUENCE_BINDING_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINML_SEQUENCE_BINDING_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINML_SEQUENCE_VARIABLE_DESC {
@@ -1735,9 +1663,6 @@ impl Default for WINML_SEQUENCE_VARIABLE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINML_SEQUENCE_VARIABLE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1752,9 +1677,6 @@ impl Default for WINML_TENSOR_BINDING_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINML_TENSOR_BINDING_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINML_TENSOR_BOOLEAN: WINML_TENSOR_DATA_TYPE = WINML_TENSOR_DATA_TYPE(9i32);
 pub const WINML_TENSOR_COMPLEX128: WINML_TENSOR_DATA_TYPE = WINML_TENSOR_DATA_TYPE(15i32);
@@ -1788,9 +1710,6 @@ impl Default for WINML_TENSOR_VARIABLE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINML_TENSOR_VARIABLE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WINML_VARIABLE_DESC {
@@ -1805,9 +1724,6 @@ impl Default for WINML_VARIABLE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINML_VARIABLE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINML_VARIABLE_DESC_0 {
@@ -1820,7 +1736,4 @@ impl Default for WINML_VARIABLE_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINML_VARIABLE_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
@@ -39,9 +39,6 @@ impl Default for COLUMNSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLUMNSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CProperty {
@@ -56,9 +53,6 @@ impl Default for CProperty {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CProperty {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CProperty_0 {
@@ -70,9 +64,6 @@ impl Default for CProperty_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CProperty_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const E_ALL_WILD: windows_core::HRESULT = windows_core::HRESULT(0x80001055_u32 as _);
 pub const E_ALREADYINIT: windows_core::HRESULT = windows_core::HRESULT(0x80001083_u32 as _);
@@ -175,10 +166,6 @@ impl Default for HHNTRACK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Controls")]
-impl windows_core::TypeKind for HHNTRACK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HHN_FIRST: u32 = 4294966436u32;
 pub const HHN_LAST: u32 = 4294966417u32;
 pub const HHN_NAVCOMPLETE: u32 = 4294966436u32;
@@ -194,10 +181,6 @@ impl Default for HHN_NOTIFY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Controls")]
-impl windows_core::TypeKind for HHN_NOTIFY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HHN_TRACK: u32 = 4294966435u32;
 pub const HHN_WINDOW_CREATE: u32 = 4294966434u32;
@@ -292,9 +275,6 @@ impl Default for HH_AKLINK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HH_AKLINK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HH_ALINK_LOOKUP: HTML_HELP_COMMAND = HTML_HELP_COMMAND(19i32);
 pub const HH_CLOSE_ALL: HTML_HELP_COMMAND = HTML_HELP_COMMAND(18i32);
 pub const HH_DISPLAY_INDEX: HTML_HELP_COMMAND = HTML_HELP_COMMAND(2i32);
@@ -314,9 +294,6 @@ impl Default for HH_ENUM_CAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HH_ENUM_CAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HH_ENUM_CATEGORY: HTML_HELP_COMMAND = HTML_HELP_COMMAND(21i32);
 pub const HH_ENUM_CATEGORY_IT: HTML_HELP_COMMAND = HTML_HELP_COMMAND(22i32);
 pub const HH_ENUM_INFO_TYPE: HTML_HELP_COMMAND = HTML_HELP_COMMAND(7i32);
@@ -333,9 +310,6 @@ impl Default for HH_ENUM_IT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HH_ENUM_IT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HH_FTS_DEFAULT_PROXIMITY: HTML_HELP_COMMAND = HTML_HELP_COMMAND(-1i32);
 #[repr(C)]
@@ -354,9 +328,6 @@ impl Default for HH_FTS_QUERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HH_FTS_QUERY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HH_GET_LAST_ERROR: HTML_HELP_COMMAND = HTML_HELP_COMMAND(20i32);
 pub const HH_GET_WIN_HANDLE: HTML_HELP_COMMAND = HTML_HELP_COMMAND(6i32);
@@ -378,10 +349,6 @@ impl Default for HH_GLOBAL_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for HH_GLOBAL_PROPERTY {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -415,9 +382,6 @@ impl Default for HH_POPUP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HH_POPUP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HH_PRETRANSLATEMESSAGE: HTML_HELP_COMMAND = HTML_HELP_COMMAND(253i32);
 pub const HH_RESERVED1: HTML_HELP_COMMAND = HTML_HELP_COMMAND(10i32);
 pub const HH_RESERVED2: HTML_HELP_COMMAND = HTML_HELP_COMMAND(11i32);
@@ -438,9 +402,6 @@ impl Default for HH_SET_INFOTYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HH_SET_INFOTYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HH_SET_INFO_TYPE: HTML_HELP_COMMAND = HTML_HELP_COMMAND(8i32);
 pub const HH_SET_QUERYSERVICE: HTML_HELP_COMMAND = HTML_HELP_COMMAND(30i32);
@@ -501,9 +462,6 @@ impl Default for HH_WINTYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HH_WINTYPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1471,9 +1429,6 @@ impl Default for ROWSTATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ROWSTATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STDPROP_DISPLAYKEY: u32 = 101u32;
 pub const STDPROP_INDEX_BREAK: u32 = 204u32;

--- a/crates/libs/windows/src/Windows/Win32/Data/RightsManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/RightsManagement/mod.rs
@@ -674,9 +674,6 @@ impl Default for DRMBOUNDLICENSEPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRMBOUNDLICENSEPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DRMBOUNDLICENSEPARAMSVERSION: u32 = 1u32;
 pub type DRMCALLBACK = Option<unsafe extern "system" fn(param0: DRM_STATUS_MSG, param1: windows_core::HRESULT, param2: *mut core::ffi::c_void, param3: *mut core::ffi::c_void) -> windows_core::HRESULT>;
 pub const DRMCALLBACKVERSION: u32 = 1u32;
@@ -709,9 +706,6 @@ impl Default for DRMID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRMID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRMIDVERSION: u32 = 0u32;
 pub const DRMLICENSEACQDATAVERSION: u32 = 0u32;
@@ -750,9 +744,6 @@ impl Default for DRM_ACTSERV_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRM_ACTSERV_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DRM_ADD_LICENSE_NOPERSIST: u32 = 0u32;
 pub const DRM_ADD_LICENSE_PERSIST: u32 = 1u32;
 pub const DRM_AILT_CANCEL: u32 = 4u32;
@@ -777,9 +768,6 @@ impl Default for DRM_CLIENT_VERSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRM_CLIENT_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRM_DEFAULTGROUPIDTYPE_PASSPORT: windows_core::PCWSTR = windows_core::w!("PassportAuthProvider");
 pub const DRM_DEFAULTGROUPIDTYPE_WINDOWSAUTH: windows_core::PCWSTR = windows_core::w!("WindowsAuthProvider");
@@ -819,9 +807,6 @@ impl Default for DRM_LICENSE_ACQ_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRM_LICENSE_ACQ_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRM_LOCKBOXTYPE_BLACKBOX: u32 = 2u32;
 pub const DRM_LOCKBOXTYPE_DEFAULT: u32 = 2u32;

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/mod.rs
@@ -12248,9 +12248,6 @@ impl Default for XHR_CERT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XHR_CERT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const XHR_CERT_ERROR_ALL_SERVER_ERRORS: XHR_CERT_ERROR_FLAG = XHR_CERT_ERROR_FLAG(125829120u32);
 pub const XHR_CERT_ERROR_CERT_CN_INVALID: XHR_CERT_ERROR_FLAG = XHR_CERT_ERROR_FLAG(33554432u32);
 pub const XHR_CERT_ERROR_CERT_DATE_INVALID: XHR_CERT_ERROR_FLAG = XHR_CERT_ERROR_FLAG(67108864u32);
@@ -12281,9 +12278,6 @@ impl Default for XHR_COOKIE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XHR_COOKIE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XHR_COOKIE_APPLY_P3P: XHR_COOKIE_FLAG = XHR_COOKIE_FLAG(128i32);
 pub const XHR_COOKIE_EVALUATE_P3P: XHR_COOKIE_FLAG = XHR_COOKIE_FLAG(64i32);
@@ -12393,9 +12387,6 @@ impl Default for XML_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XML_ERROR {
-    type TypeKind = windows_core::CloneType;
-}
 pub const XSLTemplate60: windows_core::GUID = windows_core::GUID::from_u128(0x88d96a08_f192_11d4_a65f_0040963251e5);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12427,7 +12418,4 @@ impl Default for __msxml6_ReferenceRemainingTypes__ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for __msxml6_ReferenceRemainingTypes__ {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Devices/AllJoyn/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/AllJoyn/mod.rs
@@ -3886,9 +3886,6 @@ impl Default for alljoyn_aboutdatalistener_callbacks {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_aboutdatalistener_callbacks {
-    type TypeKind = windows_core::CopyType;
-}
 pub type alljoyn_aboutdatalistener_getaboutdata_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, msgarg: alljoyn_msgarg, language: windows_core::PCSTR) -> QStatus>;
 pub type alljoyn_aboutdatalistener_getannouncedaboutdata_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, msgarg: alljoyn_msgarg) -> QStatus>;
 #[repr(transparent)]
@@ -3924,9 +3921,6 @@ impl Default for alljoyn_aboutlistener_callback {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for alljoyn_aboutlistener_callback {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -3965,9 +3959,6 @@ impl Default for alljoyn_applicationstatelistener_callbacks {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_applicationstatelistener_callbacks {
-    type TypeKind = windows_core::CopyType;
-}
 pub type alljoyn_applicationstatelistener_state_ptr = Option<unsafe extern "system" fn(busname: *mut i8, publickey: *mut i8, applicationstate: alljoyn_applicationstate, context: *mut core::ffi::c_void)>;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -3989,9 +3980,6 @@ impl Default for alljoyn_authlistener_callbacks {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_authlistener_callbacks {
-    type TypeKind = windows_core::CopyType;
-}
 pub type alljoyn_authlistener_requestcredentials_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, authmechanism: windows_core::PCSTR, peername: windows_core::PCSTR, authcount: u16, username: windows_core::PCSTR, credmask: u16, credentials: alljoyn_credentials) -> i32>;
 pub type alljoyn_authlistener_requestcredentialsasync_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, listener: alljoyn_authlistener, authmechanism: windows_core::PCSTR, peername: windows_core::PCSTR, authcount: u16, username: windows_core::PCSTR, credmask: u16, authcontext: *mut core::ffi::c_void) -> QStatus>;
 pub type alljoyn_authlistener_securityviolation_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, status: QStatus, msg: alljoyn_message)>;
@@ -4009,9 +3997,6 @@ impl Default for alljoyn_authlistenerasync_callbacks {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for alljoyn_authlistenerasync_callbacks {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -4055,9 +4040,6 @@ impl Default for alljoyn_buslistener_callbacks {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_buslistener_callbacks {
-    type TypeKind = windows_core::CopyType;
-}
 pub type alljoyn_buslistener_found_advertised_name_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, name: windows_core::PCSTR, transport: u16, nameprefix: windows_core::PCSTR)>;
 pub type alljoyn_buslistener_listener_registered_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, bus: alljoyn_busattachment)>;
 pub type alljoyn_buslistener_listener_unregistered_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void)>;
@@ -4082,9 +4064,6 @@ impl Default for alljoyn_busobject_callbacks {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_busobject_callbacks {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct alljoyn_busobject_methodentry {
@@ -4095,9 +4074,6 @@ impl Default for alljoyn_busobject_methodentry {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for alljoyn_busobject_methodentry {
-    type TypeKind = windows_core::CopyType;
 }
 pub type alljoyn_busobject_object_registration_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void)>;
 pub type alljoyn_busobject_prop_get_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, ifcname: windows_core::PCSTR, propname: windows_core::PCSTR, val: alljoyn_msgarg) -> QStatus>;
@@ -4116,9 +4092,6 @@ impl Default for alljoyn_certificateid {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_certificateid {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct alljoyn_certificateidarray {
@@ -4129,9 +4102,6 @@ impl Default for alljoyn_certificateidarray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for alljoyn_certificateidarray {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4167,9 +4137,6 @@ impl Default for alljoyn_interfacedescription_member {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_interfacedescription_member {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct alljoyn_interfacedescription_property {
@@ -4182,9 +4149,6 @@ impl Default for alljoyn_interfacedescription_property {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for alljoyn_interfacedescription_property {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4214,9 +4178,6 @@ impl Default for alljoyn_keystorelistener_callbacks {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_keystorelistener_callbacks {
-    type TypeKind = windows_core::CopyType;
-}
 pub type alljoyn_keystorelistener_loadrequest_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, listener: alljoyn_keystorelistener, keystore: alljoyn_keystore) -> QStatus>;
 pub type alljoyn_keystorelistener_releaseexclusivelock_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, listener: alljoyn_keystorelistener)>;
 pub type alljoyn_keystorelistener_storerequest_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, listener: alljoyn_keystorelistener, keystore: alljoyn_keystore) -> QStatus>;
@@ -4233,9 +4194,6 @@ impl Default for alljoyn_keystorelistener_with_synchronization_callbacks {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_keystorelistener_with_synchronization_callbacks {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct alljoyn_manifestarray {
@@ -4246,9 +4204,6 @@ impl Default for alljoyn_manifestarray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for alljoyn_manifestarray {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -4293,9 +4248,6 @@ impl Default for alljoyn_observerlistener_callback {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_observerlistener_callback {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct alljoyn_permissionconfigurationlistener(pub isize);
@@ -4314,9 +4266,6 @@ impl Default for alljoyn_permissionconfigurationlistener_callbacks {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for alljoyn_permissionconfigurationlistener_callbacks {
-    type TypeKind = windows_core::CopyType;
 }
 pub type alljoyn_permissionconfigurationlistener_endmanagement_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void)>;
 pub type alljoyn_permissionconfigurationlistener_factoryreset_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void) -> QStatus>;
@@ -4344,9 +4293,6 @@ impl Default for alljoyn_pinglistener_callback {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for alljoyn_pinglistener_callback {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -4389,9 +4335,6 @@ impl Default for alljoyn_sessionlistener_callbacks {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for alljoyn_sessionlistener_callbacks {
-    type TypeKind = windows_core::CopyType;
-}
 pub type alljoyn_sessionlistener_sessionlost_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, sessionid: u32, reason: alljoyn_sessionlostreason)>;
 pub type alljoyn_sessionlistener_sessionmemberadded_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, sessionid: u32, uniquename: windows_core::PCSTR)>;
 pub type alljoyn_sessionlistener_sessionmemberremoved_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, sessionid: u32, uniquename: windows_core::PCSTR)>;
@@ -4421,9 +4364,6 @@ impl Default for alljoyn_sessionportlistener_callbacks {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for alljoyn_sessionportlistener_callbacks {
-    type TypeKind = windows_core::CopyType;
 }
 pub type alljoyn_sessionportlistener_sessionjoined_ptr = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, sessionport: u16, id: u32, joiner: windows_core::PCSTR)>;
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Beep/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Beep/mod.rs
@@ -11,9 +11,6 @@ impl Default for BEEP_SET_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BEEP_SET_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DD_BEEP_DEVICE_NAME: windows_core::PCSTR = windows_core::s!("\\Device\\Beep");
 pub const DD_BEEP_DEVICE_NAME_U: windows_core::PCWSTR = windows_core::w!("\\Device\\Beep");
 pub const IOCTL_BEEP_SET: u32 = 65536u32;

--- a/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
@@ -560,9 +560,6 @@ impl Default for WINBIO_ACCOUNT_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ACCOUNT_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ADAPTER_INTERFACE_VERSION {
@@ -573,9 +570,6 @@ impl Default for WINBIO_ADAPTER_INTERFACE_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ADAPTER_INTERFACE_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINBIO_ANSI_381_IMG_BIT_PACKED: u16 = 1u16;
 pub const WINBIO_ANSI_381_IMG_COMPRESSED_JPEG: u16 = 3u16;
@@ -605,9 +599,6 @@ impl Default for WINBIO_ANTI_SPOOF_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ANTI_SPOOF_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WINBIO_ANTI_SPOOF_POLICY_ACTION(pub i32);
@@ -635,9 +626,6 @@ impl Default for WINBIO_ASYNC_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -669,9 +657,6 @@ impl Default for WINBIO_ASYNC_RESULT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_6 {
@@ -683,9 +668,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -704,9 +686,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_11 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_11 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WINBIO_ASYNC_RESULT_0_7 {
@@ -718,9 +697,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_2 {
@@ -731,9 +707,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_3 {
@@ -743,9 +716,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -758,9 +728,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_17 {
@@ -770,9 +737,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_17 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_17 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -785,9 +749,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_13 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_13 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_14 {
@@ -798,9 +759,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_14 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_14 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -814,9 +772,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_12 {
@@ -828,9 +783,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_12 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_12 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WINBIO_ASYNC_RESULT_0_10 {
@@ -840,9 +792,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_10 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_10 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -859,9 +808,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_8 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WINBIO_ASYNC_RESULT_0_19 {
@@ -872,9 +818,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_19 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_19 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -889,9 +832,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_16 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_16 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WINBIO_ASYNC_RESULT_0_1 {
@@ -903,9 +843,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -919,9 +856,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_18 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_18 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_20 {
@@ -931,9 +865,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_20 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_20 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -950,9 +881,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_9 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_15 {
@@ -965,9 +893,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_15 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_15 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ASYNC_RESULT_0_0 {
@@ -978,9 +903,6 @@ impl Default for WINBIO_ASYNC_RESULT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ASYNC_RESULT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1006,9 +928,6 @@ impl Default for WINBIO_BDB_ANSI_381_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_BDB_ANSI_381_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_BDB_ANSI_381_RECORD {
@@ -1027,9 +946,6 @@ impl Default for WINBIO_BDB_ANSI_381_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_BDB_ANSI_381_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_BIR {
@@ -1043,9 +959,6 @@ impl Default for WINBIO_BIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_BIR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WINBIO_BIR_ALGIN_SIZE: u32 = 8u32;
 pub const WINBIO_BIR_ALIGN_SIZE: u32 = 8u32;
 #[repr(C)]
@@ -1058,9 +971,6 @@ impl Default for WINBIO_BIR_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_BIR_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1083,9 +993,6 @@ impl Default for WINBIO_BIR_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_BIR_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_BIR_HEADER_0 {
@@ -1097,9 +1004,6 @@ impl Default for WINBIO_BIR_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_BIR_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_BLANK_PAYLOAD {
@@ -1110,9 +1014,6 @@ impl Default for WINBIO_BLANK_PAYLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_BLANK_PAYLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1128,9 +1029,6 @@ impl Default for WINBIO_BSP_SCHEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_BSP_SCHEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_CALIBRATION_INFO {
@@ -1142,9 +1040,6 @@ impl Default for WINBIO_CALIBRATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_CALIBRATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1160,9 +1055,6 @@ impl Default for WINBIO_CAPTURE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_CAPTURE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_CAPTURE_PARAMETERS {
@@ -1176,9 +1068,6 @@ impl Default for WINBIO_CAPTURE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_CAPTURE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1210,9 +1099,6 @@ impl Default for WINBIO_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WINBIO_DATA_FLAG_INTEGRITY: u16 = 1u16;
 pub const WINBIO_DATA_FLAG_INTERMEDIATE: u16 = 64u16;
 pub const WINBIO_DATA_FLAG_OPTION_MASK_PRESENT: u16 = 8u16;
@@ -1233,9 +1119,6 @@ impl Default for WINBIO_DIAGNOSTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_DIAGNOSTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_ENCRYPTED_CAPTURE_PARAMS {
@@ -1250,9 +1133,6 @@ impl Default for WINBIO_ENCRYPTED_CAPTURE_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_ENCRYPTED_CAPTURE_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
@@ -1310,10 +1190,6 @@ impl Default for WINBIO_ENGINE_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WINBIO_ENGINE_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WINBIO_EVENT {
@@ -1324,9 +1200,6 @@ impl Default for WINBIO_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1340,9 +1213,6 @@ impl Default for WINBIO_EVENT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EVENT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EVENT_0_2 {
@@ -1352,9 +1222,6 @@ impl Default for WINBIO_EVENT_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EVENT_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1369,9 +1236,6 @@ impl Default for WINBIO_EVENT_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EVENT_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EVENT_0_0 {
@@ -1382,9 +1246,6 @@ impl Default for WINBIO_EVENT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EVENT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1397,9 +1258,6 @@ impl Default for WINBIO_EXTENDED_ENGINE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENGINE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1415,9 +1273,6 @@ impl Default for WINBIO_EXTENDED_ENGINE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENGINE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_ENGINE_INFO_0_0 {
@@ -1429,9 +1284,6 @@ impl Default for WINBIO_EXTENDED_ENGINE_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENGINE_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_ENGINE_INFO_0_0_0 {
@@ -1441,9 +1293,6 @@ impl Default for WINBIO_EXTENDED_ENGINE_INFO_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENGINE_INFO_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1455,9 +1304,6 @@ impl Default for WINBIO_EXTENDED_ENGINE_INFO_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENGINE_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1474,9 +1320,6 @@ impl Default for WINBIO_EXTENDED_ENGINE_INFO_0_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENGINE_INFO_0_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_ENGINE_INFO_0_2 {
@@ -1488,9 +1331,6 @@ impl Default for WINBIO_EXTENDED_ENGINE_INFO_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENGINE_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_ENGINE_INFO_0_2_0 {
@@ -1500,9 +1340,6 @@ impl Default for WINBIO_EXTENDED_ENGINE_INFO_0_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENGINE_INFO_0_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1515,9 +1352,6 @@ impl Default for WINBIO_EXTENDED_ENGINE_INFO_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENGINE_INFO_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_ENGINE_INFO_0_3_0 {
@@ -1527,9 +1361,6 @@ impl Default for WINBIO_EXTENDED_ENGINE_INFO_0_3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENGINE_INFO_0_3_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1541,9 +1372,6 @@ impl Default for WINBIO_EXTENDED_ENROLLMENT_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENROLLMENT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1560,9 +1388,6 @@ impl Default for WINBIO_EXTENDED_ENROLLMENT_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENROLLMENT_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINBIO_EXTENDED_ENROLLMENT_STATUS_0 {
@@ -1577,9 +1402,6 @@ impl Default for WINBIO_EXTENDED_ENROLLMENT_STATUS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENROLLMENT_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0 {
@@ -1592,9 +1414,6 @@ impl Default for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0_0 {
@@ -1605,9 +1424,6 @@ impl Default for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1623,9 +1439,6 @@ impl Default for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1645,9 +1458,6 @@ impl Default for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2_0 {
@@ -1660,9 +1470,6 @@ impl Default for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_ENROLLMENT_STATUS_0_3 {
@@ -1672,9 +1479,6 @@ impl Default for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_ENROLLMENT_STATUS_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1687,9 +1491,6 @@ impl Default for WINBIO_EXTENDED_SENSOR_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_SENSOR_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1705,9 +1506,6 @@ impl Default for WINBIO_EXTENDED_SENSOR_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_SENSOR_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_SENSOR_INFO_0_0 {
@@ -1721,9 +1519,6 @@ impl Default for WINBIO_EXTENDED_SENSOR_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_SENSOR_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_SENSOR_INFO_0_0_0 {
@@ -1736,9 +1531,6 @@ impl Default for WINBIO_EXTENDED_SENSOR_INFO_0_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_SENSOR_INFO_0_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_SENSOR_INFO_0_1 {
@@ -1748,9 +1540,6 @@ impl Default for WINBIO_EXTENDED_SENSOR_INFO_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_SENSOR_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1764,9 +1553,6 @@ impl Default for WINBIO_EXTENDED_SENSOR_INFO_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_SENSOR_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_SENSOR_INFO_0_3 {
@@ -1776,9 +1562,6 @@ impl Default for WINBIO_EXTENDED_SENSOR_INFO_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_SENSOR_INFO_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1791,9 +1574,6 @@ impl Default for WINBIO_EXTENDED_STORAGE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_STORAGE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1809,9 +1589,6 @@ impl Default for WINBIO_EXTENDED_STORAGE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_STORAGE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_STORAGE_INFO_0_0 {
@@ -1821,9 +1598,6 @@ impl Default for WINBIO_EXTENDED_STORAGE_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_STORAGE_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1835,9 +1609,6 @@ impl Default for WINBIO_EXTENDED_STORAGE_INFO_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_STORAGE_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_STORAGE_INFO_0_2 {
@@ -1847,9 +1618,6 @@ impl Default for WINBIO_EXTENDED_STORAGE_INFO_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_STORAGE_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1861,9 +1629,6 @@ impl Default for WINBIO_EXTENDED_STORAGE_INFO_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_EXTENDED_STORAGE_INFO_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_EXTENDED_UNIT_STATUS {
@@ -1874,9 +1639,6 @@ impl Default for WINBIO_EXTENDED_UNIT_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_EXTENDED_UNIT_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINBIO_E_ADAPTER_INTEGRITY_FAILURE: windows_core::HRESULT = windows_core::HRESULT(0x8009803D_u32 as _);
 pub const WINBIO_E_AUTO_LOGON_DISABLED: windows_core::HRESULT = windows_core::HRESULT(0x80098043_u32 as _);
@@ -1973,9 +1735,6 @@ impl Default for WINBIO_FP_BU_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_FP_BU_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2035,10 +1794,6 @@ impl Default for WINBIO_FRAMEWORK_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WINBIO_FRAMEWORK_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_GESTURE_METADATA {
@@ -2052,9 +1807,6 @@ impl Default for WINBIO_GESTURE_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_GESTURE_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_GET_INDICATOR {
@@ -2067,9 +1819,6 @@ impl Default for WINBIO_GET_INDICATOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_GET_INDICATOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WINBIO_IDENTITY {
@@ -2080,9 +1829,6 @@ impl Default for WINBIO_IDENTITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_IDENTITY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2098,9 +1844,6 @@ impl Default for WINBIO_IDENTITY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_IDENTITY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_IDENTITY_0_0 {
@@ -2111,9 +1854,6 @@ impl Default for WINBIO_IDENTITY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_IDENTITY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINBIO_I_EXTENDED_STATUS_INFORMATION: windows_core::HRESULT = windows_core::HRESULT(0x90002_u32 as _);
 pub const WINBIO_I_MORE_DATA: windows_core::HRESULT = windows_core::HRESULT(0x90001_u32 as _);
@@ -2129,9 +1869,6 @@ impl Default for WINBIO_NOTIFY_WAKE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_NOTIFY_WAKE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINBIO_PASSWORD_GENERIC: WINBIO_CREDENTIAL_FORMAT = WINBIO_CREDENTIAL_FORMAT(1i32);
 pub const WINBIO_PASSWORD_PACKED: WINBIO_CREDENTIAL_FORMAT = WINBIO_CREDENTIAL_FORMAT(2i32);
@@ -2156,10 +1893,6 @@ impl Default for WINBIO_PIPELINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WINBIO_PIPELINE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINBIO_POLICY_ADMIN: WINBIO_POLICY_SOURCE = WINBIO_POLICY_SOURCE(3i32);
 pub const WINBIO_POLICY_DEFAULT: WINBIO_POLICY_SOURCE = WINBIO_POLICY_SOURCE(1i32);
@@ -2191,9 +1924,6 @@ impl Default for WINBIO_PRESENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_PRESENCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_PRESENCE_0 {
@@ -2205,9 +1935,6 @@ impl Default for WINBIO_PRESENCE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_PRESENCE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINBIO_PRESENCE_PROPERTIES {
@@ -2218,9 +1945,6 @@ impl Default for WINBIO_PRESENCE_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_PRESENCE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2234,9 +1958,6 @@ impl Default for WINBIO_PRESENCE_PROPERTIES_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_PRESENCE_PROPERTIES_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_PRESENCE_PROPERTIES_0_0 {
@@ -2247,9 +1968,6 @@ impl Default for WINBIO_PRESENCE_PROPERTIES_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_PRESENCE_PROPERTIES_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2265,9 +1983,6 @@ impl Default for WINBIO_PRESENCE_PROPERTIES_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_PRESENCE_PROPERTIES_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_PRIVATE_SENSOR_TYPE_INFO {
@@ -2279,9 +1994,6 @@ impl Default for WINBIO_PRIVATE_SENSOR_TYPE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_PRIVATE_SENSOR_TYPE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2298,9 +2010,6 @@ impl Default for WINBIO_PROTECTION_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_PROTECTION_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_REGISTERED_FORMAT {
@@ -2311,9 +2020,6 @@ impl Default for WINBIO_REGISTERED_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_REGISTERED_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINBIO_SCP_CURVE_FIELD_SIZE_V1: u32 = 32u32;
 pub const WINBIO_SCP_DIGEST_SIZE_V1: u32 = 32u32;
@@ -2337,9 +2043,6 @@ impl Default for WINBIO_SECURE_BUFFER_HEADER_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_SECURE_BUFFER_HEADER_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_SECURE_CONNECTION_DATA {
@@ -2355,9 +2058,6 @@ impl Default for WINBIO_SECURE_CONNECTION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_SECURE_CONNECTION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_SECURE_CONNECTION_PARAMS {
@@ -2369,9 +2069,6 @@ impl Default for WINBIO_SECURE_CONNECTION_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_SECURE_CONNECTION_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2393,9 +2090,6 @@ impl Default for WINBIO_SENSOR_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_SENSOR_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
@@ -2443,10 +2137,6 @@ impl Default for WINBIO_SENSOR_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WINBIO_SENSOR_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WINBIO_SETTING_SOURCE(pub u32);
@@ -2464,9 +2154,6 @@ impl Default for WINBIO_SET_INDICATOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_SET_INDICATOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
@@ -2513,10 +2200,6 @@ impl Default for WINBIO_STORAGE_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WINBIO_STORAGE_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_STORAGE_RECORD {
@@ -2534,9 +2217,6 @@ impl Default for WINBIO_STORAGE_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_STORAGE_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_STORAGE_SCHEMA {
@@ -2552,9 +2232,6 @@ impl Default for WINBIO_STORAGE_SCHEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_STORAGE_SCHEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_SUPPORTED_ALGORITHMS {
@@ -2567,9 +2244,6 @@ impl Default for WINBIO_SUPPORTED_ALGORITHMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_SUPPORTED_ALGORITHMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2591,9 +2265,6 @@ impl Default for WINBIO_UNIT_SCHEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_UNIT_SCHEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_UPDATE_FIRMWARE {
@@ -2605,9 +2276,6 @@ impl Default for WINBIO_UPDATE_FIRMWARE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINBIO_UPDATE_FIRMWARE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINBIO_VERSION {
@@ -2618,9 +2286,6 @@ impl Default for WINBIO_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINBIO_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINBIO_WBDI_MAJOR_VERSION: u32 = 1u32;
 pub const WINBIO_WBDI_MINOR_VERSION: u32 = 0u32;

--- a/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
@@ -322,9 +322,6 @@ impl Default for BLUETOOTH_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BLUETOOTH_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union BLUETOOTH_ADDRESS_0 {
@@ -335,9 +332,6 @@ impl Default for BLUETOOTH_ADDRESS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLUETOOTH_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -352,9 +346,6 @@ impl Default for BLUETOOTH_AUTHENTICATE_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BLUETOOTH_AUTHENTICATE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union BLUETOOTH_AUTHENTICATE_RESPONSE_0 {
@@ -367,9 +358,6 @@ impl Default for BLUETOOTH_AUTHENTICATE_RESPONSE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLUETOOTH_AUTHENTICATE_RESPONSE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -385,9 +373,6 @@ impl Default for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS_0 {
@@ -398,9 +383,6 @@ impl Default for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLUETOOTH_AUTHENTICATION_CALLBACK_PARAMS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -424,9 +406,6 @@ impl Default for BLUETOOTH_COD_PAIRS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BLUETOOTH_COD_PAIRS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct BLUETOOTH_DEVICE_INFO {
@@ -444,9 +423,6 @@ impl Default for BLUETOOTH_DEVICE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLUETOOTH_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BLUETOOTH_DEVICE_NAME_SIZE: u32 = 256u32;
 #[repr(C)]
@@ -466,9 +442,6 @@ impl Default for BLUETOOTH_DEVICE_SEARCH_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BLUETOOTH_DEVICE_SEARCH_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BLUETOOTH_FIND_RADIO_PARAMS {
@@ -478,9 +451,6 @@ impl Default for BLUETOOTH_FIND_RADIO_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLUETOOTH_FIND_RADIO_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BLUETOOTH_GATT_FLAG_CONNECTION_AUTHENTICATED: u32 = 2u32;
 pub const BLUETOOTH_GATT_FLAG_CONNECTION_ENCRYPTED: u32 = 1u32;
@@ -502,9 +472,6 @@ impl Default for BLUETOOTH_GATT_VALUE_CHANGED_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BLUETOOTH_GATT_VALUE_CHANGED_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRATION {
@@ -515,9 +482,6 @@ impl Default for BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLUETOOTH_GATT_VALUE_CHANGED_EVENT_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -540,9 +504,6 @@ impl Default for BLUETOOTH_LOCAL_SERVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BLUETOOTH_LOCAL_SERVICE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BLUETOOTH_MAX_NAME_SIZE: u32 = 248u32;
 pub const BLUETOOTH_MAX_PASSKEY_BUFFER_SIZE: u32 = 17u32;
 pub const BLUETOOTH_MAX_PASSKEY_SIZE: u32 = 16u32;
@@ -564,9 +525,6 @@ impl Default for BLUETOOTH_NUMERIC_COMPARISON_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BLUETOOTH_NUMERIC_COMPARISON_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BLUETOOTH_OOB_DATA_INFO {
@@ -578,9 +536,6 @@ impl Default for BLUETOOTH_OOB_DATA_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BLUETOOTH_OOB_DATA_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BLUETOOTH_PASSKEY_INFO {
@@ -590,9 +545,6 @@ impl Default for BLUETOOTH_PASSKEY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLUETOOTH_PASSKEY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -604,9 +556,6 @@ impl Default for BLUETOOTH_PIN_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLUETOOTH_PIN_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -622,9 +571,6 @@ impl Default for BLUETOOTH_RADIO_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLUETOOTH_RADIO_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -649,9 +595,6 @@ impl Default for BLUETOOTH_SELECT_DEVICE_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLUETOOTH_SELECT_DEVICE_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BLUETOOTH_SERVICE_DISABLE: u32 = 0u32;
 pub const BLUETOOTH_SERVICE_ENABLE: u32 = 1u32;
@@ -682,9 +625,6 @@ impl Default for BTH_DEVICE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BTH_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BTH_EIR_128_UUIDS_COMPLETE_ID: u32 = 7u32;
 pub const BTH_EIR_128_UUIDS_PARTIAL_ID: u32 = 6u32;
@@ -783,9 +723,6 @@ impl Default for BTH_HCI_EVENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_HCI_EVENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BTH_HOST_FEATURE_ENHANCED_RETRANSMISSION_MODE: u64 = 1u64;
 pub const BTH_HOST_FEATURE_LOW_ENERGY: u64 = 4u64;
 pub const BTH_HOST_FEATURE_SCO_HCI: u64 = 8u64;
@@ -802,9 +739,6 @@ impl Default for BTH_INFO_REQ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_INFO_REQ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct BTH_INFO_RSP {
@@ -817,9 +751,6 @@ impl Default for BTH_INFO_RSP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_INFO_RSP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union BTH_INFO_RSP_0 {
@@ -830,9 +761,6 @@ impl Default for BTH_INFO_RSP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BTH_INFO_RSP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BTH_IOCTL_BASE: u32 = 0u32;
 #[repr(C)]
@@ -847,9 +775,6 @@ impl Default for BTH_L2CAP_EVENT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BTH_L2CAP_EVENT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BTH_LE_ATT_BLUETOOTH_BASE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x00000000_0000_1000_8000_00805f9b34fb);
 pub const BTH_LE_ATT_CID: u32 = 4u32;
@@ -1001,9 +926,6 @@ impl Default for BTH_LE_GATT_CHARACTERISTIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_LE_GATT_CHARACTERISTIC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BTH_LE_GATT_CHARACTERISTIC_DESCRIPTOR_AGGREGATE_FORMAT: u32 = 10501u32;
 pub const BTH_LE_GATT_CHARACTERISTIC_DESCRIPTOR_CLIENT_CONFIGURATION: u32 = 10498u32;
 pub const BTH_LE_GATT_CHARACTERISTIC_DESCRIPTOR_EXTENDED_PROPERTIES: u32 = 10496u32;
@@ -1027,9 +949,6 @@ impl Default for BTH_LE_GATT_CHARACTERISTIC_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_LE_GATT_CHARACTERISTIC_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BTH_LE_GATT_DEFAULT_MAX_INCLUDED_SERVICES_DEPTH: u32 = 3u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1044,9 +963,6 @@ impl Default for BTH_LE_GATT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1065,9 +981,6 @@ impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union BTH_LE_GATT_DESCRIPTOR_VALUE_0 {
@@ -1081,9 +994,6 @@ impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_0 {
@@ -1094,9 +1004,6 @@ impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1112,9 +1019,6 @@ impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
@@ -1126,9 +1030,6 @@ impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BTH_LE_GATT_DESCRIPTOR_VALUE_0_2 {
@@ -1138,9 +1039,6 @@ impl Default for BTH_LE_GATT_DESCRIPTOR_VALUE_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BTH_LE_GATT_DESCRIPTOR_VALUE_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1156,9 +1054,6 @@ impl Default for BTH_LE_GATT_SERVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_LE_GATT_SERVICE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BTH_LE_SERVICE_GAP: u32 = 6144u32;
 pub const BTH_LE_SERVICE_GATT: u32 = 6145u32;
 #[repr(C)]
@@ -1172,9 +1067,6 @@ impl Default for BTH_LE_UUID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_LE_UUID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union BTH_LE_UUID_0 {
@@ -1185,9 +1077,6 @@ impl Default for BTH_LE_UUID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BTH_LE_UUID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BTH_LINK_KEY_LENGTH: u32 = 16u32;
 pub const BTH_MAJORVERSION: u32 = 2u32;
@@ -1257,9 +1146,6 @@ impl Default for BTH_PING_REQ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_PING_REQ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BTH_PING_RSP {
@@ -1271,9 +1157,6 @@ impl Default for BTH_PING_RSP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_PING_RSP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct BTH_QUERY_DEVICE {
@@ -1284,9 +1167,6 @@ impl Default for BTH_QUERY_DEVICE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BTH_QUERY_DEVICE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1302,9 +1182,6 @@ impl Default for BTH_QUERY_SERVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BTH_QUERY_SERVICE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BTH_RADIO_IN_RANGE {
@@ -1315,9 +1192,6 @@ impl Default for BTH_RADIO_IN_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BTH_RADIO_IN_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BTH_SDP_VERSION: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -1334,9 +1208,6 @@ impl Default for BTH_SET_SERVICE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BTH_SET_SERVICE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BTH_VID_DEFAULT_VALUE: u32 = 65535u32;
 pub const BT_PORT_DYN_FIRST: u32 = 4097u32;
@@ -1687,9 +1558,6 @@ impl Default for RFCOMM_COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RFCOMM_COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RFCOMM_COMMAND_0 {
@@ -1701,9 +1569,6 @@ impl Default for RFCOMM_COMMAND_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RFCOMM_COMMAND_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RFCOMM_MAX_MTU: u32 = 1011u32;
 pub const RFCOMM_MIN_MTU: u32 = 23u32;
@@ -1718,9 +1583,6 @@ impl Default for RFCOMM_MSC_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RFCOMM_MSC_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RFCOMM_PROTOCOL_UUID16: u32 = 3u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1731,9 +1593,6 @@ impl Default for RFCOMM_RLS_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RFCOMM_RLS_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1750,9 +1609,6 @@ impl Default for RFCOMM_RPN_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RFCOMM_RPN_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RLS_ERROR: u32 = 1u32;
 pub const RLS_FRAMING: u32 = 8u32;
@@ -1881,9 +1737,6 @@ impl Default for SDP_ELEMENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SDP_ELEMENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SDP_ELEMENT_DATA_0 {
@@ -1911,9 +1764,6 @@ impl Default for SDP_ELEMENT_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SDP_ELEMENT_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SDP_ELEMENT_DATA_0_3 {
@@ -1924,9 +1774,6 @@ impl Default for SDP_ELEMENT_DATA_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SDP_ELEMENT_DATA_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1939,9 +1786,6 @@ impl Default for SDP_ELEMENT_DATA_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SDP_ELEMENT_DATA_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SDP_ELEMENT_DATA_0_0 {
@@ -1953,9 +1797,6 @@ impl Default for SDP_ELEMENT_DATA_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SDP_ELEMENT_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SDP_ELEMENT_DATA_0_1 {
@@ -1966,9 +1807,6 @@ impl Default for SDP_ELEMENT_DATA_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SDP_ELEMENT_DATA_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SDP_ERROR_INSUFFICIENT_RESOURCES: u32 = 6u32;
 pub const SDP_ERROR_INVALID_CONTINUATION_STATE: u32 = 5u32;
@@ -1986,9 +1824,6 @@ impl Default for SDP_LARGE_INTEGER_16 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SDP_LARGE_INTEGER_16 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SDP_MAX_INQUIRY_SECONDS: u32 = 60u32;
 pub const SDP_PROTOCOL_UUID16: u32 = 1u32;
@@ -2014,9 +1849,6 @@ impl Default for SDP_STRING_TYPE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SDP_STRING_TYPE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SDP_ST_INT128: SDP_SPECIFICTYPE = SDP_SPECIFICTYPE(1056i32);
 pub const SDP_ST_INT16: SDP_SPECIFICTYPE = SDP_SPECIFICTYPE(288i32);
@@ -2056,9 +1888,6 @@ impl Default for SDP_ULARGE_INTEGER_16 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SDP_ULARGE_INTEGER_16 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SERVICE_OPTION_DO_NOT_PUBLISH: u32 = 2u32;
 pub const SERVICE_OPTION_DO_NOT_PUBLISH_EIR: u32 = 8u32;
 pub const SERVICE_OPTION_NO_PUBLIC_BROWSE: u32 = 4u32;
@@ -2082,9 +1911,6 @@ impl Default for SOCKADDR_BTH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKADDR_BTH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SOL_L2CAP: u32 = 256u32;
 pub const SOL_RFCOMM: u32 = 3u32;
@@ -2122,9 +1948,6 @@ impl Default for SdpAttributeRange {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SdpAttributeRange {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct SdpQueryUuid {
@@ -2135,9 +1958,6 @@ impl Default for SdpQueryUuid {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SdpQueryUuid {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2150,9 +1970,6 @@ impl Default for SdpQueryUuidUnion {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SdpQueryUuidUnion {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SerialPortServiceClassID_UUID16: u32 = 4353u32;
 pub const ServerCharacteristicConfiguration: BTH_LE_GATT_DESCRIPTOR_TYPE = BTH_LE_GATT_DESCRIPTOR_TYPE(3i32);

--- a/crates/libs/windows/src/Windows/Win32/Devices/Cdrom/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Cdrom/mod.rs
@@ -34,9 +34,6 @@ impl Default for CDROM_DISK_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_DISK_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CDROM_DISK_DATA_TRACK: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -49,9 +46,6 @@ impl Default for CDROM_EXCEPTION_PERFORMANCE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_EXCEPTION_PERFORMANCE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_EXCLUSIVE_ACCESS {
@@ -62,9 +56,6 @@ impl Default for CDROM_EXCLUSIVE_ACCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_EXCLUSIVE_ACCESS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CDROM_EXCLUSIVE_CALLER_LENGTH: u32 = 64u32;
 #[repr(C)]
@@ -78,9 +69,6 @@ impl Default for CDROM_EXCLUSIVE_LOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_EXCLUSIVE_LOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_EXCLUSIVE_LOCK_STATE {
@@ -91,9 +79,6 @@ impl Default for CDROM_EXCLUSIVE_LOCK_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_EXCLUSIVE_LOCK_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CDROM_IN_EXCLUSIVE_MODE: u32 = 1u32;
 pub const CDROM_LOCK_IGNORE_VOLUME: u32 = 1u32;
@@ -109,9 +94,6 @@ impl Default for CDROM_NOMINAL_PERFORMANCE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_NOMINAL_PERFORMANCE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CDROM_NOT_IN_EXCLUSIVE_MODE: u32 = 0u32;
 pub const CDROM_NO_MEDIA_NOTIFICATIONS: u32 = 2u32;
@@ -134,9 +116,6 @@ impl Default for CDROM_PERFORMANCE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_PERFORMANCE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_PERFORMANCE_REQUEST {
@@ -150,9 +129,6 @@ impl Default for CDROM_PERFORMANCE_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_PERFORMANCE_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -178,9 +154,6 @@ impl Default for CDROM_PLAY_AUDIO_MSF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_PLAY_AUDIO_MSF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_READ_TOC_EX {
@@ -193,9 +166,6 @@ impl Default for CDROM_READ_TOC_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_READ_TOC_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CDROM_READ_TOC_EX_FORMAT_ATIP: u32 = 4u32;
 pub const CDROM_READ_TOC_EX_FORMAT_CDTEXT: u32 = 5u32;
@@ -215,9 +185,6 @@ impl Default for CDROM_SEEK_AUDIO_MSF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_SEEK_AUDIO_MSF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_SET_SPEED {
@@ -230,9 +197,6 @@ impl Default for CDROM_SET_SPEED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_SET_SPEED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -255,9 +219,6 @@ impl Default for CDROM_SET_STREAMING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_SET_STREAMING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_SIMPLE_OPC_INFO {
@@ -269,9 +230,6 @@ impl Default for CDROM_SIMPLE_OPC_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_SIMPLE_OPC_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -286,9 +244,6 @@ impl Default for CDROM_STREAMING_CONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_STREAMING_CONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_SUB_Q_DATA_FORMAT {
@@ -299,9 +254,6 @@ impl Default for CDROM_SUB_Q_DATA_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_SUB_Q_DATA_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -316,9 +268,6 @@ impl Default for CDROM_TOC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_TOC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_TOC_ATIP_DATA {
@@ -331,9 +280,6 @@ impl Default for CDROM_TOC_ATIP_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_TOC_ATIP_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -358,9 +304,6 @@ impl Default for CDROM_TOC_ATIP_DATA_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_TOC_ATIP_DATA_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CDROM_TOC_CD_TEXT_DATA {
@@ -373,9 +316,6 @@ impl Default for CDROM_TOC_CD_TEXT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_TOC_CD_TEXT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -392,9 +332,6 @@ impl Default for CDROM_TOC_CD_TEXT_DATA_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_TOC_CD_TEXT_DATA_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CDROM_TOC_CD_TEXT_DATA_BLOCK_0 {
@@ -405,9 +342,6 @@ impl Default for CDROM_TOC_CD_TEXT_DATA_BLOCK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_TOC_CD_TEXT_DATA_BLOCK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -421,9 +355,6 @@ impl Default for CDROM_TOC_FULL_TOC_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_TOC_FULL_TOC_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -441,9 +372,6 @@ impl Default for CDROM_TOC_FULL_TOC_DATA_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_TOC_FULL_TOC_DATA_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_TOC_PMA_DATA {
@@ -457,9 +385,6 @@ impl Default for CDROM_TOC_PMA_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_TOC_PMA_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_TOC_SESSION_DATA {
@@ -472,9 +397,6 @@ impl Default for CDROM_TOC_SESSION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_TOC_SESSION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -490,9 +412,6 @@ impl Default for CDROM_WRITE_SPEED_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDROM_WRITE_SPEED_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CDROM_WRITE_SPEED_REQUEST {
@@ -502,9 +421,6 @@ impl Default for CDROM_WRITE_SPEED_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CDROM_WRITE_SPEED_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CD_RAW_READ_C2_SIZE: u32 = 296u32;
 pub const CD_RAW_READ_SUBCODE_SIZE: u32 = 96u32;
@@ -598,9 +514,6 @@ impl Default for RAW_READ_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAW_READ_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RawWithC2: TRACK_MODE_TYPE = TRACK_MODE_TYPE(4i32);
 pub const RawWithC2AndSubCode: TRACK_MODE_TYPE = TRACK_MODE_TYPE(3i32);
 pub const RawWithSubCode: TRACK_MODE_TYPE = TRACK_MODE_TYPE(5i32);
@@ -619,9 +532,6 @@ impl Default for SUB_Q_CHANNEL_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SUB_Q_CHANNEL_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SUB_Q_CURRENT_POSITION {
@@ -638,9 +548,6 @@ impl Default for SUB_Q_CURRENT_POSITION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SUB_Q_CURRENT_POSITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SUB_Q_HEADER {
@@ -652,9 +559,6 @@ impl Default for SUB_Q_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SUB_Q_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -669,9 +573,6 @@ impl Default for SUB_Q_MEDIA_CATALOG_NUMBER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SUB_Q_MEDIA_CATALOG_NUMBER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -689,9 +590,6 @@ impl Default for SUB_Q_TRACK_ISRC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SUB_Q_TRACK_ISRC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SimpleOpcInfo: CDROM_OPC_INFO_TYPE = CDROM_OPC_INFO_TYPE(1i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -707,9 +605,6 @@ impl Default for TRACK_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRACK_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TRACK_MODE_TYPE(pub i32);
@@ -723,9 +618,6 @@ impl Default for VOLUME_CONTROL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUME_CONTROL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Communication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Communication/mod.rs
@@ -240,9 +240,6 @@ impl Default for COMMCONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMMCONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COMMPROP {
@@ -269,9 +266,6 @@ impl Default for COMMPROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COMMPROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -323,9 +317,6 @@ impl Default for COMMTIMEOUTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMMTIMEOUTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct COMM_EVENT_MASK(pub u32);
@@ -374,9 +365,6 @@ impl Default for COMSTAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMSTAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DCB {
@@ -400,9 +388,6 @@ impl Default for DCB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DCB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -565,9 +550,6 @@ impl Default for MODEMDEVCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MODEMDEVCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MODEMDEVCAPS_DIAL_OPTIONS(pub u32);
@@ -696,9 +678,6 @@ impl Default for MODEMSETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MODEMSETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
@@ -3921,9 +3921,6 @@ impl Default for BUSNUMBER_DES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BUSNUMBER_DES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct BUSNUMBER_RANGE {
@@ -3937,9 +3934,6 @@ impl Default for BUSNUMBER_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BUSNUMBER_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct BUSNUMBER_RESOURCE {
@@ -3951,9 +3945,6 @@ impl Default for BUSNUMBER_RESOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BUSNUMBER_RESOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -3969,10 +3960,6 @@ impl Default for CABINET_INFO_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for CABINET_INFO_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -3990,10 +3977,6 @@ impl Default for CABINET_INFO_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for CABINET_INFO_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -4010,10 +3993,6 @@ impl Default for CABINET_INFO_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for CABINET_INFO_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4029,10 +4008,6 @@ impl Default for CABINET_INFO_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for CABINET_INFO_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CM_ADD_ID_BITS: u32 = 1u32;
 pub const CM_ADD_ID_COMPATIBLE: u32 = 1u32;
@@ -4417,9 +4392,6 @@ impl Default for CM_NOTIFY_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_NOTIFY_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CM_NOTIFY_EVENT_DATA_0 {
@@ -4431,9 +4403,6 @@ impl Default for CM_NOTIFY_EVENT_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_NOTIFY_EVENT_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4448,9 +4417,6 @@ impl Default for CM_NOTIFY_EVENT_DATA_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_NOTIFY_EVENT_DATA_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_NOTIFY_EVENT_DATA_0_2 {
@@ -4460,9 +4426,6 @@ impl Default for CM_NOTIFY_EVENT_DATA_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_NOTIFY_EVENT_DATA_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4474,9 +4437,6 @@ impl Default for CM_NOTIFY_EVENT_DATA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_NOTIFY_EVENT_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4492,9 +4452,6 @@ impl Default for CM_NOTIFY_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_NOTIFY_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CM_NOTIFY_FILTER_0 {
@@ -4507,9 +4464,6 @@ impl Default for CM_NOTIFY_FILTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_NOTIFY_FILTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_NOTIFY_FILTER_0_1 {
@@ -4519,9 +4473,6 @@ impl Default for CM_NOTIFY_FILTER_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_NOTIFY_FILTER_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4533,9 +4484,6 @@ impl Default for CM_NOTIFY_FILTER_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_NOTIFY_FILTER_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_NOTIFY_FILTER_0_0 {
@@ -4545,9 +4493,6 @@ impl Default for CM_NOTIFY_FILTER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_NOTIFY_FILTER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CM_NOTIFY_FILTER_FLAG_ALL_DEVICE_INSTANCES: u32 = 2u32;
 pub const CM_NOTIFY_FILTER_FLAG_ALL_INTERFACE_CLASSES: u32 = 1u32;
@@ -4732,10 +4677,6 @@ impl Default for COINSTALLER_CONTEXT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for COINSTALLER_CONTEXT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4749,10 +4690,6 @@ impl Default for COINSTALLER_CONTEXT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for COINSTALLER_CONTEXT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONFIGFLAG_BOOT_DEVICE: SETUP_DI_DEVICE_CONFIGURATION_FLAGS = SETUP_DI_DEVICE_CONFIGURATION_FLAGS(262144u32);
 pub const CONFIGFLAG_CANTSTOPACHILD: SETUP_DI_DEVICE_CONFIGURATION_FLAGS = SETUP_DI_DEVICE_CONFIGURATION_FLAGS(128u32);
@@ -4793,9 +4730,6 @@ impl Default for CONFLICT_DETAILS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONFLICT_DETAILS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONFLICT_DETAILS_W {
@@ -4810,9 +4744,6 @@ impl Default for CONFLICT_DETAILS_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONFLICT_DETAILS_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -4830,9 +4761,6 @@ impl Default for CONNECTION_DES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONNECTION_DES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct CONNECTION_RESOURCE {
@@ -4842,9 +4770,6 @@ impl Default for CONNECTION_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONNECTION_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COPYFLG_FORCE_FILE_IN_USE: u32 = 8u32;
 pub const COPYFLG_IN_USE_TRY_RENAME: u32 = 16384u32;
@@ -4938,9 +4863,6 @@ impl Default for CS_DES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CS_DES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct CS_RESOURCE {
@@ -4950,9 +4872,6 @@ impl Default for CS_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CS_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5007,9 +4926,6 @@ impl Default for DEVPRIVATE_DES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVPRIVATE_DES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DEVPRIVATE_RANGE {
@@ -5022,9 +4938,6 @@ impl Default for DEVPRIVATE_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVPRIVATE_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DEVPRIVATE_RESOURCE {
@@ -5035,9 +4948,6 @@ impl Default for DEVPRIVATE_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVPRIVATE_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIBCI_NODISPLAYCLASS: u32 = 2u32;
 pub const DIBCI_NOINSTALLCLASS: u32 = 1u32;
@@ -5397,9 +5307,6 @@ impl Default for DMA_DES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_DES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DMA_RANGE {
@@ -5412,9 +5319,6 @@ impl Default for DMA_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMA_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DMA_RESOURCE {
@@ -5425,9 +5329,6 @@ impl Default for DMA_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMA_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMI_BKCOLOR: u32 = 2u32;
 pub const DMI_MASK: u32 = 1u32;
@@ -5550,10 +5451,6 @@ impl Default for FILEPATHS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FILEPATHS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5569,10 +5466,6 @@ impl Default for FILEPATHS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FILEPATHS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -5590,10 +5483,6 @@ impl Default for FILEPATHS_SIGNERINFO_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FILEPATHS_SIGNERINFO_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -5613,10 +5502,6 @@ impl Default for FILEPATHS_SIGNERINFO_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FILEPATHS_SIGNERINFO_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -5634,10 +5519,6 @@ impl Default for FILEPATHS_SIGNERINFO_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FILEPATHS_SIGNERINFO_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -5657,10 +5538,6 @@ impl Default for FILEPATHS_SIGNERINFO_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FILEPATHS_SIGNERINFO_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -5676,10 +5553,6 @@ impl Default for FILEPATHS_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FILEPATHS_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5694,10 +5567,6 @@ impl Default for FILEPATHS_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FILEPATHS_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_COMPRESSION_MSZIP: FILE_COMPRESSION_TYPE = FILE_COMPRESSION_TYPE(2u32);
 pub const FILE_COMPRESSION_NONE: FILE_COMPRESSION_TYPE = FILE_COMPRESSION_TYPE(0u32);
@@ -5757,10 +5626,6 @@ impl Default for FILE_IN_CABINET_INFO_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FILE_IN_CABINET_INFO_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5778,10 +5643,6 @@ impl Default for FILE_IN_CABINET_INFO_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FILE_IN_CABINET_INFO_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -5801,10 +5662,6 @@ impl Default for FILE_IN_CABINET_INFO_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FILE_IN_CABINET_INFO_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5822,10 +5679,6 @@ impl Default for FILE_IN_CABINET_INFO_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FILE_IN_CABINET_INFO_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILTERED_LOG_CONF: CM_LOG_CONF = CM_LOG_CONF(1u32);
 pub const FLG_ADDPROPERTY_AND: u32 = 16u32;
@@ -6111,9 +5964,6 @@ impl Default for HWPROFILEINFO_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HWPROFILEINFO_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct HWPROFILEINFO_W {
@@ -6125,9 +5975,6 @@ impl Default for HWPROFILEINFO_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HWPROFILEINFO_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IDD_DYNAWIZ_ANALYZEDEV_PAGE: u32 = 10010u32;
 pub const IDD_DYNAWIZ_ANALYZE_NEXTPAGE: u32 = 10004u32;
@@ -6178,10 +6025,6 @@ impl Default for INFCONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for INFCONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6196,10 +6039,6 @@ impl Default for INFCONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for INFCONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INFINFO_DEFAULT_SEARCH: u32 = 3u32;
 pub const INFINFO_INF_NAME_IS_ABSOLUTE: u32 = 2u32;
@@ -6492,9 +6331,6 @@ impl Default for IO_DES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_DES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IO_RANGE {
@@ -6510,9 +6346,6 @@ impl Default for IO_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IO_RESOURCE {
@@ -6523,9 +6356,6 @@ impl Default for IO_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6577,9 +6407,6 @@ impl Default for IRQ_DES_32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IRQ_DES_32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IRQ_DES_64 {
@@ -6594,9 +6421,6 @@ impl Default for IRQ_DES_64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IRQ_DES_64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IRQ_RANGE {
@@ -6609,9 +6433,6 @@ impl Default for IRQ_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IRQ_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IRQ_RESOURCE_32 {
@@ -6623,9 +6444,6 @@ impl Default for IRQ_RESOURCE_32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IRQ_RESOURCE_32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IRQ_RESOURCE_64 {
@@ -6636,9 +6454,6 @@ impl Default for IRQ_RESOURCE_64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IRQ_RESOURCE_64 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LCPRI_BOOTCONFIG: u32 = 1u32;
 pub const LCPRI_DESIRED: u32 = 8192u32;
@@ -6737,9 +6552,6 @@ impl Default for MEM_DES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEM_DES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MEM_LARGE_DES {
@@ -6754,9 +6566,6 @@ impl Default for MEM_LARGE_DES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEM_LARGE_DES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -6773,9 +6582,6 @@ impl Default for MEM_LARGE_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEM_LARGE_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MEM_LARGE_RESOURCE {
@@ -6786,9 +6592,6 @@ impl Default for MEM_LARGE_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEM_LARGE_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -6805,9 +6608,6 @@ impl Default for MEM_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEM_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MEM_RESOURCE {
@@ -6818,9 +6618,6 @@ impl Default for MEM_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEM_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -6838,9 +6635,6 @@ impl Default for MFCARD_DES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFCARD_DES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MFCARD_RESOURCE {
@@ -6850,9 +6644,6 @@ impl Default for MFCARD_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFCARD_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIN_IDD_DYNAWIZ_RESOURCE_ID: u32 = 10000u32;
 pub const NDW_INSTALLFLAG_CI_PICKED_OEM: u32 = 32768u32;
@@ -6903,9 +6694,6 @@ impl Default for PCCARD_DES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PCCARD_DES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct PCCARD_RESOURCE {
@@ -6915,9 +6703,6 @@ impl Default for PCCARD_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCCARD_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7340,10 +7125,6 @@ impl Default for SOURCE_MEDIA_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SOURCE_MEDIA_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7360,10 +7141,6 @@ impl Default for SOURCE_MEDIA_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SOURCE_MEDIA_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -7382,10 +7159,6 @@ impl Default for SOURCE_MEDIA_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SOURCE_MEDIA_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7402,10 +7175,6 @@ impl Default for SOURCE_MEDIA_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SOURCE_MEDIA_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPCRP_CHARACTERISTICS: u32 = 27u32;
 pub const SPCRP_DEVTYPE: u32 = 25u32;
@@ -7627,11 +7396,6 @@ impl Default for SP_ALTPLATFORM_INFO_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for SP_ALTPLATFORM_INFO_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
@@ -7651,11 +7415,6 @@ impl Default for SP_ALTPLATFORM_INFO_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for SP_ALTPLATFORM_INFO_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_SystemInformation"))]
@@ -7677,11 +7436,6 @@ impl Default for SP_ALTPLATFORM_INFO_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_SystemInformation"))]
-impl windows_core::TypeKind for SP_ALTPLATFORM_INFO_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_SystemInformation"))]
@@ -7696,11 +7450,6 @@ impl Default for SP_ALTPLATFORM_INFO_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_SystemInformation"))]
-impl windows_core::TypeKind for SP_ALTPLATFORM_INFO_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -7723,11 +7472,6 @@ impl Default for SP_ALTPLATFORM_INFO_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_SystemInformation"))]
-impl windows_core::TypeKind for SP_ALTPLATFORM_INFO_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_SystemInformation"))]
@@ -7742,11 +7486,6 @@ impl Default for SP_ALTPLATFORM_INFO_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_SystemInformation"))]
-impl windows_core::TypeKind for SP_ALTPLATFORM_INFO_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -7770,10 +7509,6 @@ impl Default for SP_ALTPLATFORM_INFO_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_ALTPLATFORM_INFO_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -7786,10 +7521,6 @@ impl Default for SP_ALTPLATFORM_INFO_V3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_ALTPLATFORM_INFO_V3_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -7813,10 +7544,6 @@ impl Default for SP_ALTPLATFORM_INFO_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_ALTPLATFORM_INFO_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -7829,10 +7556,6 @@ impl Default for SP_ALTPLATFORM_INFO_V3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_ALTPLATFORM_INFO_V3_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SP_BACKUP_BACKUPPASS: u32 = 1u32;
 pub const SP_BACKUP_BOOTFILE: u32 = 8u32;
@@ -7851,10 +7574,6 @@ impl Default for SP_BACKUP_QUEUE_PARAMS_V1_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_BACKUP_QUEUE_PARAMS_V1_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7869,10 +7588,6 @@ impl Default for SP_BACKUP_QUEUE_PARAMS_V1_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_BACKUP_QUEUE_PARAMS_V1_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -7887,10 +7602,6 @@ impl Default for SP_BACKUP_QUEUE_PARAMS_V1_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_BACKUP_QUEUE_PARAMS_V1_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7904,10 +7615,6 @@ impl Default for SP_BACKUP_QUEUE_PARAMS_V1_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_BACKUP_QUEUE_PARAMS_V1_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -7924,10 +7631,6 @@ impl Default for SP_BACKUP_QUEUE_PARAMS_V2_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_BACKUP_QUEUE_PARAMS_V2_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7942,10 +7645,6 @@ impl Default for SP_BACKUP_QUEUE_PARAMS_V2_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_BACKUP_QUEUE_PARAMS_V2_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -7962,10 +7661,6 @@ impl Default for SP_BACKUP_QUEUE_PARAMS_V2_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_BACKUP_QUEUE_PARAMS_V2_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7980,10 +7675,6 @@ impl Default for SP_BACKUP_QUEUE_PARAMS_V2_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_BACKUP_QUEUE_PARAMS_V2_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SP_BACKUP_SPECIAL: u32 = 4u32;
 #[repr(C, packed(1))]
@@ -8002,11 +7693,6 @@ impl Default for SP_CLASSIMAGELIST_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_Controls")]
-impl windows_core::TypeKind for SP_CLASSIMAGELIST_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_Controls")]
@@ -8023,11 +7709,6 @@ impl Default for SP_CLASSIMAGELIST_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_Controls")]
-impl windows_core::TypeKind for SP_CLASSIMAGELIST_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8041,10 +7722,6 @@ impl Default for SP_CLASSINSTALL_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_CLASSINSTALL_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8057,10 +7734,6 @@ impl Default for SP_CLASSINSTALL_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_CLASSINSTALL_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SP_COPY_ALREADYDECOMP: SP_COPY_STYLE = SP_COPY_STYLE(4194304u32);
 pub const SP_COPY_DELETESOURCE: SP_COPY_STYLE = SP_COPY_STYLE(1u32);
@@ -8140,10 +7813,6 @@ impl Default for SP_DETECTDEVICE_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DETECTDEVICE_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8158,10 +7827,6 @@ impl Default for SP_DETECTDEVICE_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DETECTDEVICE_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8176,10 +7841,6 @@ impl Default for SP_DEVICE_INTERFACE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DEVICE_INTERFACE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -8196,10 +7857,6 @@ impl Default for SP_DEVICE_INTERFACE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DEVICE_INTERFACE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8212,10 +7869,6 @@ impl Default for SP_DEVICE_INTERFACE_DETAIL_DATA_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DEVICE_INTERFACE_DETAIL_DATA_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -8230,10 +7883,6 @@ impl Default for SP_DEVICE_INTERFACE_DETAIL_DATA_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DEVICE_INTERFACE_DETAIL_DATA_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8247,10 +7896,6 @@ impl Default for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8263,10 +7908,6 @@ impl Default for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DEVICE_INTERFACE_DETAIL_DATA_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -8283,10 +7924,6 @@ impl Default for SP_DEVINFO_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DEVINFO_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8302,10 +7939,6 @@ impl Default for SP_DEVINFO_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DEVINFO_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8320,10 +7953,6 @@ impl Default for SP_DEVINFO_LIST_DETAIL_DATA_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DEVINFO_LIST_DETAIL_DATA_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -8340,10 +7969,6 @@ impl Default for SP_DEVINFO_LIST_DETAIL_DATA_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DEVINFO_LIST_DETAIL_DATA_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8359,10 +7984,6 @@ impl Default for SP_DEVINFO_LIST_DETAIL_DATA_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DEVINFO_LIST_DETAIL_DATA_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8377,10 +7998,6 @@ impl Default for SP_DEVINFO_LIST_DETAIL_DATA_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DEVINFO_LIST_DETAIL_DATA_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -8403,10 +8020,6 @@ impl Default for SP_DEVINSTALL_PARAMS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DEVINSTALL_PARAMS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8428,10 +8041,6 @@ impl Default for SP_DEVINSTALL_PARAMS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DEVINSTALL_PARAMS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8452,10 +8061,6 @@ impl Default for SP_DEVINSTALL_PARAMS_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DEVINSTALL_PARAMS_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -8478,10 +8083,6 @@ impl Default for SP_DEVINSTALL_PARAMS_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DEVINSTALL_PARAMS_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8498,10 +8099,6 @@ impl Default for SP_DRVINFO_DATA_V1_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DRVINFO_DATA_V1_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -8520,10 +8117,6 @@ impl Default for SP_DRVINFO_DATA_V1_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DRVINFO_DATA_V1_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8541,10 +8134,6 @@ impl Default for SP_DRVINFO_DATA_V1_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DRVINFO_DATA_V1_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8561,10 +8150,6 @@ impl Default for SP_DRVINFO_DATA_V1_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DRVINFO_DATA_V1_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -8585,10 +8170,6 @@ impl Default for SP_DRVINFO_DATA_V2_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DRVINFO_DATA_V2_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8607,10 +8188,6 @@ impl Default for SP_DRVINFO_DATA_V2_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DRVINFO_DATA_V2_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -8631,10 +8208,6 @@ impl Default for SP_DRVINFO_DATA_V2_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DRVINFO_DATA_V2_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8653,10 +8226,6 @@ impl Default for SP_DRVINFO_DATA_V2_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DRVINFO_DATA_V2_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -8678,10 +8247,6 @@ impl Default for SP_DRVINFO_DETAIL_DATA_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DRVINFO_DETAIL_DATA_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8702,10 +8267,6 @@ impl Default for SP_DRVINFO_DETAIL_DATA_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DRVINFO_DETAIL_DATA_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8725,10 +8286,6 @@ impl Default for SP_DRVINFO_DETAIL_DATA_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DRVINFO_DETAIL_DATA_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -8750,10 +8307,6 @@ impl Default for SP_DRVINFO_DETAIL_DATA_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DRVINFO_DETAIL_DATA_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8769,10 +8322,6 @@ impl Default for SP_DRVINSTALL_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_DRVINSTALL_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -8790,10 +8339,6 @@ impl Default for SP_DRVINSTALL_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_DRVINSTALL_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8808,10 +8353,6 @@ impl Default for SP_ENABLECLASS_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_ENABLECLASS_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8825,10 +8366,6 @@ impl Default for SP_ENABLECLASS_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_ENABLECLASS_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -8853,10 +8390,6 @@ impl Default for SP_FILE_COPY_PARAMS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_FILE_COPY_PARAMS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8879,10 +8412,6 @@ impl Default for SP_FILE_COPY_PARAMS_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_FILE_COPY_PARAMS_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -8907,10 +8436,6 @@ impl Default for SP_FILE_COPY_PARAMS_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_FILE_COPY_PARAMS_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8933,10 +8458,6 @@ impl Default for SP_FILE_COPY_PARAMS_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_FILE_COPY_PARAMS_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SP_FLAG_CABINETCONTINUATION: u32 = 2048u32;
 #[repr(C, packed(1))]
@@ -8953,10 +8474,6 @@ impl Default for SP_INF_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_INF_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8971,10 +8488,6 @@ impl Default for SP_INF_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_INF_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -8989,10 +8502,6 @@ impl Default for SP_INF_SIGNER_INFO_V1_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_INF_SIGNER_INFO_V1_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -9009,10 +8518,6 @@ impl Default for SP_INF_SIGNER_INFO_V1_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_INF_SIGNER_INFO_V1_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9028,10 +8533,6 @@ impl Default for SP_INF_SIGNER_INFO_V1_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_INF_SIGNER_INFO_V1_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9046,10 +8547,6 @@ impl Default for SP_INF_SIGNER_INFO_V1_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_INF_SIGNER_INFO_V1_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -9067,10 +8564,6 @@ impl Default for SP_INF_SIGNER_INFO_V2_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_INF_SIGNER_INFO_V2_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9086,10 +8579,6 @@ impl Default for SP_INF_SIGNER_INFO_V2_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_INF_SIGNER_INFO_V2_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -9107,10 +8596,6 @@ impl Default for SP_INF_SIGNER_INFO_V2_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_INF_SIGNER_INFO_V2_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9126,10 +8611,6 @@ impl Default for SP_INF_SIGNER_INFO_V2_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_INF_SIGNER_INFO_V2_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -9152,11 +8633,6 @@ impl Default for SP_INSTALLWIZARD_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_Controls")]
-impl windows_core::TypeKind for SP_INSTALLWIZARD_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_Controls")]
@@ -9177,11 +8653,6 @@ impl Default for SP_INSTALLWIZARD_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_Controls")]
-impl windows_core::TypeKind for SP_INSTALLWIZARD_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SP_MAX_MACHINENAME_LENGTH: u32 = 263u32;
 #[repr(C, packed(1))]
@@ -9202,11 +8673,6 @@ impl Default for SP_NEWDEVICEWIZARD_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_Controls")]
-impl windows_core::TypeKind for SP_NEWDEVICEWIZARD_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_Controls")]
@@ -9225,11 +8691,6 @@ impl Default for SP_NEWDEVICEWIZARD_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_Controls")]
-impl windows_core::TypeKind for SP_NEWDEVICEWIZARD_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9243,10 +8704,6 @@ impl Default for SP_ORIGINAL_FILE_INFO_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_ORIGINAL_FILE_INFO_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -9262,10 +8719,6 @@ impl Default for SP_ORIGINAL_FILE_INFO_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_ORIGINAL_FILE_INFO_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9280,10 +8733,6 @@ impl Default for SP_ORIGINAL_FILE_INFO_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_ORIGINAL_FILE_INFO_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9297,10 +8746,6 @@ impl Default for SP_ORIGINAL_FILE_INFO_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_ORIGINAL_FILE_INFO_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9313,9 +8758,6 @@ impl Default for SP_POWERMESSAGEWAKE_PARAMS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SP_POWERMESSAGEWAKE_PARAMS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9329,10 +8771,6 @@ impl Default for SP_POWERMESSAGEWAKE_PARAMS_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_POWERMESSAGEWAKE_PARAMS_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9345,10 +8783,6 @@ impl Default for SP_POWERMESSAGEWAKE_PARAMS_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_POWERMESSAGEWAKE_PARAMS_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -9365,10 +8799,6 @@ impl Default for SP_PROPCHANGE_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_PROPCHANGE_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9384,10 +8814,6 @@ impl Default for SP_PROPCHANGE_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_PROPCHANGE_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9402,10 +8828,6 @@ impl Default for SP_PROPSHEETPAGE_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_PROPSHEETPAGE_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -9422,10 +8844,6 @@ impl Default for SP_PROPSHEETPAGE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_PROPSHEETPAGE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9440,10 +8858,6 @@ impl Default for SP_REGISTER_CONTROL_STATUSA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_REGISTER_CONTROL_STATUSA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -9460,10 +8874,6 @@ impl Default for SP_REGISTER_CONTROL_STATUSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_REGISTER_CONTROL_STATUSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9478,10 +8888,6 @@ impl Default for SP_REGISTER_CONTROL_STATUSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_REGISTER_CONTROL_STATUSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -9498,10 +8904,6 @@ impl Default for SP_REGISTER_CONTROL_STATUSW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_REGISTER_CONTROL_STATUSW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9516,10 +8918,6 @@ impl Default for SP_REMOVEDEVICE_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_REMOVEDEVICE_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9533,10 +8931,6 @@ impl Default for SP_REMOVEDEVICE_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_REMOVEDEVICE_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9553,9 +8947,6 @@ impl Default for SP_SELECTDEVICE_PARAMS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SP_SELECTDEVICE_PARAMS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9572,10 +8963,6 @@ impl Default for SP_SELECTDEVICE_PARAMS_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_SELECTDEVICE_PARAMS_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9591,10 +8978,6 @@ impl Default for SP_SELECTDEVICE_PARAMS_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_SELECTDEVICE_PARAMS_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9608,9 +8991,6 @@ impl Default for SP_TROUBLESHOOTER_PARAMS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SP_TROUBLESHOOTER_PARAMS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9624,10 +9004,6 @@ impl Default for SP_TROUBLESHOOTER_PARAMS_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_TROUBLESHOOTER_PARAMS_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -9643,10 +9019,6 @@ impl Default for SP_TROUBLESHOOTER_PARAMS_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_TROUBLESHOOTER_PARAMS_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -9661,10 +9033,6 @@ impl Default for SP_UNREMOVEDEVICE_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SP_UNREMOVEDEVICE_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9678,10 +9046,6 @@ impl Default for SP_UNREMOVEDEVICE_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SP_UNREMOVEDEVICE_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SRCINFO_DESCRIPTION: u32 = 3u32;
 pub const SRCINFO_FLAGS: u32 = 4u32;

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceQuery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceQuery/mod.rs
@@ -219,10 +219,6 @@ impl Default for DEVPROP_FILTER_EXPRESSION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Devices_Properties")]
-impl windows_core::TypeKind for DEVPROP_FILTER_EXPRESSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DEVPROP_OPERATOR(pub u32);
@@ -316,10 +312,6 @@ impl Default for DEV_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Devices_Properties")]
-impl windows_core::TypeKind for DEV_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DEV_OBJECT_TYPE(pub i32);
@@ -341,10 +333,6 @@ impl Default for DEV_QUERY_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Devices_Properties")]
-impl windows_core::TypeKind for DEV_QUERY_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DEV_QUERY_RESULT_ACTION(pub i32);
@@ -361,10 +349,6 @@ impl Default for DEV_QUERY_RESULT_ACTION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Devices_Properties")]
-impl windows_core::TypeKind for DEV_QUERY_RESULT_ACTION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Devices_Properties")]
 #[derive(Clone, Copy)]
@@ -377,10 +361,6 @@ impl Default for DEV_QUERY_RESULT_ACTION_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Devices_Properties")]
-impl windows_core::TypeKind for DEV_QUERY_RESULT_ACTION_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
@@ -691,9 +691,6 @@ impl Default for Adapter {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Adapter {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Adapters {
@@ -704,9 +701,6 @@ impl Default for Adapters {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for Adapters {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -723,9 +717,6 @@ impl Default for BACKLIGHT_REDUCTION_GAMMA_RAMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BACKLIGHT_REDUCTION_GAMMA_RAMP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BANK_POSITION {
@@ -736,9 +727,6 @@ impl Default for BANK_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BANK_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BITMAP_ARRAY_BYTE: u32 = 3u32;
 pub const BITMAP_BITS_BYTE_ALIGN: u32 = 8u32;
@@ -756,10 +744,6 @@ impl Default for BLENDOBJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for BLENDOBJ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BMF_16BPP: i32 = 4i32;
 pub const BMF_1BPP: i32 = 1i32;
@@ -800,9 +784,6 @@ impl Default for BRIGHTNESS_LEVEL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BRIGHTNESS_LEVEL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BRIGHTNESS_MAX_LEVEL_COUNT: u32 = 103u32;
 pub const BRIGHTNESS_MAX_NIT_RANGE_COUNT: u32 = 16u32;
 #[repr(C)]
@@ -817,9 +798,6 @@ impl Default for BRIGHTNESS_NIT_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BRIGHTNESS_NIT_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BRIGHTNESS_NIT_RANGES {
@@ -833,9 +811,6 @@ impl Default for BRIGHTNESS_NIT_RANGES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BRIGHTNESS_NIT_RANGES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BRUSHOBJ {
@@ -847,9 +822,6 @@ impl Default for BRUSHOBJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BRUSHOBJ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BR_CMYKCOLOR: u32 = 4u32;
 pub const BR_DEVICE_ICM: u32 = 1u32;
@@ -884,9 +856,6 @@ impl Default for CDDDXGK_REDIRBITMAPPRESENTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CDDDXGK_REDIRBITMAPPRESENTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CD_ANY: i32 = 4i32;
 pub const CD_LEFTDOWN: i32 = 1i32;
 pub const CD_LEFTUP: i32 = 3i32;
@@ -907,10 +876,6 @@ impl Default for CHAR_IMAGE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Console")]
-impl windows_core::TypeKind for CHAR_IMAGE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CHAR_TYPE_LEADING: u32 = 2u32;
 pub const CHAR_TYPE_SBCS: u32 = 0u32;
 pub const CHAR_TYPE_TRAILING: u32 = 3u32;
@@ -925,9 +890,6 @@ impl Default for CHROMATICITY_COORDINATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHROMATICITY_COORDINATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CIECHROMA {
@@ -939,9 +901,6 @@ impl Default for CIECHROMA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CIECHROMA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -957,9 +916,6 @@ impl Default for CLIPLINE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLIPLINE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLIPOBJ {
@@ -974,9 +930,6 @@ impl Default for CLIPOBJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLIPOBJ {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1003,9 +956,6 @@ impl Default for COLORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct COLORSPACE_TRANSFORM {
@@ -1016,9 +966,6 @@ impl Default for COLORSPACE_TRANSFORM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1033,9 +980,6 @@ impl Default for COLORSPACE_TRANSFORM_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct COLORSPACE_TRANSFORM_1DLUT_CAP {
@@ -1046,9 +990,6 @@ impl Default for COLORSPACE_TRANSFORM_1DLUT_CAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_1DLUT_CAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1061,9 +1002,6 @@ impl Default for COLORSPACE_TRANSFORM_3x4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_3x4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1078,9 +1016,6 @@ impl Default for COLORSPACE_TRANSFORM_DATA_CAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_DATA_CAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union COLORSPACE_TRANSFORM_DATA_CAP_0 {
@@ -1093,9 +1028,6 @@ impl Default for COLORSPACE_TRANSFORM_DATA_CAP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_DATA_CAP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COLORSPACE_TRANSFORM_DATA_CAP_0_0 {
@@ -1106,9 +1038,6 @@ impl Default for COLORSPACE_TRANSFORM_DATA_CAP_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_DATA_CAP_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COLORSPACE_TRANSFORM_DATA_CAP_0_1 {
@@ -1118,9 +1047,6 @@ impl Default for COLORSPACE_TRANSFORM_DATA_CAP_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_DATA_CAP_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1138,9 +1064,6 @@ impl Default for COLORSPACE_TRANSFORM_MATRIX_CAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_MATRIX_CAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union COLORSPACE_TRANSFORM_MATRIX_CAP_0 {
@@ -1152,9 +1075,6 @@ impl Default for COLORSPACE_TRANSFORM_MATRIX_CAP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_MATRIX_CAP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COLORSPACE_TRANSFORM_MATRIX_CAP_0_0 {
@@ -1164,9 +1084,6 @@ impl Default for COLORSPACE_TRANSFORM_MATRIX_CAP_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_MATRIX_CAP_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1183,9 +1100,6 @@ impl Default for COLORSPACE_TRANSFORM_MATRIX_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_MATRIX_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct COLORSPACE_TRANSFORM_SET_INPUT {
@@ -1197,9 +1111,6 @@ impl Default for COLORSPACE_TRANSFORM_SET_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_SET_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1216,9 +1127,6 @@ impl Default for COLORSPACE_TRANSFORM_TARGET_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLORSPACE_TRANSFORM_TARGET_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1269,9 +1177,6 @@ impl Default for DEVHTADJDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVHTADJDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEVHTADJF_ADDITIVE_DEVICE: u32 = 2u32;
 pub const DEVHTADJF_COLOR_DEVICE: u32 = 1u32;
 #[repr(C)]
@@ -1286,9 +1191,6 @@ impl Default for DEVHTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVHTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1310,10 +1212,6 @@ impl Default for DEVINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DEVINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVPKEY_Device_ActivityId: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0xc50a3f10_aa5c_4247_b830_d6a6f8eaa310), pid: 4 };
 pub const DEVPKEY_Device_AdapterLuid: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0xc50a3f10_aa5c_4247_b830_d6a6f8eaa310), pid: 3 };
@@ -1362,9 +1260,6 @@ impl Default for DISPLAYCONFIG_2DREGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_2DREGION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAYCONFIG_ADAPTER_NAME {
@@ -1375,9 +1270,6 @@ impl Default for DISPLAYCONFIG_ADAPTER_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_ADAPTER_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1390,9 +1282,6 @@ impl Default for DISPLAYCONFIG_DESKTOP_IMAGE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_DESKTOP_IMAGE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DISPLAYCONFIG_DEVICE_INFO_GET_ADAPTER_NAME: DISPLAYCONFIG_DEVICE_INFO_TYPE = DISPLAYCONFIG_DEVICE_INFO_TYPE(4i32);
 pub const DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO: DISPLAYCONFIG_DEVICE_INFO_TYPE = DISPLAYCONFIG_DEVICE_INFO_TYPE(9i32);
@@ -1416,9 +1305,6 @@ impl Default for DISPLAYCONFIG_DEVICE_INFO_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_DEVICE_INFO_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE: DISPLAYCONFIG_DEVICE_INFO_TYPE = DISPLAYCONFIG_DEVICE_INFO_TYPE(10i32);
 pub const DISPLAYCONFIG_DEVICE_INFO_SET_MONITOR_SPECIALIZATION: DISPLAYCONFIG_DEVICE_INFO_TYPE = DISPLAYCONFIG_DEVICE_INFO_TYPE(13i32);
 pub const DISPLAYCONFIG_DEVICE_INFO_SET_SUPPORT_VIRTUAL_RESOLUTION: DISPLAYCONFIG_DEVICE_INFO_TYPE = DISPLAYCONFIG_DEVICE_INFO_TYPE(8i32);
@@ -1441,10 +1327,6 @@ impl Default for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -1458,10 +1340,6 @@ impl Default for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1474,10 +1352,6 @@ impl Default for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION {
@@ -1488,9 +1362,6 @@ impl Default for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1503,9 +1374,6 @@ impl Default for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0_0 {
@@ -1515,9 +1383,6 @@ impl Default for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_GET_MONITOR_SPECIALIZATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1532,9 +1397,6 @@ impl Default for DISPLAYCONFIG_MODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_MODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISPLAYCONFIG_MODE_INFO_0 {
@@ -1546,9 +1408,6 @@ impl Default for DISPLAYCONFIG_MODE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_MODE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1588,9 +1447,6 @@ impl Default for DISPLAYCONFIG_PATH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_PATH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DISPLAYCONFIG_PATH_SOURCE_INFO {
@@ -1604,9 +1460,6 @@ impl Default for DISPLAYCONFIG_PATH_SOURCE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_PATH_SOURCE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISPLAYCONFIG_PATH_SOURCE_INFO_0 {
@@ -1618,9 +1471,6 @@ impl Default for DISPLAYCONFIG_PATH_SOURCE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_PATH_SOURCE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAYCONFIG_PATH_SOURCE_INFO_0_0 {
@@ -1630,9 +1480,6 @@ impl Default for DISPLAYCONFIG_PATH_SOURCE_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_PATH_SOURCE_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1653,9 +1500,6 @@ impl Default for DISPLAYCONFIG_PATH_TARGET_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_PATH_TARGET_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISPLAYCONFIG_PATH_TARGET_INFO_0 {
@@ -1667,9 +1511,6 @@ impl Default for DISPLAYCONFIG_PATH_TARGET_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_PATH_TARGET_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAYCONFIG_PATH_TARGET_INFO_0_0 {
@@ -1679,9 +1520,6 @@ impl Default for DISPLAYCONFIG_PATH_TARGET_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_PATH_TARGET_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1701,9 +1539,6 @@ impl Default for DISPLAYCONFIG_RATIONAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_RATIONAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1740,9 +1575,6 @@ impl Default for DISPLAYCONFIG_SDR_WHITE_LEVEL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_SDR_WHITE_LEVEL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE {
@@ -1753,9 +1585,6 @@ impl Default for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1768,9 +1597,6 @@ impl Default for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0_0 {
@@ -1780,9 +1606,6 @@ impl Default for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1798,9 +1621,6 @@ impl Default for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0 {
@@ -1812,9 +1632,6 @@ impl Default for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0_0 {
@@ -1824,9 +1641,6 @@ impl Default for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_SET_MONITOR_SPECIALIZATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1839,9 +1653,6 @@ impl Default for DISPLAYCONFIG_SET_TARGET_PERSISTENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_SET_TARGET_PERSISTENCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0 {
@@ -1853,9 +1664,6 @@ impl Default for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0_0 {
@@ -1865,9 +1673,6 @@ impl Default for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_SET_TARGET_PERSISTENCE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1879,9 +1684,6 @@ impl Default for DISPLAYCONFIG_SOURCE_DEVICE_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_SOURCE_DEVICE_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1896,9 +1698,6 @@ impl Default for DISPLAYCONFIG_SOURCE_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_SOURCE_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION {
@@ -1909,9 +1708,6 @@ impl Default for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1924,9 +1720,6 @@ impl Default for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0_0 {
@@ -1936,9 +1729,6 @@ impl Default for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_SUPPORT_VIRTUAL_RESOLUTION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1950,9 +1740,6 @@ impl Default for DISPLAYCONFIG_TARGET_BASE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_TARGET_BASE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1971,9 +1758,6 @@ impl Default for DISPLAYCONFIG_TARGET_DEVICE_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_TARGET_DEVICE_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS {
@@ -1983,9 +1767,6 @@ impl Default for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1998,9 +1779,6 @@ impl Default for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0_0 {
@@ -2011,9 +1789,6 @@ impl Default for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DISPLAYCONFIG_TARGET_MODE {
@@ -2023,9 +1798,6 @@ impl Default for DISPLAYCONFIG_TARGET_MODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_TARGET_MODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2039,9 +1811,6 @@ impl Default for DISPLAYCONFIG_TARGET_PREFERRED_MODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_TARGET_PREFERRED_MODE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DISPLAYCONFIG_TOPOLOGY_CLONE: DISPLAYCONFIG_TOPOLOGY_ID = DISPLAYCONFIG_TOPOLOGY_ID(2i32);
 pub const DISPLAYCONFIG_TOPOLOGY_EXTEND: DISPLAYCONFIG_TOPOLOGY_ID = DISPLAYCONFIG_TOPOLOGY_ID(4i32);
@@ -2069,9 +1838,6 @@ impl Default for DISPLAYCONFIG_VIDEO_SIGNAL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_VIDEO_SIGNAL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0 {
@@ -2083,9 +1849,6 @@ impl Default for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0_0 {
@@ -2095,9 +1858,6 @@ impl Default for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAYCONFIG_VIDEO_SIGNAL_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DISPLAYPOLICY_AC: u32 = 1u32;
 pub const DISPLAYPOLICY_DC: u32 = 2u32;
@@ -2112,9 +1872,6 @@ impl Default for DISPLAY_BRIGHTNESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAY_BRIGHTNESS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DM_DEFAULT: u32 = 1u32;
 pub const DM_MONOCHROME: u32 = 2u32;
@@ -2140,9 +1897,6 @@ impl Default for DRH_APIBITMAPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRH_APIBITMAPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVEROBJ {
@@ -2156,9 +1910,6 @@ impl Default for DRIVEROBJ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVEROBJ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRVENABLEDATA {
@@ -2171,9 +1922,6 @@ impl Default for DRVENABLEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRVENABLEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRVFN {
@@ -2184,9 +1932,6 @@ impl Default for DRVFN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRVFN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRVQUERY_USERMODE: u32 = 1u32;
 pub const DSI_CHECKSUM_ERROR_CORRECTED: u32 = 256u32;
@@ -2228,9 +1973,6 @@ impl Default for DXGK_WIN32K_PARAM_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGK_WIN32K_PARAM_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXGK_WIN32K_PARAM_FLAG_DISABLEVIEW: u32 = 4u32;
 pub const DXGK_WIN32K_PARAM_FLAG_MODESWITCH: u32 = 2u32;
 pub const DXGK_WIN32K_PARAM_FLAG_UPDATEREGISTRY: u32 = 1u32;
@@ -2247,10 +1989,6 @@ impl Default for DisplayMode {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DisplayMode {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -2263,10 +2001,6 @@ impl Default for DisplayModes {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DisplayModes {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ECS_REDRAW: u32 = 2u32;
 pub const ECS_TEARDOWN: u32 = 1u32;
@@ -2288,10 +2022,6 @@ impl Default for EMFINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for EMFINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ENDCAP_BUTT: i32 = 2i32;
 pub const ENDCAP_ROUND: i32 = 0i32;
 pub const ENDCAP_SQUARE: i32 = 1i32;
@@ -2306,9 +2036,6 @@ impl Default for ENGSAFESEMAPHORE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENGSAFESEMAPHORE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ENG_DEVICE_ATTRIBUTE(pub i32);
@@ -2322,9 +2049,6 @@ impl Default for ENG_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENG_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENG_FNT_CACHE_READ_FAULT: u32 = 1u32;
 pub const ENG_FNT_CACHE_WRITE_FAULT: u32 = 2u32;
@@ -2348,9 +2072,6 @@ impl Default for ENG_TIME_FIELDS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENG_TIME_FIELDS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENUMRECTS {
@@ -2361,9 +2082,6 @@ impl Default for ENUMRECTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENUMRECTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EngNumberOfProcessors: ENG_SYSTEM_ATTRIBUTE = ENG_SYSTEM_ATTRIBUTE(2i32);
 pub const EngOptimumAvailableSystemMemory: ENG_SYSTEM_ATTRIBUTE = ENG_SYSTEM_ATTRIBUTE(4i32);
@@ -2408,9 +2126,6 @@ impl Default for FD_DEVICEMETRICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FD_DEVICEMETRICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FD_ERROR: u32 = 4294967295u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2424,9 +2139,6 @@ impl Default for FD_GLYPHATTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FD_GLYPHATTR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2442,9 +2154,6 @@ impl Default for FD_GLYPHSET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FD_GLYPHSET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FD_KERNINGPAIR {
@@ -2456,9 +2165,6 @@ impl Default for FD_KERNINGPAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FD_KERNINGPAIR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2472,9 +2178,6 @@ impl Default for FD_LIGATURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FD_LIGATURE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FD_NEGATIVE_FONT: i32 = 1i32;
 #[repr(C)]
@@ -2492,10 +2195,6 @@ impl Default for FD_XFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FD_XFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2511,10 +2210,6 @@ impl Default for FD_XFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FD_XFORM {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FF_IGNORED_SIGNATURE: u32 = 2u32;
 pub const FF_SIGNATURE_VERIFIED: u32 = 1u32;
 #[repr(C)]
@@ -2529,10 +2224,6 @@ impl Default for FLOATOBJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FLOATOBJ {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -2551,10 +2242,6 @@ impl Default for FLOATOBJ_XFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FLOATOBJ_XFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2572,10 +2259,6 @@ impl Default for FLOATOBJ_XFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FLOATOBJ_XFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -2589,10 +2272,6 @@ impl Default for FLOAT_LONG {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FLOAT_LONG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -2605,10 +2284,6 @@ impl Default for FLOAT_LONG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FLOAT_LONG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FL_NONPAGED_MEMORY: u32 = 2u32;
 pub const FL_NON_SESSION: u32 = 4u32;
@@ -2676,9 +2351,6 @@ impl Default for FONTDIFF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FONTDIFF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FONTINFO {
@@ -2694,9 +2366,6 @@ impl Default for FONTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FONTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2717,9 +2386,6 @@ impl Default for FONTOBJ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FONTOBJ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FONTSIM {
@@ -2731,9 +2397,6 @@ impl Default for FONTSIM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FONTSIM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Console")]
@@ -2747,10 +2410,6 @@ impl Default for FONT_IMAGE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Console")]
-impl windows_core::TypeKind for FONT_IMAGE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FO_ATTR_MODE_ROTATE: u32 = 1u32;
 pub const FO_CFF: u32 = 1048576u32;
@@ -2791,10 +2450,6 @@ impl Default for FSCNTL_SCREEN_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Console")]
-impl windows_core::TypeKind for FSCNTL_SCREEN_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Console")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2808,10 +2463,6 @@ impl Default for FSVIDEO_COPY_FRAME_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Console")]
-impl windows_core::TypeKind for FSVIDEO_COPY_FRAME_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSVIDEO_CURSOR_POSITION {
@@ -2823,9 +2474,6 @@ impl Default for FSVIDEO_CURSOR_POSITION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSVIDEO_CURSOR_POSITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSVIDEO_MODE_INFORMATION {
@@ -2836,9 +2484,6 @@ impl Default for FSVIDEO_MODE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSVIDEO_MODE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Console")]
@@ -2853,10 +2498,6 @@ impl Default for FSVIDEO_REVERSE_MOUSE_POINTER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Console")]
-impl windows_core::TypeKind for FSVIDEO_REVERSE_MOUSE_POINTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Console")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2869,10 +2510,6 @@ impl Default for FSVIDEO_SCREEN_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Console")]
-impl windows_core::TypeKind for FSVIDEO_SCREEN_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Console")]
@@ -2887,10 +2524,6 @@ impl Default for FSVIDEO_WRITE_TO_FRAME_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Console")]
-impl windows_core::TypeKind for FSVIDEO_WRITE_TO_FRAME_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GAMMARAMP {
@@ -2902,9 +2535,6 @@ impl Default for GAMMARAMP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GAMMARAMP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2918,9 +2548,6 @@ impl Default for GAMMA_RAMP_DXGI_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GAMMA_RAMP_DXGI_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GAMMA_RAMP_RGB {
@@ -2933,9 +2560,6 @@ impl Default for GAMMA_RAMP_RGB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GAMMA_RAMP_RGB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GAMMA_RAMP_RGB256x3x16 {
@@ -2947,9 +2571,6 @@ impl Default for GAMMA_RAMP_RGB256x3x16 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GAMMA_RAMP_RGB256x3x16 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GCAPS2_ACC_DRIVER: u32 = 32768u32;
 pub const GCAPS2_ALPHACURSOR: u32 = 32u32;
@@ -3052,9 +2673,6 @@ impl Default for GDIINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GDIINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GDI_DRIVER_VERSION: u32 = 16384u32;
 pub const GETCONNECTEDIDS_SOURCE: u32 = 1u32;
 pub const GETCONNECTEDIDS_TARGET: u32 = 0u32;
@@ -3069,9 +2687,6 @@ impl Default for GLYPHBITS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GLYPHBITS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3091,9 +2706,6 @@ impl Default for GLYPHDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GLYPHDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union GLYPHDEF {
@@ -3104,9 +2716,6 @@ impl Default for GLYPHDEF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GLYPHDEF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3119,9 +2728,6 @@ impl Default for GLYPHPOS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GLYPHPOS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GS_16BIT_HANDLES: u32 = 4u32;
 pub const GS_8BIT_HANDLES: u32 = 2u32;
@@ -3408,9 +3014,6 @@ impl Default for IFIEXTRA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IFIEXTRA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -3482,11 +3085,6 @@ impl Default for IFIMETRICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for IFIMETRICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -3560,11 +3158,6 @@ impl Default for IFIMETRICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for IFIMETRICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IGRF_RGB_256BYTES: u32 = 0u32;
 pub const IGRF_RGB_256WORDS: u32 = 1u32;
@@ -3680,9 +3273,6 @@ impl Default for INDIRECT_DISPLAY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INDIRECT_DISPLAY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INDIRECT_DISPLAY_INFO_FLAGS_CREATED_IDDCX_ADAPTER: u32 = 1u32;
 pub const IOCTL_COLORSPACE_TRANSFORM_QUERY_TARGET_CAPS: u32 = 2297856u32;
@@ -3886,9 +3476,6 @@ impl Default for LIGATURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LIGATURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -3908,10 +3495,6 @@ impl Default for LINEATTRS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for LINEATTRS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -3930,10 +3513,6 @@ impl Default for LINEATTRS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for LINEATTRS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MAXCHARSETS: u32 = 16u32;
 pub const MAX_PACKET_COUNT: u32 = 128u32;
@@ -4017,9 +3596,6 @@ impl Default for MC_TIMING_REPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MC_TIMING_REPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MC_VCP_CODE_TYPE(pub i32);
@@ -4052,9 +3628,6 @@ impl Default for MIPI_DSI_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIPI_DSI_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MIPI_DSI_PACKET {
@@ -4068,9 +3641,6 @@ impl Default for MIPI_DSI_PACKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIPI_DSI_PACKET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIPI_DSI_PACKET_0 {
@@ -4082,9 +3652,6 @@ impl Default for MIPI_DSI_PACKET_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIPI_DSI_PACKET_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIPI_DSI_PACKET_0_0 {
@@ -4094,9 +3661,6 @@ impl Default for MIPI_DSI_PACKET_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIPI_DSI_PACKET_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4109,9 +3673,6 @@ impl Default for MIPI_DSI_PACKET_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIPI_DSI_PACKET_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIPI_DSI_PACKET_1_0 {
@@ -4122,9 +3683,6 @@ impl Default for MIPI_DSI_PACKET_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIPI_DSI_PACKET_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4137,9 +3695,6 @@ impl Default for MIPI_DSI_RESET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIPI_DSI_RESET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIPI_DSI_RESET_0 {
@@ -4151,9 +3706,6 @@ impl Default for MIPI_DSI_RESET_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIPI_DSI_RESET_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIPI_DSI_RESET_0_0 {
@@ -4163,9 +3715,6 @@ impl Default for MIPI_DSI_RESET_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIPI_DSI_RESET_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4185,9 +3734,6 @@ impl Default for MIPI_DSI_TRANSMISSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIPI_DSI_TRANSMISSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIPI_DSI_TRANSMISSION_0 {
@@ -4197,9 +3743,6 @@ impl Default for MIPI_DSI_TRANSMISSION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIPI_DSI_TRANSMISSION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MS_CDDDEVICEBITMAP: u32 = 4u32;
 pub const MS_NOTSYSTEMMEMORY: u32 = 1u32;
@@ -4279,9 +3822,6 @@ impl Default for OUTPUT_WIRE_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OUTPUT_WIRE_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PALOBJ {
@@ -4291,9 +3831,6 @@ impl Default for PALOBJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PALOBJ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PAL_BGR: u32 = 8u32;
 pub const PAL_BITFIELDS: u32 = 2u32;
@@ -4313,9 +3850,6 @@ impl Default for PANEL_BRIGHTNESS_SENSOR_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_BRIGHTNESS_SENSOR_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PANEL_BRIGHTNESS_SENSOR_DATA_0 {
@@ -4327,9 +3861,6 @@ impl Default for PANEL_BRIGHTNESS_SENSOR_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_BRIGHTNESS_SENSOR_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PANEL_BRIGHTNESS_SENSOR_DATA_0_0 {
@@ -4339,9 +3870,6 @@ impl Default for PANEL_BRIGHTNESS_SENSOR_DATA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PANEL_BRIGHTNESS_SENSOR_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4355,9 +3883,6 @@ impl Default for PANEL_GET_BACKLIGHT_REDUCTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_GET_BACKLIGHT_REDUCTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PANEL_GET_BRIGHTNESS {
@@ -4368,9 +3893,6 @@ impl Default for PANEL_GET_BRIGHTNESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PANEL_GET_BRIGHTNESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4383,9 +3905,6 @@ impl Default for PANEL_GET_BRIGHTNESS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_GET_BRIGHTNESS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PANEL_GET_BRIGHTNESS_0_0 {
@@ -4396,9 +3915,6 @@ impl Default for PANEL_GET_BRIGHTNESS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PANEL_GET_BRIGHTNESS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4411,9 +3927,6 @@ impl Default for PANEL_QUERY_BRIGHTNESS_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_QUERY_BRIGHTNESS_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PANEL_QUERY_BRIGHTNESS_CAPS_0 {
@@ -4425,9 +3938,6 @@ impl Default for PANEL_QUERY_BRIGHTNESS_CAPS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_QUERY_BRIGHTNESS_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PANEL_QUERY_BRIGHTNESS_CAPS_0_0 {
@@ -4437,9 +3947,6 @@ impl Default for PANEL_QUERY_BRIGHTNESS_CAPS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PANEL_QUERY_BRIGHTNESS_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4452,9 +3959,6 @@ impl Default for PANEL_QUERY_BRIGHTNESS_RANGES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_QUERY_BRIGHTNESS_RANGES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PANEL_QUERY_BRIGHTNESS_RANGES_0 {
@@ -4466,9 +3970,6 @@ impl Default for PANEL_QUERY_BRIGHTNESS_RANGES_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_QUERY_BRIGHTNESS_RANGES_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PANEL_SET_BACKLIGHT_OPTIMIZATION {
@@ -4478,9 +3979,6 @@ impl Default for PANEL_SET_BACKLIGHT_OPTIMIZATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PANEL_SET_BACKLIGHT_OPTIMIZATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4493,9 +3991,6 @@ impl Default for PANEL_SET_BRIGHTNESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_SET_BRIGHTNESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PANEL_SET_BRIGHTNESS_0 {
@@ -4506,9 +4001,6 @@ impl Default for PANEL_SET_BRIGHTNESS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PANEL_SET_BRIGHTNESS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4522,9 +4014,6 @@ impl Default for PANEL_SET_BRIGHTNESS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_SET_BRIGHTNESS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PANEL_SET_BRIGHTNESS_STATE {
@@ -4534,9 +4023,6 @@ impl Default for PANEL_SET_BRIGHTNESS_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PANEL_SET_BRIGHTNESS_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4549,9 +4035,6 @@ impl Default for PANEL_SET_BRIGHTNESS_STATE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PANEL_SET_BRIGHTNESS_STATE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PANEL_SET_BRIGHTNESS_STATE_0_0 {
@@ -4561,9 +4044,6 @@ impl Default for PANEL_SET_BRIGHTNESS_STATE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PANEL_SET_BRIGHTNESS_STATE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4577,9 +4057,6 @@ impl Default for PATHDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PATHDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PATHOBJ {
@@ -4590,9 +4067,6 @@ impl Default for PATHOBJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PATHOBJ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PD_BEGINSUBPATH: u32 = 1u32;
 pub const PD_BEZIERS: u32 = 16u32;
@@ -4611,9 +4085,6 @@ impl Default for PERBANDINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERBANDINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PFN = Option<unsafe extern "system" fn() -> isize>;
 pub type PFN_DrvAccumulateD3DDirtyRect = Option<unsafe extern "system" fn(param0: *mut SURFOBJ, param1: *mut CDDDXGK_REDIRBITMAPPRESENTINFO) -> super::super::Foundation::BOOL>;
@@ -4738,9 +4209,6 @@ impl Default for PHYSICAL_MONITOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_MONITOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PHYSICAL_MONITOR_DESCRIPTION_SIZE: u32 = 128u32;
 pub const PLANAR_HC: u32 = 1u32;
 #[repr(C)]
@@ -4756,10 +4224,6 @@ impl Default for POINTE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for POINTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4773,10 +4237,6 @@ impl Default for POINTE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for POINTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POINTFIX {
@@ -4788,9 +4248,6 @@ impl Default for POINTFIX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POINTFIX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POINTQF {
@@ -4801,9 +4258,6 @@ impl Default for POINTQF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POINTQF {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PO_ALL_INTEGERS: u32 = 4u32;
 pub const PO_BEZIERS: u32 = 1u32;
@@ -4910,9 +4364,6 @@ impl Default for RECTFX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RECTFX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RUN {
@@ -4923,9 +4374,6 @@ impl Default for RUN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RUN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SDC_ALLOW_CHANGES: SET_DISPLAY_CONFIG_FLAGS = SET_DISPLAY_CONFIG_FLAGS(1024u32);
 pub const SDC_ALLOW_PATH_ORDER_CHANGES: SET_DISPLAY_CONFIG_FLAGS = SET_DISPLAY_CONFIG_FLAGS(8192u32);
@@ -4956,9 +4404,6 @@ impl Default for SET_ACTIVE_COLOR_PROFILE_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SET_ACTIVE_COLOR_PROFILE_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5044,9 +4489,6 @@ impl Default for STROBJ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STROBJ {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STYPE_BITMAP: i32 = 0i32;
 pub const STYPE_DEVBITMAP: i32 = 3i32;
 #[repr(C)]
@@ -5071,9 +4513,6 @@ impl Default for SURFOBJ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SURFOBJ {
-    type TypeKind = windows_core::CopyType;
-}
 pub const S_INIT: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5086,9 +4525,6 @@ impl Default for Sources {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for Sources {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TC_PATHOBJ: u32 = 2u32;
 pub const TC_RECTANGLES: u32 = 0u32;
@@ -5107,9 +4543,6 @@ impl Default for TYPE1_FONT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TYPE1_FONT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VGA_CHAR {
@@ -5120,9 +4553,6 @@ impl Default for VGA_CHAR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VGA_CHAR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5156,9 +4586,6 @@ impl Default for VIDEOPARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEOPARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_BANK_SELECT {
@@ -5181,9 +4608,6 @@ impl Default for VIDEO_BANK_SELECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_BANK_SELECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VIDEO_BANK_TYPE(pub i32);
@@ -5199,9 +4623,6 @@ impl Default for VIDEO_BRIGHTNESS_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_BRIGHTNESS_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_BRIGHTNESS_POLICY_0 {
@@ -5212,9 +4633,6 @@ impl Default for VIDEO_BRIGHTNESS_POLICY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_BRIGHTNESS_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5228,9 +4646,6 @@ impl Default for VIDEO_CLUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_CLUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIDEO_CLUT_0 {
@@ -5241,9 +4656,6 @@ impl Default for VIDEO_CLUT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_CLUT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5257,9 +4669,6 @@ impl Default for VIDEO_CLUTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_CLUTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5288,9 +4697,6 @@ impl Default for VIDEO_COLOR_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_COLOR_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_COLOR_LUT_DATA {
@@ -5302,9 +4708,6 @@ impl Default for VIDEO_COLOR_LUT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_COLOR_LUT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIDEO_COLOR_LUT_DATA_FORMAT_PRIVATEFORMAT: u32 = 2147483648u32;
 pub const VIDEO_COLOR_LUT_DATA_FORMAT_RGB256WORDS: u32 = 1u32;
@@ -5323,9 +4726,6 @@ impl Default for VIDEO_CURSOR_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_CURSOR_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_CURSOR_POSITION {
@@ -5336,9 +4736,6 @@ impl Default for VIDEO_CURSOR_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_CURSOR_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIDEO_DEVICE_COLOR: u32 = 1u32;
 pub const VIDEO_DEVICE_NAME: windows_core::PCSTR = windows_core::s!("DISPLAY%d");
@@ -5352,9 +4749,6 @@ impl Default for VIDEO_DEVICE_SESSION_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_DEVICE_SESSION_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIDEO_DUALVIEW_PRIMARY: u32 = 2147483648u32;
 pub const VIDEO_DUALVIEW_REMOVABLE: u32 = 1u32;
@@ -5370,9 +4764,6 @@ impl Default for VIDEO_HARDWARE_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_HARDWARE_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5413,9 +4804,6 @@ impl Default for VIDEO_HARDWARE_STATE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_HARDWARE_STATE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_LOAD_FONT_INFORMATION {
@@ -5429,9 +4817,6 @@ impl Default for VIDEO_LOAD_FONT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_LOAD_FONT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_LUT_RGB256WORDS {
@@ -5444,9 +4829,6 @@ impl Default for VIDEO_LUT_RGB256WORDS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_LUT_RGB256WORDS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VIDEO_MAX_REASON: u32 = 9u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5457,9 +4839,6 @@ impl Default for VIDEO_MEMORY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_MEMORY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5474,9 +4853,6 @@ impl Default for VIDEO_MEMORY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_MEMORY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_MODE {
@@ -5486,9 +4862,6 @@ impl Default for VIDEO_MODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_MODE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIDEO_MODE_ANIMATE_START: u32 = 8u32;
 pub const VIDEO_MODE_ANIMATE_UPDATE: u32 = 16u32;
@@ -5526,9 +4899,6 @@ impl Default for VIDEO_MODE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_MODE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VIDEO_MODE_INTERLACED: u32 = 16u32;
 pub const VIDEO_MODE_LINEAR: u32 = 256u32;
 pub const VIDEO_MODE_MANAGED_PALETTE: u32 = 8u32;
@@ -5549,9 +4919,6 @@ impl Default for VIDEO_MONITOR_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_MONITOR_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_NUM_MODES {
@@ -5562,9 +4929,6 @@ impl Default for VIDEO_NUM_MODES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_NUM_MODES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIDEO_OPTIONAL_GAMMET_TABLE: u32 = 2u32;
 #[repr(C)]
@@ -5578,9 +4942,6 @@ impl Default for VIDEO_PALETTE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_PALETTE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5612,9 +4973,6 @@ impl Default for VIDEO_PERFORMANCE_COUNTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_PERFORMANCE_COUNTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_POINTER_ATTRIBUTES {
@@ -5632,9 +4990,6 @@ impl Default for VIDEO_POINTER_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_POINTER_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_POINTER_CAPABILITIES {
@@ -5649,9 +5004,6 @@ impl Default for VIDEO_POINTER_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_POINTER_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_POINTER_POSITION {
@@ -5662,9 +5014,6 @@ impl Default for VIDEO_POINTER_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_POINTER_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5677,9 +5026,6 @@ impl Default for VIDEO_POWER_MANAGEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_POWER_MANAGEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5696,9 +5042,6 @@ impl Default for VIDEO_PUBLIC_ACCESS_RANGES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_PUBLIC_ACCESS_RANGES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_QUERY_PERFORMANCE_COUNTER {
@@ -5709,9 +5052,6 @@ impl Default for VIDEO_QUERY_PERFORMANCE_COUNTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_QUERY_PERFORMANCE_COUNTER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIDEO_REASON_ALLOCATION: u32 = 6u32;
 pub const VIDEO_REASON_CONFIGURATION: u32 = 9u32;
@@ -5733,9 +5073,6 @@ impl Default for VIDEO_REGISTER_VDM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_REGISTER_VDM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_SHARE_MEMORY {
@@ -5749,9 +5086,6 @@ impl Default for VIDEO_SHARE_MEMORY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_SHARE_MEMORY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_SHARE_MEMORY_INFORMATION {
@@ -5763,9 +5097,6 @@ impl Default for VIDEO_SHARE_MEMORY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_SHARE_MEMORY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIDEO_STATE_NON_STANDARD_VGA: u32 = 1u32;
 pub const VIDEO_STATE_PACKED_CHAIN4_MODE: u32 = 4u32;
@@ -5780,9 +5111,6 @@ impl Default for VIDEO_VDM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_VDM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIDEO_WIN32K_CALLBACKS {
@@ -5796,9 +5124,6 @@ impl Default for VIDEO_WIN32K_CALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_WIN32K_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5816,9 +5141,6 @@ impl Default for VIDEO_WIN32K_CALLBACKS_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEO_WIN32K_CALLBACKS_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5859,9 +5181,6 @@ impl Default for WCRUN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WCRUN {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WINDDI_MAXSETPALETTECOLORINDEX: u32 = 255u32;
 pub const WINDDI_MAXSETPALETTECOLORS: u32 = 256u32;
 pub const WINDDI_MAX_BROADCAST_CONTEXT: u32 = 64u32;
@@ -5877,9 +5196,6 @@ impl Default for WNDOBJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WNDOBJ {
-    type TypeKind = windows_core::CopyType;
 }
 pub type WNDOBJCHANGEPROC = Option<unsafe extern "system" fn(pwo: *mut WNDOBJ, fl: u32)>;
 pub const WNDOBJ_SETUP: u32 = 4354u32;
@@ -5921,10 +5237,6 @@ impl Default for XFORML {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for XFORML {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5942,10 +5254,6 @@ impl Default for XFORML {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for XFORML {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XFORMOBJ {
@@ -5955,9 +5263,6 @@ impl Default for XFORMOBJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XFORMOBJ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XF_INV_FXTOL: i32 = 3i32;
 pub const XF_INV_LTOL: i32 = 1i32;
@@ -5977,9 +5282,6 @@ impl Default for XLATEOBJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XLATEOBJ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XO_DESTBITFIELDS: u32 = 5u32;
 pub const XO_DESTDCPALETTE: u32 = 3u32;

--- a/crates/libs/windows/src/Windows/Win32/Devices/Dvd/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Dvd/mod.rs
@@ -9,9 +9,6 @@ impl Default for AACS_BINDING_NONCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AACS_BINDING_NONCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AACS_CERTIFICATE {
@@ -22,9 +19,6 @@ impl Default for AACS_CERTIFICATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AACS_CERTIFICATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -37,9 +31,6 @@ impl Default for AACS_CHALLENGE_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AACS_CHALLENGE_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AACS_MEDIA_ID {
@@ -50,9 +41,6 @@ impl Default for AACS_MEDIA_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AACS_MEDIA_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -67,9 +55,6 @@ impl Default for AACS_READ_BINDING_NONCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AACS_READ_BINDING_NONCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AACS_READ_BINDING_NONCE_0 {
@@ -80,9 +65,6 @@ impl Default for AACS_READ_BINDING_NONCE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AACS_READ_BINDING_NONCE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -95,9 +77,6 @@ impl Default for AACS_SEND_CERTIFICATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AACS_SEND_CERTIFICATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AACS_SEND_CHALLENGE_KEY {
@@ -108,9 +87,6 @@ impl Default for AACS_SEND_CHALLENGE_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AACS_SEND_CHALLENGE_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -123,9 +99,6 @@ impl Default for AACS_SERIAL_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AACS_SERIAL_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AACS_VOLUME_ID {
@@ -136,9 +109,6 @@ impl Default for AACS_VOLUME_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AACS_VOLUME_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -154,9 +124,6 @@ impl Default for BD_DISC_WRITE_PROTECT_PAC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BD_DISC_WRITE_PROTECT_PAC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -176,9 +143,6 @@ impl Default for BD_PAC_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BD_PAC_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DISC_CONTROL_BLOCK_TYPE(pub i32);
@@ -193,9 +157,6 @@ impl Default for DVD_ASF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_ASF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_BCA_DESCRIPTOR {
@@ -205,9 +166,6 @@ impl Default for DVD_BCA_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_BCA_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -220,9 +178,6 @@ impl Default for DVD_BD_SPARE_AREA_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_BD_SPARE_AREA_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVD_CGMS_COPY_ONCE: u32 = 16u32;
 pub const DVD_CGMS_COPY_PERMITTED: u32 = 0u32;
@@ -242,9 +197,6 @@ impl Default for DVD_COPYRIGHT_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_COPYRIGHT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR {
@@ -255,9 +207,6 @@ impl Default for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -273,9 +222,6 @@ impl Default for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_1 {
@@ -285,9 +231,6 @@ impl Default for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -299,9 +242,6 @@ impl Default for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_2 {
@@ -312,9 +252,6 @@ impl Default for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_0 {
@@ -324,9 +261,6 @@ impl Default for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_COPYRIGHT_MANAGEMENT_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVD_COPYRIGHT_MASK: u32 = 64u32;
 #[repr(C, packed(1))]
@@ -344,9 +278,6 @@ impl Default for DVD_COPY_PROTECT_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_COPY_PROTECT_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union DVD_COPY_PROTECT_KEY_0 {
@@ -357,9 +288,6 @@ impl Default for DVD_COPY_PROTECT_KEY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_COPY_PROTECT_KEY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -373,9 +301,6 @@ impl Default for DVD_DESCRIPTOR_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DESCRIPTOR_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DVD_DISC_CONTROL_BLOCK_HEADER {
@@ -388,9 +313,6 @@ impl Default for DVD_DISC_CONTROL_BLOCK_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DISC_CONTROL_BLOCK_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DVD_DISC_CONTROL_BLOCK_HEADER_0 {
@@ -402,9 +324,6 @@ impl Default for DVD_DISC_CONTROL_BLOCK_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DISC_CONTROL_BLOCK_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_DISC_CONTROL_BLOCK_HEADER_0_0 {
@@ -415,9 +334,6 @@ impl Default for DVD_DISC_CONTROL_BLOCK_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_DISC_CONTROL_BLOCK_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -434,9 +350,6 @@ impl Default for DVD_DISC_CONTROL_BLOCK_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DISC_CONTROL_BLOCK_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_DISC_CONTROL_BLOCK_LIST_DCB {
@@ -446,9 +359,6 @@ impl Default for DVD_DISC_CONTROL_BLOCK_LIST_DCB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_DISC_CONTROL_BLOCK_LIST_DCB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -466,9 +376,6 @@ impl Default for DVD_DISC_CONTROL_BLOCK_SESSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DISC_CONTROL_BLOCK_SESSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_DISC_CONTROL_BLOCK_SESSION_ITEM {
@@ -478,9 +385,6 @@ impl Default for DVD_DISC_CONTROL_BLOCK_SESSION_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_DISC_CONTROL_BLOCK_SESSION_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -497,9 +401,6 @@ impl Default for DVD_DISC_CONTROL_BLOCK_WRITE_INHIBIT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DISC_CONTROL_BLOCK_WRITE_INHIBIT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DVD_DISC_CONTROL_BLOCK_WRITE_INHIBIT_0 {
@@ -510,9 +411,6 @@ impl Default for DVD_DISC_CONTROL_BLOCK_WRITE_INHIBIT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_DISC_CONTROL_BLOCK_WRITE_INHIBIT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -525,9 +423,6 @@ impl Default for DVD_DISC_CONTROL_BLOCK_WRITE_INHIBIT_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DISC_CONTROL_BLOCK_WRITE_INHIBIT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_DISK_KEY_DESCRIPTOR {
@@ -537,9 +432,6 @@ impl Default for DVD_DISK_KEY_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_DISK_KEY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -552,9 +444,6 @@ impl Default for DVD_DUAL_LAYER_JUMP_INTERVAL_SIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DUAL_LAYER_JUMP_INTERVAL_SIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_DUAL_LAYER_MANUAL_LAYER_JUMP {
@@ -565,9 +454,6 @@ impl Default for DVD_DUAL_LAYER_MANUAL_LAYER_JUMP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_DUAL_LAYER_MANUAL_LAYER_JUMP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -581,9 +467,6 @@ impl Default for DVD_DUAL_LAYER_MIDDLE_ZONE_START_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DUAL_LAYER_MIDDLE_ZONE_START_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_DUAL_LAYER_RECORDING_INFORMATION {
@@ -596,9 +479,6 @@ impl Default for DVD_DUAL_LAYER_RECORDING_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DUAL_LAYER_RECORDING_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_DUAL_LAYER_REMAPPING_INFORMATION {
@@ -610,9 +490,6 @@ impl Default for DVD_DUAL_LAYER_REMAPPING_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_DUAL_LAYER_REMAPPING_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DVD_FULL_LAYER_DESCRIPTOR {
@@ -623,9 +500,6 @@ impl Default for DVD_FULL_LAYER_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_FULL_LAYER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -647,9 +521,6 @@ impl Default for DVD_LAYER_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_LAYER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_LIST_OF_RECOGNIZED_FORMAT_LAYERS {
@@ -659,9 +530,6 @@ impl Default for DVD_LIST_OF_RECOGNIZED_FORMAT_LAYERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_LIST_OF_RECOGNIZED_FORMAT_LAYERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -674,9 +542,6 @@ impl Default for DVD_LIST_OF_RECOGNIZED_FORMAT_LAYERS_TYPE_CODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_LIST_OF_RECOGNIZED_FORMAT_LAYERS_TYPE_CODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_MANUFACTURER_DESCRIPTOR {
@@ -686,9 +551,6 @@ impl Default for DVD_MANUFACTURER_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_MANUFACTURER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVD_NOT_COPYRIGHTED: u32 = 0u32;
 #[repr(C)]
@@ -721,9 +583,6 @@ impl Default for DVD_PRERECORDED_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_PRERECORDED_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_RAM_MEDIUM_STATUS {
@@ -737,9 +596,6 @@ impl Default for DVD_RAM_MEDIUM_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_RAM_MEDIUM_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_RAM_RECORDING_TYPE {
@@ -750,9 +606,6 @@ impl Default for DVD_RAM_RECORDING_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_RAM_RECORDING_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -765,9 +618,6 @@ impl Default for DVD_RAM_SPARE_AREA_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_RAM_SPARE_AREA_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -782,9 +632,6 @@ impl Default for DVD_READ_STRUCTURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_READ_STRUCTURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_RECORDING_MANAGEMENT_AREA_DATA {
@@ -795,9 +642,6 @@ impl Default for DVD_RECORDING_MANAGEMENT_AREA_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_RECORDING_MANAGEMENT_AREA_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -812,9 +656,6 @@ impl Default for DVD_REGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_REGION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_RPC_KEY {
@@ -827,9 +668,6 @@ impl Default for DVD_RPC_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_RPC_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVD_SECTOR_NOT_PROTECTED: u32 = 0u32;
 pub const DVD_SECTOR_PROTECTED: u32 = 32u32;
@@ -845,9 +683,6 @@ impl Default for DVD_SET_RPC_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_SET_RPC_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DVD_STRUCTURE_FORMAT(pub i32);
@@ -862,9 +697,6 @@ impl Default for DVD_STRUCTURE_LIST_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_STRUCTURE_LIST_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -883,9 +715,6 @@ impl Default for DVD_UNIQUE_DISC_IDENTIFIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_UNIQUE_DISC_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_WRITE_PROTECTION_STATUS {
@@ -896,9 +725,6 @@ impl Default for DVD_WRITE_PROTECTION_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_WRITE_PROTECTION_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DiscControlBlockList: DISC_CONTROL_BLOCK_TYPE = DISC_CONTROL_BLOCK_TYPE(-1i32);
 pub const DvdAsf: DVD_KEY_TYPE = DVD_KEY_TYPE(5i32);
@@ -928,9 +754,6 @@ impl Default for HD_DVD_R_MEDIUM_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HD_DVD_R_MEDIUM_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IOCTL_AACS_END_SESSION: u32 = 3363020u32;
 pub const IOCTL_AACS_GENERATE_BINDING_NONCE: u32 = 3395824u32;
@@ -965,9 +788,6 @@ impl Default for STORAGE_SET_READ_AHEAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_SET_READ_AHEAD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SessionInfoDiscControlBlock: DISC_CONTROL_BLOCK_TYPE = DISC_CONTROL_BLOCK_TYPE(1396982528i32);
 pub const WriteInhibitDiscControlBlock: DISC_CONTROL_BLOCK_TYPE = DISC_CONTROL_BLOCK_TYPE(1464091392i32);

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
@@ -2106,10 +2106,6 @@ impl Default for SW_DEVICE_CREATE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SW_DEVICE_CREATE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SW_DEVICE_LIFETIME(pub i32);

--- a/crates/libs/windows/src/Windows/Win32/Devices/Fax/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Fax/mod.rs
@@ -421,9 +421,6 @@ impl Default for FAX_CONFIGURATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_CONFIGURATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_CONFIGURATIONW {
@@ -446,9 +443,6 @@ impl Default for FAX_CONFIGURATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_CONFIGURATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FAX_CONFIG_QUERY: u32 = 4u32;
 pub const FAX_CONFIG_SET: u32 = 8u32;
 #[repr(C)]
@@ -465,10 +459,6 @@ impl Default for FAX_CONTEXT_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for FAX_CONTEXT_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -482,10 +472,6 @@ impl Default for FAX_CONTEXT_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for FAX_CONTEXT_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -525,9 +511,6 @@ impl Default for FAX_COVERPAGE_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_COVERPAGE_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_COVERPAGE_INFOW {
@@ -566,9 +549,6 @@ impl Default for FAX_COVERPAGE_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_COVERPAGE_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FAX_COVERPAGE_TYPE_ENUM(pub i32);
@@ -604,9 +584,6 @@ impl Default for FAX_DEVICE_STATUSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_DEVICE_STATUSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_DEVICE_STATUSW {
@@ -636,9 +613,6 @@ impl Default for FAX_DEVICE_STATUSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_DEVICE_STATUSW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_DEV_STATUS {
@@ -656,9 +630,6 @@ impl Default for FAX_DEV_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_DEV_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -710,9 +681,6 @@ impl Default for FAX_EVENTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_EVENTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_EVENTW {
@@ -726,9 +694,6 @@ impl Default for FAX_EVENTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_EVENTW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FAX_E_BAD_GROUP_CONFIGURATION: windows_core::HRESULT = windows_core::HRESULT(0x80041B5B_u32 as _);
 pub const FAX_E_DEVICE_NUM_LIMIT_EXCEEDED: windows_core::HRESULT = windows_core::HRESULT(0x80041B62_u32 as _);
@@ -759,9 +724,6 @@ impl Default for FAX_GLOBAL_ROUTING_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_GLOBAL_ROUTING_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_GLOBAL_ROUTING_INFOW {
@@ -777,9 +739,6 @@ impl Default for FAX_GLOBAL_ROUTING_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_GLOBAL_ROUTING_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -813,9 +772,6 @@ impl Default for FAX_JOB_ENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_JOB_ENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_JOB_ENTRYW {
@@ -844,9 +800,6 @@ impl Default for FAX_JOB_ENTRYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_JOB_ENTRYW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -879,9 +832,6 @@ impl Default for FAX_JOB_PARAMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_JOB_PARAMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_JOB_PARAMW {
@@ -906,9 +856,6 @@ impl Default for FAX_JOB_PARAMW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_JOB_PARAMW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FAX_JOB_QUERY: u32 = 2u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -929,9 +876,6 @@ impl Default for FAX_LOG_CATEGORYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_LOG_CATEGORYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_LOG_CATEGORYW {
@@ -943,9 +887,6 @@ impl Default for FAX_LOG_CATEGORYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_LOG_CATEGORYW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -968,9 +909,6 @@ impl Default for FAX_PORT_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_PORT_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_PORT_INFOW {
@@ -988,9 +926,6 @@ impl Default for FAX_PORT_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_PORT_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FAX_PORT_QUERY: u32 = 16u32;
 pub const FAX_PORT_SET: u32 = 32u32;
@@ -1014,9 +949,6 @@ impl Default for FAX_PRINT_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_PRINT_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_PRINT_INFOW {
@@ -1036,9 +968,6 @@ impl Default for FAX_PRINT_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_PRINT_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1062,9 +991,6 @@ impl Default for FAX_RECEIVE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_RECEIVE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1090,9 +1016,6 @@ impl Default for FAX_ROUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_ROUTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_ROUTE_CALLBACKROUTINES {
@@ -1107,9 +1030,6 @@ impl Default for FAX_ROUTE_CALLBACKROUTINES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_ROUTE_CALLBACKROUTINES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1129,9 +1049,6 @@ impl Default for FAX_ROUTING_METHODA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_ROUTING_METHODA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FAX_ROUTING_METHODW {
@@ -1149,9 +1066,6 @@ impl Default for FAX_ROUTING_METHODW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_ROUTING_METHODW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1180,9 +1094,6 @@ impl Default for FAX_SEND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAX_SEND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FAX_SERVER_APIVERSION_ENUM(pub i32);
@@ -1202,9 +1113,6 @@ impl Default for FAX_TIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FAX_TIME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FEI_ABORTING: u32 = 15u32;
 pub const FEI_ANSWERED: u32 = 21u32;
@@ -13157,9 +13065,6 @@ impl Default for STINOTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STINOTIFY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STISUBSCRIBE {
@@ -13174,9 +13079,6 @@ impl Default for STISUBSCRIBE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STISUBSCRIBE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STI_ADD_DEVICE_BROADCAST_ACTION: windows_core::PCSTR = windows_core::s!("Arrival");
 pub const STI_ADD_DEVICE_BROADCAST_STRING: windows_core::PCSTR = windows_core::s!("STI\\");
@@ -13205,9 +13107,6 @@ impl Default for STI_DEVICE_INFORMATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STI_DEVICE_INFORMATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct STI_DEVICE_MJ_TYPE(pub i32);
@@ -13225,9 +13124,6 @@ impl Default for STI_DEVICE_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STI_DEVICE_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STI_DEVICE_VALUE_DEFAULT_LAUNCHAPP: windows_core::PCWSTR = windows_core::w!("DefaultLaunchApp");
 pub const STI_DEVICE_VALUE_DEFAULT_LAUNCHAPP_A: windows_core::PCSTR = windows_core::s!("DefaultLaunchApp");
@@ -13253,9 +13149,6 @@ impl Default for STI_DEV_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STI_DEV_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STI_DIAG {
@@ -13269,9 +13162,6 @@ impl Default for STI_DIAG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STI_DIAG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STI_DIAGCODE_HWPRESENCE: u32 = 1u32;
 pub const STI_ERROR_NO_ERROR: i32 = 0i32;
@@ -13327,9 +13217,6 @@ impl Default for STI_USD_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STI_USD_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STI_USD_GENCAP_NATIVE_PUSHSUPPORT: u32 = 1u32;
 pub const STI_VERSION: u32 = 2u32;
 pub const STI_VERSION_FLAG_MASK: u32 = 4278190080u32;
@@ -13357,9 +13244,6 @@ impl Default for STI_WIA_DEVICE_INFORMATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STI_WIA_DEVICE_INFORMATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SUPPORTS_MSCPLUS_STR: windows_core::PCWSTR = windows_core::w!("SupportsMSCPlus");
 pub const SUPPORTS_MSCPLUS_VAL: u32 = 1u32;
 #[repr(transparent)]
@@ -13382,9 +13266,6 @@ impl Default for _ERROR_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _ERROR_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const faetFXSSVC_ENDED: FAX_ACCOUNT_EVENTS_TYPE_ENUM = FAX_ACCOUNT_EVENTS_TYPE_ENUM(16i32);
 pub const faetIN_ARCHIVE: FAX_ACCOUNT_EVENTS_TYPE_ENUM = FAX_ACCOUNT_EVENTS_TYPE_ENUM(4i32);

--- a/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/mod.rs
@@ -29,9 +29,6 @@ impl Default for GNSS_AGNSS_INJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_AGNSS_INJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union GNSS_AGNSS_INJECT_0 {
@@ -43,9 +40,6 @@ impl Default for GNSS_AGNSS_INJECT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_AGNSS_INJECT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -63,9 +57,6 @@ impl Default for GNSS_AGNSS_INJECTBLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_AGNSS_INJECTBLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_AGNSS_INJECTPOSITION {
@@ -80,9 +71,6 @@ impl Default for GNSS_AGNSS_INJECTPOSITION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_AGNSS_INJECTPOSITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_AGNSS_INJECTTIME {
@@ -95,9 +83,6 @@ impl Default for GNSS_AGNSS_INJECTTIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_AGNSS_INJECTTIME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GNSS_AGNSS_PositionInjection: GNSS_AGNSS_REQUEST_TYPE = GNSS_AGNSS_REQUEST_TYPE(2i32);
 #[repr(C)]
@@ -112,9 +97,6 @@ impl Default for GNSS_AGNSS_REQUEST_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_AGNSS_REQUEST_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -132,9 +114,6 @@ impl Default for GNSS_BREADCRUMBING_ALERT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_BREADCRUMBING_ALERT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_BREADCRUMBING_PARAM {
@@ -150,9 +129,6 @@ impl Default for GNSS_BREADCRUMBING_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_BREADCRUMBING_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct GNSS_BREADCRUMB_LIST {
@@ -166,9 +142,6 @@ impl Default for GNSS_BREADCRUMB_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_BREADCRUMB_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union GNSS_BREADCRUMB_LIST_0 {
@@ -178,9 +151,6 @@ impl Default for GNSS_BREADCRUMB_LIST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_BREADCRUMB_LIST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -202,9 +172,6 @@ impl Default for GNSS_BREADCRUMB_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_BREADCRUMB_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_CHIPSETINFO {
@@ -220,9 +187,6 @@ impl Default for GNSS_CHIPSETINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_CHIPSETINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_CONTINUOUSTRACKING_PARAM {
@@ -234,9 +198,6 @@ impl Default for GNSS_CONTINUOUSTRACKING_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_CONTINUOUSTRACKING_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -250,9 +211,6 @@ impl Default for GNSS_CP_NI_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_CP_NI_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -268,9 +226,6 @@ impl Default for GNSS_CWTESTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_CWTESTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GNSS_ClearAgnssData: GNSS_DRIVERCOMMAND_TYPE = GNSS_DRIVERCOMMAND_TYPE(10i32);
 pub const GNSS_CustomCommand: GNSS_DRIVERCOMMAND_TYPE = GNSS_DRIVERCOMMAND_TYPE(256i32);
@@ -310,9 +265,6 @@ impl Default for GNSS_DEVICE_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_DEVICE_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_DISTANCETRACKING_PARAM {
@@ -324,9 +276,6 @@ impl Default for GNSS_DISTANCETRACKING_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_DISTANCETRACKING_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -343,9 +292,6 @@ impl Default for GNSS_DRIVERCOMMAND_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_DRIVERCOMMAND_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -365,9 +311,6 @@ impl Default for GNSS_DRIVER_REQUEST_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_DRIVER_REQUEST_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GNSS_DRIVER_VERSION_1: u32 = 1u32;
 pub const GNSS_DRIVER_VERSION_2: u32 = 2u32;
@@ -390,9 +333,6 @@ impl Default for GNSS_ERRORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_ERRORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct GNSS_EVENT {
@@ -407,9 +347,6 @@ impl Default for GNSS_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -430,9 +367,6 @@ impl Default for GNSS_EVENT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_EVENT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct GNSS_EVENT_2 {
@@ -447,9 +381,6 @@ impl Default for GNSS_EVENT_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_EVENT_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -470,9 +401,6 @@ impl Default for GNSS_EVENT_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_EVENT_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -507,9 +435,6 @@ impl Default for GNSS_FIXDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_FIXDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_FIXDATA_2 {
@@ -528,9 +453,6 @@ impl Default for GNSS_FIXDATA_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_FIXDATA_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -556,9 +478,6 @@ impl Default for GNSS_FIXDATA_ACCURACY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_FIXDATA_ACCURACY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -587,9 +506,6 @@ impl Default for GNSS_FIXDATA_ACCURACY_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_FIXDATA_ACCURACY_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_FIXDATA_BASIC {
@@ -605,9 +521,6 @@ impl Default for GNSS_FIXDATA_BASIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_FIXDATA_BASIC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -626,9 +539,6 @@ impl Default for GNSS_FIXDATA_BASIC_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_FIXDATA_BASIC_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_FIXDATA_SATELLITE {
@@ -641,9 +551,6 @@ impl Default for GNSS_FIXDATA_SATELLITE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_FIXDATA_SATELLITE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GNSS_FIXDETAIL_ACCURACY: u32 = 2u32;
 pub const GNSS_FIXDETAIL_BASIC: u32 = 1u32;
@@ -670,9 +577,6 @@ impl Default for GNSS_FIXSESSION_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_FIXSESSION_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union GNSS_FIXSESSION_PARAM_0 {
@@ -686,9 +590,6 @@ impl Default for GNSS_FIXSESSION_PARAM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_FIXSESSION_PARAM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GNSS_FixSession_ContinuousTracking: GNSS_FIXSESSIONTYPE = GNSS_FIXSESSIONTYPE(3i32);
 pub const GNSS_FixSession_DistanceTracking: GNSS_FIXSESSIONTYPE = GNSS_FIXSESSIONTYPE(2i32);
@@ -712,9 +613,6 @@ impl Default for GNSS_GEOFENCES_TRACKINGSTATUS_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_GEOFENCES_TRACKINGSTATUS_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_GEOFENCE_ALERT_DATA {
@@ -731,9 +629,6 @@ impl Default for GNSS_GEOFENCE_ALERT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_GEOFENCE_ALERT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct GNSS_GEOFENCE_CREATE_PARAM {
@@ -749,9 +644,6 @@ impl Default for GNSS_GEOFENCE_CREATE_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_GEOFENCE_CREATE_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_GEOFENCE_CREATE_RESPONSE {
@@ -766,9 +658,6 @@ impl Default for GNSS_GEOFENCE_CREATE_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_GEOFENCE_CREATE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_GEOFENCE_DELETE_PARAM {
@@ -781,9 +670,6 @@ impl Default for GNSS_GEOFENCE_DELETE_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_GEOFENCE_DELETE_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -801,9 +687,6 @@ impl Default for GNSS_GEOREGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_GEOREGION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union GNSS_GEOREGION_0 {
@@ -814,9 +697,6 @@ impl Default for GNSS_GEOREGION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_GEOREGION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -833,9 +713,6 @@ impl Default for GNSS_GEOREGION_CIRCLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_GEOREGION_CIRCLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GNSS_GeoRegion_Circle: GNSS_GEOREGIONTYPE = GNSS_GEOREGIONTYPE(1i32);
 pub const GNSS_GeofenceState_Entered: GNSS_GEOFENCE_STATE = GNSS_GEOFENCE_STATE(1i32);
 pub const GNSS_GeofenceState_Exited: GNSS_GEOFENCE_STATE = GNSS_GEOFENCE_STATE(2i32);
@@ -850,9 +727,6 @@ impl Default for GNSS_LKGFIX_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_LKGFIX_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GNSS_MAXSATELLITE: u32 = 64u32;
 pub const GNSS_NI_CP: GNSS_NI_PLANE_TYPE = GNSS_NI_PLANE_TYPE(2i32);
@@ -885,9 +759,6 @@ impl Default for GNSS_NI_REQUEST_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_NI_REQUEST_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union GNSS_NI_REQUEST_PARAM_0 {
@@ -899,9 +770,6 @@ impl Default for GNSS_NI_REQUEST_PARAM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_NI_REQUEST_PARAM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -918,9 +786,6 @@ impl Default for GNSS_NI_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_NI_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GNSS_NI_Request_AreaTrigger: GNSS_NI_REQUEST_TYPE = GNSS_NI_REQUEST_TYPE(2i32);
 pub const GNSS_NI_Request_SingleShot: GNSS_NI_REQUEST_TYPE = GNSS_NI_REQUEST_TYPE(1i32);
@@ -942,9 +807,6 @@ impl Default for GNSS_NMEA_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_NMEA_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GNSS_Ni_UserResponseAccept: GNSS_NI_USER_RESPONSE = GNSS_NI_USER_RESPONSE(1i32);
 pub const GNSS_Ni_UserResponseDeny: GNSS_NI_USER_RESPONSE = GNSS_NI_USER_RESPONSE(2i32);
@@ -970,9 +832,6 @@ impl Default for GNSS_PLATFORM_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_PLATFORM_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GNSS_ResetEngine: GNSS_DRIVERCOMMAND_TYPE = GNSS_DRIVERCOMMAND_TYPE(9i32);
 pub const GNSS_ResetGeofencesTracking: GNSS_DRIVERCOMMAND_TYPE = GNSS_DRIVERCOMMAND_TYPE(16i32);
 #[repr(C)]
@@ -988,9 +847,6 @@ impl Default for GNSS_SATELLITEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_SATELLITEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GNSS_SATELLITE_ANY: u32 = 0u32;
 pub const GNSS_SATELLITE_BEIDOU: u32 = 4u32;
@@ -1012,9 +868,6 @@ impl Default for GNSS_SELFTESTCONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_SELFTESTCONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_SELFTESTRESULT {
@@ -1032,9 +885,6 @@ impl Default for GNSS_SELFTESTRESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_SELFTESTRESULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_SINGLESHOT_PARAM {
@@ -1046,9 +896,6 @@ impl Default for GNSS_SINGLESHOT_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_SINGLESHOT_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1062,9 +909,6 @@ impl Default for GNSS_STOPFIXSESSION_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_STOPFIXSESSION_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1085,9 +929,6 @@ impl Default for GNSS_SUPL_CERT_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_SUPL_CERT_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_SUPL_HSLP_CONFIG {
@@ -1103,9 +944,6 @@ impl Default for GNSS_SUPL_HSLP_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_SUPL_HSLP_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_SUPL_NI_INFO {
@@ -1120,9 +958,6 @@ impl Default for GNSS_SUPL_NI_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_SUPL_NI_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_SUPL_VERSION {
@@ -1133,9 +968,6 @@ impl Default for GNSS_SUPL_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_SUPL_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1148,9 +980,6 @@ impl Default for GNSS_SUPL_VERSION_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_SUPL_VERSION_2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GNSS_SetLocationNIRequestAllowed: GNSS_DRIVERCOMMAND_TYPE = GNSS_DRIVERCOMMAND_TYPE(2i32);
 pub const GNSS_SetLocationServiceEnabled: GNSS_DRIVERCOMMAND_TYPE = GNSS_DRIVERCOMMAND_TYPE(1i32);
@@ -1177,9 +1006,6 @@ impl Default for GNSS_V2UPL_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GNSS_V2UPL_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GNSS_V2UPL_NI_INFO {
@@ -1191,9 +1017,6 @@ impl Default for GNSS_V2UPL_NI_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GNSS_V2UPL_NI_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GUID_DEVINTERFACE_GNSS: windows_core::GUID = windows_core::GUID::from_u128(0x3336e5e4_018a_4669_84c5_bd05f3bd368b);
 windows_core::imp::define_interface!(ICivicAddressReport, ICivicAddressReport_Vtbl, 0xc0b19f70_4adf_445d_87f2_cad8fd711792);

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -272,9 +272,6 @@ impl Default for CPOINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CPOINT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DD_KEYBOARD_DEVICE_NAME: windows_core::PCSTR = windows_core::s!("\\Device\\KeyboardClass");
 pub const DD_KEYBOARD_DEVICE_NAME_U: windows_core::PCWSTR = windows_core::w!("\\Device\\KeyboardClass");
 pub const DD_MOUSE_DEVICE_NAME: windows_core::PCSTR = windows_core::s!("\\Device\\PointerClass");
@@ -378,9 +375,6 @@ impl Default for DIACTIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIACTIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DIACTIONA_0 {
@@ -391,9 +385,6 @@ impl Default for DIACTIONA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIACTIONA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -418,9 +409,6 @@ impl Default for DIACTIONFORMATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIACTIONFORMATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIACTIONFORMATW {
@@ -444,9 +432,6 @@ impl Default for DIACTIONFORMATW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIACTIONFORMATW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DIACTIONW {
@@ -463,9 +448,6 @@ impl Default for DIACTIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIACTIONW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DIACTIONW_0 {
@@ -476,9 +458,6 @@ impl Default for DIACTIONW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIACTIONW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIAFTS_NEWDEVICEHIGH: u32 = 4294967295u32;
 pub const DIAFTS_NEWDEVICELOW: u32 = 4294967295u32;
@@ -1341,9 +1320,6 @@ impl Default for DICOLORSET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DICOLORSET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DICONDITION {
@@ -1358,9 +1334,6 @@ impl Default for DICONDITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DICONDITION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -1379,9 +1352,6 @@ impl Default for DICONFIGUREDEVICESPARAMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DICONFIGUREDEVICESPARAMSA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct DICONFIGUREDEVICESPARAMSW {
@@ -1399,9 +1369,6 @@ impl Default for DICONFIGUREDEVICESPARAMSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DICONFIGUREDEVICESPARAMSW {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DICONSTANTFORCE {
@@ -1411,9 +1378,6 @@ impl Default for DICONSTANTFORCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DICONSTANTFORCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1427,9 +1391,6 @@ impl Default for DICUSTOMFORCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DICUSTOMFORCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIDAL_BOTTOMALIGNED: u32 = 8u32;
 pub const DIDAL_CENTERED: u32 = 0u32;
@@ -1451,9 +1412,6 @@ impl Default for DIDATAFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIDATAFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIDBAM_DEFAULT: u32 = 0u32;
 pub const DIDBAM_HWDEFAULTS: u32 = 4u32;
@@ -1494,9 +1452,6 @@ impl Default for DIDEVCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDEVCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIDEVCAPS_DX3 {
@@ -1511,9 +1466,6 @@ impl Default for DIDEVCAPS_DX3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIDEVCAPS_DX3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1533,9 +1485,6 @@ impl Default for DIDEVICEIMAGEINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDEVICEIMAGEINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIDEVICEIMAGEINFOHEADERA {
@@ -1553,9 +1502,6 @@ impl Default for DIDEVICEIMAGEINFOHEADERA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIDEVICEIMAGEINFOHEADERA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1575,9 +1521,6 @@ impl Default for DIDEVICEIMAGEINFOHEADERW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDEVICEIMAGEINFOHEADERW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIDEVICEIMAGEINFOW {
@@ -1595,9 +1538,6 @@ impl Default for DIDEVICEIMAGEINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIDEVICEIMAGEINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1617,9 +1557,6 @@ impl Default for DIDEVICEINSTANCEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDEVICEINSTANCEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIDEVICEINSTANCEW {
@@ -1638,9 +1575,6 @@ impl Default for DIDEVICEINSTANCEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDEVICEINSTANCEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIDEVICEINSTANCE_DX3A {
@@ -1655,9 +1589,6 @@ impl Default for DIDEVICEINSTANCE_DX3A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIDEVICEINSTANCE_DX3A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1674,9 +1605,6 @@ impl Default for DIDEVICEINSTANCE_DX3W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDEVICEINSTANCE_DX3W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIDEVICEOBJECTDATA {
@@ -1691,9 +1619,6 @@ impl Default for DIDEVICEOBJECTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDEVICEOBJECTDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIDEVICEOBJECTDATA_DX3 {
@@ -1706,9 +1631,6 @@ impl Default for DIDEVICEOBJECTDATA_DX3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIDEVICEOBJECTDATA_DX3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1734,9 +1656,6 @@ impl Default for DIDEVICEOBJECTINSTANCEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDEVICEOBJECTINSTANCEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIDEVICEOBJECTINSTANCEW {
@@ -1761,9 +1680,6 @@ impl Default for DIDEVICEOBJECTINSTANCEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDEVICEOBJECTINSTANCEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIDEVICEOBJECTINSTANCE_DX3A {
@@ -1778,9 +1694,6 @@ impl Default for DIDEVICEOBJECTINSTANCE_DX3A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIDEVICEOBJECTINSTANCE_DX3A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1797,9 +1710,6 @@ impl Default for DIDEVICEOBJECTINSTANCE_DX3W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDEVICEOBJECTINSTANCE_DX3W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIDEVICESTATE {
@@ -1811,9 +1721,6 @@ impl Default for DIDEVICESTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIDEVICESTATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIDEVTYPEJOYSTICK_FLIGHTSTICK: u32 = 3u32;
 pub const DIDEVTYPEJOYSTICK_GAMEPAD: u32 = 4u32;
@@ -1890,9 +1797,6 @@ impl Default for DIDRIVERVERSIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIDRIVERVERSIONS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DIDSAM_DEFAULT: u32 = 0u32;
 pub const DIDSAM_FORCESAVE: u32 = 2u32;
 pub const DIDSAM_NOUSER: u32 = 1u32;
@@ -1937,9 +1841,6 @@ impl Default for DIEFFECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIEFFECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIEFFECTATTRIBUTES {
@@ -1953,9 +1854,6 @@ impl Default for DIEFFECTATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIEFFECTATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1972,9 +1870,6 @@ impl Default for DIEFFECTINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIEFFECTINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIEFFECTINFOW {
@@ -1989,9 +1884,6 @@ impl Default for DIEFFECTINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIEFFECTINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2015,9 +1907,6 @@ impl Default for DIEFFECT_DX5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIEFFECT_DX5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIEFFESCAPE {
@@ -2032,9 +1921,6 @@ impl Default for DIEFFESCAPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIEFFESCAPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIEFF_CARTESIAN: u32 = 16u32;
 pub const DIEFF_OBJECTIDS: u32 = 1u32;
@@ -2072,9 +1958,6 @@ impl Default for DIENVELOPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIENVELOPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIEP_ALLPARAMS: u32 = 1023u32;
 pub const DIEP_ALLPARAMS_DX5: u32 = 511u32;
@@ -2146,9 +2029,6 @@ impl Default for DIFFDEVICEATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIFFDEVICEATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIFFOBJECTATTRIBUTES {
@@ -2159,9 +2039,6 @@ impl Default for DIFFOBJECTATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIFFOBJECTATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2175,9 +2052,6 @@ impl Default for DIFILEEFFECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIFILEEFFECT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIGDD_PEEK: u32 = 1u32;
 pub const DIGFFS_ACTUATORSOFF: u32 = 32u32;
@@ -2235,9 +2109,6 @@ impl Default for DIHIDFFINITINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIHIDFFINITINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DIJC_CALLOUT: u32 = 8u32;
 pub const DIJC_GAIN: u32 = 4u32;
 pub const DIJC_GUIDINSTANCE: u32 = 1u32;
@@ -2259,9 +2130,6 @@ impl Default for DIJOYCONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIJOYCONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIJOYCONFIG_DX5 {
@@ -2276,9 +2144,6 @@ impl Default for DIJOYCONFIG_DX5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIJOYCONFIG_DX5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2297,9 +2162,6 @@ impl Default for DIJOYSTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIJOYSTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2340,9 +2202,6 @@ impl Default for DIJOYSTATE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIJOYSTATE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIJOYTYPEINFO {
@@ -2361,9 +2220,6 @@ impl Default for DIJOYTYPEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIJOYTYPEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIJOYTYPEINFO_DX5 {
@@ -2377,9 +2233,6 @@ impl Default for DIJOYTYPEINFO_DX5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIJOYTYPEINFO_DX5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2397,9 +2250,6 @@ impl Default for DIJOYTYPEINFO_DX6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIJOYTYPEINFO_DX6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIJOYUSERVALUES {
@@ -2412,9 +2262,6 @@ impl Default for DIJOYUSERVALUES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIJOYUSERVALUES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIJU_GAMEPORTEMULATOR: u32 = 4u32;
 pub const DIJU_GLOBALDRIVER: u32 = 2u32;
@@ -2736,9 +2583,6 @@ impl Default for DIMOUSESTATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIMOUSESTATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIMOUSESTATE2 {
@@ -2751,9 +2595,6 @@ impl Default for DIMOUSESTATE2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIMOUSESTATE2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIMSGWP_DX8APPSTART: u32 = 2u32;
 pub const DIMSGWP_DX8MAPPERAPPSTART: u32 = 3u32;
@@ -2770,9 +2611,6 @@ impl Default for DIOBJECTATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIOBJECTATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIOBJECTCALIBRATION {
@@ -2784,9 +2622,6 @@ impl Default for DIOBJECTCALIBRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIOBJECTCALIBRATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2801,9 +2636,6 @@ impl Default for DIOBJECTDATAFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIOBJECTDATAFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIPERIODIC {
@@ -2816,9 +2648,6 @@ impl Default for DIPERIODIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIPERIODIC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIPH_BYID: u32 = 2u32;
 pub const DIPH_BYOFFSET: u32 = 1u32;
@@ -2834,9 +2663,6 @@ impl Default for DIPOVCALIBRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIPOVCALIBRATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIPOV_ANY_1: u32 = 4278208001u32;
 pub const DIPOV_ANY_2: u32 = 4278208002u32;
@@ -2859,9 +2685,6 @@ impl Default for DIPROPCAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIPROPCAL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DIPROPCALIBRATIONMODE_COOKED: u32 = 0u32;
 pub const DIPROPCALIBRATIONMODE_RAW: u32 = 1u32;
 #[repr(C)]
@@ -2876,9 +2699,6 @@ impl Default for DIPROPCALPOV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIPROPCALPOV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIPROPCPOINTS {
@@ -2891,9 +2711,6 @@ impl Default for DIPROPCPOINTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIPROPCPOINTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIPROPDWORD {
@@ -2904,9 +2721,6 @@ impl Default for DIPROPDWORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIPROPDWORD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2919,9 +2733,6 @@ impl Default for DIPROPGUIDANDPATH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIPROPGUIDANDPATH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2936,9 +2747,6 @@ impl Default for DIPROPHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIPROPHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIPROPPOINTER {
@@ -2949,9 +2757,6 @@ impl Default for DIPROPPOINTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIPROPPOINTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2965,9 +2770,6 @@ impl Default for DIPROPRANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIPROPRANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIPROPSTRING {
@@ -2978,9 +2780,6 @@ impl Default for DIPROPSTRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIPROPSTRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIPROP_APPDATA: windows_core::GUID = windows_core::GUID::from_u128(0x00000000_0000_0000_0000_000000000016);
 pub const DIPROP_AUTOCENTER: windows_core::GUID = windows_core::GUID::from_u128(0x00000000_0000_0000_0000_000000000009);
@@ -3017,9 +2816,6 @@ impl Default for DIRAMPFORCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIRAMPFORCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIRECTINPUT_HEADER_VERSION: u32 = 2048u32;
 pub const DIRECTINPUT_NOTIFICATION_MSGSTRING: windows_core::PCWSTR = windows_core::w!("DIRECTINPUT_NOTIFICATION_MSGSTRING");
@@ -3213,9 +3009,6 @@ impl Default for HIDD_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDD_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct HIDD_CONFIGURATION {
@@ -3228,9 +3021,6 @@ impl Default for HIDD_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDD_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HIDP_BUTTON_ARRAY_DATA {
@@ -3241,9 +3031,6 @@ impl Default for HIDP_BUTTON_ARRAY_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HIDP_BUTTON_ARRAY_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3269,9 +3056,6 @@ impl Default for HIDP_BUTTON_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_BUTTON_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HIDP_BUTTON_CAPS_0 {
@@ -3282,9 +3066,6 @@ impl Default for HIDP_BUTTON_CAPS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HIDP_BUTTON_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3303,9 +3084,6 @@ impl Default for HIDP_BUTTON_CAPS_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_BUTTON_CAPS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HIDP_BUTTON_CAPS_0_0 {
@@ -3322,9 +3100,6 @@ impl Default for HIDP_BUTTON_CAPS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HIDP_BUTTON_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3351,9 +3126,6 @@ impl Default for HIDP_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HIDP_DATA {
@@ -3366,9 +3138,6 @@ impl Default for HIDP_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HIDP_DATA_0 {
@@ -3379,9 +3148,6 @@ impl Default for HIDP_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HIDP_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -3396,9 +3162,6 @@ impl Default for HIDP_EXTENDED_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_EXTENDED_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HIDP_KEYBOARD_DIRECTION(pub i32);
@@ -3412,9 +3175,6 @@ impl Default for HIDP_KEYBOARD_MODIFIER_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_KEYBOARD_MODIFIER_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HIDP_KEYBOARD_MODIFIER_STATE_0 {
@@ -3426,9 +3186,6 @@ impl Default for HIDP_KEYBOARD_MODIFIER_STATE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_KEYBOARD_MODIFIER_STATE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HIDP_KEYBOARD_MODIFIER_STATE_0_0 {
@@ -3438,9 +3195,6 @@ impl Default for HIDP_KEYBOARD_MODIFIER_STATE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HIDP_KEYBOARD_MODIFIER_STATE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -3458,9 +3212,6 @@ impl Default for HIDP_LINK_COLLECTION_NODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HIDP_LINK_COLLECTION_NODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3498,9 +3249,6 @@ impl Default for HIDP_UNKNOWN_TOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_UNKNOWN_TOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HIDP_VALUE_CAPS {
@@ -3533,9 +3281,6 @@ impl Default for HIDP_VALUE_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_VALUE_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HIDP_VALUE_CAPS_0 {
@@ -3546,9 +3291,6 @@ impl Default for HIDP_VALUE_CAPS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HIDP_VALUE_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3567,9 +3309,6 @@ impl Default for HIDP_VALUE_CAPS_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_VALUE_CAPS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HIDP_VALUE_CAPS_0_0 {
@@ -3587,9 +3326,6 @@ impl Default for HIDP_VALUE_CAPS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIDP_VALUE_CAPS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HID_COLLECTION_INFORMATION {
@@ -3605,9 +3341,6 @@ impl Default for HID_COLLECTION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HID_COLLECTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HID_DRIVER_CONFIG {
@@ -3618,9 +3351,6 @@ impl Default for HID_DRIVER_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HID_DRIVER_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HID_REVISION: u32 = 1u32;
 pub const HID_USAGE_ALPHANUMERIC_14_SEGMENT_DIRECT_MAP: u16 = 69u16;
@@ -4249,9 +3979,6 @@ impl Default for HID_XFER_PACKET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HID_XFER_PACKET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HORIZONTAL_WHEEL_PRESENT: u32 = 32768u32;
 pub const HidP_Feature: HIDP_REPORT_TYPE = HIDP_REPORT_TYPE(2i32);
@@ -6787,9 +6514,6 @@ impl Default for INDICATOR_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INDICATOR_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INPUT_BUTTON_ENABLE_INFO {
@@ -6800,9 +6524,6 @@ impl Default for INPUT_BUTTON_ENABLE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INPUT_BUTTON_ENABLE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IOCTL_BUTTON_GET_ENABLED_ON_IDLE: u32 = 721580u32;
 pub const IOCTL_BUTTON_SET_ENABLED_ON_IDLE: u32 = 721576u32;
@@ -6833,9 +6554,6 @@ impl Default for JOYCALIBRATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOYCALIBRATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOYPOS {
@@ -6851,9 +6569,6 @@ impl Default for JOYPOS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOYPOS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOYRANGE {
@@ -6865,9 +6580,6 @@ impl Default for JOYRANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOYRANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6883,9 +6595,6 @@ impl Default for JOYREGHWCONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOYREGHWCONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOYREGHWSETTINGS {
@@ -6896,9 +6605,6 @@ impl Default for JOYREGHWSETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOYREGHWSETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6912,9 +6618,6 @@ impl Default for JOYREGHWVALUES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOYREGHWVALUES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOYREGUSERVALUES {
@@ -6926,9 +6629,6 @@ impl Default for JOYREGUSERVALUES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOYREGUSERVALUES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JOYTYPE_ANALOGCOMPAT: i32 = 8i32;
 pub const JOYTYPE_DEFAULTPROPSHEET: i32 = -2147483648i32;
@@ -7030,9 +6730,6 @@ impl Default for KEYBOARD_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEYBOARD_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KEYBOARD_CAPS_LOCK_ON: u32 = 4u32;
 pub const KEYBOARD_ERROR_VALUE_BASE: u32 = 10000u32;
 #[repr(C)]
@@ -7051,9 +6748,6 @@ impl Default for KEYBOARD_EXTENDED_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEYBOARD_EXTENDED_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KEYBOARD_EXTENDED_ATTRIBUTES_STRUCT_VERSION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7065,9 +6759,6 @@ impl Default for KEYBOARD_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEYBOARD_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7081,9 +6772,6 @@ impl Default for KEYBOARD_IME_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEYBOARD_IME_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEYBOARD_INDICATOR_PARAMETERS {
@@ -7095,9 +6783,6 @@ impl Default for KEYBOARD_INDICATOR_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEYBOARD_INDICATOR_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEYBOARD_INDICATOR_TRANSLATION {
@@ -7108,9 +6793,6 @@ impl Default for KEYBOARD_INDICATOR_TRANSLATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEYBOARD_INDICATOR_TRANSLATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7125,9 +6807,6 @@ impl Default for KEYBOARD_INPUT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEYBOARD_INPUT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KEYBOARD_KANA_LOCK_ON: u32 = 8u32;
 pub const KEYBOARD_LED_INJECTED: u32 = 32768u32;
@@ -7147,9 +6826,6 @@ impl Default for KEYBOARD_TYPEMATIC_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEYBOARD_TYPEMATIC_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KEYBOARD_UNIT_ID_PARAMETER {
@@ -7159,9 +6835,6 @@ impl Default for KEYBOARD_UNIT_ID_PARAMETER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEYBOARD_UNIT_ID_PARAMETER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KEY_BREAK: u32 = 1u32;
 pub const KEY_E0: u32 = 2u32;
@@ -7203,9 +6876,6 @@ impl Default for MOUSE_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MOUSE_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MOUSE_BUTTON_1_DOWN: u32 = 1u32;
 pub const MOUSE_BUTTON_1_UP: u32 = 2u32;
 pub const MOUSE_BUTTON_2_DOWN: u32 = 4u32;
@@ -7237,9 +6907,6 @@ impl Default for MOUSE_INPUT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MOUSE_INPUT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MOUSE_INPUT_DATA_0 {
@@ -7251,9 +6918,6 @@ impl Default for MOUSE_INPUT_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MOUSE_INPUT_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MOUSE_INPUT_DATA_0_0 {
@@ -7264,9 +6928,6 @@ impl Default for MOUSE_INPUT_DATA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MOUSE_INPUT_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MOUSE_LEFT_BUTTON_DOWN: u32 = 1u32;
 pub const MOUSE_LEFT_BUTTON_UP: u32 = 2u32;
@@ -7285,9 +6946,6 @@ impl Default for MOUSE_UNIT_ID_PARAMETER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MOUSE_UNIT_ID_PARAMETER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MOUSE_WHEEL: u32 = 1024u32;
 pub type PFN_HidP_GetVersionInternal = Option<unsafe extern "system" fn(version: *mut u32) -> super::super::Foundation::NTSTATUS>;
@@ -7308,9 +6966,6 @@ impl Default for USAGE_AND_PAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USAGE_AND_PAGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEELMOUSE_HID_HARDWARE: u32 = 256u32;
 pub const WHEELMOUSE_I8042_HARDWARE: u32 = 32u32;

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
@@ -86,9 +86,6 @@ impl Default for DEVICEDIALOGDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICEDIALOGDATA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct DEVICEDIALOGDATA2 {
@@ -106,9 +103,6 @@ impl Default for DEVICEDIALOGDATA2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICEDIALOGDATA2 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DEVICE_ATTENTION: u32 = 1024u32;
 pub const DUP: u32 = 4u32;
@@ -3330,9 +3324,6 @@ impl Default for MINIDRV_TRANSFER_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDRV_TRANSFER_CONTEXT {
-    type TypeKind = windows_core::CloneType;
-}
 pub const MIRRORED: u32 = 1u32;
 pub const MULTIPLE_FEED: u32 = 512u32;
 pub const NEXT_PAGE: u32 = 128u32;
@@ -3355,9 +3346,6 @@ impl Default for RANGEVALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RANGEVALUE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RIGHT_JUSTIFIED: u32 = 2u32;
 pub const ROT180: u32 = 2u32;
@@ -3407,9 +3395,6 @@ impl Default for SCANINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCANINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCANMODE_FINALSCAN: u32 = 0u32;
 pub const SCANMODE_PREVIEWSCAN: u32 = 1u32;
 #[repr(C)]
@@ -3424,9 +3409,6 @@ impl Default for SCANWINDOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCANWINDOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCAN_FINISHED: u32 = 30u32;
 pub const SCAN_FIRST: u32 = 10u32;
@@ -3458,9 +3440,6 @@ impl Default for TWAIN_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TWAIN_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TYMED_CALLBACK: u32 = 128u32;
 pub const TYMED_MULTIPAGE_CALLBACK: u32 = 512u32;
 pub const TYMED_MULTIPAGE_FILE: u32 = 256u32;
@@ -3481,9 +3460,6 @@ impl Default for VAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHITEBALANCE_AUTO: u32 = 2u32;
 pub const WHITEBALANCE_DAYLIGHT: u32 = 4u32;
@@ -3509,9 +3485,6 @@ impl Default for WIAS_CHANGED_VALUE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIAS_CHANGED_VALUE_INFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union WIAS_CHANGED_VALUE_INFO_1 {
     pub lVal: i32,
@@ -3529,9 +3502,6 @@ impl Default for WIAS_CHANGED_VALUE_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIAS_CHANGED_VALUE_INFO_1 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union WIAS_CHANGED_VALUE_INFO_0 {
     pub lVal: i32,
@@ -3548,9 +3518,6 @@ impl Default for WIAS_CHANGED_VALUE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIAS_CHANGED_VALUE_INFO_0 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3573,9 +3540,6 @@ impl Default for WIAS_DOWN_SAMPLE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIAS_DOWN_SAMPLE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIAS_ENDORSER_INFO {
@@ -3588,9 +3552,6 @@ impl Default for WIAS_ENDORSER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIAS_ENDORSER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIAS_ENDORSER_VALUE {
@@ -3601,9 +3562,6 @@ impl Default for WIAS_ENDORSER_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIAS_ENDORSER_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIAU_DEBUG_TSTR: windows_core::PCSTR = windows_core::s!("S");
 pub const WIAVIDEO_CREATING_VIDEO: WIAVIDEO_STATE = WIAVIDEO_STATE(2i32);
@@ -3647,9 +3605,6 @@ impl Default for WIA_BARCODES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIA_BARCODES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WIA_BARCODE_AUTO_SEARCH: u32 = 4u32;
 pub const WIA_BARCODE_AZTEC: u32 = 36u32;
 pub const WIA_BARCODE_CODABAR: u32 = 2u32;
@@ -3691,9 +3646,6 @@ impl Default for WIA_BARCODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIA_BARCODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIA_BARCODE_INTELLIGENT_MAIL: u32 = 23u32;
 pub const WIA_BARCODE_INTERLEAVED_2OF5: u32 = 4u32;
@@ -3786,9 +3738,6 @@ impl Default for WIA_DATA_CALLBACK_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIA_DATA_CALLBACK_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WIA_DATA_COLOR: u32 = 3u32;
 pub const WIA_DATA_COLOR_DITHER: u32 = 5u32;
 pub const WIA_DATA_COLOR_THRESHOLD: u32 = 4u32;
@@ -3817,9 +3766,6 @@ impl Default for WIA_DATA_TRANSFER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIA_DATA_TRANSFER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WIA_DEPTH_AUTO: u32 = 0u32;
 pub const WIA_DEVICE_COMMANDS: u32 = 1u32;
 pub const WIA_DEVICE_CONNECTED: u32 = 1u32;
@@ -3844,9 +3790,6 @@ impl Default for WIA_DEV_CAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIA_DEV_CAP {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIA_DEV_CAP_DRV {
@@ -3860,9 +3803,6 @@ impl Default for WIA_DEV_CAP_DRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIA_DEV_CAP_DRV {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIA_DIP_BAUDRATE: u32 = 12u32;
 pub const WIA_DIP_BAUDRATE_STR: windows_core::PCWSTR = windows_core::w!("BaudRate");
@@ -3911,9 +3851,6 @@ impl Default for WIA_DITHER_PATTERN_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIA_DITHER_PATTERN_DATA {
-    type TypeKind = windows_core::CloneType;
 }
 pub const WIA_DONT_SHOW_PREVIEW_CONTROL: u32 = 1u32;
 pub const WIA_DONT_USE_SEGMENTATION_FILTER: u32 = 1u32;
@@ -4171,9 +4108,6 @@ impl Default for WIA_EXTENDED_TRANSFER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIA_EXTENDED_TRANSFER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WIA_FEEDER_CONTROL_AUTO: u32 = 0u32;
 pub const WIA_FEEDER_CONTROL_MANUAL: u32 = 1u32;
 pub const WIA_FILM_BW_NEGATIVE: u32 = 2u32;
@@ -4193,9 +4127,6 @@ impl Default for WIA_FORMAT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIA_FORMAT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIA_IMAGEPROC_FILTER_STR: windows_core::PCWSTR = windows_core::w!("ImageProcessingFilter");
 pub const WIA_INTENT_BEST_PREVIEW: u32 = 262144u32;
@@ -4534,9 +4465,6 @@ impl Default for WIA_MICR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIA_MICR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIA_MICR_INFO {
@@ -4549,9 +4477,6 @@ impl Default for WIA_MICR_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIA_MICR_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIA_MICR_READER_AUTO: u32 = 1u32;
 pub const WIA_MICR_READER_DISABLED: u32 = 0u32;
@@ -4647,9 +4572,6 @@ impl Default for WIA_PATCH_CODES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIA_PATCH_CODES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WIA_PATCH_CODE_1: u32 = 1u32;
 pub const WIA_PATCH_CODE_10: u32 = 10u32;
 pub const WIA_PATCH_CODE_11: u32 = 11u32;
@@ -4673,9 +4595,6 @@ impl Default for WIA_PATCH_CODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIA_PATCH_CODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIA_PATCH_CODE_READER_AUTO: u32 = 1u32;
 pub const WIA_PATCH_CODE_READER_DISABLED: u32 = 0u32;
@@ -4761,9 +4680,6 @@ impl Default for WIA_PROPERTY_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIA_PROPERTY_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 pub struct WIA_PROPERTY_INFO {
@@ -4782,10 +4698,6 @@ impl Default for WIA_PROPERTY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
@@ -4811,10 +4723,6 @@ impl Default for WIA_PROPERTY_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4827,10 +4735,6 @@ impl Default for WIA_PROPERTY_INFO_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
@@ -4846,10 +4750,6 @@ impl Default for WIA_PROPERTY_INFO_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_5 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4863,10 +4763,6 @@ impl Default for WIA_PROPERTY_INFO_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
@@ -4882,10 +4778,6 @@ impl Default for WIA_PROPERTY_INFO_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4900,10 +4792,6 @@ impl Default for WIA_PROPERTY_INFO_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4915,10 +4803,6 @@ impl Default for WIA_PROPERTY_INFO_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
@@ -4935,10 +4819,6 @@ impl Default for WIA_PROPERTY_INFO_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4954,10 +4834,6 @@ impl Default for WIA_PROPERTY_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for WIA_PROPERTY_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIA_PROPID_TO_NAME {
@@ -4968,9 +4844,6 @@ impl Default for WIA_PROPID_TO_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIA_PROPID_TO_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIA_PROPPAGE_CAMERA_ITEM_GENERAL: u32 = 2u32;
 pub const WIA_PROPPAGE_DEVICE_GENERAL: u32 = 4u32;
@@ -5015,9 +4888,6 @@ impl Default for WIA_RAW_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIA_RAW_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIA_REGISTER_EVENT_CALLBACK: u32 = 1u32;
 pub const WIA_RESERVED_FOR_NEW_PROPS: u32 = 1024u32;
@@ -5154,9 +5024,6 @@ impl Default for WiaTransferParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WiaTransferParams {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WiaVideo: windows_core::GUID = windows_core::GUID::from_u128(0x3908c3cd_4478_4536_af2f_10c25d4ef89a);
 pub const g_dwDebugFlags: u32 = 0u32;

--- a/crates/libs/windows/src/Windows/Win32/Devices/Nfc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Nfc/mod.rs
@@ -106,9 +106,6 @@ impl Default for NFCRM_RADIO_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFCRM_RADIO_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFCRM_SET_RADIO_STATE {
@@ -120,9 +117,6 @@ impl Default for NFCRM_SET_RADIO_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFCRM_SET_RADIO_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_DATA_BUFFER {
@@ -133,9 +127,6 @@ impl Default for NFC_DATA_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_DATA_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -154,9 +145,6 @@ impl Default for NFC_LLCP_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_LLCP_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NFC_LLCP_LINK_STATUS(pub i32);
@@ -172,9 +160,6 @@ impl Default for NFC_LLCP_SERVICE_DISCOVER_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_LLCP_SERVICE_DISCOVER_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_LLCP_SERVICE_DISCOVER_SAP {
@@ -185,9 +170,6 @@ impl Default for NFC_LLCP_SERVICE_DISCOVER_SAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_LLCP_SERVICE_DISCOVER_SAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -200,9 +182,6 @@ impl Default for NFC_LLCP_SERVICE_NAME_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_LLCP_SERVICE_NAME_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_LLCP_SOCKET_ACCEPT_INFO {
@@ -213,9 +192,6 @@ impl Default for NFC_LLCP_SOCKET_ACCEPT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_LLCP_SOCKET_ACCEPT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -228,9 +204,6 @@ impl Default for NFC_LLCP_SOCKET_CL_PAYLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_LLCP_SOCKET_CL_PAYLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -245,9 +218,6 @@ impl Default for NFC_LLCP_SOCKET_CONNECT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_LLCP_SOCKET_CONNECT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NFC_LLCP_SOCKET_CONNECT_INFO_0 {
@@ -258,9 +228,6 @@ impl Default for NFC_LLCP_SOCKET_CONNECT_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_LLCP_SOCKET_CONNECT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -279,9 +246,6 @@ impl Default for NFC_LLCP_SOCKET_ERROR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_LLCP_SOCKET_ERROR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_LLCP_SOCKET_INFO {
@@ -293,9 +257,6 @@ impl Default for NFC_LLCP_SOCKET_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_LLCP_SOCKET_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_LLCP_SOCKET_OPTION {
@@ -306,9 +267,6 @@ impl Default for NFC_LLCP_SOCKET_OPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_LLCP_SOCKET_OPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -322,9 +280,6 @@ impl Default for NFC_LLCP_SOCKET_PAYLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_LLCP_SOCKET_PAYLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_LLCP_SOCKET_SERVICE_INFO {
@@ -336,9 +291,6 @@ impl Default for NFC_LLCP_SOCKET_SERVICE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_LLCP_SOCKET_SERVICE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -356,9 +308,6 @@ impl Default for NFC_NDEF_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_NDEF_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NFC_P2P_MODE(pub i32);
@@ -374,9 +323,6 @@ impl Default for NFC_P2P_PARAM_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_P2P_PARAM_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NFC_RELEASE_TYPE(pub i32);
@@ -390,9 +336,6 @@ impl Default for NFC_REMOTE_DEVICE_DISCONNET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_REMOTE_DEVICE_DISCONNET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -409,9 +352,6 @@ impl Default for NFC_REMOTE_DEV_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_REMOTE_DEV_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_REMOTE_DEV_RECV_INFO {
@@ -422,9 +362,6 @@ impl Default for NFC_REMOTE_DEV_RECV_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_REMOTE_DEV_RECV_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -437,9 +374,6 @@ impl Default for NFC_REMOTE_DEV_SEND_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_REMOTE_DEV_SEND_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -462,9 +396,6 @@ impl Default for NFC_RF_DISCOVERY_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_RF_DISCOVERY_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NFC_RF_DISCOVERY_MODE(pub i32);
@@ -481,9 +412,6 @@ impl Default for NFC_SE_AID_ROUTING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SE_AID_ROUTING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NFC_SE_EMULATION_MODE(pub i32);
@@ -498,9 +426,6 @@ impl Default for NFC_SE_EMULATION_MODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SE_EMULATION_MODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_SE_EVENT_INFO {
@@ -514,9 +439,6 @@ impl Default for NFC_SE_EVENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SE_EVENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_SE_INFO {
@@ -528,9 +450,6 @@ impl Default for NFC_SE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_SE_LIST {
@@ -541,9 +460,6 @@ impl Default for NFC_SE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_SE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -557,9 +473,6 @@ impl Default for NFC_SE_PROTO_ROUTING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SE_PROTO_ROUTING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NFC_SE_ROUTING_TABLE {
@@ -571,9 +484,6 @@ impl Default for NFC_SE_ROUTING_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SE_ROUTING_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NFC_SE_ROUTING_TABLE_ENTRY {
@@ -584,9 +494,6 @@ impl Default for NFC_SE_ROUTING_TABLE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_SE_ROUTING_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -600,9 +507,6 @@ impl Default for NFC_SE_ROUTING_TABLE_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SE_ROUTING_TABLE_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_SE_TECH_ROUTING_INFO {
@@ -615,9 +519,6 @@ impl Default for NFC_SE_TECH_ROUTING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SE_TECH_ROUTING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_SNEP_CLIENT_GET_INFO {
@@ -628,9 +529,6 @@ impl Default for NFC_SNEP_CLIENT_GET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_SNEP_CLIENT_GET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -645,9 +543,6 @@ impl Default for NFC_SNEP_CLIENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SNEP_CLIENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_SNEP_CLIENT_PUT_INFO {
@@ -658,9 +553,6 @@ impl Default for NFC_SNEP_CLIENT_PUT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_SNEP_CLIENT_PUT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -677,9 +569,6 @@ impl Default for NFC_SNEP_SERVER_ACCEPT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SNEP_SERVER_ACCEPT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_SNEP_SERVER_INFO {
@@ -694,9 +583,6 @@ impl Default for NFC_SNEP_SERVER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SNEP_SERVER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_SNEP_SERVER_REQUEST {
@@ -710,9 +596,6 @@ impl Default for NFC_SNEP_SERVER_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NFC_SNEP_SERVER_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NFC_SNEP_SERVER_RESPONSE_INFO {
@@ -725,9 +608,6 @@ impl Default for NFC_SNEP_SERVER_RESPONSE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NFC_SNEP_SERVER_RESPONSE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -766,9 +646,6 @@ impl Default for SECURE_ELEMENT_AID_ROUTING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURE_ELEMENT_AID_ROUTING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SECURE_ELEMENT_CARD_EMULATION_MODE(pub i32);
@@ -783,9 +660,6 @@ impl Default for SECURE_ELEMENT_ENDPOINT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURE_ELEMENT_ENDPOINT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECURE_ELEMENT_ENDPOINT_LIST {
@@ -796,9 +670,6 @@ impl Default for SECURE_ELEMENT_ENDPOINT_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURE_ELEMENT_ENDPOINT_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -813,9 +684,6 @@ impl Default for SECURE_ELEMENT_EVENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURE_ELEMENT_EVENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECURE_ELEMENT_EVENT_SUBSCRIPTION_INFO {
@@ -826,9 +694,6 @@ impl Default for SECURE_ELEMENT_EVENT_SUBSCRIPTION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURE_ELEMENT_EVENT_SUBSCRIPTION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -845,9 +710,6 @@ impl Default for SECURE_ELEMENT_HCE_ACTIVATION_PAYLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURE_ELEMENT_HCE_ACTIVATION_PAYLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECURE_ELEMENT_HCE_DATA_PACKET {
@@ -859,9 +721,6 @@ impl Default for SECURE_ELEMENT_HCE_DATA_PACKET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURE_ELEMENT_HCE_DATA_PACKET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -875,9 +734,6 @@ impl Default for SECURE_ELEMENT_NFCC_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURE_ELEMENT_NFCC_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -893,9 +749,6 @@ impl Default for SECURE_ELEMENT_PROTO_ROUTING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURE_ELEMENT_PROTO_ROUTING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct SECURE_ELEMENT_ROUTING_TABLE {
@@ -906,9 +759,6 @@ impl Default for SECURE_ELEMENT_ROUTING_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURE_ELEMENT_ROUTING_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -921,9 +771,6 @@ impl Default for SECURE_ELEMENT_ROUTING_TABLE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURE_ELEMENT_ROUTING_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SECURE_ELEMENT_ROUTING_TABLE_ENTRY_0 {
@@ -935,9 +782,6 @@ impl Default for SECURE_ELEMENT_ROUTING_TABLE_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURE_ELEMENT_ROUTING_TABLE_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -953,9 +797,6 @@ impl Default for SECURE_ELEMENT_SET_CARD_EMULATION_MODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURE_ELEMENT_SET_CARD_EMULATION_MODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECURE_ELEMENT_SET_POWER_MODE_INFO {
@@ -967,9 +808,6 @@ impl Default for SECURE_ELEMENT_SET_POWER_MODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURE_ELEMENT_SET_POWER_MODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECURE_ELEMENT_TECH_ROUTING_INFO {
@@ -980,9 +818,6 @@ impl Default for SECURE_ELEMENT_TECH_ROUTING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURE_ELEMENT_TECH_ROUTING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Nfp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Nfp/mod.rs
@@ -18,6 +18,3 @@ impl Default for SUBSCRIBED_MESSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SUBSCRIBED_MESSAGE {
-    type TypeKind = windows_core::CopyType;
-}

--- a/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/mod.rs
@@ -4123,9 +4123,6 @@ impl Default for WPD_COMMAND_ACCESS_LOOKUP_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WPD_COMMAND_ACCESS_LOOKUP_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WPD_COMMAND_ACCESS_READ: WPD_COMMAND_ACCESS_TYPES = WPD_COMMAND_ACCESS_TYPES(1i32);
 pub const WPD_COMMAND_ACCESS_READWRITE: WPD_COMMAND_ACCESS_TYPES = WPD_COMMAND_ACCESS_TYPES(3i32);
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Properties/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Properties/mod.rs
@@ -208,9 +208,6 @@ impl Default for DEVPROPCOMPKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVPROPCOMPKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVPROPERTY {
@@ -223,9 +220,6 @@ impl Default for DEVPROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVPROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVPROPID_FIRST_USABLE: u32 = 2u32;
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Pwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Pwm/mod.rs
@@ -22,9 +22,6 @@ impl Default for PWM_CONTROLLER_GET_ACTUAL_PERIOD_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PWM_CONTROLLER_GET_ACTUAL_PERIOD_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PWM_CONTROLLER_INFO {
@@ -38,9 +35,6 @@ impl Default for PWM_CONTROLLER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PWM_CONTROLLER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PWM_CONTROLLER_SET_DESIRED_PERIOD_INPUT {
@@ -51,9 +45,6 @@ impl Default for PWM_CONTROLLER_SET_DESIRED_PERIOD_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PWM_CONTROLLER_SET_DESIRED_PERIOD_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PWM_CONTROLLER_SET_DESIRED_PERIOD_OUTPUT {
@@ -63,9 +54,6 @@ impl Default for PWM_CONTROLLER_SET_DESIRED_PERIOD_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PWM_CONTROLLER_SET_DESIRED_PERIOD_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PWM_IOCTL_ID_CONTROLLER_GET_ACTUAL_PERIOD: i32 = 1i32;
 pub const PWM_IOCTL_ID_CONTROLLER_GET_INFO: i32 = 0i32;
@@ -87,9 +75,6 @@ impl Default for PWM_PIN_GET_ACTIVE_DUTY_CYCLE_PERCENTAGE_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PWM_PIN_GET_ACTIVE_DUTY_CYCLE_PERCENTAGE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PWM_PIN_GET_POLARITY_OUTPUT {
@@ -99,9 +84,6 @@ impl Default for PWM_PIN_GET_POLARITY_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PWM_PIN_GET_POLARITY_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -113,9 +95,6 @@ impl Default for PWM_PIN_IS_STARTED_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PWM_PIN_IS_STARTED_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PWM_PIN_SET_ACTIVE_DUTY_CYCLE_PERCENTAGE_INPUT {
@@ -126,9 +105,6 @@ impl Default for PWM_PIN_SET_ACTIVE_DUTY_CYCLE_PERCENTAGE_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PWM_PIN_SET_ACTIVE_DUTY_CYCLE_PERCENTAGE_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PWM_PIN_SET_POLARITY_INPUT {
@@ -138,9 +114,6 @@ impl Default for PWM_PIN_SET_POLARITY_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PWM_PIN_SET_POLARITY_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Sensors/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Sensors/mod.rs
@@ -1074,9 +1074,6 @@ impl Default for MATRIX3X3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MATRIX3X3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MATRIX3X3_0 {
@@ -1088,9 +1085,6 @@ impl Default for MATRIX3X3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MATRIX3X3_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1110,9 +1104,6 @@ impl Default for MATRIX3X3_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MATRIX3X3_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MATRIX3X3_0_1 {
@@ -1124,9 +1115,6 @@ impl Default for MATRIX3X3_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MATRIX3X3_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1172,9 +1160,6 @@ impl Default for QUATERNION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUATERNION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SENSOR_CATEGORY_ALL: windows_core::GUID = windows_core::GUID::from_u128(0xc317c286_c468_4288_9975_d4c4587c442c);
 pub const SENSOR_CATEGORY_BIOMETRIC: windows_core::GUID = windows_core::GUID::from_u128(0xca19690f_a2c7_477d_a99e_99ec6e2b5648);
 pub const SENSOR_CATEGORY_ELECTRICAL: windows_core::GUID = windows_core::GUID::from_u128(0xfb73fcd8_fc4a_483c_ac58_27b691c6beff);
@@ -1205,10 +1190,6 @@ impl Default for SENSOR_COLLECTION_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SENSOR_COLLECTION_LIST {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1389,9 +1370,6 @@ impl Default for SENSOR_PROPERTY_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SENSOR_PROPERTY_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SENSOR_PROPERTY_LIST_HEADER_SIZE: u32 = 8u32;
 pub const SENSOR_PROPERTY_LOCATION_DESIRED_ACCURACY: super::super::Foundation::PROPERTYKEY = super::super::Foundation::PROPERTYKEY { fmtid: windows_core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 19 };
 pub const SENSOR_PROPERTY_MANUFACTURER: super::super::Foundation::PROPERTYKEY = super::super::Foundation::PROPERTYKEY { fmtid: windows_core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 6 };
@@ -1492,10 +1470,6 @@ impl Default for SENSOR_VALUE_PAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SENSOR_VALUE_PAIR {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SIMPLE_DEVICE_ORIENTATION(pub i32);
@@ -1542,7 +1516,4 @@ impl Default for VEC3D {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VEC3D {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Devices/SerialCommunication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/SerialCommunication/mod.rs
@@ -135,9 +135,6 @@ impl Default for SERENUM_PORT_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERENUM_PORT_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERENUM_PORT_PARAMETERS {
@@ -155,9 +152,6 @@ impl Default for SERENUM_PORT_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERENUM_PORT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERIALCONFIG {
@@ -172,9 +166,6 @@ impl Default for SERIALCONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERIALCONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -191,9 +182,6 @@ impl Default for SERIALPERF_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERIALPERF_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERIAL_BASIC_SETTINGS {
@@ -207,9 +195,6 @@ impl Default for SERIAL_BASIC_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERIAL_BASIC_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERIAL_BAUD_RATE {
@@ -219,9 +204,6 @@ impl Default for SERIAL_BAUD_RATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERIAL_BAUD_RATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -237,9 +219,6 @@ impl Default for SERIAL_CHARS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERIAL_CHARS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -268,9 +247,6 @@ impl Default for SERIAL_COMMPROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERIAL_COMMPROP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SERIAL_EV_BREAK: u32 = 64u32;
 pub const SERIAL_EV_CTS: u32 = 8u32;
 pub const SERIAL_EV_DSR: u32 = 16u32;
@@ -297,9 +273,6 @@ impl Default for SERIAL_HANDFLOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERIAL_HANDFLOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERIAL_LINE_CONTROL {
@@ -311,9 +284,6 @@ impl Default for SERIAL_LINE_CONTROL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERIAL_LINE_CONTROL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERIAL_LSRMST_ESCAPE: u16 = 0u16;
 pub const SERIAL_LSRMST_LSR_DATA: u16 = 1u16;
@@ -334,9 +304,6 @@ impl Default for SERIAL_QUEUE_SIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERIAL_QUEUE_SIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERIAL_STATUS {
@@ -352,9 +319,6 @@ impl Default for SERIAL_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERIAL_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERIAL_TIMEOUTS {
@@ -369,9 +333,6 @@ impl Default for SERIAL_TIMEOUTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERIAL_TIMEOUTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERIAL_XOFF_COUNTER {
@@ -383,9 +344,6 @@ impl Default for SERIAL_XOFF_COUNTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERIAL_XOFF_COUNTER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPACE_PARITY: u32 = 4u32;
 pub const STOP_BITS_1_5: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Tapi/mod.rs
@@ -1689,9 +1689,6 @@ impl Default for ADDRALIAS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADDRALIAS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ADDRESS_CAPABILITY(pub i32);
@@ -1954,9 +1951,6 @@ impl Default for DTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DTR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DT_ILS: DIRECTORY_TYPE = DIRECTORY_TYPE(2i32);
 pub const DT_NTDS: DIRECTORY_TYPE = DIRECTORY_TYPE(1i32);
@@ -16149,9 +16143,6 @@ impl Default for LINEADDRESSCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEADDRESSCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LINEADDRESSMODE_ADDRESSID: u32 = 1u32;
 pub const LINEADDRESSMODE_DIALABLEADDR: u32 = 2u32;
 pub const LINEADDRESSSHARING_BRIDGEDEXCL: u32 = 2u32;
@@ -16193,9 +16184,6 @@ impl Default for LINEADDRESSSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEADDRESSSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LINEADDRESSTYPE_DOMAINNAME: u32 = 8u32;
 pub const LINEADDRESSTYPE_EMAILNAME: u32 = 4u32;
 pub const LINEADDRESSTYPE_IPADDRESS: u32 = 16u32;
@@ -16227,9 +16215,6 @@ impl Default for LINEAGENTACTIVITYENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEAGENTACTIVITYENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEAGENTACTIVITYLIST {
@@ -16244,9 +16229,6 @@ impl Default for LINEAGENTACTIVITYLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEAGENTACTIVITYLIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -16272,9 +16254,6 @@ impl Default for LINEAGENTCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEAGENTCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEAGENTENTRY {
@@ -16290,9 +16269,6 @@ impl Default for LINEAGENTENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEAGENTENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEAGENTFEATURE_AGENTSPECIFIC: u32 = 8u32;
 pub const LINEAGENTFEATURE_GETAGENTACTIVITYLIST: u32 = 16u32;
@@ -16312,9 +16288,6 @@ impl Default for LINEAGENTGROUPENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEAGENTGROUPENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEAGENTGROUPENTRY_0 {
@@ -16327,9 +16300,6 @@ impl Default for LINEAGENTGROUPENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEAGENTGROUPENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -16345,9 +16315,6 @@ impl Default for LINEAGENTGROUPLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEAGENTGROUPLIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -16373,10 +16340,6 @@ impl Default for LINEAGENTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEAGENTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEAGENTLIST {
@@ -16392,9 +16355,6 @@ impl Default for LINEAGENTLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEAGENTLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEAGENTSESSIONENTRY {
@@ -16407,9 +16367,6 @@ impl Default for LINEAGENTSESSIONENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEAGENTSESSIONENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -16439,10 +16396,6 @@ impl Default for LINEAGENTSESSIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEAGENTSESSIONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEAGENTSESSIONLIST {
@@ -16457,9 +16410,6 @@ impl Default for LINEAGENTSESSIONLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEAGENTSESSIONLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEAGENTSESSIONSTATE_BUSYONCALL: u32 = 4u32;
 pub const LINEAGENTSESSIONSTATE_BUSYWRAPUP: u32 = 8u32;
@@ -16510,9 +16460,6 @@ impl Default for LINEAGENTSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEAGENTSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LINEAGENTSTATUSEX_NEWAGENT: u32 = 1u32;
 pub const LINEAGENTSTATUSEX_STATE: u32 = 2u32;
 pub const LINEAGENTSTATUSEX_UPDATEINFO: u32 = 4u32;
@@ -16546,9 +16493,6 @@ impl Default for LINEAPPINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEAPPINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEBEARERMODE_ALTSPEECHDATA: u32 = 16u32;
 pub const LINEBEARERMODE_DATA: u32 = 8u32;
@@ -16701,9 +16645,6 @@ impl Default for LINECALLINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINECALLINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LINECALLINFOSTATE_APPSPECIFIC: u32 = 32u32;
 pub const LINECALLINFOSTATE_BEARERMODE: u32 = 4u32;
 pub const LINECALLINFOSTATE_CALLDATA: u32 = 1073741824u32;
@@ -16749,9 +16690,6 @@ impl Default for LINECALLLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINECALLLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINECALLORIGIN_CONFERENCE: u32 = 64u32;
 pub const LINECALLORIGIN_EXTERNAL: u32 = 4u32;
@@ -16817,9 +16755,6 @@ impl Default for LINECALLPARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINECALLPARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINECALLPARTYID_ADDRESS: u32 = 8u32;
 pub const LINECALLPARTYID_BLOCKED: u32 = 1u32;
@@ -16888,9 +16823,6 @@ impl Default for LINECALLSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINECALLSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINECALLTREATMENTENTRY {
@@ -16902,9 +16834,6 @@ impl Default for LINECALLTREATMENTENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINECALLTREATMENTENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINECALLTREATMENT_BUSY: u32 = 3u32;
 pub const LINECALLTREATMENT_MUSIC: u32 = 4u32;
@@ -16929,9 +16858,6 @@ impl Default for LINECARDENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINECARDENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINECARDOPTION_HIDDEN: u32 = 2u32;
 pub const LINECARDOPTION_PREDEFINED: u32 = 1u32;
@@ -16960,9 +16886,6 @@ impl Default for LINECOUNTRYENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINECOUNTRYENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINECOUNTRYLIST {
@@ -16977,9 +16900,6 @@ impl Default for LINECOUNTRYLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINECOUNTRYLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEDEVCAPFLAGS_CALLHUB: u32 = 1024u32;
 pub const LINEDEVCAPFLAGS_CALLHUBTRACKING: u32 = 2048u32;
@@ -17059,9 +16979,6 @@ impl Default for LINEDEVCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEDEVCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LINEDEVSTATE_BATTERY: u32 = 32768u32;
 pub const LINEDEVSTATE_CAPSCHANGE: u32 = 1048576u32;
 pub const LINEDEVSTATE_CLOSE: u32 = 1024u32;
@@ -17118,9 +17035,6 @@ impl Default for LINEDEVSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEDEVSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LINEDEVSTATUSFLAGS_CONNECTED: u32 = 1u32;
 pub const LINEDEVSTATUSFLAGS_INSERVICE: u32 = 4u32;
 pub const LINEDEVSTATUSFLAGS_LOCKED: u32 = 8u32;
@@ -17137,9 +17051,6 @@ impl Default for LINEDIALPARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEDIALPARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEDIALTONEMODE_EXTERNAL: u32 = 8u32;
 pub const LINEDIALTONEMODE_INTERNAL: u32 = 4u32;
@@ -17285,9 +17196,6 @@ impl Default for LINEEXTENSIONID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEEXTENSIONID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LINEFEATURE_DEVSPECIFIC: u32 = 1u32;
 pub const LINEFEATURE_DEVSPECIFICFEAT: u32 = 2u32;
 pub const LINEFEATURE_FORWARD: u32 = 4u32;
@@ -17312,9 +17220,6 @@ impl Default for LINEFORWARD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEFORWARD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEFORWARDLIST {
@@ -17326,9 +17231,6 @@ impl Default for LINEFORWARDLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEFORWARDLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEFORWARDMODE_BUSY: u32 = 16u32;
 pub const LINEFORWARDMODE_BUSYEXTERNAL: u32 = 64u32;
@@ -17368,9 +17270,6 @@ impl Default for LINEGENERATETONE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEGENERATETONE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LINEGROUPSTATUS_GROUPREMOVED: u32 = 2u32;
 pub const LINEGROUPSTATUS_NEWGROUP: u32 = 1u32;
 pub const LINEINITIALIZEEXOPTION_CALLHUBTRACKING: u32 = 2147483648u32;
@@ -17392,9 +17291,6 @@ impl Default for LINEINITIALIZEEXPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEINITIALIZEEXPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union LINEINITIALIZEEXPARAMS_0 {
@@ -17405,9 +17301,6 @@ impl Default for LINEINITIALIZEEXPARAMS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEINITIALIZEEXPARAMS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -17435,9 +17328,6 @@ impl Default for LINELOCATIONENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINELOCATIONENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LINELOCATIONOPTION_PULSEDIAL: u32 = 1u32;
 pub const LINEMAPPER: u32 = 4294967295u32;
 #[repr(C, packed(1))]
@@ -17451,9 +17341,6 @@ impl Default for LINEMEDIACONTROLCALLSTATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEMEDIACONTROLCALLSTATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEMEDIACONTROLDIGIT {
@@ -17466,9 +17353,6 @@ impl Default for LINEMEDIACONTROLDIGIT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEMEDIACONTROLDIGIT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEMEDIACONTROLMEDIA {
@@ -17480,9 +17364,6 @@ impl Default for LINEMEDIACONTROLMEDIA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEMEDIACONTROLMEDIA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -17498,9 +17379,6 @@ impl Default for LINEMEDIACONTROLTONE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEMEDIACONTROLTONE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEMEDIACONTROL_NONE: u32 = 1u32;
 pub const LINEMEDIACONTROL_PAUSE: u32 = 8u32;
@@ -17543,9 +17421,6 @@ impl Default for LINEMESSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEMESSAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEMONITORTONE {
@@ -17559,9 +17434,6 @@ impl Default for LINEMONITORTONE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEMONITORTONE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEOFFERINGMODE_ACTIVE: u32 = 1u32;
 pub const LINEOFFERINGMODE_INACTIVE: u32 = 2u32;
@@ -17581,9 +17453,6 @@ impl Default for LINEPROVIDERENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEPROVIDERENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEPROVIDERLIST {
@@ -17598,9 +17467,6 @@ impl Default for LINEPROVIDERLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEPROVIDERLIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -17620,10 +17486,6 @@ impl Default for LINEPROXYREQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -17656,10 +17518,6 @@ impl Default for LINEPROXYREQUEST_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17674,10 +17532,6 @@ impl Default for LINEPROXYREQUEST_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -17696,10 +17550,6 @@ impl Default for LINEPROXYREQUEST_0_12 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_12 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17716,10 +17566,6 @@ impl Default for LINEPROXYREQUEST_0_8 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17732,10 +17578,6 @@ impl Default for LINEPROXYREQUEST_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -17750,10 +17592,6 @@ impl Default for LINEPROXYREQUEST_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17766,10 +17604,6 @@ impl Default for LINEPROXYREQUEST_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -17784,10 +17618,6 @@ impl Default for LINEPROXYREQUEST_0_11 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_11 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17800,10 +17630,6 @@ impl Default for LINEPROXYREQUEST_0_14 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_14 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -17818,10 +17644,6 @@ impl Default for LINEPROXYREQUEST_0_13 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_13 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17835,10 +17657,6 @@ impl Default for LINEPROXYREQUEST_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17850,10 +17668,6 @@ impl Default for LINEPROXYREQUEST_0_19 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_19 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -17868,10 +17682,6 @@ impl Default for LINEPROXYREQUEST_0_18 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_18 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17884,10 +17694,6 @@ impl Default for LINEPROXYREQUEST_0_16 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_16 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -17902,10 +17708,6 @@ impl Default for LINEPROXYREQUEST_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17919,10 +17721,6 @@ impl Default for LINEPROXYREQUEST_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17935,10 +17733,6 @@ impl Default for LINEPROXYREQUEST_0_10 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_10 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -17954,10 +17748,6 @@ impl Default for LINEPROXYREQUEST_0_15 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_15 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -17971,10 +17761,6 @@ impl Default for LINEPROXYREQUEST_0_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_9 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
@@ -17990,10 +17776,6 @@ impl Default for LINEPROXYREQUEST_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -18006,10 +17788,6 @@ impl Default for LINEPROXYREQUEST_0_17 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for LINEPROXYREQUEST_0_17 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18025,9 +17803,6 @@ impl Default for LINEPROXYREQUESTLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEPROXYREQUESTLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEPROXYREQUEST_AGENTSPECIFIC: u32 = 6u32;
 pub const LINEPROXYREQUEST_CREATEAGENT: u32 = 9u32;
@@ -18068,9 +17843,6 @@ impl Default for LINEQUEUEENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEQUEUEENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEQUEUEINFO {
@@ -18093,9 +17865,6 @@ impl Default for LINEQUEUEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEQUEUEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEQUEUELIST {
@@ -18110,9 +17879,6 @@ impl Default for LINEQUEUELIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEQUEUELIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEQUEUESTATUS_NEWQUEUE: u32 = 2u32;
 pub const LINEQUEUESTATUS_QUEUEREMOVED: u32 = 4u32;
@@ -18133,9 +17899,6 @@ impl Default for LINEREQMAKECALL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEREQMAKECALL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEREQMAKECALLW {
@@ -18148,9 +17911,6 @@ impl Default for LINEREQMAKECALLW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEREQMAKECALLW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -18171,9 +17931,6 @@ impl Default for LINEREQMEDIACALL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINEREQMEDIACALL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LINEREQMEDIACALLW {
@@ -18192,9 +17949,6 @@ impl Default for LINEREQMEDIACALLW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINEREQMEDIACALLW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINEREQUESTMODE_DROP: u32 = 4u32;
 pub const LINEREQUESTMODE_MAKECALL: u32 = 1u32;
@@ -18220,9 +17974,6 @@ impl Default for LINETERMCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINETERMCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINETERMDEV_HEADSET: u32 = 2u32;
 pub const LINETERMDEV_PHONE: u32 = 1u32;
@@ -18267,9 +18018,6 @@ impl Default for LINETRANSLATECAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINETRANSLATECAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LINETRANSLATEOPTION_CANCELCALLWAITING: u32 = 2u32;
 pub const LINETRANSLATEOPTION_CARDOVERRIDE: u32 = 1u32;
 pub const LINETRANSLATEOPTION_FORCELD: u32 = 8u32;
@@ -18292,9 +18040,6 @@ impl Default for LINETRANSLATEOUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINETRANSLATEOUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINETRANSLATERESULT_CANONICAL: u32 = 1u32;
 pub const LINETRANSLATERESULT_DIALBILLING: u32 = 64u32;
@@ -18391,10 +18136,6 @@ impl Default for MSP_EVENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 pub union MSP_EVENT_INFO_0 {
@@ -18419,10 +18160,6 @@ impl Default for MSP_EVENT_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Debug, PartialEq)]
@@ -18436,10 +18173,6 @@ impl Default for MSP_EVENT_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Debug, PartialEq)]
@@ -18452,10 +18185,6 @@ impl Default for MSP_EVENT_INFO_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_5 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -18473,10 +18202,6 @@ impl Default for MSP_EVENT_INFO_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_1 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Debug, PartialEq)]
@@ -18493,10 +18218,6 @@ impl Default for MSP_EVENT_INFO_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_4 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Debug, PartialEq)]
@@ -18509,10 +18230,6 @@ impl Default for MSP_EVENT_INFO_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_3 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -18527,10 +18244,6 @@ impl Default for MSP_EVENT_INFO_0_7 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_7 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18544,10 +18257,6 @@ impl Default for MSP_EVENT_INFO_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Debug, PartialEq)]
@@ -18560,10 +18269,6 @@ impl Default for MSP_EVENT_INFO_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MSP_EVENT_INFO_0_6 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const McastAddressAllocation: windows_core::GUID = windows_core::GUID::from_u128(0xdf0daef2_a289_11d1_8697_006008b0e5d2);
 #[repr(C)]
@@ -18580,9 +18285,6 @@ impl Default for NSID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NSID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NSID_0 {
@@ -18593,9 +18295,6 @@ impl Default for NSID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NSID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPENTNEFSTREAM: windows_core::PCSTR = windows_core::s!("OpenTnefStream");
 pub const OPENTNEFSTREAMEX: windows_core::PCSTR = windows_core::s!("OpenTnefStreamEx");
@@ -18752,9 +18451,6 @@ impl Default for PHONEBUTTONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHONEBUTTONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PHONEBUTTONMODE_CALL: u32 = 2u32;
 pub const PHONEBUTTONMODE_DISPLAY: u32 = 32u32;
 pub const PHONEBUTTONMODE_DUMMY: u32 = 1u32;
@@ -18821,9 +18517,6 @@ impl Default for PHONECAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHONECAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PHONECAPS_BUFFER(pub i32);
@@ -18883,9 +18576,6 @@ impl Default for PHONEEXTENSIONID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHONEEXTENSIONID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PHONEFEATURE_GENERICPHONE: u32 = 268435456u32;
 pub const PHONEFEATURE_GETBUTTONINFO: u32 = 1u32;
 pub const PHONEFEATURE_GETDATA: u32 = 2u32;
@@ -18941,9 +18631,6 @@ impl Default for PHONEINITIALIZEEXPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHONEINITIALIZEEXPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union PHONEINITIALIZEEXPARAMS_0 {
@@ -18954,9 +18641,6 @@ impl Default for PHONEINITIALIZEEXPARAMS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PHONEINITIALIZEEXPARAMS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PHONELAMPMODE_BROKENFLUTTER: u32 = 64u32;
 pub const PHONELAMPMODE_DUMMY: u32 = 1u32;
@@ -18980,9 +18664,6 @@ impl Default for PHONEMESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PHONEMESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PHONEPRIVILEGE_MONITOR: u32 = 1u32;
 pub const PHONEPRIVILEGE_OWNER: u32 = 2u32;
@@ -19044,9 +18725,6 @@ impl Default for PHONESTATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PHONESTATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PHONESTATUSFLAGS_CONNECTED: u32 = 1u32;
 pub const PHONESTATUSFLAGS_SUSPENDED: u32 = 2u32;
@@ -19158,9 +18836,6 @@ impl Default for RENDDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RENDDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct RND_ADVERTISING_SCOPE(pub i32);
@@ -19189,9 +18864,6 @@ impl Default for STnefProblem {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STnefProblem {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STnefProblemArray {
@@ -19202,9 +18874,6 @@ impl Default for STnefProblemArray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STnefProblemArray {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TAPI: windows_core::GUID = windows_core::GUID::from_u128(0x21d6d48e_a88b_11d0_83dd_00aa003ccabd);
 pub const TAPIERR_CONNECTED: i32 = 0i32;
@@ -19259,9 +18928,6 @@ impl Default for TAPI_CUSTOMTONE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TAPI_CUSTOMTONE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TAPI_DETECTTONE {
@@ -19275,9 +18941,6 @@ impl Default for TAPI_DETECTTONE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TAPI_DETECTTONE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -19461,9 +19124,6 @@ impl Default for TRP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TSPI_LINEACCEPT: u32 = 500u32;
 pub const TSPI_LINEADDTOCONFERENCE: u32 = 501u32;
 pub const TSPI_LINEANSWER: u32 = 502u32;
@@ -19599,9 +19259,6 @@ impl Default for TUISPICREATEDIALOGINSTANCEPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TUISPICREATEDIALOGINSTANCEPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub type TUISPIDLLCALLBACK = Option<unsafe extern "system" fn(dwobjectid: usize, dwobjecttype: u32, lpparams: *mut core::ffi::c_void, dwsize: u32) -> i32>;
 pub const TUISPIDLL_OBJECT_DIALOGINSTANCE: i32 = 4i32;
 pub const TUISPIDLL_OBJECT_LINEID: i32 = 1i32;
@@ -19621,9 +19278,6 @@ impl Default for VARSTRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VARSTRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const atypFile: i32 = 1i32;
 pub const atypMax: i32 = 4i32;

--- a/crates/libs/windows/src/Windows/Win32/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Usb/mod.rs
@@ -198,9 +198,6 @@ impl Default for ALTERNATE_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ALTERNATE_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AUTO_CLEAR_STALL: WINUSB_PIPE_POLICY = WINUSB_PIPE_POLICY(2u32);
 pub const AUTO_FLUSH: WINUSB_PIPE_POLICY = WINUSB_PIPE_POLICY(6u32);
 pub const AUTO_SUSPEND: WINUSB_POWER_POLICY = WINUSB_POWER_POLICY(129u32);
@@ -227,9 +224,6 @@ impl Default for BM_REQUEST_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BM_REQUEST_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BM_REQUEST_TYPE_0 {
@@ -239,9 +233,6 @@ impl Default for BM_REQUEST_TYPE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BM_REQUEST_TYPE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BULKIN_FLAG: u32 = 128u32;
 #[repr(C)]
@@ -255,9 +246,6 @@ impl Default for CHANNEL_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANNEL_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CompositeDevice: USB_WMI_DEVICE_NODE_TYPE = USB_WMI_DEVICE_NODE_TYPE(2i32);
 #[repr(C)]
@@ -273,9 +261,6 @@ impl Default for DEVICE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEVICE_SPEED: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -288,9 +273,6 @@ impl Default for DRV_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRV_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DeviceCausedOvercurrent: USB_CONNECTION_STATUS = USB_CONNECTION_STATUS(4i32);
 pub const DeviceConnected: USB_CONNECTION_STATUS = USB_CONNECTION_STATUS(1i32);
@@ -363,9 +345,6 @@ impl Default for HCD_ISO_STAT_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HCD_ISO_STAT_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct HCD_STAT_COUNTERS {
@@ -386,9 +365,6 @@ impl Default for HCD_STAT_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HCD_STAT_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct HCD_STAT_INFORMATION_1 {
@@ -402,9 +378,6 @@ impl Default for HCD_STAT_INFORMATION_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HCD_STAT_INFORMATION_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -421,9 +394,6 @@ impl Default for HCD_STAT_INFORMATION_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HCD_STAT_INFORMATION_2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HCD_TRACE_READ_REQUEST: u32 = 275u32;
 pub const HCD_USER_REQUEST: u32 = 270u32;
@@ -443,9 +413,6 @@ impl Default for HUB_DEVICE_CONFIG_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HUB_DEVICE_CONFIG_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HighSpeed: u32 = 3u32;
 pub const HubDevice: USB_WMI_DEVICE_NODE_TYPE = USB_WMI_DEVICE_NODE_TYPE(1i32);
@@ -552,9 +519,6 @@ impl Default for IO_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IO_BLOCK_EX {
@@ -570,9 +534,6 @@ impl Default for IO_BLOCK_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_BLOCK_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const InsufficentBandwidth: USB_NOTIFICATION_TYPE = USB_NOTIFICATION_TYPE(1i32);
 pub const InsufficentPower: USB_NOTIFICATION_TYPE = USB_NOTIFICATION_TYPE(2i32);
@@ -612,9 +573,6 @@ impl Default for OS_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OS_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union OS_STRING_0 {
@@ -625,9 +583,6 @@ impl Default for OS_STRING_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OS_STRING_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OS_STRING_DESCRIPTOR_INDEX: u32 = 238u32;
 pub const OverCurrent: USB_NOTIFICATION_TYPE = USB_NOTIFICATION_TYPE(3i32);
@@ -651,9 +606,6 @@ impl Default for PACKET_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PACKET_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PIPE_TRANSFER_TIMEOUT: WINUSB_PIPE_POLICY = WINUSB_PIPE_POLICY(3u32);
 #[repr(transparent)]
@@ -687,9 +639,6 @@ impl Default for RAW_RESET_PORT_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAW_RESET_PORT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct RAW_ROOTPORT_FEATURE {
@@ -702,9 +651,6 @@ impl Default for RAW_ROOTPORT_FEATURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAW_ROOTPORT_FEATURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct RAW_ROOTPORT_PARAMETERS {
@@ -715,9 +661,6 @@ impl Default for RAW_ROOTPORT_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAW_ROOTPORT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const READ_DATA_PIPE: PIPE_TYPE = PIPE_TYPE(1i32);
 pub const RESET_PIPE_ON_RESUME: WINUSB_PIPE_POLICY = WINUSB_PIPE_POLICY(9u32);
@@ -751,9 +694,6 @@ impl Default for URB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for URB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union URB_0 {
@@ -783,9 +723,6 @@ impl Default for URB_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for URB_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const URB_FUNCTION_ABORT_PIPE: u32 = 2u32;
 pub const URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER: u32 = 9u32;
@@ -864,9 +801,6 @@ impl Default for USBD_DEVICE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBD_DEVICE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USBD_ENDPOINT_OFFLOAD_INFORMATION {
@@ -891,9 +825,6 @@ impl Default for USBD_ENDPOINT_OFFLOAD_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBD_ENDPOINT_OFFLOAD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct USBD_ENDPOINT_OFFLOAD_MODE(pub i32);
@@ -916,9 +847,6 @@ impl Default for USBD_INTERFACE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBD_INTERFACE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USBD_ISO_PACKET_DESCRIPTOR {
@@ -930,9 +858,6 @@ impl Default for USBD_ISO_PACKET_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBD_ISO_PACKET_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USBD_ISO_START_FRAME_RANGE: u32 = 1024u32;
 pub const USBD_PF_CHANGE_MAX_PACKET: u32 = 1u32;
@@ -961,9 +886,6 @@ impl Default for USBD_PIPE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBD_PIPE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct USBD_PIPE_TYPE(pub i32);
@@ -984,9 +906,6 @@ impl Default for USBD_STREAM_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBD_STREAM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USBD_TRANSFER_DIRECTION: u32 = 1u32;
 pub const USBD_TRANSFER_DIRECTION_IN: u32 = 1u32;
 pub const USBD_TRANSFER_DIRECTION_OUT: u32 = 0u32;
@@ -1001,9 +920,6 @@ impl Default for USBD_VERSION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBD_VERSION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USBFN_BUS_CONFIGURATION_INFO {
@@ -1015,9 +931,6 @@ impl Default for USBFN_BUS_CONFIGURATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBFN_BUS_CONFIGURATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1037,9 +950,6 @@ impl Default for USBFN_CLASS_INFORMATION_PACKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBFN_CLASS_INFORMATION_PACKET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct USBFN_CLASS_INFORMATION_PACKET_EX {
@@ -1055,9 +965,6 @@ impl Default for USBFN_CLASS_INFORMATION_PACKET_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBFN_CLASS_INFORMATION_PACKET_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct USBFN_CLASS_INTERFACE {
@@ -1069,9 +976,6 @@ impl Default for USBFN_CLASS_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBFN_CLASS_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1085,9 +989,6 @@ impl Default for USBFN_CLASS_INTERFACE_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBFN_CLASS_INTERFACE_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1111,9 +1012,6 @@ impl Default for USBFN_INTERFACE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBFN_INTERFACE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USBFN_INTERRUPT_ENDPOINT_SIZE_NOT_UPDATEABLE_MASK: u32 = 128u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1125,9 +1023,6 @@ impl Default for USBFN_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBFN_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1143,9 +1038,6 @@ impl Default for USBFN_NOTIFICATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBFN_NOTIFICATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct USBFN_PIPE_INFORMATION {
@@ -1156,9 +1048,6 @@ impl Default for USBFN_PIPE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBFN_PIPE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1174,9 +1063,6 @@ impl Default for USBFN_USB_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBFN_USB_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USBSCAN_GET_DESCRIPTOR {
@@ -1189,9 +1075,6 @@ impl Default for USBSCAN_GET_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBSCAN_GET_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USBSCAN_PIPE_BULK: RAW_PIPE_TYPE = RAW_PIPE_TYPE(2i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1203,9 +1086,6 @@ impl Default for USBSCAN_PIPE_CONFIGURATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBSCAN_PIPE_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USBSCAN_PIPE_CONTROL: RAW_PIPE_TYPE = RAW_PIPE_TYPE(0i32);
 #[repr(C)]
@@ -1221,9 +1101,6 @@ impl Default for USBSCAN_PIPE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBSCAN_PIPE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USBSCAN_PIPE_INTERRUPT: RAW_PIPE_TYPE = RAW_PIPE_TYPE(3i32);
 pub const USBSCAN_PIPE_ISOCHRONOUS: RAW_PIPE_TYPE = RAW_PIPE_TYPE(1i32);
 #[repr(C)]
@@ -1238,9 +1115,6 @@ impl Default for USBSCAN_TIMEOUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBSCAN_TIMEOUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USBUSER_BANDWIDTH_INFO_REQUEST {
@@ -1252,9 +1126,6 @@ impl Default for USBUSER_BANDWIDTH_INFO_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBUSER_BANDWIDTH_INFO_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USBUSER_BUS_STATISTICS_0_REQUEST {
@@ -1265,9 +1136,6 @@ impl Default for USBUSER_BUS_STATISTICS_0_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBUSER_BUS_STATISTICS_0_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USBUSER_CLEAR_ROOTPORT_FEATURE: u32 = 536870918u32;
 #[repr(C, packed(1))]
@@ -1281,9 +1149,6 @@ impl Default for USBUSER_CLOSE_RAW_DEVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBUSER_CLOSE_RAW_DEVICE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USBUSER_CONTROLLER_INFO_0 {
@@ -1295,9 +1160,6 @@ impl Default for USBUSER_CONTROLLER_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBUSER_CONTROLLER_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USBUSER_CONTROLLER_UNICODE_NAME {
@@ -1308,9 +1170,6 @@ impl Default for USBUSER_CONTROLLER_UNICODE_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBUSER_CONTROLLER_UNICODE_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USBUSER_GET_BANDWIDTH_INFORMATION: u32 = 5u32;
 pub const USBUSER_GET_BUS_STATISTICS_0: u32 = 6u32;
@@ -1327,9 +1186,6 @@ impl Default for USBUSER_GET_DRIVER_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBUSER_GET_DRIVER_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USBUSER_GET_POWER_STATE_MAP: u32 = 4u32;
 pub const USBUSER_GET_ROOTHUB_SYMBOLIC_NAME: u32 = 7u32;
 pub const USBUSER_GET_ROOTPORT_STATUS: u32 = 536870919u32;
@@ -1344,9 +1200,6 @@ impl Default for USBUSER_GET_USB2HW_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBUSER_GET_USB2HW_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USBUSER_GET_USB2_HW_VERSION: u32 = 9u32;
 pub const USBUSER_GET_USB_DRIVER_VERSION: u32 = 8u32;
 pub const USBUSER_INVALID_REQUEST: u32 = 4294967280u32;
@@ -1360,9 +1213,6 @@ impl Default for USBUSER_OPEN_RAW_DEVICE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBUSER_OPEN_RAW_DEVICE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USBUSER_OP_CLOSE_RAW_DEVICE: u32 = 536870915u32;
 pub const USBUSER_OP_MASK_DEVONLY_API: u32 = 268435456u32;
@@ -1383,9 +1233,6 @@ impl Default for USBUSER_PASS_THRU_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBUSER_PASS_THRU_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USBUSER_POWER_INFO_REQUEST {
@@ -1396,9 +1243,6 @@ impl Default for USBUSER_POWER_INFO_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBUSER_POWER_INFO_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1411,9 +1255,6 @@ impl Default for USBUSER_RAW_RESET_ROOT_PORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBUSER_RAW_RESET_ROOT_PORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USBUSER_REFRESH_HCT_REG {
@@ -1424,9 +1265,6 @@ impl Default for USBUSER_REFRESH_HCT_REG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBUSER_REFRESH_HCT_REG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1441,9 +1279,6 @@ impl Default for USBUSER_REQUEST_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBUSER_REQUEST_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USBUSER_ROOTPORT_FEATURE_REQUEST {
@@ -1454,9 +1289,6 @@ impl Default for USBUSER_ROOTPORT_FEATURE_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBUSER_ROOTPORT_FEATURE_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1469,9 +1301,6 @@ impl Default for USBUSER_ROOTPORT_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBUSER_ROOTPORT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USBUSER_SEND_ONE_PACKET {
@@ -1483,9 +1312,6 @@ impl Default for USBUSER_SEND_ONE_PACKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USBUSER_SEND_ONE_PACKET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USBUSER_SEND_RAW_COMMAND {
@@ -1496,9 +1322,6 @@ impl Default for USBUSER_SEND_RAW_COMMAND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USBUSER_SEND_RAW_COMMAND {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USBUSER_SET_ROOTPORT_FEATURE: u32 = 536870917u32;
 pub const USBUSER_USB_REFRESH_HCT_REG: u32 = 10u32;
@@ -1516,9 +1339,6 @@ impl Default for USB_20_PORT_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_20_PORT_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_20_PORT_CHANGE_0 {
@@ -1528,9 +1348,6 @@ impl Default for USB_20_PORT_CHANGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_20_PORT_CHANGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1543,9 +1360,6 @@ impl Default for USB_20_PORT_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_20_PORT_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_20_PORT_STATUS_0 {
@@ -1555,9 +1369,6 @@ impl Default for USB_20_PORT_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_20_PORT_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_30_ENDPOINT_TYPE_INTERRUPT_RESERVED_MASK: u32 = 204u32;
 pub const USB_30_ENDPOINT_TYPE_INTERRUPT_USAGE_MASK: u32 = 48u32;
@@ -1583,9 +1394,6 @@ impl Default for USB_30_HUB_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_30_HUB_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_30_HUB_DESCRIPTOR_TYPE: u32 = 42u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1598,9 +1406,6 @@ impl Default for USB_30_PORT_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_30_PORT_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_30_PORT_CHANGE_0 {
@@ -1610,9 +1415,6 @@ impl Default for USB_30_PORT_CHANGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_30_PORT_CHANGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1625,9 +1427,6 @@ impl Default for USB_30_PORT_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_30_PORT_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_30_PORT_STATUS_0 {
@@ -1637,9 +1436,6 @@ impl Default for USB_30_PORT_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_30_PORT_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1652,9 +1448,6 @@ impl Default for USB_ACQUIRE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_ACQUIRE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_ALLOW_FIRMWARE_UPDATE: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -1677,9 +1470,6 @@ impl Default for USB_BANDWIDTH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_BANDWIDTH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_BOS_DESCRIPTOR {
@@ -1692,9 +1482,6 @@ impl Default for USB_BOS_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_BOS_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_BOS_DESCRIPTOR_TYPE: u32 = 15u32;
 #[repr(C, packed(1))]
@@ -1709,9 +1496,6 @@ impl Default for USB_BUS_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_BUS_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1737,9 +1521,6 @@ impl Default for USB_BUS_STATISTICS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_BUS_STATISTICS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1771,9 +1552,6 @@ impl Default for USB_CLOSE_RAW_DEVICE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_CLOSE_RAW_DEVICE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USB_COMMON_DESCRIPTOR {
@@ -1784,9 +1562,6 @@ impl Default for USB_COMMON_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_COMMON_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1802,9 +1577,6 @@ impl Default for USB_COMPOSITE_DEVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_COMPOSITE_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USB_COMPOSITE_FUNCTION_INFO {
@@ -1817,9 +1589,6 @@ impl Default for USB_COMPOSITE_FUNCTION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_COMPOSITE_FUNCTION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1837,9 +1606,6 @@ impl Default for USB_CONFIGURATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_CONFIGURATION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_CONFIGURATION_DESCRIPTOR_TYPE: u32 = 2u32;
 #[repr(C, packed(1))]
@@ -1864,9 +1630,6 @@ impl Default for USB_CONFIGURATION_POWER_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_CONFIGURATION_POWER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_CONFIG_BUS_POWERED: u32 = 128u32;
 pub const USB_CONFIG_POWERED_MASK: u32 = 192u32;
 pub const USB_CONFIG_POWER_DESCRIPTOR_TYPE: u32 = 7u32;
@@ -1888,9 +1651,6 @@ impl Default for USB_CONNECTION_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_CONNECTION_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct USB_CONNECTION_STATUS(pub i32);
@@ -1907,9 +1667,6 @@ impl Default for USB_CONTROLLER_DEVICE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_CONTROLLER_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1929,9 +1686,6 @@ impl Default for USB_CONTROLLER_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_CONTROLLER_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_CYCLE_PORT: u32 = 7u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1943,9 +1697,6 @@ impl Default for USB_CYCLE_PORT_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_CYCLE_PORT_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEBUG_DESCRIPTOR_TYPE: u32 = 10u32;
 pub const USB_DEFAULT_DEVICE_ADDRESS: u32 = 0u32;
@@ -1965,9 +1716,6 @@ impl Default for USB_DEFAULT_PIPE_SETUP_PACKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_DEFAULT_PIPE_SETUP_PACKET_1 {
@@ -1978,9 +1726,6 @@ impl Default for USB_DEFAULT_PIPE_SETUP_PACKET_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1993,9 +1738,6 @@ impl Default for USB_DEFAULT_PIPE_SETUP_PACKET_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_DEFAULT_PIPE_SETUP_PACKET_0 {
@@ -2006,9 +1748,6 @@ impl Default for USB_DEFAULT_PIPE_SETUP_PACKET_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2021,9 +1760,6 @@ impl Default for USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEFAULT_PIPE_SETUP_PACKET_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DESCRIPTOR_REQUEST {
@@ -2035,9 +1771,6 @@ impl Default for USB_DESCRIPTOR_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DESCRIPTOR_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2052,9 +1785,6 @@ impl Default for USB_DESCRIPTOR_REQUEST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DESCRIPTOR_REQUEST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CAPABILITY_BATTERY_INFO: u32 = 7u32;
 pub const USB_DEVICE_CAPABILITY_BILLBOARD: u32 = 13u32;
@@ -2077,9 +1807,6 @@ impl Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
@@ -2092,9 +1819,6 @@ impl Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
@@ -2106,9 +1830,6 @@ impl Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0_0 {
@@ -2118,9 +1839,6 @@ impl Default for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_BILLBOARD_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CAPABILITY_CONTAINER_ID: u32 = 4u32;
 #[repr(C)]
@@ -2137,9 +1855,6 @@ impl Default for USB_DEVICE_CAPABILITY_CONTAINER_ID_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_CONTAINER_ID_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USB_DEVICE_CAPABILITY_DESCRIPTOR {
@@ -2151,9 +1866,6 @@ impl Default for USB_DEVICE_CAPABILITY_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CAPABILITY_DESCRIPTOR_TYPE: u32 = 16u32;
 pub const USB_DEVICE_CAPABILITY_FIRMWARE_STATUS: u32 = 17u32;
@@ -2171,9 +1883,6 @@ impl Default for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0 {
@@ -2185,9 +1894,6 @@ impl Default for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0_0 {
@@ -2197,9 +1903,6 @@ impl Default for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_FIRMWARE_STATUS_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CAPABILITY_MAX_U1_LATENCY: u32 = 10u32;
 pub const USB_DEVICE_CAPABILITY_MAX_U2_LATENCY: u32 = 2047u32;
@@ -2224,9 +1927,6 @@ impl Default for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0 {
@@ -2238,9 +1938,6 @@ impl Default for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0_0 {
@@ -2250,9 +1947,6 @@ impl Default for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CAPABILITY_PD_PROVIDER_PORT: u32 = 9u32;
 pub const USB_DEVICE_CAPABILITY_PLATFORM: u32 = 5u32;
@@ -2270,9 +1964,6 @@ impl Default for USB_DEVICE_CAPABILITY_PLATFORM_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_PLATFORM_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CAPABILITY_POWER_DELIVERY: u32 = 6u32;
 #[repr(C, packed(1))]
@@ -2294,9 +1985,6 @@ impl Default for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0 {
@@ -2308,9 +1996,6 @@ impl Default for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0_0 {
@@ -2320,9 +2005,6 @@ impl Default for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_POWER_DELIVERY_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CAPABILITY_PRECISION_TIME_MEASUREMENT: u32 = 11u32;
 #[repr(C, packed(1))]
@@ -2336,9 +2018,6 @@ impl Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_0 {
@@ -2348,9 +2027,6 @@ impl Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_DIR_RX: u32 = 0u32;
 pub const USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_SPEED_DIR_TX: u32 = 1u32;
@@ -2380,9 +2056,6 @@ impl Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0 {
@@ -2394,9 +2067,6 @@ impl Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0_0 {
@@ -2406,9 +2076,6 @@ impl Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2421,9 +2088,6 @@ impl Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1_0 {
@@ -2433,9 +2097,6 @@ impl Default for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_SUPERSPEEDPLUS_USB_DESCRIPTOR_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CAPABILITY_SUPERSPEED_BMATTRIBUTES_LTM_CAPABLE: u32 = 2u32;
 pub const USB_DEVICE_CAPABILITY_SUPERSPEED_BMATTRIBUTES_RESERVED_MASK: u32 = 253u32;
@@ -2464,9 +2125,6 @@ impl Default for USB_DEVICE_CAPABILITY_SUPERSPEED_USB_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_SUPERSPEED_USB_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_DEVICE_CAPABILITY_USB20_EXTENSION: u32 = 2u32;
 pub const USB_DEVICE_CAPABILITY_USB20_EXTENSION_BMATTRIBUTES_RESERVED_MASK: u32 = 4294901985u32;
 #[repr(C)]
@@ -2482,9 +2140,6 @@ impl Default for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0 {
@@ -2496,9 +2151,6 @@ impl Default for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0_0 {
@@ -2508,9 +2160,6 @@ impl Default for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CAPABILITY_USB20_EXTENSION_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CAPABILITY_WIRELESS_USB: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -2526,9 +2175,6 @@ impl Default for USB_DEVICE_CHARACTERISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_CHARACTERISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_DEVICE_CHARACTERISTICS_MAXIMUM_PATH_DELAYS_AVAILABLE: u32 = 1u32;
 pub const USB_DEVICE_CHARACTERISTICS_VERSION_1: u32 = 1u32;
@@ -2578,9 +2224,6 @@ impl Default for USB_DEVICE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_DEVICE_DESCRIPTOR_TYPE: u32 = 1u32;
 pub const USB_DEVICE_FIRMWARE_HASH_LENGTH: u32 = 32u32;
 #[repr(C, packed(1))]
@@ -2606,9 +2249,6 @@ impl Default for USB_DEVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_NODE_INFO {
@@ -2624,9 +2264,6 @@ impl Default for USB_DEVICE_NODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_NODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union USB_DEVICE_NODE_INFO_0 {
@@ -2640,9 +2277,6 @@ impl Default for USB_DEVICE_NODE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_NODE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2676,9 +2310,6 @@ impl Default for USB_DEVICE_PERFORMANCE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_PERFORMANCE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_QUALIFIER_DESCRIPTOR {
@@ -2697,9 +2328,6 @@ impl Default for USB_DEVICE_QUALIFIER_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_QUALIFIER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE: u32 = 6u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2714,9 +2342,6 @@ impl Default for USB_DEVICE_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_DEVICE_STATUS {
@@ -2728,9 +2353,6 @@ impl Default for USB_DEVICE_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DEVICE_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_DEVICE_STATUS_0 {
@@ -2740,9 +2362,6 @@ impl Default for USB_DEVICE_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_DEVICE_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2765,9 +2384,6 @@ impl Default for USB_DRIVER_VERSION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_DRIVER_VERSION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_ENABLE_PORT: u32 = 5u32;
 pub const USB_ENDPOINT_ADDRESS_MASK: u32 = 15u32;
 #[repr(C, packed(1))]
@@ -2785,9 +2401,6 @@ impl Default for USB_ENDPOINT_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_ENDPOINT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_ENDPOINT_DESCRIPTOR_TYPE: u32 = 5u32;
 pub const USB_ENDPOINT_DIRECTION_MASK: u32 = 128u32;
 #[repr(C, packed(1))]
@@ -2801,9 +2414,6 @@ impl Default for USB_ENDPOINT_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_ENDPOINT_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_ENDPOINT_STATUS_0 {
@@ -2813,9 +2423,6 @@ impl Default for USB_ENDPOINT_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_ENDPOINT_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_ENDPOINT_SUPERSPEED_BULK_MAX_PACKET_SIZE: u32 = 1024u32;
 pub const USB_ENDPOINT_SUPERSPEED_CONTROL_MAX_PACKET_SIZE: u32 = 512u32;
@@ -2876,9 +2483,6 @@ impl Default for USB_FRAME_NUMBER_AND_QPC_FOR_TIME_SYNC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_FRAME_NUMBER_AND_QPC_FOR_TIME_SYNC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union USB_FUNCTION_SUSPEND_OPTIONS {
@@ -2890,9 +2494,6 @@ impl Default for USB_FUNCTION_SUSPEND_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_FUNCTION_SUSPEND_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USB_FUNCTION_SUSPEND_OPTIONS_0 {
@@ -2902,9 +2503,6 @@ impl Default for USB_FUNCTION_SUSPEND_OPTIONS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_FUNCTION_SUSPEND_OPTIONS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_GETSTATUS_LTM_ENABLE: u32 = 16u32;
 pub const USB_GETSTATUS_REMOTE_WAKEUP_ENABLED: u32 = 2u32;
@@ -2952,9 +2550,6 @@ impl Default for USB_HCD_DRIVERKEY_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HCD_DRIVERKEY_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_HC_FEATURE_FLAG_PORT_POWER_SWITCHING: u32 = 1u32;
 pub const USB_HC_FEATURE_FLAG_SEL_SUSPEND: u32 = 2u32;
 pub const USB_HC_FEATURE_LEGACY_BIOS: u32 = 4u32;
@@ -2969,9 +2564,6 @@ impl Default for USB_HIGH_SPEED_MAXPACKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HIGH_SPEED_MAXPACKET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_HIGH_SPEED_MAXPACKET_0 {
@@ -2981,9 +2573,6 @@ impl Default for USB_HIGH_SPEED_MAXPACKET_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_HIGH_SPEED_MAXPACKET_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2996,9 +2585,6 @@ impl Default for USB_HUB_30_PORT_REMOTE_WAKE_MASK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_30_PORT_REMOTE_WAKE_MASK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USB_HUB_30_PORT_REMOTE_WAKE_MASK_0 {
@@ -3008,9 +2594,6 @@ impl Default for USB_HUB_30_PORT_REMOTE_WAKE_MASK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_HUB_30_PORT_REMOTE_WAKE_MASK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3022,9 +2605,6 @@ impl Default for USB_HUB_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct USB_HUB_CAPABILITIES_EX {
@@ -3034,9 +2614,6 @@ impl Default for USB_HUB_CAPABILITIES_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_HUB_CAPABILITIES_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3049,9 +2626,6 @@ impl Default for USB_HUB_CAP_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_CAP_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_HUB_CAP_FLAGS_0 {
@@ -3061,9 +2635,6 @@ impl Default for USB_HUB_CAP_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_HUB_CAP_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3076,9 +2647,6 @@ impl Default for USB_HUB_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_HUB_CHANGE_0 {
@@ -3088,9 +2656,6 @@ impl Default for USB_HUB_CHANGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_HUB_CHANGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_HUB_CYCLE_PORT: u32 = 273u32;
 #[repr(C, packed(1))]
@@ -3109,9 +2674,6 @@ impl Default for USB_HUB_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_HUB_DEVICE_INFO {
@@ -3129,9 +2691,6 @@ impl Default for USB_HUB_DEVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_HUB_DEVICE_UXD_SETTINGS {
@@ -3148,9 +2707,6 @@ impl Default for USB_HUB_DEVICE_UXD_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_DEVICE_UXD_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct USB_HUB_INFORMATION {
@@ -3161,9 +2717,6 @@ impl Default for USB_HUB_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_HUB_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3177,9 +2730,6 @@ impl Default for USB_HUB_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union USB_HUB_INFORMATION_EX_0 {
@@ -3191,9 +2741,6 @@ impl Default for USB_HUB_INFORMATION_EX_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_INFORMATION_EX_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_HUB_NAME {
@@ -3204,9 +2751,6 @@ impl Default for USB_HUB_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_HUB_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3225,9 +2769,6 @@ impl Default for USB_HUB_PORT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_PORT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_HUB_STATUS {
@@ -3239,9 +2780,6 @@ impl Default for USB_HUB_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_HUB_STATUS_0 {
@@ -3251,9 +2789,6 @@ impl Default for USB_HUB_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_HUB_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3266,9 +2801,6 @@ impl Default for USB_HUB_STATUS_AND_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_HUB_STATUS_AND_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct USB_HUB_STATUS_AND_CHANGE_0 {
@@ -3279,9 +2811,6 @@ impl Default for USB_HUB_STATUS_AND_CHANGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_HUB_STATUS_AND_CHANGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3299,9 +2828,6 @@ impl Default for USB_IDLE_CALLBACK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_IDLE_CALLBACK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_IDLE_NOTIFICATION: u32 = 9u32;
 pub const USB_IDLE_NOTIFICATION_EX: u32 = 272u32;
 #[repr(C, packed(1))]
@@ -3316,9 +2842,6 @@ impl Default for USB_ID_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_ID_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3336,9 +2859,6 @@ impl Default for USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_INTERFACE_ASSOCIATION_DESCRIPTOR_TYPE: u32 = 11u32;
 #[repr(C)]
@@ -3358,9 +2878,6 @@ impl Default for USB_INTERFACE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_INTERFACE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_INTERFACE_DESCRIPTOR_TYPE: u32 = 4u32;
 #[repr(C, packed(1))]
@@ -3384,9 +2901,6 @@ impl Default for USB_INTERFACE_POWER_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_INTERFACE_POWER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_INTERFACE_POWER_DESCRIPTOR_TYPE: u32 = 8u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3399,9 +2913,6 @@ impl Default for USB_INTERFACE_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_INTERFACE_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_INTERFACE_STATUS_0 {
@@ -3412,9 +2923,6 @@ impl Default for USB_INTERFACE_STATUS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_INTERFACE_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_MI_PARENT_INFORMATION {
@@ -3424,9 +2932,6 @@ impl Default for USB_MI_PARENT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_MI_PARENT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3440,9 +2945,6 @@ impl Default for USB_NODE_CONNECTION_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_NODE_CONNECTION_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_NODE_CONNECTION_DRIVERKEY_NAME {
@@ -3454,9 +2956,6 @@ impl Default for USB_NODE_CONNECTION_DRIVERKEY_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_NODE_CONNECTION_DRIVERKEY_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3476,9 +2975,6 @@ impl Default for USB_NODE_CONNECTION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_NODE_CONNECTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_NODE_CONNECTION_INFORMATION_EX {
@@ -3497,9 +2993,6 @@ impl Default for USB_NODE_CONNECTION_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_NODE_CONNECTION_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_NODE_CONNECTION_INFORMATION_EX_V2 {
@@ -3513,9 +3006,6 @@ impl Default for USB_NODE_CONNECTION_INFORMATION_EX_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_NODE_CONNECTION_INFORMATION_EX_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_NODE_CONNECTION_INFORMATION_EX_V2_FLAGS {
@@ -3527,9 +3017,6 @@ impl Default for USB_NODE_CONNECTION_INFORMATION_EX_V2_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_NODE_CONNECTION_INFORMATION_EX_V2_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_NODE_CONNECTION_INFORMATION_EX_V2_FLAGS_0 {
@@ -3539,9 +3026,6 @@ impl Default for USB_NODE_CONNECTION_INFORMATION_EX_V2_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_NODE_CONNECTION_INFORMATION_EX_V2_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3555,9 +3039,6 @@ impl Default for USB_NODE_CONNECTION_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_NODE_CONNECTION_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_NODE_INFORMATION {
@@ -3568,9 +3049,6 @@ impl Default for USB_NODE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_NODE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3583,9 +3061,6 @@ impl Default for USB_NODE_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_NODE_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_NOTIFICATION {
@@ -3595,9 +3070,6 @@ impl Default for USB_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3613,9 +3085,6 @@ impl Default for USB_OPEN_RAW_DEVICE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_OPEN_RAW_DEVICE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_OTG_DESCRIPTOR_TYPE: u32 = 9u32;
 pub const USB_OTHER_SPEED_CONFIGURATION_DESCRIPTOR_TYPE: u32 = 7u32;
@@ -3641,9 +3110,6 @@ impl Default for USB_PASS_THRU_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_PASS_THRU_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_PIPE_INFO {
@@ -3654,9 +3120,6 @@ impl Default for USB_PIPE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_PIPE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_PORTATTR_MINI_CONNECTOR: u32 = 4u32;
 pub const USB_PORTATTR_NO_CONNECTOR: u32 = 1u32;
@@ -3676,9 +3139,6 @@ impl Default for USB_PORT_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_PORT_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_PORT_CONNECTOR_PROPERTIES {
@@ -3694,9 +3154,6 @@ impl Default for USB_PORT_CONNECTOR_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_PORT_CONNECTOR_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_PORT_EXT_STATUS {
@@ -3708,9 +3165,6 @@ impl Default for USB_PORT_EXT_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_PORT_EXT_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_PORT_EXT_STATUS_0 {
@@ -3720,9 +3174,6 @@ impl Default for USB_PORT_EXT_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_PORT_EXT_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3735,9 +3186,6 @@ impl Default for USB_PORT_EXT_STATUS_AND_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_PORT_EXT_STATUS_AND_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct USB_PORT_EXT_STATUS_AND_CHANGE_0 {
@@ -3748,9 +3196,6 @@ impl Default for USB_PORT_EXT_STATUS_AND_CHANGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_PORT_EXT_STATUS_AND_CHANGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3763,9 +3208,6 @@ impl Default for USB_PORT_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_PORT_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_PORT_PROPERTIES_0 {
@@ -3775,9 +3217,6 @@ impl Default for USB_PORT_PROPERTIES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_PORT_PROPERTIES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3791,9 +3230,6 @@ impl Default for USB_PORT_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_PORT_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_PORT_STATUS_AND_CHANGE {
@@ -3805,9 +3241,6 @@ impl Default for USB_PORT_STATUS_AND_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_PORT_STATUS_AND_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct USB_PORT_STATUS_AND_CHANGE_0 {
@@ -3818,9 +3251,6 @@ impl Default for USB_PORT_STATUS_AND_CHANGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_PORT_STATUS_AND_CHANGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_PORT_STATUS_CONNECT: u32 = 1u32;
 pub const USB_PORT_STATUS_ENABLE: u32 = 2u32;
@@ -3849,9 +3279,6 @@ impl Default for USB_POWER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_POWER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union USB_PROTOCOLS {
@@ -3863,9 +3290,6 @@ impl Default for USB_PROTOCOLS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_PROTOCOLS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_PROTOCOLS_0 {
@@ -3875,9 +3299,6 @@ impl Default for USB_PROTOCOLS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_PROTOCOLS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_RECORD_FAILURE: u32 = 10u32;
 pub const USB_REGISTER_COMPOSITE_DEVICE: u32 = 0u32;
@@ -3924,9 +3345,6 @@ impl Default for USB_ROOT_HUB_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_ROOT_HUB_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_SEND_RAW_COMMAND_PARAMETERS {
@@ -3947,9 +3365,6 @@ impl Default for USB_SEND_RAW_COMMAND_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_SEND_RAW_COMMAND_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_START_TRACKING_FOR_TIME_SYNC: u32 = 285u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3961,9 +3376,6 @@ impl Default for USB_START_TRACKING_FOR_TIME_SYNC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_START_TRACKING_FOR_TIME_SYNC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_STATUS_EXT_PORT_STATUS: u32 = 2u32;
 pub const USB_STATUS_PD_STATUS: u32 = 1u32;
@@ -3979,9 +3391,6 @@ impl Default for USB_STOP_TRACKING_FOR_TIME_SYNC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_STOP_TRACKING_FOR_TIME_SYNC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_STRING_DESCRIPTOR {
@@ -3993,9 +3402,6 @@ impl Default for USB_STRING_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_STRING_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_STRING_DESCRIPTOR_TYPE: u32 = 3u32;
 pub const USB_SUBMIT_URB: u32 = 0u32;
@@ -4014,9 +3420,6 @@ impl Default for USB_SUPERSPEEDPLUS_ISOCH_ENDPOINT_COMPANION_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_SUPERSPEEDPLUS_ISOCH_ENDPOINT_COMPANION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_SUPERSPEEDPLUS_ISOCH_ENDPOINT_COMPANION_DESCRIPTOR_TYPE: u32 = 49u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -4032,9 +3435,6 @@ impl Default for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0 {
@@ -4047,9 +3447,6 @@ impl Default for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_0 {
@@ -4060,9 +3457,6 @@ impl Default for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_1 {
@@ -4072,9 +3466,6 @@ impl Default for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_SUPERSPEED_ENDPOINT_COMPANION_DESCRIPTOR_TYPE: u32 = 48u32;
 pub const USB_SUPERSPEED_ISOCHRONOUS_MAX_MULTIPLIER: u32 = 2u32;
@@ -4105,9 +3496,6 @@ impl Default for USB_TOPOLOGY_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_TOPOLOGY_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_TRANSPORT_CHARACTERISTICS {
@@ -4121,9 +3509,6 @@ impl Default for USB_TRANSPORT_CHARACTERISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_TRANSPORT_CHARACTERISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_TRANSPORT_CHARACTERISTICS_BANDWIDTH_AVAILABLE: u32 = 2u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -4135,9 +3520,6 @@ impl Default for USB_TRANSPORT_CHARACTERISTICS_CHANGE_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_TRANSPORT_CHARACTERISTICS_CHANGE_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -4151,9 +3533,6 @@ impl Default for USB_TRANSPORT_CHARACTERISTICS_CHANGE_REGISTRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_TRANSPORT_CHARACTERISTICS_CHANGE_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct USB_TRANSPORT_CHARACTERISTICS_CHANGE_UNREGISTRATION {
@@ -4163,9 +3542,6 @@ impl Default for USB_TRANSPORT_CHARACTERISTICS_CHANGE_UNREGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_TRANSPORT_CHARACTERISTICS_CHANGE_UNREGISTRATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USB_TRANSPORT_CHARACTERISTICS_LATENCY_AVAILABLE: u32 = 1u32;
 pub const USB_TRANSPORT_CHARACTERISTICS_VERSION_1: u32 = 1u32;
@@ -4180,9 +3556,6 @@ impl Default for USB_UNICODE_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USB_UNICODE_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USB_UNREGISTER_COMPOSITE_DEVICE: u32 = 1u32;
 pub const USB_UNREGISTER_FOR_TRANSPORT_CHARACTERISTICS_CHANGE: u32 = 284u32;
 #[repr(C, packed(1))]
@@ -4194,9 +3567,6 @@ impl Default for USB_USB2HW_VERSION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USB_USB2HW_VERSION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4315,9 +3685,6 @@ impl Default for WINUSB_PIPE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINUSB_PIPE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINUSB_PIPE_INFORMATION_EX {
@@ -4331,9 +3698,6 @@ impl Default for WINUSB_PIPE_INFORMATION_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINUSB_PIPE_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4354,9 +3718,6 @@ impl Default for WINUSB_SETUP_PACKET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINUSB_SETUP_PACKET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMI_USB_DEVICE_NODE_INFORMATION: u32 = 2u32;
 pub const WMI_USB_DRIVER_INFORMATION: u32 = 0u32;
@@ -4396,9 +3757,6 @@ impl Default for _URB_BULK_OR_INTERRUPT_TRANSFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_BULK_OR_INTERRUPT_TRANSFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_CONTROL_DESCRIPTOR_REQUEST {
@@ -4421,9 +3779,6 @@ impl Default for _URB_CONTROL_DESCRIPTOR_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_CONTROL_DESCRIPTOR_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_CONTROL_FEATURE_REQUEST {
@@ -4445,9 +3800,6 @@ impl Default for _URB_CONTROL_FEATURE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_CONTROL_FEATURE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_CONTROL_GET_CONFIGURATION_REQUEST {
@@ -4465,9 +3817,6 @@ impl Default for _URB_CONTROL_GET_CONFIGURATION_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _URB_CONTROL_GET_CONFIGURATION_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4489,9 +3838,6 @@ impl Default for _URB_CONTROL_GET_INTERFACE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_CONTROL_GET_INTERFACE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_CONTROL_GET_STATUS_REQUEST {
@@ -4512,9 +3858,6 @@ impl Default for _URB_CONTROL_GET_STATUS_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_CONTROL_GET_STATUS_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_CONTROL_TRANSFER {
@@ -4533,9 +3876,6 @@ impl Default for _URB_CONTROL_TRANSFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_CONTROL_TRANSFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_CONTROL_TRANSFER_EX {
@@ -4553,9 +3893,6 @@ impl Default for _URB_CONTROL_TRANSFER_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _URB_CONTROL_TRANSFER_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4579,9 +3916,6 @@ impl Default for _URB_CONTROL_VENDOR_OR_CLASS_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_CONTROL_VENDOR_OR_CLASS_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_FRAME_LENGTH_CONTROL {
@@ -4591,9 +3925,6 @@ impl Default for _URB_FRAME_LENGTH_CONTROL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _URB_FRAME_LENGTH_CONTROL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4606,9 +3937,6 @@ impl Default for _URB_GET_CURRENT_FRAME_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_GET_CURRENT_FRAME_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_GET_FRAME_LENGTH {
@@ -4620,9 +3948,6 @@ impl Default for _URB_GET_FRAME_LENGTH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _URB_GET_FRAME_LENGTH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4637,9 +3962,6 @@ impl Default for _URB_GET_ISOCH_PIPE_TRANSFER_PATH_DELAYS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_GET_ISOCH_PIPE_TRANSFER_PATH_DELAYS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_HCD_AREA {
@@ -4649,9 +3971,6 @@ impl Default for _URB_HCD_AREA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _URB_HCD_AREA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4666,9 +3985,6 @@ impl Default for _URB_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _URB_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4691,9 +4007,6 @@ impl Default for _URB_ISOCH_TRANSFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_ISOCH_TRANSFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_OPEN_STATIC_STREAMS {
@@ -4708,9 +4021,6 @@ impl Default for _URB_OPEN_STATIC_STREAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _URB_OPEN_STATIC_STREAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4735,9 +4045,6 @@ impl Default for _URB_OS_FEATURE_DESCRIPTOR_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_OS_FEATURE_DESCRIPTOR_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_PIPE_REQUEST {
@@ -4749,9 +4056,6 @@ impl Default for _URB_PIPE_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _URB_PIPE_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4766,9 +4070,6 @@ impl Default for _URB_SELECT_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_SELECT_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_SELECT_INTERFACE {
@@ -4781,9 +4082,6 @@ impl Default for _URB_SELECT_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _URB_SELECT_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _URB_SET_FRAME_LENGTH {
@@ -4794,7 +4092,4 @@ impl Default for _URB_SET_FRAME_LENGTH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _URB_SET_FRAME_LENGTH {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/mod.rs
@@ -3331,9 +3331,6 @@ impl Default for REQUESTBODY_GetStatus {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REQUESTBODY_GetStatus {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REQUESTBODY_Renew {
@@ -3344,9 +3341,6 @@ impl Default for REQUESTBODY_Renew {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REQUESTBODY_Renew {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3362,9 +3356,6 @@ impl Default for REQUESTBODY_Subscribe {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REQUESTBODY_Subscribe {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REQUESTBODY_Unsubscribe {
@@ -3375,9 +3366,6 @@ impl Default for REQUESTBODY_Unsubscribe {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REQUESTBODY_Unsubscribe {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RESPONSEBODY_GetMetadata {
@@ -3387,9 +3375,6 @@ impl Default for RESPONSEBODY_GetMetadata {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESPONSEBODY_GetMetadata {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3402,9 +3387,6 @@ impl Default for RESPONSEBODY_GetStatus {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESPONSEBODY_GetStatus {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RESPONSEBODY_Renew {
@@ -3415,9 +3397,6 @@ impl Default for RESPONSEBODY_Renew {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESPONSEBODY_Renew {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3431,9 +3410,6 @@ impl Default for RESPONSEBODY_Subscribe {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESPONSEBODY_Subscribe {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RESPONSEBODY_SubscriptionEnd {
@@ -3446,9 +3422,6 @@ impl Default for RESPONSEBODY_SubscriptionEnd {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESPONSEBODY_SubscriptionEnd {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SecureDirectedDiscovery: DeviceDiscoveryMechanism = DeviceDiscoveryMechanism(2i32);
 pub const TWO_WAY: WSDUdpMessageType = WSDUdpMessageType(1i32);
@@ -3489,9 +3462,6 @@ impl Default for WSDUdpRetransmitParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSDUdpRetransmitParams {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSDXML_ATTRIBUTE {
@@ -3504,9 +3474,6 @@ impl Default for WSDXML_ATTRIBUTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSDXML_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3522,9 +3489,6 @@ impl Default for WSDXML_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSDXML_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSDXML_ELEMENT_LIST {
@@ -3536,9 +3500,6 @@ impl Default for WSDXML_ELEMENT_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSDXML_ELEMENT_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSDXML_NAME {
@@ -3549,9 +3510,6 @@ impl Default for WSDXML_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSDXML_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3566,9 +3524,6 @@ impl Default for WSDXML_NAMESPACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSDXML_NAMESPACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3586,9 +3541,6 @@ impl Default for WSDXML_NODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSDXML_NODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WSDXML_OP(pub i32);
@@ -3605,9 +3557,6 @@ impl Default for WSDXML_PREFIX_MAPPING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSDXML_PREFIX_MAPPING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSDXML_TEXT {
@@ -3619,9 +3568,6 @@ impl Default for WSDXML_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSDXML_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSDXML_TYPE {
@@ -3632,9 +3578,6 @@ impl Default for WSDXML_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSDXML_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3648,9 +3591,6 @@ impl Default for WSD_APP_SEQUENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_APP_SEQUENCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_BYE {
@@ -3662,9 +3602,6 @@ impl Default for WSD_BYE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_BYE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_CONFIG_ADDRESSES {
@@ -3675,9 +3612,6 @@ impl Default for WSD_CONFIG_ADDRESSES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_CONFIG_ADDRESSES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSD_CONFIG_DEVICE_ADDRESSES: WSD_CONFIG_PARAM_TYPE = WSD_CONFIG_PARAM_TYPE(10i32);
 pub const WSD_CONFIG_HOSTING_ADDRESSES: WSD_CONFIG_PARAM_TYPE = WSD_CONFIG_PARAM_TYPE(9i32);
@@ -3694,9 +3628,6 @@ impl Default for WSD_CONFIG_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_CONFIG_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3722,9 +3653,6 @@ impl Default for WSD_DATETIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_DATETIME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WSD_DEFAULT_EVENTING_ADDRESS: windows_core::PCWSTR = windows_core::w!("http://*:5357/");
 pub const WSD_DEFAULT_HOSTING_ADDRESS: windows_core::PCWSTR = windows_core::w!("http://*:5357/");
 pub const WSD_DEFAULT_SECURE_HOSTING_ADDRESS: windows_core::PCWSTR = windows_core::w!("https://*:5358/");
@@ -3745,9 +3673,6 @@ impl Default for WSD_DURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_DURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_ENDPOINT_REFERENCE {
@@ -3763,9 +3688,6 @@ impl Default for WSD_ENDPOINT_REFERENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_ENDPOINT_REFERENCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_ENDPOINT_REFERENCE_LIST {
@@ -3776,9 +3698,6 @@ impl Default for WSD_ENDPOINT_REFERENCE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_ENDPOINT_REFERENCE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -3796,9 +3715,6 @@ impl Default for WSD_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_EVENTING_DELIVERY_MODE {
@@ -3811,9 +3727,6 @@ impl Default for WSD_EVENTING_DELIVERY_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_EVENTING_DELIVERY_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_EVENTING_DELIVERY_MODE_PUSH {
@@ -3823,9 +3736,6 @@ impl Default for WSD_EVENTING_DELIVERY_MODE_PUSH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_EVENTING_DELIVERY_MODE_PUSH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3837,9 +3747,6 @@ impl Default for WSD_EVENTING_EXPIRES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_EVENTING_EXPIRES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3853,9 +3760,6 @@ impl Default for WSD_EVENTING_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_EVENTING_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_EVENTING_FILTER_ACTION {
@@ -3865,9 +3769,6 @@ impl Default for WSD_EVENTING_FILTER_ACTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_EVENTING_FILTER_ACTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -3881,9 +3782,6 @@ impl Default for WSD_HANDLER_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_HANDLER_CONTEXT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_HEADER_RELATESTO {
@@ -3894,9 +3792,6 @@ impl Default for WSD_HEADER_RELATESTO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_HEADER_RELATESTO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3913,9 +3808,6 @@ impl Default for WSD_HELLO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_HELLO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_HOST_METADATA {
@@ -3926,9 +3818,6 @@ impl Default for WSD_HOST_METADATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_HOST_METADATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3941,9 +3830,6 @@ impl Default for WSD_LOCALIZED_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_LOCALIZED_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_LOCALIZED_STRING_LIST {
@@ -3954,9 +3840,6 @@ impl Default for WSD_LOCALIZED_STRING_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_LOCALIZED_STRING_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3973,9 +3856,6 @@ impl Default for WSD_METADATA_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_METADATA_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_METADATA_SECTION_LIST {
@@ -3986,9 +3866,6 @@ impl Default for WSD_METADATA_SECTION_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_METADATA_SECTION_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4001,9 +3878,6 @@ impl Default for WSD_NAME_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_NAME_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_OPERATION {
@@ -4015,9 +3889,6 @@ impl Default for WSD_OPERATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_OPERATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4032,9 +3903,6 @@ impl Default for WSD_PORT_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_PORT_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_PROBE {
@@ -4046,9 +3914,6 @@ impl Default for WSD_PROBE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_PROBE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4065,9 +3930,6 @@ impl Default for WSD_PROBE_MATCH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_PROBE_MATCH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_PROBE_MATCHES {
@@ -4079,9 +3941,6 @@ impl Default for WSD_PROBE_MATCHES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_PROBE_MATCHES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_PROBE_MATCH_LIST {
@@ -4092,9 +3951,6 @@ impl Default for WSD_PROBE_MATCH_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_PROBE_MATCH_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4114,9 +3970,6 @@ impl Default for WSD_REFERENCE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_REFERENCE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_REFERENCE_PROPERTIES {
@@ -4126,9 +3979,6 @@ impl Default for WSD_REFERENCE_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_REFERENCE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4142,9 +3992,6 @@ impl Default for WSD_RELATIONSHIP_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_RELATIONSHIP_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_RESOLVE {
@@ -4155,9 +4002,6 @@ impl Default for WSD_RESOLVE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_RESOLVE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4174,9 +4018,6 @@ impl Default for WSD_RESOLVE_MATCH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_RESOLVE_MATCH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_RESOLVE_MATCHES {
@@ -4188,9 +4029,6 @@ impl Default for WSD_RESOLVE_MATCHES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_RESOLVE_MATCHES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_SCOPES {
@@ -4201,9 +4039,6 @@ impl Default for WSD_SCOPES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_SCOPES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -4224,10 +4059,6 @@ impl Default for WSD_SECURITY_CERT_VALIDATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WSD_SECURITY_CERT_VALIDATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4243,10 +4074,6 @@ impl Default for WSD_SECURITY_CERT_VALIDATION_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WSD_SECURITY_CERT_VALIDATION_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSD_SECURITY_COMPACTSIG_SIGNING_CERT: WSD_CONFIG_PARAM_TYPE = WSD_CONFIG_PARAM_TYPE(7i32);
 pub const WSD_SECURITY_COMPACTSIG_VALIDATION: WSD_CONFIG_PARAM_TYPE = WSD_CONFIG_PARAM_TYPE(8i32);
@@ -4269,10 +4096,6 @@ impl Default for WSD_SECURITY_SIGNATURE_VALIDATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WSD_SECURITY_SIGNATURE_VALIDATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WSD_SECURITY_SSL_CERT_FOR_CLIENT_AUTH: WSD_CONFIG_PARAM_TYPE = WSD_CONFIG_PARAM_TYPE(3i32);
 pub const WSD_SECURITY_SSL_CLIENT_CERT_VALIDATION: WSD_CONFIG_PARAM_TYPE = WSD_CONFIG_PARAM_TYPE(5i32);
 pub const WSD_SECURITY_SSL_NEGOTIATE_CLIENT_CERT: WSD_CONFIG_PARAM_TYPE = WSD_CONFIG_PARAM_TYPE(6i32);
@@ -4291,9 +4114,6 @@ impl Default for WSD_SERVICE_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_SERVICE_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_SERVICE_METADATA_LIST {
@@ -4304,9 +4124,6 @@ impl Default for WSD_SERVICE_METADATA_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_SERVICE_METADATA_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4322,9 +4139,6 @@ impl Default for WSD_SOAP_FAULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_SOAP_FAULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_SOAP_FAULT_CODE {
@@ -4336,9 +4150,6 @@ impl Default for WSD_SOAP_FAULT_CODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_SOAP_FAULT_CODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_SOAP_FAULT_REASON {
@@ -4348,9 +4159,6 @@ impl Default for WSD_SOAP_FAULT_REASON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_SOAP_FAULT_REASON {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4362,9 +4170,6 @@ impl Default for WSD_SOAP_FAULT_SUBCODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_SOAP_FAULT_SUBCODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4384,9 +4189,6 @@ impl Default for WSD_SOAP_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_SOAP_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_SOAP_MESSAGE {
@@ -4398,9 +4200,6 @@ impl Default for WSD_SOAP_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_SOAP_MESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub type WSD_STUB_FUNCTION = Option<unsafe extern "system" fn(server: Option<windows_core::IUnknown>, session: Option<IWSDServiceMessaging>, event: *mut WSD_EVENT) -> windows_core::HRESULT>;
 #[repr(C)]
@@ -4416,9 +4215,6 @@ impl Default for WSD_SYNCHRONOUS_RESPONSE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_SYNCHRONOUS_RESPONSE_CONTEXT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_THIS_DEVICE_METADATA {
@@ -4431,9 +4227,6 @@ impl Default for WSD_THIS_DEVICE_METADATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_THIS_DEVICE_METADATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4451,9 +4244,6 @@ impl Default for WSD_THIS_MODEL_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSD_THIS_MODEL_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSD_UNKNOWN_LOOKUP {
@@ -4463,9 +4253,6 @@ impl Default for WSD_UNKNOWN_LOOKUP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_UNKNOWN_LOOKUP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4477,7 +4264,4 @@ impl Default for WSD_URI_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSD_URI_LIST {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/mod.rs
@@ -82,9 +82,6 @@ impl Default for IEEE1394_API_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IEEE1394_API_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IEEE1394_API_REQUEST_0 {
@@ -95,9 +92,6 @@ impl Default for IEEE1394_API_REQUEST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IEEE1394_API_REQUEST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IEEE1394_API_SET_LOCAL_NODE_PROPERTIES: u32 = 4u32;
 pub const IEEE1394_REQUEST_FLAG_PERSISTENT: u32 = 2u32;
@@ -115,8 +109,5 @@ impl Default for IEEE1394_VDEV_PNP_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IEEE1394_VDEV_PNP_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IOCTL_IEEE1394_API_REQUEST: u32 = 2229248u32;

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -165,9 +165,6 @@ impl Default for APP_LOCAL_DEVICE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APP_LOCAL_DEVICE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const APP_LOCAL_DEVICE_ID_SIZE: u32 = 32u32;
 #[must_use]
 #[repr(transparent)]
@@ -776,9 +773,6 @@ impl Default for DECIMAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DECIMAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DECIMAL_0 {
@@ -789,9 +783,6 @@ impl Default for DECIMAL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DECIMAL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -804,9 +795,6 @@ impl Default for DECIMAL_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DECIMAL_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DECIMAL_1 {
@@ -817,9 +805,6 @@ impl Default for DECIMAL_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DECIMAL_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -832,9 +817,6 @@ impl Default for DECIMAL_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DECIMAL_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVPROPKEY {
@@ -845,9 +827,6 @@ impl Default for DEVPROPKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVPROPKEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIGSIG_E_CRYPTO: windows_core::HRESULT = windows_core::HRESULT(0x800B0008_u32 as _);
 pub const DIGSIG_E_DECODE: windows_core::HRESULT = windows_core::HRESULT(0x800B0006_u32 as _);
@@ -4966,9 +4945,6 @@ impl Default for FILETIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILETIME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILTER_E_ALREADY_OPEN: windows_core::HRESULT = windows_core::HRESULT(0x80041736_u32 as _);
 pub const FILTER_E_CONTENTINDEXCORRUPT: windows_core::HRESULT = windows_core::HRESULT(0xC0041734_u32 as _);
 pub const FILTER_E_IN_USE: windows_core::HRESULT = windows_core::HRESULT(0x80041738_u32 as _);
@@ -4994,9 +4970,6 @@ impl Default for FLOAT128 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLOAT128 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FRS_ERR_AUTHENTICATION: i32 = 8008i32;
 pub const FRS_ERR_CHILD_TO_PARENT_COMM: i32 = 8011i32;
@@ -5923,9 +5896,6 @@ impl Default for LUID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LUID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MARSHAL_E_FIRST: i32 = -2147221216i32;
 pub const MARSHAL_E_LAST: i32 = -2147221201i32;
 pub const MARSHAL_S_FIRST: i32 = 262432i32;
@@ -6499,9 +6469,6 @@ impl Default for POINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POINTL {
@@ -6513,9 +6480,6 @@ impl Default for POINTL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POINTL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POINTS {
@@ -6526,9 +6490,6 @@ impl Default for POINTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POINTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRESENTATION_ERROR_LOST: windows_core::HRESULT = windows_core::HRESULT(0x88810001_u32 as _);
 pub type PROC = Option<unsafe extern "system" fn() -> isize>;
@@ -6542,9 +6503,6 @@ impl Default for PROPERTYKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROPERTYKEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PSINK_E_INDEX_ONLY: windows_core::HRESULT = windows_core::HRESULT(0x80041791_u32 as _);
 pub const PSINK_E_LARGE_ATTACHMENT: windows_core::HRESULT = windows_core::HRESULT(0x80041792_u32 as _);
@@ -6618,9 +6576,6 @@ impl Default for RECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RECTL {
@@ -6633,9 +6588,6 @@ impl Default for RECTL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RECTL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REGDB_E_BADTHREADINGMODEL: windows_core::HRESULT = windows_core::HRESULT(0x80040156_u32 as _);
 pub const REGDB_E_CLASSNOTREG: windows_core::HRESULT = windows_core::HRESULT(0x80040154_u32 as _);
@@ -7091,9 +7043,6 @@ impl Default for SIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIZE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPAPI_E_AUTHENTICODE_DISALLOWED: windows_core::HRESULT = windows_core::HRESULT(0x800F0240_u32 as _);
 pub const SPAPI_E_AUTHENTICODE_PUBLISHER_NOT_TRUSTED: windows_core::HRESULT = windows_core::HRESULT(0x800F0243_u32 as _);
@@ -10085,9 +10034,6 @@ impl Default for SYSTEMTIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEMTIME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const S_APPLICATION_ACTIVATION_ERROR_HANDLED_BY_DIALOG: windows_core::HRESULT = windows_core::HRESULT(0x270259_u32 as _);
 pub const S_FALSE: windows_core::HRESULT = windows_core::HRESULT(0x1_u32 as _);
 pub const S_OK: windows_core::HRESULT = windows_core::HRESULT(0x0_u32 as _);
@@ -10553,9 +10499,6 @@ impl Default for UNICODE_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UNICODE_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UTC_E_ACTION_NOT_SUPPORTED_IN_DESTINATION: windows_core::HRESULT = windows_core::HRESULT(0x87C51044_u32 as _);
 pub const UTC_E_AGENT_DIAGNOSTICS_TOO_LARGE: windows_core::HRESULT = windows_core::HRESULT(0x87C51055_u32 as _);

--- a/crates/libs/windows/src/Windows/Win32/Gaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Gaming/mod.rs
@@ -250,9 +250,6 @@ impl Default for GAMING_DEVICE_MODEL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GAMING_DEVICE_MODEL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct GAMING_DEVICE_VENDOR_ID(pub i32);

--- a/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
@@ -7135,9 +7135,6 @@ impl Default for CALDATETIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CALDATETIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CALDATETIME_DATEUNIT(pub i32);
@@ -7238,9 +7235,6 @@ impl Default for CHARSETINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHARSETINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CMLangConvertCharset: windows_core::GUID = windows_core::GUID::from_u128(0xd66d6f99_cdaa_11d0_b822_00c04fc9b31f);
 pub const CMLangString: windows_core::GUID = windows_core::GUID::from_u128(0xc04d65cf_b70d_11d0_b188_00aa0038c969);
 pub const CMultiLanguage: windows_core::GUID = windows_core::GUID::from_u128(0x275c23e2_3747_11d0_9fea_00aa003f8646);
@@ -7305,9 +7299,6 @@ impl Default for CPINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CPINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CPINFOEXA {
@@ -7323,9 +7314,6 @@ impl Default for CPINFOEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CPINFOEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CPINFOEXW {
@@ -7340,9 +7328,6 @@ impl Default for CPINFOEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CPINFOEXW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CPIOD_FORCE_PROMPT: i32 = -2147483648i32;
 pub const CPIOD_PEEK: i32 = 1073741824i32;
@@ -7490,9 +7475,6 @@ impl Default for CURRENCYFMTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CURRENCYFMTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CURRENCYFMTW {
@@ -7509,9 +7491,6 @@ impl Default for CURRENCYFMTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CURRENCYFMTW {
-    type TypeKind = windows_core::CopyType;
 }
 pub type DATEFMT_ENUMPROCA = Option<unsafe extern "system" fn(param0: windows_core::PCSTR) -> super::Foundation::BOOL>;
 pub type DATEFMT_ENUMPROCEXA = Option<unsafe extern "system" fn(param0: windows_core::PCSTR, param1: u32) -> super::Foundation::BOOL>;
@@ -7540,9 +7519,6 @@ impl Default for DetectEncodingInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DetectEncodingInfo {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ELS_GUID_LANGUAGE_DETECTION: windows_core::GUID = windows_core::GUID::from_u128(0xcf7e00b1_909b_4d95_a8f4_611f7c377702);
 pub const ELS_GUID_SCRIPT_DETECTION: windows_core::GUID = windows_core::GUID::from_u128(0x2d64b439_6caf_4f6b_b688_e5d0f4faa7d7);
 pub const ELS_GUID_TRANSLITERATION_BENGALI_TO_LATIN: windows_core::GUID = windows_core::GUID::from_u128(0xf4dfd825_91a4_489f_855e_9ad9bee55727);
@@ -7565,10 +7541,6 @@ impl Default for ENUMTEXTMETRICA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ENUMTEXTMETRICA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7581,10 +7553,6 @@ impl Default for ENUMTEXTMETRICW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ENUMTEXTMETRICW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENUM_ALL_CALENDARS: u32 = 4294967295u32;
 #[repr(transparent)]
@@ -7618,9 +7586,6 @@ impl Default for FILEMUIINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILEMUIINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FIND_ENDSWITH: u32 = 2097152u32;
 pub const FIND_FROMEND: u32 = 8388608u32;
@@ -7673,9 +7638,6 @@ impl Default for FONTSIGNATURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FONTSIGNATURE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GEOCLASS_ALL: SYSGEOCLASS = SYSGEOCLASS(0i32);
 pub const GEOCLASS_NATION: SYSGEOCLASS = SYSGEOCLASS(16i32);
 pub const GEOCLASS_REGION: SYSGEOCLASS = SYSGEOCLASS(14i32);
@@ -7710,9 +7672,6 @@ impl Default for GOFFSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GOFFSET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GSS_ALLOW_INHERITED_COMMON: u32 = 1u32;
 pub const HIGHLEVEL_SERVICE_TYPES: u32 = 1u32;
@@ -10625,9 +10584,6 @@ impl Default for LOCALESIGNATURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOCALESIGNATURE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LOCALE_ALL: u32 = 0u32;
 pub const LOCALE_ALLOW_NEUTRAL_NAMES: u32 = 134217728u32;
 pub const LOCALE_ALTERNATE_SORTS: u32 = 4u32;
@@ -10827,9 +10783,6 @@ impl Default for MAPPING_DATA_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MAPPING_DATA_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MAPPING_ENUM_OPTIONS {
@@ -10848,9 +10801,6 @@ impl Default for MAPPING_ENUM_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MAPPING_ENUM_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10877,9 +10827,6 @@ impl Default for MAPPING_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MAPPING_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MAPPING_PROPERTY_BAG {
@@ -10896,9 +10843,6 @@ impl Default for MAPPING_PROPERTY_BAG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MAPPING_PROPERTY_BAG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10933,9 +10877,6 @@ impl Default for MAPPING_SERVICE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MAPPING_SERVICE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MAP_COMPOSITE: FOLD_STRING_MAP_FLAGS = FOLD_STRING_MAP_FLAGS(64u32);
 pub const MAP_EXPAND_LIGATURES: FOLD_STRING_MAP_FLAGS = FOLD_STRING_MAP_FLAGS(8192u32);
@@ -10989,9 +10930,6 @@ impl Default for MIMECPINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIMECPINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIMECSETINFO {
@@ -11003,9 +10941,6 @@ impl Default for MIMECSETINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIMECSETINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIN_SPELLING_NTDDI: u32 = 100794368u32;
 #[repr(transparent)]
@@ -11127,10 +11062,6 @@ impl Default for NEWTEXTMETRICEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NEWTEXTMETRICEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11143,10 +11074,6 @@ impl Default for NEWTEXTMETRICEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NEWTEXTMETRICEXW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11162,9 +11089,6 @@ impl Default for NLSVERSIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NLSVERSIONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NLSVERSIONINFOEX {
@@ -11178,9 +11102,6 @@ impl Default for NLSVERSIONINFOEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NLSVERSIONINFOEX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NLS_CP_CPINFO: u32 = 268435456u32;
 pub const NLS_CP_MBTOWC: u32 = 1073741824u32;
@@ -11209,9 +11130,6 @@ impl Default for NUMBERFMTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NUMBERFMTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NUMBERFMTW {
@@ -11226,9 +11144,6 @@ impl Default for NUMBERFMTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NUMBERFMTW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NUMSYS_NAME_CAPACITY: u32 = 8u32;
 pub const NormalizationC: NORM_FORM = NORM_FORM(1i32);
@@ -11249,9 +11164,6 @@ impl Default for OPENTYPE_FEATURE_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPENTYPE_FEATURE_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 pub type PFN_MAPPINGCALLBACKPROC = Option<unsafe extern "system" fn(pbag: *mut MAPPING_PROPERTY_BAG, data: *mut core::ffi::c_void, dwdatasize: u32, result: windows_core::HRESULT)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11264,9 +11176,6 @@ impl Default for RFC1766INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RFC1766INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11290,9 +11199,6 @@ impl Default for SCRIPTFONTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCRIPTFONTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCRIPTINFO {
@@ -11307,9 +11213,6 @@ impl Default for SCRIPTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCRIPTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCRIPT_ANALYSIS {
@@ -11321,9 +11224,6 @@ impl Default for SCRIPT_ANALYSIS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCRIPT_ANALYSIS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCRIPT_CHARPROP {
@@ -11334,9 +11234,6 @@ impl Default for SCRIPT_CHARPROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCRIPT_CHARPROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCRIPT_CONTROL {
@@ -11346,9 +11243,6 @@ impl Default for SCRIPT_CONTROL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCRIPT_CONTROL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11361,9 +11255,6 @@ impl Default for SCRIPT_DIGITSUBSTITUTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCRIPT_DIGITSUBSTITUTE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCRIPT_DIGITSUBSTITUTE_CONTEXT: u32 = 0u32;
 pub const SCRIPT_DIGITSUBSTITUTE_NATIONAL: u32 = 2u32;
@@ -11384,9 +11275,6 @@ impl Default for SCRIPT_FONTPROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCRIPT_FONTPROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCRIPT_GLYPHPROP {
@@ -11397,9 +11285,6 @@ impl Default for SCRIPT_GLYPHPROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCRIPT_GLYPHPROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11414,9 +11299,6 @@ impl Default for SCRIPT_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCRIPT_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11447,9 +11329,6 @@ impl Default for SCRIPT_LOGATTR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCRIPT_LOGATTR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCRIPT_PROPERTIES {
@@ -11461,9 +11340,6 @@ impl Default for SCRIPT_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCRIPT_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCRIPT_STATE {
@@ -11473,9 +11349,6 @@ impl Default for SCRIPT_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCRIPT_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11490,9 +11363,6 @@ impl Default for SCRIPT_TABDEF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCRIPT_TABDEF {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCRIPT_TAG_UNKNOWN: u32 = 0u32;
 pub const SCRIPT_UNDEFINED: u32 = 0u32;
 #[repr(C)]
@@ -11504,9 +11374,6 @@ impl Default for SCRIPT_VISATTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCRIPT_VISATTR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SGCM_RTL: u32 = 1u32;
 pub const SIC_ASCIIDIGIT: SCRIPT_IS_COMPLEX_FLAGS = SCRIPT_IS_COMPLEX_FLAGS(2u32);
@@ -11562,9 +11429,6 @@ impl Default for TEXTRANGE_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TEXTRANGE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub type TIMEFMT_ENUMPROCA = Option<unsafe extern "system" fn(param0: windows_core::PCSTR) -> super::Foundation::BOOL>;
 pub type TIMEFMT_ENUMPROCEX = Option<unsafe extern "system" fn(param0: windows_core::PCWSTR, param1: super::Foundation::LPARAM) -> super::Foundation::BOOL>;
@@ -12393,9 +12257,6 @@ impl Default for UCPTrie {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UCPTrie {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union UCPTrieData {
@@ -12408,9 +12269,6 @@ impl Default for UCPTrieData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UCPTrieData {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12495,9 +12353,6 @@ impl Default for UCharIterator {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UCharIterator {
-    type TypeKind = windows_core::CopyType;
 }
 pub type UCharIteratorCurrent = Option<unsafe extern "system" fn(iter: *mut UCharIterator) -> i32>;
 pub type UCharIteratorGetIndex = Option<unsafe extern "system" fn(iter: *mut UCharIterator, origin: UCharIteratorOrigin) -> i32>;
@@ -12590,9 +12445,6 @@ impl Default for UConverterFromUnicodeArgs {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UConverterFromUnicodeArgs {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct UConverterPlatform(pub i32);
@@ -12619,9 +12471,6 @@ impl Default for UConverterToUnicodeArgs {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UConverterToUnicodeArgs {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12968,9 +12817,6 @@ impl Default for UFieldPosition {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UFieldPosition {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct UFieldPositionIterator(pub isize);
@@ -13060,9 +12906,6 @@ impl Default for UIDNAInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UIDNAInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UIDNA_CHECK_BIDI: i32 = 4i32;
 pub const UIDNA_CHECK_CONTEXTJ: i32 = 8i32;
@@ -13282,9 +13125,6 @@ impl Default for UNICODERANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UNICODERANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UNISCRIBE_OPENTYPE: u32 = 256u32;
 pub const UNORM2_COMPOSE: UNormalization2Mode = UNormalization2Mode(0i32);
@@ -13545,9 +13385,6 @@ impl Default for UParseError {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UParseError {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct UPluralRules(pub isize);
@@ -13632,9 +13469,6 @@ impl Default for UReplaceableCallbacks {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UReplaceableCallbacks {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13947,9 +13781,6 @@ impl Default for USerializedSet {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USerializedSet {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct USet(pub isize);
@@ -14128,9 +13959,6 @@ impl Default for UText {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UText {
-    type TypeKind = windows_core::CopyType;
-}
 pub type UTextAccess = Option<unsafe extern "system" fn(ut: *mut UText, nativeindex: i64, forward: i8) -> i8>;
 pub type UTextClone = Option<unsafe extern "system" fn(dest: *mut UText, src: *const UText, deep: i8, status: *mut UErrorCode) -> *mut UText>;
 pub type UTextClose = Option<unsafe extern "system" fn(ut: *mut UText)>;
@@ -14160,9 +13988,6 @@ impl Default for UTextFuncs {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UTextFuncs {
-    type TypeKind = windows_core::CopyType;
 }
 pub type UTextMapNativeIndexToUTF16 = Option<unsafe extern "system" fn(ut: *const UText, nativeindex: i64) -> i32>;
 pub type UTextMapOffsetToNative = Option<unsafe extern "system" fn(ut: *const UText) -> i64>;
@@ -14213,9 +14038,6 @@ impl Default for UTransPosition {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UTransPosition {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
@@ -27,10 +27,6 @@ impl Default for CompositionFrameDisplayInstance {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for CompositionFrameDisplayInstance {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CompositionFrameInstanceKind(pub i32);
@@ -757,9 +753,6 @@ impl Default for PresentationTransform {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PresentationTransform {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SystemInterruptTime {
@@ -769,7 +762,4 @@ impl Default for SystemInterruptTime {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SystemInterruptTime {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
@@ -30,9 +30,6 @@ impl Default for DXCoreAdapterMemoryBudget {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXCoreAdapterMemoryBudget {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXCoreAdapterMemoryBudgetNodeSegmentGroup {
@@ -43,9 +40,6 @@ impl Default for DXCoreAdapterMemoryBudgetNodeSegmentGroup {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXCoreAdapterMemoryBudgetNodeSegmentGroup {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -69,9 +63,6 @@ impl Default for DXCoreHardwareID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXCoreHardwareID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXCoreHardwareIDParts {
@@ -85,9 +76,6 @@ impl Default for DXCoreHardwareIDParts {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXCoreHardwareIDParts {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
@@ -26,9 +26,6 @@ impl Default for D2D1_BEZIER_SEGMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_BEZIER_SEGMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_BLEND_MODE(pub i32);
@@ -81,9 +78,6 @@ impl Default for D2D1_COLOR_F {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_COLOR_F {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_COMPOSITE_MODE(pub i32);
@@ -125,9 +119,6 @@ impl Default for D2D1_GRADIENT_STOP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_GRADIENT_STOP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -181,10 +172,6 @@ impl Default for D2D1_PIXEL_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D2D1_PIXEL_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_TURBULENCE_NOISE(pub i32);
@@ -203,9 +190,6 @@ impl Default for D2D_COLOR_F {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D_COLOR_F {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D2D_MATRIX_4X3_F {
@@ -215,9 +199,6 @@ impl Default for D2D_MATRIX_4X3_F {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D_MATRIX_4X3_F {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -229,9 +210,6 @@ impl Default for D2D_MATRIX_4X3_F_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D_MATRIX_4X3_F_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -254,9 +232,6 @@ impl Default for D2D_MATRIX_4X3_F_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D_MATRIX_4X3_F_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D2D_MATRIX_4X4_F {
@@ -266,9 +241,6 @@ impl Default for D2D_MATRIX_4X4_F {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D_MATRIX_4X4_F {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -280,9 +252,6 @@ impl Default for D2D_MATRIX_4X4_F_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D_MATRIX_4X4_F_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -309,9 +278,6 @@ impl Default for D2D_MATRIX_4X4_F_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D_MATRIX_4X4_F_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D2D_MATRIX_5X4_F {
@@ -321,9 +287,6 @@ impl Default for D2D_MATRIX_5X4_F {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D_MATRIX_5X4_F {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -335,9 +298,6 @@ impl Default for D2D_MATRIX_5X4_F_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D_MATRIX_5X4_F_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -368,9 +328,6 @@ impl Default for D2D_MATRIX_5X4_F_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D_MATRIX_5X4_F_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D2D_POINT_2F {
@@ -382,9 +339,6 @@ impl Default for D2D_POINT_2F {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D_POINT_2F {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D2D_POINT_2U {
@@ -395,9 +349,6 @@ impl Default for D2D_POINT_2U {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D_POINT_2U {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -412,9 +363,6 @@ impl Default for D2D_RECT_F {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D_RECT_F {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D2D_RECT_U {
@@ -428,9 +376,6 @@ impl Default for D2D_RECT_U {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D_RECT_U {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D2D_SIZE_F {
@@ -441,9 +386,6 @@ impl Default for D2D_SIZE_F {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D_SIZE_F {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -456,9 +398,6 @@ impl Default for D2D_SIZE_U {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D_SIZE_U {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D2D_VECTOR_2F {
@@ -469,9 +408,6 @@ impl Default for D2D_VECTOR_2F {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D_VECTOR_2F {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -485,9 +421,6 @@ impl Default for D2D_VECTOR_3F {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D_VECTOR_3F {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D2D_VECTOR_4F {
@@ -500,9 +433,6 @@ impl Default for D2D_VECTOR_4F {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D_VECTOR_4F {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(ID2D1SimplifiedGeometrySink, ID2D1SimplifiedGeometrySink_Vtbl, 0x2cd9069e_12e2_11dc_9fed_001143a055f9);
 windows_core::imp::interface_hierarchy!(ID2D1SimplifiedGeometrySink, windows_core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
@@ -230,10 +230,6 @@ impl Default for D2D1_ARC_SEGMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_ARC_SEGMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_ARC_SIZE(pub i32);
@@ -294,9 +290,6 @@ impl Default for D2D1_BITMAP_BRUSH_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_BITMAP_BRUSH_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D2D1_BITMAP_BRUSH_PROPERTIES1 {
@@ -308,9 +301,6 @@ impl Default for D2D1_BITMAP_BRUSH_PROPERTIES1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_BITMAP_BRUSH_PROPERTIES1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -372,10 +362,6 @@ impl Default for D2D1_BITMAP_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D2D1_BITMAP_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -391,10 +377,6 @@ impl Default for D2D1_BITMAP_PROPERTIES1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D2D1_BITMAP_PROPERTIES1 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -415,9 +397,6 @@ impl Default for D2D1_BLEND_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_BLEND_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D2D1_BLEND_DEST_ALPHA: D2D1_BLEND = D2D1_BLEND(7i32);
 pub const D2D1_BLEND_DEST_COLOR: D2D1_BLEND = D2D1_BLEND(9i32);
@@ -471,10 +450,6 @@ impl Default for D2D1_BRUSH_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Foundation_Numerics")]
-impl windows_core::TypeKind for D2D1_BRUSH_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -696,9 +671,6 @@ impl Default for D2D1_CREATION_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_CREATION_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_CROP_PROP(pub i32);
@@ -723,10 +695,6 @@ impl Default for D2D1_CUSTOM_VERTEX_BUFFER_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D2D1_CUSTOM_VERTEX_BUFFER_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -889,10 +857,6 @@ impl Default for D2D1_DRAWING_STATE_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Foundation_Numerics")]
-impl windows_core::TypeKind for D2D1_DRAWING_STATE_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Foundation_Numerics")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -910,10 +874,6 @@ impl Default for D2D1_DRAWING_STATE_DESCRIPTION1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Foundation_Numerics")]
-impl windows_core::TypeKind for D2D1_DRAWING_STATE_DESCRIPTION1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -983,10 +943,6 @@ impl Default for D2D1_EFFECT_INPUT_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_EFFECT_INPUT_DESCRIPTION {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1000,10 +956,6 @@ impl Default for D2D1_ELLIPSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_ELLIPSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1030,9 +982,6 @@ impl Default for D2D1_FACTORY_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_FACTORY_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_FACTORY_TYPE(pub i32);
@@ -1052,9 +1001,6 @@ impl Default for D2D1_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D2D1_FEATURE_DATA_DOUBLES {
@@ -1064,9 +1010,6 @@ impl Default for D2D1_FEATURE_DATA_DOUBLES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_FEATURE_DATA_DOUBLES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D2D1_FEATURE_DOUBLES: D2D1_FEATURE = D2D1_FEATURE(0i32);
 #[repr(transparent)]
@@ -1182,10 +1125,6 @@ impl Default for D2D1_GRADIENT_MESH_PATCH {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_GRADIENT_MESH_PATCH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_HDRTONEMAP_DISPLAY_MODE(pub i32);
@@ -1243,10 +1182,6 @@ impl Default for D2D1_HWND_RENDER_TARGET_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_HWND_RENDER_TARGET_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1261,10 +1196,6 @@ impl Default for D2D1_IMAGE_BRUSH_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_IMAGE_BRUSH_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1355,9 +1286,6 @@ impl Default for D2D1_INK_BEZIER_SEGMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_INK_BEZIER_SEGMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_INK_NIB_SHAPE(pub i32);
@@ -1375,9 +1303,6 @@ impl Default for D2D1_INK_POINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_INK_POINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Foundation_Numerics")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1391,10 +1316,6 @@ impl Default for D2D1_INK_STYLE_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Foundation_Numerics")]
-impl windows_core::TypeKind for D2D1_INK_STYLE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D2D1_INPUT_DESCRIPTION {
@@ -1405,9 +1326,6 @@ impl Default for D2D1_INPUT_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_INPUT_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -1424,10 +1342,6 @@ impl Default for D2D1_INPUT_ELEMENT_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D2D1_INPUT_ELEMENT_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1544,10 +1458,6 @@ impl Default for D2D1_LAYER_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-impl windows_core::TypeKind for D2D1_LAYER_PARAMETERS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -1565,10 +1475,6 @@ impl Default for D2D1_LAYER_PARAMETERS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
-impl windows_core::TypeKind for D2D1_LAYER_PARAMETERS1 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1599,10 +1505,6 @@ impl Default for D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_LINE_JOIN(pub i32);
@@ -1625,9 +1527,6 @@ impl Default for D2D1_MAPPED_RECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_MAPPED_RECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1802,10 +1701,6 @@ impl Default for D2D1_POINT_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_POINT_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_POSTERIZE_PROP(pub i32);
@@ -1871,9 +1766,6 @@ impl Default for D2D1_PRINT_CONTROL_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_PRINT_CONTROL_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_PRINT_FONT_SUBSET_MODE(pub i32);
@@ -1895,9 +1787,6 @@ impl Default for D2D1_PROPERTY_BINDING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_PROPERTY_BINDING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D2D1_PROPERTY_CACHED: D2D1_PROPERTY = D2D1_PROPERTY(-2147483642i32);
 pub const D2D1_PROPERTY_CATEGORY: D2D1_PROPERTY = D2D1_PROPERTY(-2147483645i32);
@@ -1943,10 +1832,6 @@ impl Default for D2D1_QUADRATIC_BEZIER_SEGMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_QUADRATIC_BEZIER_SEGMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1962,10 +1847,6 @@ impl Default for D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1978,10 +1859,6 @@ impl Default for D2D1_RENDERING_CONTROLS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_RENDERING_CONTROLS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2004,10 +1881,6 @@ impl Default for D2D1_RENDER_TARGET_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D2D1_RENDER_TARGET_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2069,9 +1942,6 @@ impl Default for D2D1_RESOURCE_TEXTURE_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_RESOURCE_TEXTURE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_RGBTOHUE_OUTPUT_COLOR_SPACE(pub i32);
@@ -2094,10 +1964,6 @@ impl Default for D2D1_ROUNDED_RECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_ROUNDED_RECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2158,10 +2024,6 @@ impl Default for D2D1_SIMPLE_COLOR_PROFILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_SIMPLE_COLOR_PROFILE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2274,9 +2136,6 @@ impl Default for D2D1_STROKE_STYLE_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_STROKE_STYLE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D2D1_STROKE_STYLE_PROPERTIES1 {
@@ -2293,9 +2152,6 @@ impl Default for D2D1_STROKE_STYLE_PROPERTIES1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_STROKE_STYLE_PROPERTIES1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2369,9 +2225,6 @@ impl Default for D2D1_SVG_LENGTH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_SVG_LENGTH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_SVG_LENGTH_UNITS(pub i32);
@@ -2438,9 +2291,6 @@ impl Default for D2D1_SVG_PRESERVE_ASPECT_RATIO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_SVG_PRESERVE_ASPECT_RATIO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D2D1_SVG_UNIT_TYPE(pub i32);
@@ -2458,9 +2308,6 @@ impl Default for D2D1_SVG_VIEWBOX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_SVG_VIEWBOX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2562,9 +2409,6 @@ impl Default for D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2578,10 +2422,6 @@ impl Default for D2D1_TRIANGLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for D2D1_TRIANGLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2610,9 +2450,6 @@ impl Default for D2D1_VERTEX_BUFFER_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_VERTEX_BUFFER_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2664,9 +2501,6 @@ impl Default for D2D1_VERTEX_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D2D1_VERTEX_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/mod.rs
@@ -83,9 +83,6 @@ impl Default for DxcArgPair {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DxcArgPair {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DxcBuffer {
@@ -97,9 +94,6 @@ impl Default for DxcBuffer {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DxcBuffer {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
 pub type DxcCreateInstance2Proc = Option<unsafe extern "system" fn(pmalloc: Option<super::super::super::System::Com::IMalloc>, rclsid: *const windows_core::GUID, riid: *const windows_core::GUID, ppv: *mut *mut core::ffi::c_void) -> windows_core::HRESULT>;
@@ -115,9 +109,6 @@ impl Default for DxcDefine {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DxcDefine {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DxcShaderHash {
@@ -128,9 +119,6 @@ impl Default for DxcShaderHash {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DxcShaderHash {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DxcValidatorFlags_Default: u32 = 0u32;
 pub const DxcValidatorFlags_InPlaceEdit: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Fxc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Fxc/mod.rs
@@ -282,9 +282,6 @@ impl Default for D3D_SHADER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D_SHADER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub type pD3DCompile = Option<unsafe extern "system" fn(psrcdata: *const core::ffi::c_void, srcdatasize: usize, pfilename: windows_core::PCSTR, pdefines: *const super::D3D_SHADER_MACRO, pinclude: Option<super::ID3DInclude>, pentrypoint: windows_core::PCSTR, ptarget: windows_core::PCSTR, flags1: u32, flags2: u32, ppcode: *mut Option<super::ID3DBlob>, pperrormsgs: *mut Option<super::ID3DBlob>) -> windows_core::HRESULT>;
 pub type pD3DDisassemble = Option<unsafe extern "system" fn(psrcdata: *const core::ffi::c_void, srcdatasize: usize, flags: u32, szcomments: windows_core::PCSTR, ppdisassembly: *mut Option<super::ID3DBlob>) -> windows_core::HRESULT>;
 pub type pD3DPreprocess = Option<unsafe extern "system" fn(psrcdata: *const core::ffi::c_void, srcdatasize: usize, pfilename: windows_core::PCSTR, pdefines: *const super::D3D_SHADER_MACRO, pinclude: Option<super::ID3DInclude>, ppcodetext: *mut Option<super::ID3DBlob>, pperrormsgs: *mut Option<super::ID3DBlob>) -> windows_core::HRESULT>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
@@ -318,9 +318,6 @@ impl Default for D3DVECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D_CBF_USERPACKED: D3D_SHADER_CBUFFER_FLAGS = D3D_SHADER_CBUFFER_FLAGS(1i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -609,9 +606,6 @@ impl Default for D3D_SHADER_MACRO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D_SHADER_MACRO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
@@ -287,9 +287,6 @@ impl Default for D3D10_BLEND_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_BLEND_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_BLEND_DESC1 {
@@ -301,9 +298,6 @@ impl Default for D3D10_BLEND_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_BLEND_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_BLEND_DEST_ALPHA: D3D10_BLEND = D3D10_BLEND(7i32);
 pub const D3D10_BLEND_DEST_COLOR: D3D10_BLEND = D3D10_BLEND(9i32);
@@ -344,9 +338,6 @@ impl Default for D3D10_BOX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_BOX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_BREAKON_CATEGORY: windows_core::PCWSTR = windows_core::w!("BreakOn_CATEGORY_%s");
 pub const D3D10_BREAKON_ID_DECIMAL: windows_core::PCWSTR = windows_core::w!("BreakOn_ID_%d");
 pub const D3D10_BREAKON_ID_STRING: windows_core::PCWSTR = windows_core::w!("BreakOn_ID_%s");
@@ -365,9 +356,6 @@ impl Default for D3D10_BUFFER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_BUFFER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D10_BUFFER_RTV {
@@ -378,9 +366,6 @@ impl Default for D3D10_BUFFER_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_BUFFER_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -393,9 +378,6 @@ impl Default for D3D10_BUFFER_RTV_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_BUFFER_RTV_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D10_BUFFER_RTV_1 {
@@ -406,9 +388,6 @@ impl Default for D3D10_BUFFER_RTV_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_BUFFER_RTV_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -421,9 +400,6 @@ impl Default for D3D10_BUFFER_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_BUFFER_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D10_BUFFER_SRV_0 {
@@ -435,9 +411,6 @@ impl Default for D3D10_BUFFER_SRV_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_BUFFER_SRV_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D10_BUFFER_SRV_1 {
@@ -448,9 +421,6 @@ impl Default for D3D10_BUFFER_SRV_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_BUFFER_SRV_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_CENTER_MULTISAMPLE_PATTERN: D3D10_STANDARD_MULTISAMPLE_QUALITY_LEVELS = D3D10_STANDARD_MULTISAMPLE_QUALITY_LEVELS(-2i32);
 pub const D3D10_CLEAR_DEPTH: D3D10_CLEAR_FLAG = D3D10_CLEAR_FLAG(1i32);
@@ -528,9 +498,6 @@ impl Default for D3D10_COUNTER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_COUNTER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_COUNTER_DEVICE_DEPENDENT_0: D3D10_COUNTER = D3D10_COUNTER(1073741824i32);
 pub const D3D10_COUNTER_FILLRATE_THROUGHPUT_UTILIZATION: D3D10_COUNTER = D3D10_COUNTER(9i32);
 pub const D3D10_COUNTER_GEOMETRY_PROCESSING: D3D10_COUNTER = D3D10_COUNTER(2i32);
@@ -549,9 +516,6 @@ impl Default for D3D10_COUNTER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_COUNTER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_COUNTER_LOCAL_VIDMEM_BANDWIDTH_UTILIZATION: D3D10_COUNTER = D3D10_COUNTER(6i32);
 pub const D3D10_COUNTER_OTHER_GPU_PROCESSING: D3D10_COUNTER = D3D10_COUNTER(4i32);
@@ -637,9 +601,6 @@ impl Default for D3D10_DEPTH_STENCILOP_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_DEPTH_STENCILOP_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_DEPTH_STENCIL_DESC {
@@ -657,9 +618,6 @@ impl Default for D3D10_DEPTH_STENCIL_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_DEPTH_STENCIL_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -673,10 +631,6 @@ impl Default for D3D10_DEPTH_STENCIL_VIEW_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D10_DEPTH_STENCIL_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -694,10 +648,6 @@ impl Default for D3D10_DEPTH_STENCIL_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D10_DEPTH_STENCIL_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -766,9 +716,6 @@ impl Default for D3D10_EFFECT_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_EFFECT_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_EFFECT_SHADER_DESC {
@@ -784,9 +731,6 @@ impl Default for D3D10_EFFECT_SHADER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_EFFECT_SHADER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_EFFECT_SINGLE_THREADED: u32 = 8u32;
 #[repr(C)]
@@ -810,10 +754,6 @@ impl Default for D3D10_EFFECT_TYPE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D10_EFFECT_TYPE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_EFFECT_VARIABLE_ANNOTATION: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -829,9 +769,6 @@ impl Default for D3D10_EFFECT_VARIABLE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_EFFECT_VARIABLE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_EFFECT_VARIABLE_EXPLICIT_BIND_POINT: u32 = 4u32;
 pub const D3D10_EFFECT_VARIABLE_POOLED: u32 = 1u32;
@@ -958,9 +895,6 @@ impl Default for D3D10_INFO_QUEUE_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_INFO_QUEUE_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_INFO_QUEUE_FILTER_DESC {
@@ -975,9 +909,6 @@ impl Default for D3D10_INFO_QUEUE_FILTER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_INFO_QUEUE_FILTER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1000,10 +931,6 @@ impl Default for D3D10_INPUT_ELEMENT_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D10_INPUT_ELEMENT_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_INPUT_PER_INSTANCE_DATA: D3D10_INPUT_CLASSIFICATION = D3D10_INPUT_CLASSIFICATION(1i32);
 pub const D3D10_INPUT_PER_VERTEX_DATA: D3D10_INPUT_CLASSIFICATION = D3D10_INPUT_CLASSIFICATION(0i32);
 pub const D3D10_INTEGER_DIVIDE_BY_ZERO_QUOTIENT: u32 = 4294967295u32;
@@ -1024,9 +951,6 @@ impl Default for D3D10_MAPPED_TEXTURE2D {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_MAPPED_TEXTURE2D {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_MAPPED_TEXTURE3D {
@@ -1038,9 +962,6 @@ impl Default for D3D10_MAPPED_TEXTURE3D {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_MAPPED_TEXTURE3D {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1070,9 +991,6 @@ impl Default for D3D10_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_MESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1638,9 +1556,6 @@ impl Default for D3D10_PASS_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_PASS_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct D3D10_PASS_SHADER_DESC {
@@ -1651,9 +1566,6 @@ impl Default for D3D10_PASS_SHADER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_PASS_SHADER_DESC {
-    type TypeKind = windows_core::CloneType;
 }
 pub const D3D10_PIXEL_ADDRESS_RANGE_BIT_COUNT: u32 = 13u32;
 pub const D3D10_PRE_SCISSOR_PIXEL_ADDRESS_RANGE_BIT_COUNT: u32 = 15u32;
@@ -1693,9 +1605,6 @@ impl Default for D3D10_QUERY_DATA_PIPELINE_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_QUERY_DATA_PIPELINE_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_QUERY_DATA_SO_STATISTICS {
@@ -1706,9 +1615,6 @@ impl Default for D3D10_QUERY_DATA_SO_STATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_QUERY_DATA_SO_STATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1721,9 +1627,6 @@ impl Default for D3D10_QUERY_DATA_TIMESTAMP_DISJOINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_QUERY_DATA_TIMESTAMP_DISJOINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_QUERY_DESC {
@@ -1734,9 +1637,6 @@ impl Default for D3D10_QUERY_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_QUERY_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_QUERY_EVENT: D3D10_QUERY = D3D10_QUERY(0i32);
 #[repr(transparent)]
@@ -1773,9 +1673,6 @@ impl Default for D3D10_RASTERIZER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_RASTERIZER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_REGKEY_PATH: windows_core::PCWSTR = windows_core::w!("Software\\Microsoft\\Direct3D");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1794,9 +1691,6 @@ impl Default for D3D10_RENDER_TARGET_BLEND_DESC1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_RENDER_TARGET_BLEND_DESC1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -1810,10 +1704,6 @@ impl Default for D3D10_RENDER_TARGET_VIEW_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D10_RENDER_TARGET_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -1833,10 +1723,6 @@ impl Default for D3D10_RENDER_TARGET_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D10_RENDER_TARGET_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_REQ_BLEND_OBJECT_COUNT_PER_CONTEXT: u32 = 4096u32;
 pub const D3D10_REQ_BUFFER_RESOURCE_TEXEL_COUNT_2_TO_EXP: u32 = 27u32;
@@ -1909,9 +1795,6 @@ impl Default for D3D10_SAMPLER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_SAMPLER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_SDK_LAYERS_VERSION: u32 = 11u32;
 pub const D3D10_SDK_VERSION: u32 = 29u32;
 pub const D3D10_SHADER_AVOID_FLOW_CONTROL: u32 = 512u32;
@@ -1931,10 +1814,6 @@ impl Default for D3D10_SHADER_BUFFER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D10_SHADER_BUFFER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_SHADER_DEBUG: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1948,9 +1827,6 @@ impl Default for D3D10_SHADER_DEBUG_FILE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_SHADER_DEBUG_FILE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1982,9 +1858,6 @@ impl Default for D3D10_SHADER_DEBUG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_SHADER_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_SHADER_DEBUG_INPUT_INFO {
@@ -1999,9 +1872,6 @@ impl Default for D3D10_SHADER_DEBUG_INPUT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_SHADER_DEBUG_INPUT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2022,9 +1892,6 @@ impl Default for D3D10_SHADER_DEBUG_INST_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_SHADER_DEBUG_INST_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_SHADER_DEBUG_NAME_FOR_BINARY: u32 = 8388608u32;
 pub const D3D10_SHADER_DEBUG_NAME_FOR_SOURCE: u32 = 4194304u32;
 #[repr(C)]
@@ -2043,9 +1910,6 @@ impl Default for D3D10_SHADER_DEBUG_OUTPUTREG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_SHADER_DEBUG_OUTPUTREG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_SHADER_DEBUG_OUTPUTVAR {
@@ -2063,9 +1927,6 @@ impl Default for D3D10_SHADER_DEBUG_OUTPUTVAR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_SHADER_DEBUG_OUTPUTVAR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2106,10 +1967,6 @@ impl Default for D3D10_SHADER_DEBUG_SCOPEVAR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D10_SHADER_DEBUG_SCOPEVAR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_SHADER_DEBUG_SCOPE_ANNOTATION: D3D10_SHADER_DEBUG_SCOPETYPE = D3D10_SHADER_DEBUG_SCOPETYPE(7i32);
 pub const D3D10_SHADER_DEBUG_SCOPE_BLOCK: D3D10_SHADER_DEBUG_SCOPETYPE = D3D10_SHADER_DEBUG_SCOPETYPE(1i32);
 pub const D3D10_SHADER_DEBUG_SCOPE_FORLOOP: D3D10_SHADER_DEBUG_SCOPETYPE = D3D10_SHADER_DEBUG_SCOPETYPE(2i32);
@@ -2129,9 +1986,6 @@ impl Default for D3D10_SHADER_DEBUG_SCOPE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_SHADER_DEBUG_SCOPE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_SHADER_DEBUG_SCOPE_NAMESPACE: D3D10_SHADER_DEBUG_SCOPETYPE = D3D10_SHADER_DEBUG_SCOPETYPE(6i32);
 pub const D3D10_SHADER_DEBUG_SCOPE_STATEBLOCK: D3D10_SHADER_DEBUG_SCOPETYPE = D3D10_SHADER_DEBUG_SCOPETYPE(5i32);
 pub const D3D10_SHADER_DEBUG_SCOPE_STRUCT: D3D10_SHADER_DEBUG_SCOPETYPE = D3D10_SHADER_DEBUG_SCOPETYPE(3i32);
@@ -2148,9 +2002,6 @@ impl Default for D3D10_SHADER_DEBUG_TOKEN_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_SHADER_DEBUG_TOKEN_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2172,10 +2023,6 @@ impl Default for D3D10_SHADER_DEBUG_VAR_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D10_SHADER_DEBUG_VAR_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_SHADER_DEBUG_VAR_VARIABLE: D3D10_SHADER_DEBUG_VARTYPE = D3D10_SHADER_DEBUG_VARTYPE(0i32);
 #[repr(C)]
@@ -2217,10 +2064,6 @@ impl Default for D3D10_SHADER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D10_SHADER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_SHADER_ENABLE_BACKWARDS_COMPATIBILITY: u32 = 4096u32;
 pub const D3D10_SHADER_ENABLE_STRICTNESS: u32 = 2048u32;
 pub const D3D10_SHADER_FLAGS2_FORCE_ROOT_SIGNATURE_1_0: u32 = 16u32;
@@ -2248,10 +2091,6 @@ impl Default for D3D10_SHADER_INPUT_BIND_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D10_SHADER_INPUT_BIND_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_SHADER_MAJOR_VERSION: u32 = 4u32;
 pub const D3D10_SHADER_MINOR_VERSION: u32 = 0u32;
 pub const D3D10_SHADER_NO_PRESHADER: u32 = 256u32;
@@ -2277,10 +2116,6 @@ impl Default for D3D10_SHADER_RESOURCE_VIEW_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D10_SHADER_RESOURCE_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 #[derive(Clone, Copy)]
@@ -2301,10 +2136,6 @@ impl Default for D3D10_SHADER_RESOURCE_VIEW_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D10_SHADER_RESOURCE_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 #[derive(Clone, Copy)]
@@ -2318,10 +2149,6 @@ impl Default for D3D10_SHADER_RESOURCE_VIEW_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D10_SHADER_RESOURCE_VIEW_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -2344,10 +2171,6 @@ impl Default for D3D10_SHADER_RESOURCE_VIEW_DESC1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D10_SHADER_RESOURCE_VIEW_DESC1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_SHADER_SKIP_OPTIMIZATION: u32 = 4u32;
 pub const D3D10_SHADER_SKIP_VALIDATION: u32 = 2u32;
 #[repr(C)]
@@ -2368,10 +2191,6 @@ impl Default for D3D10_SHADER_TYPE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D10_SHADER_TYPE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_SHADER_VARIABLE_DESC {
@@ -2385,9 +2204,6 @@ impl Default for D3D10_SHADER_VARIABLE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_SHADER_VARIABLE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_SHADER_WARNINGS_ARE_ERRORS: u32 = 262144u32;
 pub const D3D10_SHIFT_INSTRUCTION_PAD_VALUE: u32 = 0u32;
@@ -2410,10 +2226,6 @@ impl Default for D3D10_SIGNATURE_PARAMETER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D10_SIGNATURE_PARAMETER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_SIMULTANEOUS_RENDER_TARGET_COUNT: u32 = 8u32;
 pub const D3D10_SO_BUFFER_MAX_STRIDE_IN_BYTES: u32 = 2048u32;
 pub const D3D10_SO_BUFFER_MAX_WRITE_WINDOW_IN_BYTES: u32 = 256u32;
@@ -2432,9 +2244,6 @@ impl Default for D3D10_SO_DECLARATION_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_SO_DECLARATION_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_SO_MULTIPLE_BUFFER_ELEMENTS_PER_BUFFER: u32 = 1u32;
 pub const D3D10_SO_SINGLE_BUFFER_COMPONENT_LIMIT: u32 = 64u32;
@@ -2490,9 +2299,6 @@ impl Default for D3D10_STATE_BLOCK_MASK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_STATE_BLOCK_MASK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D10_STENCIL_OP(pub i32);
@@ -2517,9 +2323,6 @@ impl Default for D3D10_SUBRESOURCE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_SUBRESOURCE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D10_SUBTEXEL_FRACTIONAL_BIT_COUNT: u32 = 6u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2533,9 +2336,6 @@ impl Default for D3D10_TECHNIQUE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TECHNIQUE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX1D_ARRAY_DSV {
@@ -2548,9 +2348,6 @@ impl Default for D3D10_TEX1D_ARRAY_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX1D_ARRAY_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX1D_ARRAY_RTV {
@@ -2562,9 +2359,6 @@ impl Default for D3D10_TEX1D_ARRAY_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_TEX1D_ARRAY_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2579,9 +2373,6 @@ impl Default for D3D10_TEX1D_ARRAY_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX1D_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX1D_DSV {
@@ -2592,9 +2383,6 @@ impl Default for D3D10_TEX1D_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX1D_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX1D_RTV {
@@ -2604,9 +2392,6 @@ impl Default for D3D10_TEX1D_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_TEX1D_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2619,9 +2404,6 @@ impl Default for D3D10_TEX1D_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX1D_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX2DMS_ARRAY_DSV {
@@ -2632,9 +2414,6 @@ impl Default for D3D10_TEX2DMS_ARRAY_DSV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_TEX2DMS_ARRAY_DSV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2647,9 +2426,6 @@ impl Default for D3D10_TEX2DMS_ARRAY_RTV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX2DMS_ARRAY_RTV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX2DMS_ARRAY_SRV {
@@ -2661,9 +2437,6 @@ impl Default for D3D10_TEX2DMS_ARRAY_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX2DMS_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX2DMS_DSV {
@@ -2673,9 +2446,6 @@ impl Default for D3D10_TEX2DMS_DSV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_TEX2DMS_DSV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2687,9 +2457,6 @@ impl Default for D3D10_TEX2DMS_RTV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX2DMS_RTV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX2DMS_SRV {
@@ -2699,9 +2466,6 @@ impl Default for D3D10_TEX2DMS_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_TEX2DMS_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2715,9 +2479,6 @@ impl Default for D3D10_TEX2D_ARRAY_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX2D_ARRAY_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX2D_ARRAY_RTV {
@@ -2729,9 +2490,6 @@ impl Default for D3D10_TEX2D_ARRAY_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_TEX2D_ARRAY_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2746,9 +2504,6 @@ impl Default for D3D10_TEX2D_ARRAY_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX2D_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX2D_DSV {
@@ -2758,9 +2513,6 @@ impl Default for D3D10_TEX2D_DSV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_TEX2D_DSV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2772,9 +2524,6 @@ impl Default for D3D10_TEX2D_RTV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX2D_RTV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX2D_SRV {
@@ -2785,9 +2534,6 @@ impl Default for D3D10_TEX2D_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_TEX2D_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2801,9 +2547,6 @@ impl Default for D3D10_TEX3D_RTV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEX3D_RTV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEX3D_SRV {
@@ -2814,9 +2557,6 @@ impl Default for D3D10_TEX3D_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_TEX3D_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2831,9 +2571,6 @@ impl Default for D3D10_TEXCUBE_ARRAY_SRV1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D10_TEXCUBE_ARRAY_SRV1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D10_TEXCUBE_SRV {
@@ -2844,9 +2581,6 @@ impl Default for D3D10_TEXCUBE_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_TEXCUBE_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_TEXEL_ADDRESS_RANGE_BIT_COUNT: u32 = 18u32;
 #[repr(C)]
@@ -2867,10 +2601,6 @@ impl Default for D3D10_TEXTURE1D_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D10_TEXTURE1D_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -2893,10 +2623,6 @@ impl Default for D3D10_TEXTURE2D_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D10_TEXTURE2D_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2916,10 +2642,6 @@ impl Default for D3D10_TEXTURE3D_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D10_TEXTURE3D_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2962,9 +2684,6 @@ impl Default for D3D10_VIEWPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D10_VIEWPORT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D10_VIEWPORT_AND_SCISSORRECT_MAX_INDEX: u32 = 15u32;
 pub const D3D10_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE: u32 = 16u32;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -148,9 +148,6 @@ impl Default for D3D11_AES_CTR_IV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AES_CTR_IV {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_ANISOTROPIC_FILTERING_BIT: u32 = 64u32;
 pub const D3D11_APPEND_ALIGNED_ELEMENT: u32 = 4294967295u32;
 pub const D3D11_APPNAME_STRING: windows_core::PCWSTR = windows_core::w!("Name");
@@ -177,9 +174,6 @@ impl Default for D3D11_AUTHENTICATED_CONFIGURE_ACCESSIBLE_ENCRYPTION_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_CONFIGURE_ACCESSIBLE_ENCRYPTION_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_AUTHENTICATED_CONFIGURE_CRYPTO_SESSION: windows_core::GUID = windows_core::GUID::from_u128(0x6346cc54_2cfc_4ad4_8224_d15837de7700);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -193,9 +187,6 @@ impl Default for D3D11_AUTHENTICATED_CONFIGURE_CRYPTO_SESSION_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_CONFIGURE_CRYPTO_SESSION_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_AUTHENTICATED_CONFIGURE_ENCRYPTION_WHEN_ACCESSIBLE: windows_core::GUID = windows_core::GUID::from_u128(0x41fff286_6ae0_4d43_9d55_a46e9efd158a);
 pub const D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE: windows_core::GUID = windows_core::GUID::from_u128(0x06114bdb_3523_470a_8dca_fbc2845154f0);
@@ -211,9 +202,6 @@ impl Default for D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_AUTHENTICATED_CONFIGURE_INPUT {
@@ -226,9 +214,6 @@ impl Default for D3D11_AUTHENTICATED_CONFIGURE_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_CONFIGURE_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -244,9 +229,6 @@ impl Default for D3D11_AUTHENTICATED_CONFIGURE_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_CONFIGURE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_AUTHENTICATED_CONFIGURE_PROTECTION: windows_core::GUID = windows_core::GUID::from_u128(0x50455658_3f47_4362_bf99_bfdfcde9ed29);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -258,9 +240,6 @@ impl Default for D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_AUTHENTICATED_CONFIGURE_SHARED_RESOURCE: windows_core::GUID = windows_core::GUID::from_u128(0x0772d047_1b40_48e8_9ca6_b5f510de9f01);
 #[repr(C)]
@@ -276,9 +255,6 @@ impl Default for D3D11_AUTHENTICATED_CONFIGURE_SHARED_RESOURCE_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_CONFIGURE_SHARED_RESOURCE_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D11_AUTHENTICATED_PROCESS_IDENTIFIER_TYPE(pub i32);
@@ -293,9 +269,6 @@ impl Default for D3D11_AUTHENTICATED_PROTECTION_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_PROTECTION_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_AUTHENTICATED_PROTECTION_FLAGS_0 {
@@ -305,9 +278,6 @@ impl Default for D3D11_AUTHENTICATED_PROTECTION_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_PROTECTION_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ATTRIBUTES: windows_core::GUID = windows_core::GUID::from_u128(0x6214d9d2_432c_4abb_9fce_216eea269e3b);
 #[repr(C)]
@@ -321,9 +291,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_COUNT_O
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_COUNT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_INPUT {
@@ -334,9 +301,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -349,9 +313,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_OUTPUT 
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ENCRYPTION_GUID_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -366,9 +327,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE: windows_core::GUID = windows_core::GUID::from_u128(0xbc1b18a5_b1fb_42ab_bd94_b5828b4bf7be);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -381,9 +339,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION: windows_core::GUID = windows_core::GUID::from_u128(0x2634499e_d018_4d74_ac17_7f724059528d);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -395,9 +350,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -412,9 +364,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_AUTHENTICATED_QUERY_CURRENT_ACCESSIBILITY_ENCRYPTION_OUTPUT {
@@ -425,9 +374,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_CURRENT_ACCESSIBILITY_ENCRYPTION_OUTP
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_CURRENT_ACCESSIBILITY_ENCRYPTION_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_AUTHENTICATED_QUERY_CURRENT_ENCRYPTION_WHEN_ACCESSIBLE: windows_core::GUID = windows_core::GUID::from_u128(0xec1791c7_dad3_4f15_9ec3_faa93d60d4f0);
 pub const D3D11_AUTHENTICATED_QUERY_DEVICE_HANDLE: windows_core::GUID = windows_core::GUID::from_u128(0xec1c539d_8cff_4e2a_bcc4_f5692f99f480);
@@ -441,9 +387,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_DEVICE_HANDLE_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_DEVICE_HANDLE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_AUTHENTICATED_QUERY_ENCRYPTION_WHEN_ACCESSIBLE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xf83a5958_e986_4bda_beb0_411f6a7a01b7);
 pub const D3D11_AUTHENTICATED_QUERY_ENCRYPTION_WHEN_ACCESSIBLE_GUID_COUNT: windows_core::GUID = windows_core::GUID::from_u128(0xb30f7066_203c_4b07_93fc_ceaafd61241e);
@@ -459,9 +402,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_AUTHENTICATED_QUERY_OUTPUT {
@@ -475,9 +415,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_AUTHENTICATED_QUERY_OUTPUT_ID: windows_core::GUID = windows_core::GUID::from_u128(0x839ddca3_9b4e_41e4_b053_892bd2a11ee7);
 pub const D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT: windows_core::GUID = windows_core::GUID::from_u128(0x2c042b5e_8c07_46d5_aabe_8f75cbad4c31);
@@ -493,9 +430,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_OUTPUT {
@@ -509,9 +443,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_INPUT {
@@ -524,9 +455,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -542,9 +470,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_AUTHENTICATED_QUERY_PROTECTION: windows_core::GUID = windows_core::GUID::from_u128(0xa84eb584_c495_48aa_b94d_8bd2d6fbce05);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -556,9 +481,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS: windows_core::GUID = windows_core::GUID::from_u128(0x649bbadb_f0f4_4639_a15b_24393fc3abac);
 pub const D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_COUNT: windows_core::GUID = windows_core::GUID::from_u128(0x0db207b3_9450_46a6_82de_1b96d44f9cf2);
@@ -573,9 +495,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_CO
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_COUNT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_INPUT {
@@ -586,9 +505,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_IN
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -603,9 +519,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_OU
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROTECTED_SHARED_RESOURCE_COUNT: windows_core::GUID = windows_core::GUID::from_u128(0x012f0bd6_e662_4474_befd_aa53e5143c6d);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -617,9 +530,6 @@ impl Default for D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROTECTED_SHARED_RESOURC
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROTECTED_SHARED_RESOURCE_COUNT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_BIND_CONSTANT_BUFFER: D3D11_BIND_FLAG = D3D11_BIND_FLAG(4i32);
 pub const D3D11_BIND_DECODER: D3D11_BIND_FLAG = D3D11_BIND_FLAG(512i32);
@@ -683,9 +593,6 @@ impl Default for D3D11_BLEND_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_BLEND_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_BLEND_DESC1 {
@@ -697,9 +604,6 @@ impl Default for D3D11_BLEND_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_BLEND_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_BLEND_DEST_ALPHA: D3D11_BLEND = D3D11_BLEND(7i32);
 pub const D3D11_BLEND_DEST_COLOR: D3D11_BLEND = D3D11_BLEND(9i32);
@@ -740,9 +644,6 @@ impl Default for D3D11_BOX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_BOX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_BREAKON_CATEGORY: windows_core::PCWSTR = windows_core::w!("BreakOn_CATEGORY_%s");
 pub const D3D11_BREAKON_ID_DECIMAL: windows_core::PCWSTR = windows_core::w!("BreakOn_ID_%d");
 pub const D3D11_BREAKON_ID_STRING: windows_core::PCWSTR = windows_core::w!("BreakOn_ID_%s");
@@ -758,9 +659,6 @@ impl Default for D3D11_BUFFEREX_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_BUFFEREX_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -781,9 +679,6 @@ impl Default for D3D11_BUFFER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_BUFFER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D11_BUFFER_RTV {
@@ -794,9 +689,6 @@ impl Default for D3D11_BUFFER_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_BUFFER_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -809,9 +701,6 @@ impl Default for D3D11_BUFFER_RTV_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_BUFFER_RTV_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D11_BUFFER_RTV_1 {
@@ -822,9 +711,6 @@ impl Default for D3D11_BUFFER_RTV_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_BUFFER_RTV_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -837,9 +723,6 @@ impl Default for D3D11_BUFFER_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_BUFFER_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D11_BUFFER_SRV_0 {
@@ -850,9 +733,6 @@ impl Default for D3D11_BUFFER_SRV_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_BUFFER_SRV_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -865,9 +745,6 @@ impl Default for D3D11_BUFFER_SRV_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_BUFFER_SRV_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_BUFFER_UAV {
@@ -879,9 +756,6 @@ impl Default for D3D11_BUFFER_UAV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_BUFFER_UAV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -924,9 +798,6 @@ impl Default for D3D11_CLASS_INSTANCE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_CLASS_INSTANCE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_CLEAR_DEPTH: D3D11_CLEAR_FLAG = D3D11_CLEAR_FLAG(1u32);
 #[repr(transparent)]
@@ -1036,9 +907,6 @@ impl Default for D3D11_COMPUTE_SHADER_TRACE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_COMPUTE_SHADER_TRACE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D11_CONSERVATIVE_RASTERIZATION_MODE(pub i32);
@@ -1097,9 +965,6 @@ impl Default for D3D11_COUNTER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_COUNTER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_COUNTER_DEVICE_DEPENDENT_0: D3D11_COUNTER = D3D11_COUNTER(1073741824i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1112,9 +977,6 @@ impl Default for D3D11_COUNTER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_COUNTER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1402,9 +1264,6 @@ impl Default for D3D11_DEPTH_STENCILOP_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_DEPTH_STENCILOP_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_DEPTH_STENCIL_DESC {
@@ -1422,9 +1281,6 @@ impl Default for D3D11_DEPTH_STENCIL_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_DEPTH_STENCIL_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -1439,10 +1295,6 @@ impl Default for D3D11_DEPTH_STENCIL_VIEW_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_DEPTH_STENCIL_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -1460,10 +1312,6 @@ impl Default for D3D11_DEPTH_STENCIL_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_DEPTH_STENCIL_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1486,9 +1334,6 @@ impl Default for D3D11_DOMAIN_SHADER_TRACE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_DOMAIN_SHADER_TRACE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS {
@@ -1503,9 +1348,6 @@ impl Default for D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_DRAW_INDEXED_INSTANCED_INDIRECT_ARGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_DRAW_INSTANCED_INDIRECT_ARGS {
@@ -1518,9 +1360,6 @@ impl Default for D3D11_DRAW_INSTANCED_INDIRECT_ARGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_DRAW_INSTANCED_INDIRECT_ARGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1574,9 +1413,6 @@ impl Default for D3D11_ENCRYPTED_BLOCK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_ENCRYPTED_BLOCK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D11_FEATURE(pub i32);
@@ -1602,9 +1438,6 @@ impl Default for D3D11_FEATURE_DATA_ARCHITECTURE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_ARCHITECTURE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS {
@@ -1614,9 +1447,6 @@ impl Default for D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1641,9 +1471,6 @@ impl Default for D3D11_FEATURE_DATA_D3D11_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D11_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_D3D11_OPTIONS1 {
@@ -1656,9 +1483,6 @@ impl Default for D3D11_FEATURE_DATA_D3D11_OPTIONS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D11_OPTIONS1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1677,9 +1501,6 @@ impl Default for D3D11_FEATURE_DATA_D3D11_OPTIONS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D11_OPTIONS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_D3D11_OPTIONS3 {
@@ -1689,9 +1510,6 @@ impl Default for D3D11_FEATURE_DATA_D3D11_OPTIONS3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D11_OPTIONS3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1703,9 +1521,6 @@ impl Default for D3D11_FEATURE_DATA_D3D11_OPTIONS4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D11_OPTIONS4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_D3D11_OPTIONS5 {
@@ -1716,9 +1531,6 @@ impl Default for D3D11_FEATURE_DATA_D3D11_OPTIONS5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D11_OPTIONS5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_D3D9_OPTIONS {
@@ -1728,9 +1540,6 @@ impl Default for D3D11_FEATURE_DATA_D3D9_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D9_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1745,9 +1554,6 @@ impl Default for D3D11_FEATURE_DATA_D3D9_OPTIONS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D9_OPTIONS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_D3D9_SHADOW_SUPPORT {
@@ -1758,9 +1564,6 @@ impl Default for D3D11_FEATURE_DATA_D3D9_SHADOW_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D9_SHADOW_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_D3D9_SIMPLE_INSTANCING_SUPPORT {
@@ -1770,9 +1573,6 @@ impl Default for D3D11_FEATURE_DATA_D3D9_SIMPLE_INSTANCING_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_D3D9_SIMPLE_INSTANCING_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1785,9 +1585,6 @@ impl Default for D3D11_FEATURE_DATA_DISPLAYABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_DISPLAYABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_DOUBLES {
@@ -1797,9 +1594,6 @@ impl Default for D3D11_FEATURE_DATA_DOUBLES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_DOUBLES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -1814,10 +1608,6 @@ impl Default for D3D11_FEATURE_DATA_FORMAT_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_FORMAT_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1831,10 +1621,6 @@ impl Default for D3D11_FEATURE_DATA_FORMAT_SUPPORT2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_FORMAT_SUPPORT2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT {
@@ -1846,9 +1632,6 @@ impl Default for D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_MARKER_SUPPORT {
@@ -1859,9 +1642,6 @@ impl Default for D3D11_FEATURE_DATA_MARKER_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_MARKER_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_SHADER_CACHE {
@@ -1871,9 +1651,6 @@ impl Default for D3D11_FEATURE_DATA_SHADER_CACHE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_SHADER_CACHE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1886,9 +1663,6 @@ impl Default for D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_FEATURE_DATA_THREADING {
@@ -1899,9 +1673,6 @@ impl Default for D3D11_FEATURE_DATA_THREADING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_THREADING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -1917,10 +1688,6 @@ impl Default for D3D11_FEATURE_DATA_VIDEO_DECODER_HISTOGRAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_FEATURE_DATA_VIDEO_DECODER_HISTOGRAM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_FEATURE_DISPLAYABLE: D3D11_FEATURE = D3D11_FEATURE(20i32);
 pub const D3D11_FEATURE_DOUBLES: D3D11_FEATURE = D3D11_FEATURE(1i32);
@@ -2143,10 +1910,6 @@ impl Default for D3D11_FUNCTION_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D11_FUNCTION_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_GEOMETRY_SHADER: D3D11_SHADER_TYPE = D3D11_SHADER_TYPE(4i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2157,9 +1920,6 @@ impl Default for D3D11_GEOMETRY_SHADER_TRACE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_GEOMETRY_SHADER_TRACE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_GS_INPUT_INSTANCE_ID_READS_PER_INST: u32 = 2u32;
 pub const D3D11_GS_INPUT_INSTANCE_ID_READ_PORTS: u32 = 1u32;
@@ -2231,9 +1991,6 @@ impl Default for D3D11_HULL_SHADER_TRACE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_HULL_SHADER_TRACE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_IA_DEFAULT_INDEX_BUFFER_OFFSET_IN_BYTES: u32 = 0u32;
 pub const D3D11_IA_DEFAULT_PRIMITIVE_TOPOLOGY: u32 = 0u32;
 pub const D3D11_IA_DEFAULT_VERTEX_BUFFER_OFFSET_IN_BYTES: u32 = 0u32;
@@ -2259,9 +2016,6 @@ impl Default for D3D11_INFO_QUEUE_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_INFO_QUEUE_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_INFO_QUEUE_FILTER_DESC {
@@ -2276,9 +2030,6 @@ impl Default for D3D11_INFO_QUEUE_FILTER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_INFO_QUEUE_FILTER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2301,10 +2052,6 @@ impl Default for D3D11_INPUT_ELEMENT_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_INPUT_ELEMENT_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_INPUT_PER_INSTANCE_DATA: D3D11_INPUT_CLASSIFICATION = D3D11_INPUT_CLASSIFICATION(1i32);
 pub const D3D11_INPUT_PER_VERTEX_DATA: D3D11_INPUT_CLASSIFICATION = D3D11_INPUT_CLASSIFICATION(0i32);
 pub const D3D11_INTEGER_DIVIDE_BY_ZERO_QUOTIENT: u32 = 4294967295u32;
@@ -2325,9 +2072,6 @@ impl Default for D3D11_KEY_EXCHANGE_HW_PROTECTION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_KEY_EXCHANGE_HW_PROTECTION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_KEY_EXCHANGE_HW_PROTECTION_INPUT_DATA {
@@ -2339,9 +2083,6 @@ impl Default for D3D11_KEY_EXCHANGE_HW_PROTECTION_INPUT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_KEY_EXCHANGE_HW_PROTECTION_INPUT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2358,9 +2099,6 @@ impl Default for D3D11_KEY_EXCHANGE_HW_PROTECTION_OUTPUT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_KEY_EXCHANGE_HW_PROTECTION_OUTPUT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_KEY_EXCHANGE_RSAES_OAEP: windows_core::GUID = windows_core::GUID::from_u128(0xc1949895_d72a_4a1d_8e5d_ed857d171520);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2373,9 +2111,6 @@ impl Default for D3D11_LIBRARY_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_LIBRARY_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_LINEAR_GAMMA: f32 = 1f32;
 #[repr(transparent)]
@@ -2414,9 +2149,6 @@ impl Default for D3D11_MAPPED_SUBRESOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_MAPPED_SUBRESOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D11_MAP_FLAG(pub i32);
@@ -2445,9 +2177,6 @@ impl Default for D3D11_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_MESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3838,9 +3567,6 @@ impl Default for D3D11_OMAC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_OMAC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_PACKED_MIP_DESC {
@@ -3853,9 +3579,6 @@ impl Default for D3D11_PACKED_MIP_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_PACKED_MIP_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_PACKED_TILE: u32 = 4294967295u32;
 #[repr(C)]
@@ -3881,10 +3604,6 @@ impl Default for D3D11_PARAMETER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D11_PARAMETER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_PIXEL_ADDRESS_RANGE_BIT_COUNT: u32 = 15u32;
 pub const D3D11_PIXEL_SHADER: D3D11_SHADER_TYPE = D3D11_SHADER_TYPE(5i32);
 #[repr(C)]
@@ -3899,9 +3618,6 @@ impl Default for D3D11_PIXEL_SHADER_TRACE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_PIXEL_SHADER_TRACE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_PRE_SCISSOR_PIXEL_ADDRESS_RANGE_BIT_COUNT: u32 = 16u32;
 pub const D3D11_PROCESSIDTYPE_DWM: D3D11_AUTHENTICATED_PROCESS_IDENTIFIER_TYPE = D3D11_AUTHENTICATED_PROCESS_IDENTIFIER_TYPE(1i32);
@@ -3953,9 +3669,6 @@ impl Default for D3D11_QUERY_DATA_PIPELINE_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_QUERY_DATA_PIPELINE_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_QUERY_DATA_SO_STATISTICS {
@@ -3966,9 +3679,6 @@ impl Default for D3D11_QUERY_DATA_SO_STATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_QUERY_DATA_SO_STATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3981,9 +3691,6 @@ impl Default for D3D11_QUERY_DATA_TIMESTAMP_DISJOINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_QUERY_DATA_TIMESTAMP_DISJOINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_QUERY_DESC {
@@ -3994,9 +3701,6 @@ impl Default for D3D11_QUERY_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_QUERY_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4009,9 +3713,6 @@ impl Default for D3D11_QUERY_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_QUERY_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_QUERY_EVENT: D3D11_QUERY = D3D11_QUERY(0i32);
 #[repr(transparent)]
@@ -4056,9 +3757,6 @@ impl Default for D3D11_RASTERIZER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_RASTERIZER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_RASTERIZER_DESC1 {
@@ -4078,9 +3776,6 @@ impl Default for D3D11_RASTERIZER_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_RASTERIZER_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4103,9 +3798,6 @@ impl Default for D3D11_RASTERIZER_DESC2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_RASTERIZER_DESC2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_RAW_UAV_SRV_BYTE_ALIGNMENT: u32 = 16u32;
 pub const D3D11_REGKEY_PATH: windows_core::PCWSTR = windows_core::w!("Software\\Microsoft\\Direct3D");
 #[repr(C)]
@@ -4124,9 +3816,6 @@ impl Default for D3D11_RENDER_TARGET_BLEND_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_RENDER_TARGET_BLEND_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4147,9 +3836,6 @@ impl Default for D3D11_RENDER_TARGET_BLEND_DESC1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_RENDER_TARGET_BLEND_DESC1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -4163,10 +3849,6 @@ impl Default for D3D11_RENDER_TARGET_VIEW_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_RENDER_TARGET_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -4187,10 +3869,6 @@ impl Default for D3D11_RENDER_TARGET_VIEW_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_RENDER_TARGET_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -4204,10 +3882,6 @@ impl Default for D3D11_RENDER_TARGET_VIEW_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_RENDER_TARGET_VIEW_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -4227,10 +3901,6 @@ impl Default for D3D11_RENDER_TARGET_VIEW_DESC1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_RENDER_TARGET_VIEW_DESC1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_REQ_BLEND_OBJECT_COUNT_PER_DEVICE: u32 = 4096u32;
 pub const D3D11_REQ_BUFFER_RESOURCE_TEXEL_COUNT_2_TO_EXP: u32 = 27u32;
@@ -4391,9 +4061,6 @@ impl Default for D3D11_SAMPLER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_SAMPLER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_SDK_LAYERS_VERSION: u32 = 1u32;
 pub const D3D11_SDK_VERSION: u32 = 7u32;
 #[repr(C)]
@@ -4411,10 +4078,6 @@ impl Default for D3D11_SHADER_BUFFER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D11_SHADER_BUFFER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_SHADER_CACHE_SUPPORT_AUTOMATIC_DISK_CACHE: D3D11_SHADER_CACHE_SUPPORT_FLAGS = D3D11_SHADER_CACHE_SUPPORT_FLAGS(2i32);
 pub const D3D11_SHADER_CACHE_SUPPORT_AUTOMATIC_INPROC_CACHE: D3D11_SHADER_CACHE_SUPPORT_FLAGS = D3D11_SHADER_CACHE_SUPPORT_FLAGS(1i32);
@@ -4471,10 +4134,6 @@ impl Default for D3D11_SHADER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D11_SHADER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4493,10 +4152,6 @@ impl Default for D3D11_SHADER_INPUT_BIND_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D11_SHADER_INPUT_BIND_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_SHADER_MAJOR_VERSION: u32 = 5u32;
 pub const D3D11_SHADER_MAX_INSTANCES: u32 = 65535u32;
@@ -4523,10 +4178,6 @@ impl Default for D3D11_SHADER_RESOURCE_VIEW_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D11_SHADER_RESOURCE_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 #[derive(Clone, Copy)]
@@ -4549,10 +4200,6 @@ impl Default for D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D11_SHADER_RESOURCE_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 #[derive(Clone, Copy)]
@@ -4566,10 +4213,6 @@ impl Default for D3D11_SHADER_RESOURCE_VIEW_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D11_SHADER_RESOURCE_VIEW_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -4593,10 +4236,6 @@ impl Default for D3D11_SHADER_RESOURCE_VIEW_DESC1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D11_SHADER_RESOURCE_VIEW_DESC1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D11_SHADER_TRACE_DESC {
@@ -4608,9 +4247,6 @@ impl Default for D3D11_SHADER_TRACE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_SHADER_TRACE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4626,9 +4262,6 @@ impl Default for D3D11_SHADER_TRACE_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_SHADER_TRACE_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_SHADER_TRACE_FLAG_RECORD_REGISTER_READS: u32 = 2u32;
 pub const D3D11_SHADER_TRACE_FLAG_RECORD_REGISTER_WRITES: u32 = 1u32;
@@ -4683,10 +4316,6 @@ impl Default for D3D11_SHADER_TYPE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D11_SHADER_TYPE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_SHADER_VARIABLE_DESC {
@@ -4704,9 +4333,6 @@ impl Default for D3D11_SHADER_VARIABLE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_SHADER_VARIABLE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4747,10 +4373,6 @@ impl Default for D3D11_SIGNATURE_PARAMETER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D11_SIGNATURE_PARAMETER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT: u32 = 8u32;
 pub const D3D11_SO_BUFFER_MAX_STRIDE_IN_BYTES: u32 = 2048u32;
 pub const D3D11_SO_BUFFER_MAX_WRITE_WINDOW_IN_BYTES: u32 = 512u32;
@@ -4770,9 +4392,6 @@ impl Default for D3D11_SO_DECLARATION_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_SO_DECLARATION_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_SO_NO_RASTERIZED_STREAM: u32 = 4294967295u32;
 pub const D3D11_SO_OUTPUT_COMPONENT_COUNT: u32 = 128u32;
@@ -4824,9 +4443,6 @@ impl Default for D3D11_SUBRESOURCE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_SUBRESOURCE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_SUBRESOURCE_TILING {
@@ -4839,9 +4455,6 @@ impl Default for D3D11_SUBRESOURCE_TILING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_SUBRESOURCE_TILING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_SUBTEXEL_FRACTIONAL_BIT_COUNT: u32 = 8u32;
 pub const D3D11_TESSELLATOR_MAX_EVEN_TESSELLATION_FACTOR: u32 = 64u32;
@@ -4863,9 +4476,6 @@ impl Default for D3D11_TEX1D_ARRAY_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX1D_ARRAY_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX1D_ARRAY_RTV {
@@ -4877,9 +4487,6 @@ impl Default for D3D11_TEX1D_ARRAY_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX1D_ARRAY_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4894,9 +4501,6 @@ impl Default for D3D11_TEX1D_ARRAY_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX1D_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX1D_ARRAY_UAV {
@@ -4909,9 +4513,6 @@ impl Default for D3D11_TEX1D_ARRAY_UAV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX1D_ARRAY_UAV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX1D_DSV {
@@ -4922,9 +4523,6 @@ impl Default for D3D11_TEX1D_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX1D_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX1D_RTV {
@@ -4934,9 +4532,6 @@ impl Default for D3D11_TEX1D_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX1D_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4949,9 +4544,6 @@ impl Default for D3D11_TEX1D_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX1D_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX1D_UAV {
@@ -4961,9 +4553,6 @@ impl Default for D3D11_TEX1D_UAV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX1D_UAV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4976,9 +4565,6 @@ impl Default for D3D11_TEX2DMS_ARRAY_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2DMS_ARRAY_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2DMS_ARRAY_RTV {
@@ -4989,9 +4575,6 @@ impl Default for D3D11_TEX2DMS_ARRAY_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2DMS_ARRAY_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5004,9 +4587,6 @@ impl Default for D3D11_TEX2DMS_ARRAY_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2DMS_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2DMS_DSV {
@@ -5016,9 +4596,6 @@ impl Default for D3D11_TEX2DMS_DSV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2DMS_DSV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5030,9 +4607,6 @@ impl Default for D3D11_TEX2DMS_RTV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2DMS_RTV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2DMS_SRV {
@@ -5042,9 +4616,6 @@ impl Default for D3D11_TEX2DMS_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2DMS_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5058,9 +4629,6 @@ impl Default for D3D11_TEX2D_ARRAY_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2D_ARRAY_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2D_ARRAY_RTV {
@@ -5072,9 +4640,6 @@ impl Default for D3D11_TEX2D_ARRAY_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2D_ARRAY_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5089,9 +4654,6 @@ impl Default for D3D11_TEX2D_ARRAY_RTV1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2D_ARRAY_RTV1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2D_ARRAY_SRV {
@@ -5104,9 +4666,6 @@ impl Default for D3D11_TEX2D_ARRAY_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2D_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5122,9 +4681,6 @@ impl Default for D3D11_TEX2D_ARRAY_SRV1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2D_ARRAY_SRV1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2D_ARRAY_UAV {
@@ -5136,9 +4692,6 @@ impl Default for D3D11_TEX2D_ARRAY_UAV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2D_ARRAY_UAV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5153,9 +4706,6 @@ impl Default for D3D11_TEX2D_ARRAY_UAV1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2D_ARRAY_UAV1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2D_ARRAY_VPOV {
@@ -5168,9 +4718,6 @@ impl Default for D3D11_TEX2D_ARRAY_VPOV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2D_ARRAY_VPOV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2D_DSV {
@@ -5181,9 +4728,6 @@ impl Default for D3D11_TEX2D_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2D_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2D_RTV {
@@ -5193,9 +4737,6 @@ impl Default for D3D11_TEX2D_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2D_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5208,9 +4749,6 @@ impl Default for D3D11_TEX2D_RTV1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2D_RTV1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2D_SRV {
@@ -5221,9 +4759,6 @@ impl Default for D3D11_TEX2D_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2D_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5237,9 +4772,6 @@ impl Default for D3D11_TEX2D_SRV1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2D_SRV1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2D_UAV {
@@ -5249,9 +4781,6 @@ impl Default for D3D11_TEX2D_UAV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2D_UAV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5264,9 +4793,6 @@ impl Default for D3D11_TEX2D_UAV1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2D_UAV1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2D_VDOV {
@@ -5276,9 +4802,6 @@ impl Default for D3D11_TEX2D_VDOV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2D_VDOV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5291,9 +4814,6 @@ impl Default for D3D11_TEX2D_VPIV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX2D_VPIV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX2D_VPOV {
@@ -5303,9 +4823,6 @@ impl Default for D3D11_TEX2D_VPOV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX2D_VPOV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5319,9 +4836,6 @@ impl Default for D3D11_TEX3D_RTV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEX3D_RTV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEX3D_SRV {
@@ -5332,9 +4846,6 @@ impl Default for D3D11_TEX3D_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX3D_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5347,9 +4858,6 @@ impl Default for D3D11_TEX3D_UAV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEX3D_UAV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5364,9 +4872,6 @@ impl Default for D3D11_TEXCUBE_ARRAY_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TEXCUBE_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TEXCUBE_SRV {
@@ -5377,9 +4882,6 @@ impl Default for D3D11_TEXCUBE_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TEXCUBE_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_TEXEL_ADDRESS_RANGE_BIT_COUNT: u32 = 16u32;
 #[repr(C)]
@@ -5401,10 +4903,6 @@ impl Default for D3D11_TEXTURE1D_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_TEXTURE1D_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5425,10 +4923,6 @@ impl Default for D3D11_TEXTURE2D_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_TEXTURE2D_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -5452,10 +4946,6 @@ impl Default for D3D11_TEXTURE2D_DESC1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_TEXTURE2D_DESC1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5475,10 +4965,6 @@ impl Default for D3D11_TEXTURE3D_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_TEXTURE3D_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -5500,10 +4986,6 @@ impl Default for D3D11_TEXTURE3D_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_TEXTURE3D_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5548,9 +5030,6 @@ impl Default for D3D11_TILED_RESOURCE_COORDINATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TILED_RESOURCE_COORDINATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D11_TILE_COPY_FLAG(pub i32);
@@ -5581,9 +5060,6 @@ impl Default for D3D11_TILE_REGION_SIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TILE_REGION_SIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TILE_SHAPE {
@@ -5595,9 +5071,6 @@ impl Default for D3D11_TILE_SHAPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TILE_SHAPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_TRACE_COMPONENT_W: u32 = 8u32;
 pub const D3D11_TRACE_COMPONENT_X: u32 = 1u32;
@@ -5661,9 +5134,6 @@ impl Default for D3D11_TRACE_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TRACE_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D11_TRACE_REGISTER_0 {
@@ -5674,9 +5144,6 @@ impl Default for D3D11_TRACE_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TRACE_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_TRACE_REGISTER_FLAGS_RELATIVE_INDEXING: u32 = 1u32;
 #[repr(transparent)]
@@ -5716,9 +5183,6 @@ impl Default for D3D11_TRACE_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TRACE_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_TRACE_STEP {
@@ -5735,9 +5199,6 @@ impl Default for D3D11_TRACE_STEP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_TRACE_STEP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_TRACE_STREAM: D3D11_TRACE_REGISTER_TYPE = D3D11_TRACE_REGISTER_TYPE(14i32);
 pub const D3D11_TRACE_TEMP_REGISTER: D3D11_TRACE_REGISTER_TYPE = D3D11_TRACE_REGISTER_TYPE(4i32);
 pub const D3D11_TRACE_THIS_POINTER: D3D11_TRACE_REGISTER_TYPE = D3D11_TRACE_REGISTER_TYPE(15i32);
@@ -5753,9 +5214,6 @@ impl Default for D3D11_TRACE_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_TRACE_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5783,10 +5241,6 @@ impl Default for D3D11_UNORDERED_ACCESS_VIEW_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_UNORDERED_ACCESS_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -5804,10 +5258,6 @@ impl Default for D3D11_UNORDERED_ACCESS_VIEW_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_UNORDERED_ACCESS_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -5821,10 +5271,6 @@ impl Default for D3D11_UNORDERED_ACCESS_VIEW_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_UNORDERED_ACCESS_VIEW_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -5842,10 +5288,6 @@ impl Default for D3D11_UNORDERED_ACCESS_VIEW_DESC1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_UNORDERED_ACCESS_VIEW_DESC1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5870,9 +5312,6 @@ impl Default for D3D11_VERTEX_SHADER_TRACE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VERTEX_SHADER_TRACE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D11_VIDEO_COLOR {
@@ -5882,9 +5321,6 @@ impl Default for D3D11_VIDEO_COLOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_COLOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5896,9 +5332,6 @@ impl Default for D3D11_VIDEO_COLOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_COLOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5913,9 +5346,6 @@ impl Default for D3D11_VIDEO_COLOR_RGBA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VIDEO_COLOR_RGBA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_VIDEO_COLOR_YCbCrA {
@@ -5929,9 +5359,6 @@ impl Default for D3D11_VIDEO_COLOR_YCbCrA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VIDEO_COLOR_YCbCrA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_VIDEO_CONTENT_PROTECTION_CAPS {
@@ -5944,9 +5371,6 @@ impl Default for D3D11_VIDEO_CONTENT_PROTECTION_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_CONTENT_PROTECTION_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -5962,9 +5386,6 @@ impl Default for D3D11_VIDEO_DECODER_BEGIN_FRAME_CRYPTO_SESSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_DECODER_BEGIN_FRAME_CRYPTO_SESSION {
-    type TypeKind = windows_core::CloneType;
 }
 pub const D3D11_VIDEO_DECODER_BUFFER_BITSTREAM: D3D11_VIDEO_DECODER_BUFFER_TYPE = D3D11_VIDEO_DECODER_BUFFER_TYPE(6i32);
 pub const D3D11_VIDEO_DECODER_BUFFER_DEBLOCKING_CONTROL: D3D11_VIDEO_DECODER_BUFFER_TYPE = D3D11_VIDEO_DECODER_BUFFER_TYPE(3i32);
@@ -5991,9 +5412,6 @@ impl Default for D3D11_VIDEO_DECODER_BUFFER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VIDEO_DECODER_BUFFER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_VIDEO_DECODER_BUFFER_DESC1 {
@@ -6009,9 +5427,6 @@ impl Default for D3D11_VIDEO_DECODER_BUFFER_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_DECODER_BUFFER_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6030,9 +5445,6 @@ impl Default for D3D11_VIDEO_DECODER_BUFFER_DESC2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_DECODER_BUFFER_DESC2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_VIDEO_DECODER_BUFFER_FILM_GRAIN: D3D11_VIDEO_DECODER_BUFFER_TYPE = D3D11_VIDEO_DECODER_BUFFER_TYPE(8i32);
 pub const D3D11_VIDEO_DECODER_BUFFER_INVERSE_QUANTIZATION_MATRIX: D3D11_VIDEO_DECODER_BUFFER_TYPE = D3D11_VIDEO_DECODER_BUFFER_TYPE(4i32);
@@ -6078,9 +5490,6 @@ impl Default for D3D11_VIDEO_DECODER_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VIDEO_DECODER_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6095,10 +5504,6 @@ impl Default for D3D11_VIDEO_DECODER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_VIDEO_DECODER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6115,9 +5520,6 @@ impl Default for D3D11_VIDEO_DECODER_EXTENSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_DECODER_EXTENSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6185,9 +5587,6 @@ impl Default for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC_0 {
@@ -6197,9 +5596,6 @@ impl Default for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6211,9 +5607,6 @@ impl Default for D3D11_VIDEO_DECODER_SUB_SAMPLE_MAPPING_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_DECODER_SUB_SAMPLE_MAPPING_BLOCK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6264,9 +5657,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D11_VIDEO_PROCESSOR_COLOR_SPACE {
@@ -6276,9 +5666,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_COLOR_SPACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_COLOR_SPACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -6299,10 +5686,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_CONTENT_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_CONTENT_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6317,10 +5700,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_CUSTOM_RATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_CUSTOM_RATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6378,9 +5757,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_FILTER_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_FILTER_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D11_VIDEO_PROCESSOR_FILTER_SATURATION: D3D11_VIDEO_PROCESSOR_FILTER = D3D11_VIDEO_PROCESSOR_FILTER(3i32);
 pub const D3D11_VIDEO_PROCESSOR_FILTER_STEREO_ADJUSTMENT: D3D11_VIDEO_PROCESSOR_FILTER = D3D11_VIDEO_PROCESSOR_FILTER(7i32);
 #[repr(transparent)]
@@ -6407,9 +5783,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0 {
@@ -6419,9 +5792,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6459,9 +5829,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0 {
@@ -6472,9 +5839,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6498,9 +5862,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6554,9 +5915,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_STREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_STREAM {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6572,10 +5930,6 @@ impl Default for D3D11_VIDEO_PROCESSOR_STREAM_BEHAVIOR_HINT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_VIDEO_PROCESSOR_STREAM_BEHAVIOR_HINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6590,10 +5944,6 @@ impl Default for D3D11_VIDEO_SAMPLE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D11_VIDEO_SAMPLE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6615,9 +5965,6 @@ impl Default for D3D11_VIEWPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D11_VIEWPORT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D11_VIEWPORT_AND_SCISSORRECT_MAX_INDEX: u32 = 15u32;
 pub const D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE: u32 = 16u32;
@@ -6661,9 +6008,6 @@ impl Default for D3DX11_FFT_BUFFER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DX11_FFT_BUFFER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DX11_FFT_CREATE_FLAG(pub i32);
@@ -6685,9 +6029,6 @@ impl Default for D3DX11_FFT_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DX11_FFT_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
@@ -32,9 +32,6 @@ impl Default for D3D11_RESOURCE_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D11_RESOURCE_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 windows_core::imp::define_interface!(ID3D11On12Device, ID3D11On12Device_Vtbl, 0x85611e73_70a9_490e_9614_a9e302777904);
 windows_core::imp::interface_hierarchy!(ID3D11On12Device, windows_core::IUnknown);
 impl ID3D11On12Device {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -84,9 +84,6 @@ impl Default for D3D12_AUTO_BREADCRUMB_NODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_AUTO_BREADCRUMB_NODE {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct D3D12_AUTO_BREADCRUMB_NODE1 {
@@ -107,9 +104,6 @@ impl Default for D3D12_AUTO_BREADCRUMB_NODE1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_AUTO_BREADCRUMB_NODE1 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -250,9 +244,6 @@ impl Default for D3D12_BARRIER_GROUP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_BARRIER_GROUP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_BARRIER_GROUP_0 {
@@ -264,9 +255,6 @@ impl Default for D3D12_BARRIER_GROUP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_BARRIER_GROUP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -318,9 +306,6 @@ impl Default for D3D12_BARRIER_SUBRESOURCE_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_BARRIER_SUBRESOURCE_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -405,9 +390,6 @@ impl Default for D3D12_BLEND_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_BLEND_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_BLEND_DEST_ALPHA: D3D12_BLEND = D3D12_BLEND(7i32);
 pub const D3D12_BLEND_DEST_COLOR: D3D12_BLEND = D3D12_BLEND(9i32);
 pub const D3D12_BLEND_INV_ALPHA_FACTOR: D3D12_BLEND = D3D12_BLEND(21i32);
@@ -448,9 +430,6 @@ impl Default for D3D12_BOX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_BOX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_BROADCASTING_LAUNCH_OVERRIDES {
@@ -468,9 +447,6 @@ impl Default for D3D12_BROADCASTING_LAUNCH_OVERRIDES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_BROADCASTING_LAUNCH_OVERRIDES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct D3D12_BUFFER_BARRIER {
@@ -487,9 +463,6 @@ impl Default for D3D12_BUFFER_BARRIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_BUFFER_BARRIER {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_BUFFER_RTV {
@@ -500,9 +473,6 @@ impl Default for D3D12_BUFFER_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_BUFFER_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -516,9 +486,6 @@ impl Default for D3D12_BUFFER_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_BUFFER_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -571,9 +538,6 @@ impl Default for D3D12_BUFFER_UAV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_BUFFER_UAV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -628,10 +592,6 @@ impl Default for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -648,10 +608,6 @@ impl Default for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -666,10 +622,6 @@ impl Default for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_TOOLS_VISUALIZATION_HEADER {
@@ -681,9 +633,6 @@ impl Default for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_TOOLS_VISUALIZATI
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_TOOLS_VISUALIZATION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_CACHED_PIPELINE_STATE {
@@ -694,9 +643,6 @@ impl Default for D3D12_CACHED_PIPELINE_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_CACHED_PIPELINE_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_CENTER_MULTISAMPLE_PATTERN: D3D12_STANDARD_MULTISAMPLE_QUALITY_LEVELS = D3D12_STANDARD_MULTISAMPLE_QUALITY_LEVELS(-2i32);
 #[repr(transparent)]
@@ -750,10 +696,6 @@ impl Default for D3D12_CLEAR_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_CLEAR_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -766,10 +708,6 @@ impl Default for D3D12_CLEAR_VALUE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_CLEAR_VALUE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_CLIP_OR_CULL_DISTANCE_COUNT: u32 = 8u32;
 pub const D3D12_CLIP_OR_CULL_DISTANCE_ELEMENT_COUNT: u32 = 2u32;
@@ -787,9 +725,6 @@ impl Default for D3D12_COALESCING_LAUNCH_OVERRIDES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_COALESCING_LAUNCH_OVERRIDES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -941,9 +876,6 @@ impl Default for D3D12_COMMAND_QUEUE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_COMMAND_QUEUE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_COMMAND_QUEUE_FLAGS(pub i32);
@@ -1038,9 +970,6 @@ impl Default for D3D12_COMMAND_SIGNATURE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_COMMAND_SIGNATURE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_COMMONSHADER_CONSTANT_BUFFER_API_SLOT_COUNT: u32 = 14u32;
 pub const D3D12_COMMONSHADER_CONSTANT_BUFFER_COMPONENTS: u32 = 4u32;
 pub const D3D12_COMMONSHADER_CONSTANT_BUFFER_COMPONENT_BIT_COUNT: u32 = 32u32;
@@ -1091,9 +1020,6 @@ impl Default for D3D12_COMMON_COMPUTE_NODE_OVERRIDES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_COMMON_COMPUTE_NODE_OVERRIDES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_COMPARISON_FUNC(pub i32);
@@ -1120,9 +1046,6 @@ impl Default for D3D12_COMPUTE_PIPELINE_STATE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_COMPUTE_PIPELINE_STATE_DESC {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_CONSERVATIVE_RASTERIZATION_MODE(pub i32);
@@ -1147,9 +1070,6 @@ impl Default for D3D12_CONSTANT_BUFFER_VIEW_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_CONSTANT_BUFFER_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_CPU_DESCRIPTOR_HANDLE {
@@ -1159,9 +1079,6 @@ impl Default for D3D12_CPU_DESCRIPTOR_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_CPU_DESCRIPTOR_HANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1253,9 +1170,6 @@ impl Default for D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DEBUG_COMMAND_LIST_GPU_BASED_VALIDATION_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_DEBUG_COMMAND_LIST_PARAMETER_GPU_BASED_VALIDATION_SETTINGS: D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE = D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE(0i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1272,9 +1186,6 @@ impl Default for D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DEBUG_DEVICE_GPU_BASED_VALIDATION_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTOR {
@@ -1284,9 +1195,6 @@ impl Default for D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DEBUG_DEVICE_GPU_SLOWDOWN_PERFORMANCE_FACTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_DEBUG_DEVICE_PARAMETER_FEATURE_FLAGS: D3D12_DEBUG_DEVICE_PARAMETER_TYPE = D3D12_DEBUG_DEVICE_PARAMETER_TYPE(0i32);
 pub const D3D12_DEBUG_DEVICE_PARAMETER_GPU_BASED_VALIDATION_SETTINGS: D3D12_DEBUG_DEVICE_PARAMETER_TYPE = D3D12_DEBUG_DEVICE_PARAMETER_TYPE(1i32);
@@ -1377,9 +1285,6 @@ impl Default for D3D12_DEPTH_STENCILOP_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DEPTH_STENCILOP_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DEPTH_STENCILOP_DESC1 {
@@ -1394,9 +1299,6 @@ impl Default for D3D12_DEPTH_STENCILOP_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DEPTH_STENCILOP_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1414,9 +1316,6 @@ impl Default for D3D12_DEPTH_STENCIL_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DEPTH_STENCIL_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1436,9 +1335,6 @@ impl Default for D3D12_DEPTH_STENCIL_DESC1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DEPTH_STENCIL_DESC1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DEPTH_STENCIL_DESC2 {
@@ -1455,9 +1351,6 @@ impl Default for D3D12_DEPTH_STENCIL_DESC2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DEPTH_STENCIL_DESC2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1470,10 +1363,6 @@ impl Default for D3D12_DEPTH_STENCIL_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_DEPTH_STENCIL_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DEPTH_STENCIL_VALUE {
@@ -1484,9 +1373,6 @@ impl Default for D3D12_DEPTH_STENCIL_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DEPTH_STENCIL_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -1502,10 +1388,6 @@ impl Default for D3D12_DEPTH_STENCIL_VIEW_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_DEPTH_STENCIL_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -1524,10 +1406,6 @@ impl Default for D3D12_DEPTH_STENCIL_VIEW_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_DEPTH_STENCIL_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_DEPTH_WRITE_MASK(pub i32);
@@ -1545,9 +1423,6 @@ impl Default for D3D12_DESCRIPTOR_HEAP_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DESCRIPTOR_HEAP_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1609,9 +1484,6 @@ impl Default for D3D12_DESCRIPTOR_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DESCRIPTOR_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DESCRIPTOR_RANGE1 {
@@ -1626,9 +1498,6 @@ impl Default for D3D12_DESCRIPTOR_RANGE1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DESCRIPTOR_RANGE1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1692,9 +1561,6 @@ impl Default for D3D12_DEVICE_CONFIGURATION_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DEVICE_CONFIGURATION_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1795,9 +1661,6 @@ impl Default for D3D12_DEVICE_REMOVED_EXTENDED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DEVICE_REMOVED_EXTENDED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DEVICE_REMOVED_EXTENDED_DATA1 {
@@ -1810,9 +1673,6 @@ impl Default for D3D12_DEVICE_REMOVED_EXTENDED_DATA1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DEVICE_REMOVED_EXTENDED_DATA1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DEVICE_REMOVED_EXTENDED_DATA2 {
@@ -1824,9 +1684,6 @@ impl Default for D3D12_DEVICE_REMOVED_EXTENDED_DATA2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DEVICE_REMOVED_EXTENDED_DATA2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1841,9 +1698,6 @@ impl Default for D3D12_DEVICE_REMOVED_EXTENDED_DATA3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DEVICE_REMOVED_EXTENDED_DATA3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DISCARD_REGION {
@@ -1857,9 +1711,6 @@ impl Default for D3D12_DISCARD_REGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DISCARD_REGION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DISPATCH_ARGUMENTS {
@@ -1872,9 +1723,6 @@ impl Default for D3D12_DISPATCH_ARGUMENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DISPATCH_ARGUMENTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_DISPATCH_GRAPH_DESC {
@@ -1885,9 +1733,6 @@ impl Default for D3D12_DISPATCH_GRAPH_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DISPATCH_GRAPH_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1902,9 +1747,6 @@ impl Default for D3D12_DISPATCH_GRAPH_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DISPATCH_GRAPH_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DISPATCH_MESH_ARGUMENTS {
@@ -1916,9 +1758,6 @@ impl Default for D3D12_DISPATCH_MESH_ARGUMENTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DISPATCH_MESH_ARGUMENTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1943,9 +1782,6 @@ impl Default for D3D12_DISPATCH_RAYS_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DISPATCH_RAYS_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DRAW_ARGUMENTS {
@@ -1958,9 +1794,6 @@ impl Default for D3D12_DRAW_ARGUMENTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DRAW_ARGUMENTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1976,9 +1809,6 @@ impl Default for D3D12_DRAW_INDEXED_ARGUMENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DRAW_INDEXED_ARGUMENTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DRED_ALLOCATION_NODE {
@@ -1991,9 +1821,6 @@ impl Default for D3D12_DRED_ALLOCATION_NODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DRED_ALLOCATION_NODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -2008,9 +1835,6 @@ impl Default for D3D12_DRED_ALLOCATION_NODE1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DRED_ALLOCATION_NODE1 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2054,9 +1878,6 @@ impl Default for D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 {
@@ -2066,9 +1887,6 @@ impl Default for D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2080,9 +1898,6 @@ impl Default for D3D12_DRED_BREADCRUMB_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DRED_BREADCRUMB_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2185,9 +2000,6 @@ impl Default for D3D12_DRED_PAGE_FAULT_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DRED_PAGE_FAULT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DRED_PAGE_FAULT_OUTPUT1 {
@@ -2199,9 +2011,6 @@ impl Default for D3D12_DRED_PAGE_FAULT_OUTPUT1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DRED_PAGE_FAULT_OUTPUT1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2215,9 +2024,6 @@ impl Default for D3D12_DRED_PAGE_FAULT_OUTPUT2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DRED_PAGE_FAULT_OUTPUT2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2321,9 +2127,6 @@ impl Default for D3D12_DXIL_LIBRARY_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_DXIL_LIBRARY_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION {
@@ -2335,9 +2138,6 @@ impl Default for D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_DXIL_SUBOBJECT_TO_EXPORTS_ASSOCIATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2361,9 +2161,6 @@ impl Default for D3D12_EXISTING_COLLECTION_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_EXISTING_COLLECTION_DESC {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_EXPORT_DESC {
@@ -2375,9 +2172,6 @@ impl Default for D3D12_EXPORT_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_EXPORT_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2458,9 +2252,6 @@ impl Default for D3D12_FEATURE_DATA_ARCHITECTURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_ARCHITECTURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_ARCHITECTURE1 {
@@ -2475,9 +2266,6 @@ impl Default for D3D12_FEATURE_DATA_ARCHITECTURE1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_ARCHITECTURE1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY {
@@ -2490,9 +2278,6 @@ impl Default for D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_COMMAND_QUEUE_PRIORITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_CROSS_NODE {
@@ -2503,9 +2288,6 @@ impl Default for D3D12_FEATURE_DATA_CROSS_NODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_CROSS_NODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2531,9 +2313,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS1 {
@@ -2549,9 +2328,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS10 {
@@ -2563,9 +2339,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS10 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS10 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS11 {
@@ -2575,9 +2348,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS11 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2590,9 +2360,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS12 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS12 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2609,9 +2376,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS13 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS13 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS14 {
@@ -2624,9 +2388,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS14 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS14 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS15 {
@@ -2637,9 +2398,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS15 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS15 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2652,9 +2410,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS16 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS16 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS17 {
@@ -2666,9 +2421,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS17 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS17 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS18 {
@@ -2678,9 +2430,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS18 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS18 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2701,9 +2450,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS19 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS19 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS2 {
@@ -2715,9 +2461,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS20 {
@@ -2728,9 +2471,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS20 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS20 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2744,9 +2484,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS21 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS21 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2762,9 +2499,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS4 {
@@ -2777,9 +2511,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS5 {
@@ -2791,9 +2522,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2809,9 +2537,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS7 {
@@ -2823,9 +2548,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_D3D12_OPTIONS8 {
@@ -2835,9 +2557,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS8 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2854,9 +2573,6 @@ impl Default for D3D12_FEATURE_DATA_D3D12_OPTIONS9 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_D3D12_OPTIONS9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_DISPLAYABLE {
@@ -2868,9 +2584,6 @@ impl Default for D3D12_FEATURE_DATA_DISPLAYABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_DISPLAYABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_EXISTING_HEAPS {
@@ -2880,9 +2593,6 @@ impl Default for D3D12_FEATURE_DATA_EXISTING_HEAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_EXISTING_HEAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -2898,10 +2608,6 @@ impl Default for D3D12_FEATURE_DATA_FEATURE_LEVELS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_FEATURE_LEVELS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2914,10 +2620,6 @@ impl Default for D3D12_FEATURE_DATA_FORMAT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_FORMAT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -2933,10 +2635,6 @@ impl Default for D3D12_FEATURE_DATA_FORMAT_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_FORMAT_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT {
@@ -2948,9 +2646,6 @@ impl Default for D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_GPU_VIRTUAL_ADDRESS_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_HARDWARE_COPY {
@@ -2960,9 +2655,6 @@ impl Default for D3D12_FEATURE_DATA_HARDWARE_COPY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_HARDWARE_COPY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -2979,10 +2671,6 @@ impl Default for D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2998,10 +2686,6 @@ impl Default for D3D12_FEATURE_DATA_PLACED_RESOURCE_SUPPORT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_PLACED_RESOURCE_SUPPORT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_PREDICATION {
@@ -3011,9 +2695,6 @@ impl Default for D3D12_FEATURE_DATA_PREDICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_PREDICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3025,9 +2706,6 @@ impl Default for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3041,9 +2719,6 @@ impl Default for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNT {
@@ -3054,9 +2729,6 @@ impl Default for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPE_COUNT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3073,9 +2745,6 @@ impl Default for D3D12_FEATURE_DATA_QUERY_META_COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_QUERY_META_COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_ROOT_SIGNATURE {
@@ -3085,9 +2754,6 @@ impl Default for D3D12_FEATURE_DATA_ROOT_SIGNATURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_ROOT_SIGNATURE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3100,9 +2766,6 @@ impl Default for D3D12_FEATURE_DATA_SERIALIZATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_SERIALIZATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_SHADER_CACHE {
@@ -3113,9 +2776,6 @@ impl Default for D3D12_FEATURE_DATA_SHADER_CACHE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_SHADER_CACHE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_SHADER_MODEL {
@@ -3125,9 +2785,6 @@ impl Default for D3D12_FEATURE_DATA_SHADER_MODEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_SHADER_MODEL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_FEATURE_DISPLAYABLE: D3D12_FEATURE = D3D12_FEATURE(28i32);
 pub const D3D12_FEATURE_EXISTING_HEAPS: D3D12_FEATURE = D3D12_FEATURE(22i32);
@@ -3422,10 +3079,6 @@ impl Default for D3D12_FUNCTION_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D12_FUNCTION_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_GENERIC_PROGRAM_DESC {
@@ -3440,9 +3093,6 @@ impl Default for D3D12_GENERIC_PROGRAM_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_GENERIC_PROGRAM_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_GLOBAL_BARRIER {
@@ -3456,9 +3106,6 @@ impl Default for D3D12_GLOBAL_BARRIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_GLOBAL_BARRIER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct D3D12_GLOBAL_ROOT_SIGNATURE {
@@ -3468,9 +3115,6 @@ impl Default for D3D12_GLOBAL_ROOT_SIGNATURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_GLOBAL_ROOT_SIGNATURE {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3568,9 +3212,6 @@ impl Default for D3D12_GPU_DESCRIPTOR_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_GPU_DESCRIPTOR_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDE {
@@ -3581,9 +3222,6 @@ impl Default for D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_GPU_VIRTUAL_ADDRESS_AND_STRIDE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3596,9 +3234,6 @@ impl Default for D3D12_GPU_VIRTUAL_ADDRESS_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_GPU_VIRTUAL_ADDRESS_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE {
@@ -3610,9 +3245,6 @@ impl Default for D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_GPU_VIRTUAL_ADDRESS_RANGE_AND_STRIDE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -3645,10 +3277,6 @@ impl Default for D3D12_GRAPHICS_PIPELINE_STATE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_GRAPHICS_PIPELINE_STATE_DESC {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3739,9 +3367,6 @@ impl Default for D3D12_HEAP_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_HEAP_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_HEAP_FLAGS(pub i32);
@@ -3809,9 +3434,6 @@ impl Default for D3D12_HEAP_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_HEAP_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_HEAP_SERIALIZATION_TIER(pub i32);
@@ -3838,9 +3460,6 @@ impl Default for D3D12_HIT_GROUP_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_HIT_GROUP_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3911,9 +3530,6 @@ impl Default for D3D12_IB_STRIP_CUT_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_IB_STRIP_CUT_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_INDEX_BUFFER_STRIP_CUT_VALUE(pub i32);
@@ -3934,10 +3550,6 @@ impl Default for D3D12_INDEX_BUFFER_VIEW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_INDEX_BUFFER_VIEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_INDIRECT_ARGUMENT_DESC {
@@ -3948,9 +3560,6 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3967,9 +3576,6 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
@@ -3979,9 +3585,6 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3995,9 +3598,6 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_INDIRECT_ARGUMENT_DESC_0_5 {
@@ -4009,9 +3609,6 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_INDIRECT_ARGUMENT_DESC_0_3 {
@@ -4021,9 +3618,6 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4035,9 +3629,6 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
@@ -4047,9 +3638,6 @@ impl Default for D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_INDIRECT_ARGUMENT_DESC_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4078,9 +3666,6 @@ impl Default for D3D12_INFO_QUEUE_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_INFO_QUEUE_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_INFO_QUEUE_FILTER_DESC {
@@ -4095,9 +3680,6 @@ impl Default for D3D12_INFO_QUEUE_FILTER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_INFO_QUEUE_FILTER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4122,10 +3704,6 @@ impl Default for D3D12_INPUT_ELEMENT_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_INPUT_ELEMENT_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4138,10 +3716,6 @@ impl Default for D3D12_INPUT_LAYOUT_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_INPUT_LAYOUT_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_INTEGER_DIVIDE_BY_ZERO_QUOTIENT: u32 = 4294967295u32;
 pub const D3D12_INTEGER_DIVIDE_BY_ZERO_REMAINDER: u32 = 4294967295u32;
@@ -4158,9 +3732,6 @@ impl Default for D3D12_LIBRARY_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_LIBRARY_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4184,9 +3755,6 @@ impl Default for D3D12_LOCAL_ROOT_SIGNATURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_LOCAL_ROOT_SIGNATURE {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4240,9 +3808,6 @@ impl Default for D3D12_MEMCPY_DEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_MEMCPY_DEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_MEMORY_POOL(pub i32);
@@ -4267,9 +3832,6 @@ impl Default for D3D12_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_MESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5333,9 +4895,6 @@ impl Default for D3D12_META_COMMAND_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_META_COMMAND_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_META_COMMAND_PARAMETER_DESC {
@@ -5349,9 +4908,6 @@ impl Default for D3D12_META_COMMAND_PARAMETER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_META_COMMAND_PARAMETER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5426,9 +4982,6 @@ impl Default for D3D12_MIP_REGION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_MIP_REGION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5520,9 +5073,6 @@ impl Default for D3D12_MULTI_NODE_CPU_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_MULTI_NODE_CPU_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_MULTI_NODE_GPU_INPUT {
@@ -5533,9 +5083,6 @@ impl Default for D3D12_MULTI_NODE_GPU_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_MULTI_NODE_GPU_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5548,9 +5095,6 @@ impl Default for D3D12_NODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_NODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_NODE_0 {
@@ -5560,9 +5104,6 @@ impl Default for D3D12_NODE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_NODE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5577,9 +5118,6 @@ impl Default for D3D12_NODE_CPU_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_NODE_CPU_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_NODE_GPU_INPUT {
@@ -5592,9 +5130,6 @@ impl Default for D3D12_NODE_GPU_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_NODE_GPU_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_NODE_ID {
@@ -5606,9 +5141,6 @@ impl Default for D3D12_NODE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_NODE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_NODE_MASK {
@@ -5618,9 +5150,6 @@ impl Default for D3D12_NODE_MASK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_NODE_MASK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5635,9 +5164,6 @@ impl Default for D3D12_NODE_OUTPUT_OVERRIDES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_NODE_OUTPUT_OVERRIDES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5667,9 +5193,6 @@ impl Default for D3D12_PACKED_MIP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_PACKED_MIP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_PACKED_TILE: u32 = 4294967295u32;
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -5693,10 +5216,6 @@ impl Default for D3D12_PARAMETER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D12_PARAMETER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5749,9 +5268,6 @@ impl Default for D3D12_PIPELINE_STATE_STREAM_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_PIPELINE_STATE_STREAM_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_PIPELINE_STATE_SUBOBJECT_TYPE(pub i32);
@@ -5798,10 +5314,6 @@ impl Default for D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_PLACED_SUBRESOURCE_FOOTPRINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_PREDICATION_OP(pub i32);
@@ -5818,9 +5330,6 @@ impl Default for D3D12_PRIMITIVE_TOPOLOGY_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_PRIMITIVE_TOPOLOGY_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5846,9 +5355,6 @@ impl Default for D3D12_PROGRAM_IDENTIFIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_PROGRAM_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_PROGRAM_TYPE(pub i32);
@@ -5867,9 +5373,6 @@ impl Default for D3D12_PROTECTED_RESOURCE_SESSION_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_PROTECTED_RESOURCE_SESSION_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_PROTECTED_RESOURCE_SESSION_DESC1 {
@@ -5881,9 +5384,6 @@ impl Default for D3D12_PROTECTED_RESOURCE_SESSION_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_PROTECTED_RESOURCE_SESSION_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6008,9 +5508,6 @@ impl Default for D3D12_QUERY_DATA_PIPELINE_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_QUERY_DATA_PIPELINE_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_QUERY_DATA_PIPELINE_STATISTICS1 {
@@ -6034,9 +5531,6 @@ impl Default for D3D12_QUERY_DATA_PIPELINE_STATISTICS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_QUERY_DATA_PIPELINE_STATISTICS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_QUERY_DATA_SO_STATISTICS {
@@ -6047,9 +5541,6 @@ impl Default for D3D12_QUERY_DATA_SO_STATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_QUERY_DATA_SO_STATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6062,9 +5553,6 @@ impl Default for D3D12_QUERY_HEAP_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_QUERY_HEAP_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6100,9 +5588,6 @@ impl Default for D3D12_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_RANGE_UINT64 {
@@ -6113,9 +5598,6 @@ impl Default for D3D12_RANGE_UINT64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RANGE_UINT64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6137,9 +5619,6 @@ impl Default for D3D12_RASTERIZER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RASTERIZER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_RASTERIZER_DESC1 {
@@ -6160,9 +5639,6 @@ impl Default for D3D12_RASTERIZER_DESC1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RASTERIZER_DESC1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_RASTERIZER_DESC2 {
@@ -6182,9 +5658,6 @@ impl Default for D3D12_RASTERIZER_DESC2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RASTERIZER_DESC2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_RAW_UAV_SRV_BYTE_ALIGNMENT: u32 = 16u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6200,9 +5673,6 @@ impl Default for D3D12_RAYTRACING_AABB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RAYTRACING_AABB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_RAYTRACING_AABB_BYTE_ALIGNMENT: u32 = 8u32;
 #[repr(transparent)]
@@ -6268,9 +5738,6 @@ impl Default for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTE
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_COMPACTED_SIZE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE: D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TYPE = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TYPE(3i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6282,9 +5749,6 @@ impl Default for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_CURRENT_SIZE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC {
@@ -6295,9 +5759,6 @@ impl Default for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION: D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TYPE = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TYPE(2i32);
 #[repr(C)]
@@ -6311,9 +5772,6 @@ impl Default for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZ
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_SERIALIZATION_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TOOLS_VISUALIZATION: D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TYPE = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TYPE(1i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6324,9 +5782,6 @@ impl Default for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TOOLS_VI
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_POSTBUILD_INFO_TOOLS_VISUALIZATION_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6343,9 +5798,6 @@ impl Default for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRV {
@@ -6355,9 +5807,6 @@ impl Default for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6375,9 +5824,6 @@ impl Default for D3D12_RAYTRACING_GEOMETRY_AABBS_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RAYTRACING_GEOMETRY_AABBS_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -6392,10 +5838,6 @@ impl Default for D3D12_RAYTRACING_GEOMETRY_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RAYTRACING_GEOMETRY_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -6408,10 +5850,6 @@ impl Default for D3D12_RAYTRACING_GEOMETRY_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RAYTRACING_GEOMETRY_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6470,10 +5908,6 @@ impl Default for D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RAYTRACING_GEOMETRY_TRIANGLES_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_RAYTRACING_GEOMETRY_TYPE(pub i32);
@@ -6491,9 +5925,6 @@ impl Default for D3D12_RAYTRACING_INSTANCE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RAYTRACING_INSTANCE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_RAYTRACING_INSTANCE_DESCS_BYTE_ALIGNMENT: u32 = 16u32;
 #[repr(transparent)]
@@ -6554,9 +5985,6 @@ impl Default for D3D12_RAYTRACING_PIPELINE_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RAYTRACING_PIPELINE_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_RAYTRACING_PIPELINE_CONFIG1 {
@@ -6567,9 +5995,6 @@ impl Default for D3D12_RAYTRACING_PIPELINE_CONFIG1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RAYTRACING_PIPELINE_CONFIG1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6620,9 +6045,6 @@ impl Default for D3D12_RAYTRACING_SHADER_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RAYTRACING_SHADER_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_RAYTRACING_SHADER_RECORD_BYTE_ALIGNMENT: u32 = 32u32;
 pub const D3D12_RAYTRACING_SHADER_TABLE_BYTE_ALIGNMENT: u32 = 64u32;
@@ -6698,10 +6120,6 @@ impl Default for D3D12_RENDER_PASS_BEGINNING_ACCESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RENDER_PASS_BEGINNING_ACCESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -6715,10 +6133,6 @@ impl Default for D3D12_RENDER_PASS_BEGINNING_ACCESS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RENDER_PASS_BEGINNING_ACCESS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -6731,10 +6145,6 @@ impl Default for D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_RENDER_PASS_BEGINNING_ACCESS_PRESERVE_LOCAL_PARAMETERS {
@@ -6745,9 +6155,6 @@ impl Default for D3D12_RENDER_PASS_BEGINNING_ACCESS_PRESERVE_LOCAL_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RENDER_PASS_BEGINNING_ACCESS_PRESERVE_LOCAL_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6780,10 +6187,6 @@ impl Default for D3D12_RENDER_PASS_DEPTH_STENCIL_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RENDER_PASS_DEPTH_STENCIL_DESC {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub struct D3D12_RENDER_PASS_ENDING_ACCESS {
@@ -6801,10 +6204,6 @@ impl Default for D3D12_RENDER_PASS_ENDING_ACCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RENDER_PASS_ENDING_ACCESS {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -6824,10 +6223,6 @@ impl Default for D3D12_RENDER_PASS_ENDING_ACCESS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RENDER_PASS_ENDING_ACCESS_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_RENDER_PASS_ENDING_ACCESS_PRESERVE_LOCAL_PARAMETERS {
@@ -6838,9 +6233,6 @@ impl Default for D3D12_RENDER_PASS_ENDING_ACCESS_PRESERVE_LOCAL_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RENDER_PASS_ENDING_ACCESS_PRESERVE_LOCAL_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -6860,10 +6252,6 @@ impl Default for D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERS {
@@ -6877,9 +6265,6 @@ impl Default for D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERS 
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_SUBRESOURCE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6952,10 +6337,6 @@ impl Default for D3D12_RENDER_PASS_RENDER_TARGET_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RENDER_PASS_RENDER_TARGET_DESC {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_RENDER_PASS_TIER(pub i32);
@@ -6981,9 +6362,6 @@ impl Default for D3D12_RENDER_TARGET_BLEND_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RENDER_TARGET_BLEND_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -6997,10 +6375,6 @@ impl Default for D3D12_RENDER_TARGET_VIEW_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RENDER_TARGET_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -7020,10 +6394,6 @@ impl Default for D3D12_RENDER_TARGET_VIEW_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RENDER_TARGET_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_REQ_BLEND_OBJECT_COUNT_PER_DEVICE: u32 = 4096u32;
 pub const D3D12_REQ_BUFFER_RESOURCE_TEXEL_COUNT_2_TO_EXP: u32 = 27u32;
@@ -7118,9 +6488,6 @@ impl Default for D3D12_RESOURCE_ALIASING_BARRIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RESOURCE_ALIASING_BARRIER {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_RESOURCE_ALLOCATION_INFO {
@@ -7131,9 +6498,6 @@ impl Default for D3D12_RESOURCE_ALLOCATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RESOURCE_ALLOCATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7146,9 +6510,6 @@ impl Default for D3D12_RESOURCE_ALLOCATION_INFO1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RESOURCE_ALLOCATION_INFO1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 pub struct D3D12_RESOURCE_BARRIER {
@@ -7166,9 +6527,6 @@ impl Default for D3D12_RESOURCE_BARRIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RESOURCE_BARRIER {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union D3D12_RESOURCE_BARRIER_0 {
     pub Transition: core::mem::ManuallyDrop<D3D12_RESOURCE_TRANSITION_BARRIER>,
@@ -7184,9 +6542,6 @@ impl Default for D3D12_RESOURCE_BARRIER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RESOURCE_BARRIER_0 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES: u32 = 4294967295u32;
 #[repr(transparent)]
@@ -7261,10 +6616,6 @@ impl Default for D3D12_RESOURCE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RESOURCE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7286,10 +6637,6 @@ impl Default for D3D12_RESOURCE_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RESOURCE_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7431,9 +6778,6 @@ impl Default for D3D12_RESOURCE_TRANSITION_BARRIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RESOURCE_TRANSITION_BARRIER {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct D3D12_RESOURCE_UAV_BARRIER {
@@ -7443,9 +6787,6 @@ impl Default for D3D12_RESOURCE_UAV_BARRIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_RESOURCE_UAV_BARRIER {
-    type TypeKind = windows_core::CloneType;
 }
 pub const D3D12_RLDO_DETAIL: D3D12_RLDO_FLAGS = D3D12_RLDO_FLAGS(2i32);
 #[repr(transparent)]
@@ -7499,9 +6840,6 @@ impl Default for D3D12_ROOT_CONSTANTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_ROOT_CONSTANTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_ROOT_DESCRIPTOR {
@@ -7512,9 +6850,6 @@ impl Default for D3D12_ROOT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_ROOT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7527,9 +6862,6 @@ impl Default for D3D12_ROOT_DESCRIPTOR1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_ROOT_DESCRIPTOR1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7582,9 +6914,6 @@ impl Default for D3D12_ROOT_DESCRIPTOR_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_ROOT_DESCRIPTOR_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_ROOT_DESCRIPTOR_TABLE1 {
@@ -7595,9 +6924,6 @@ impl Default for D3D12_ROOT_DESCRIPTOR_TABLE1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_ROOT_DESCRIPTOR_TABLE1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7611,9 +6937,6 @@ impl Default for D3D12_ROOT_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_ROOT_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_ROOT_PARAMETER_0 {
@@ -7625,9 +6948,6 @@ impl Default for D3D12_ROOT_PARAMETER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_ROOT_PARAMETER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7641,9 +6961,6 @@ impl Default for D3D12_ROOT_PARAMETER1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_ROOT_PARAMETER1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_ROOT_PARAMETER1_0 {
@@ -7655,9 +6972,6 @@ impl Default for D3D12_ROOT_PARAMETER1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_ROOT_PARAMETER1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7681,9 +6995,6 @@ impl Default for D3D12_ROOT_SIGNATURE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_ROOT_SIGNATURE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_ROOT_SIGNATURE_DESC1 {
@@ -7698,9 +7009,6 @@ impl Default for D3D12_ROOT_SIGNATURE_DESC1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_ROOT_SIGNATURE_DESC1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_ROOT_SIGNATURE_DESC2 {
@@ -7714,9 +7022,6 @@ impl Default for D3D12_ROOT_SIGNATURE_DESC2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_ROOT_SIGNATURE_DESC2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7793,10 +7098,6 @@ impl Default for D3D12_RT_FORMAT_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_RT_FORMAT_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_SAMPLER_DESC {
@@ -7815,9 +7116,6 @@ impl Default for D3D12_SAMPLER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SAMPLER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7839,9 +7137,6 @@ impl Default for D3D12_SAMPLER_DESC2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_SAMPLER_DESC2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_SAMPLER_DESC2_0 {
@@ -7852,9 +7147,6 @@ impl Default for D3D12_SAMPLER_DESC2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SAMPLER_DESC2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7911,9 +7203,6 @@ impl Default for D3D12_SAMPLE_MASK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_SAMPLE_MASK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_SAMPLE_POSITION {
@@ -7924,9 +7213,6 @@ impl Default for D3D12_SAMPLE_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SAMPLE_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_SDK_VERSION: u32 = 614u32;
 #[repr(C)]
@@ -7939,9 +7225,6 @@ impl Default for D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SERIALIZED_DATA_DRIVER_MATCHING_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_SERIALIZED_DATA_RAYTRACING_ACCELERATION_STRUCTURE: D3D12_SERIALIZED_DATA_TYPE = D3D12_SERIALIZED_DATA_TYPE(0i32);
 #[repr(transparent)]
@@ -7960,9 +7243,6 @@ impl Default for D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_SERIALIZED_RAYTRACING_ACCELERATION_STRUCTURE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_SET_GENERIC_PIPELINE_DESC {
@@ -7972,9 +7252,6 @@ impl Default for D3D12_SET_GENERIC_PIPELINE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SET_GENERIC_PIPELINE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7986,9 +7263,6 @@ impl Default for D3D12_SET_PROGRAM_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SET_PROGRAM_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8002,9 +7276,6 @@ impl Default for D3D12_SET_PROGRAM_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_SET_PROGRAM_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_SET_RAYTRACING_PIPELINE_DESC {
@@ -8014,9 +7285,6 @@ impl Default for D3D12_SET_RAYTRACING_PIPELINE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SET_RAYTRACING_PIPELINE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8030,9 +7298,6 @@ impl Default for D3D12_SET_WORK_GRAPH_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SET_WORK_GRAPH_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8088,10 +7353,6 @@ impl Default for D3D12_SHADER_BUFFER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D12_SHADER_BUFFER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_SHADER_BYTECODE {
@@ -8102,9 +7363,6 @@ impl Default for D3D12_SHADER_BYTECODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SHADER_BYTECODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8245,9 +7503,6 @@ impl Default for D3D12_SHADER_CACHE_SESSION_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_SHADER_CACHE_SESSION_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_SHADER_CACHE_SUPPORT_AUTOMATIC_DISK_CACHE: D3D12_SHADER_CACHE_SUPPORT_FLAGS = D3D12_SHADER_CACHE_SUPPORT_FLAGS(8i32);
 pub const D3D12_SHADER_CACHE_SUPPORT_AUTOMATIC_INPROC_CACHE: D3D12_SHADER_CACHE_SUPPORT_FLAGS = D3D12_SHADER_CACHE_SUPPORT_FLAGS(4i32);
 pub const D3D12_SHADER_CACHE_SUPPORT_DRIVER_MANAGED_CACHE: D3D12_SHADER_CACHE_SUPPORT_FLAGS = D3D12_SHADER_CACHE_SUPPORT_FLAGS(16i32);
@@ -8353,10 +7608,6 @@ impl Default for D3D12_SHADER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D12_SHADER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_SHADER_IDENTIFIER_SIZE_IN_BYTES: u32 = 32u32;
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -8378,10 +7629,6 @@ impl Default for D3D12_SHADER_INPUT_BIND_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D12_SHADER_INPUT_BIND_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_SHADER_MAJOR_VERSION: u32 = 5u32;
 pub const D3D12_SHADER_MAX_INSTANCES: u32 = 65535u32;
@@ -8440,9 +7687,6 @@ impl Default for D3D12_SHADER_NODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_SHADER_NODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_SHADER_NODE_0 {
@@ -8455,9 +7699,6 @@ impl Default for D3D12_SHADER_NODE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SHADER_NODE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -8473,10 +7714,6 @@ impl Default for D3D12_SHADER_RESOURCE_VIEW_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_SHADER_RESOURCE_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -8500,10 +7737,6 @@ impl Default for D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_SHADER_RESOURCE_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8523,10 +7756,6 @@ impl Default for D3D12_SHADER_TYPE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D12_SHADER_TYPE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_SHADER_VARIABLE_DESC {
@@ -8544,9 +7773,6 @@ impl Default for D3D12_SHADER_VARIABLE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SHADER_VARIABLE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8627,10 +7853,6 @@ impl Default for D3D12_SIGNATURE_PARAMETER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3D12_SIGNATURE_PARAMETER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT: u32 = 8u32;
 pub const D3D12_SMALL_MSAA_RESOURCE_PLACEMENT_ALIGNMENT: u32 = 65536u32;
 pub const D3D12_SMALL_RESOURCE_PLACEMENT_ALIGNMENT: u32 = 4096u32;
@@ -8652,9 +7874,6 @@ impl Default for D3D12_SO_DECLARATION_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SO_DECLARATION_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_SO_NO_RASTERIZED_STREAM: u32 = 4294967295u32;
 pub const D3D12_SO_OUTPUT_COMPONENT_COUNT: u32 = 128u32;
@@ -8707,9 +7926,6 @@ impl Default for D3D12_STATE_OBJECT_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_STATE_OBJECT_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_STATE_OBJECT_DESC {
@@ -8721,9 +7937,6 @@ impl Default for D3D12_STATE_OBJECT_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_STATE_OBJECT_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8781,9 +7994,6 @@ impl Default for D3D12_STATE_SUBOBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_STATE_SUBOBJECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8848,9 +8058,6 @@ impl Default for D3D12_STATIC_SAMPLER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_STATIC_SAMPLER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_STATIC_SAMPLER_DESC1 {
@@ -8873,9 +8080,6 @@ impl Default for D3D12_STATIC_SAMPLER_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_STATIC_SAMPLER_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8900,9 +8104,6 @@ impl Default for D3D12_STREAM_OUTPUT_BUFFER_VIEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_STREAM_OUTPUT_BUFFER_VIEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_STREAM_OUTPUT_DESC {
@@ -8917,9 +8118,6 @@ impl Default for D3D12_STREAM_OUTPUT_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_STREAM_OUTPUT_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION {
@@ -8931,9 +8129,6 @@ impl Default for D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SUBOBJECT_TO_EXPORTS_ASSOCIATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_SUBPIXEL_FRACTIONAL_BIT_COUNT: u32 = 8u32;
 #[repr(C)]
@@ -8947,9 +8142,6 @@ impl Default for D3D12_SUBRESOURCE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SUBRESOURCE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -8967,10 +8159,6 @@ impl Default for D3D12_SUBRESOURCE_FOOTPRINT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_SUBRESOURCE_FOOTPRINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_SUBRESOURCE_INFO {
@@ -8983,9 +8171,6 @@ impl Default for D3D12_SUBRESOURCE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_SUBRESOURCE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_SUBRESOURCE_RANGE_UINT64 {
@@ -8996,9 +8181,6 @@ impl Default for D3D12_SUBRESOURCE_RANGE_UINT64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SUBRESOURCE_RANGE_UINT64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9012,9 +8194,6 @@ impl Default for D3D12_SUBRESOURCE_TILING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_SUBRESOURCE_TILING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_SUBTEXEL_FRACTIONAL_BIT_COUNT: u32 = 8u32;
 pub const D3D12_SYSTEM_RESERVED_REGISTER_SPACE_VALUES_END: u32 = 4294967295u32;
@@ -9038,9 +8217,6 @@ impl Default for D3D12_TEX1D_ARRAY_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX1D_ARRAY_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX1D_ARRAY_RTV {
@@ -9052,9 +8228,6 @@ impl Default for D3D12_TEX1D_ARRAY_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX1D_ARRAY_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9070,9 +8243,6 @@ impl Default for D3D12_TEX1D_ARRAY_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX1D_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX1D_ARRAY_UAV {
@@ -9085,9 +8255,6 @@ impl Default for D3D12_TEX1D_ARRAY_UAV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX1D_ARRAY_UAV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX1D_DSV {
@@ -9098,9 +8265,6 @@ impl Default for D3D12_TEX1D_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX1D_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX1D_RTV {
@@ -9110,9 +8274,6 @@ impl Default for D3D12_TEX1D_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX1D_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9126,9 +8287,6 @@ impl Default for D3D12_TEX1D_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX1D_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX1D_UAV {
@@ -9138,9 +8296,6 @@ impl Default for D3D12_TEX1D_UAV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX1D_UAV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9153,9 +8308,6 @@ impl Default for D3D12_TEX2DMS_ARRAY_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX2DMS_ARRAY_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX2DMS_ARRAY_RTV {
@@ -9166,9 +8318,6 @@ impl Default for D3D12_TEX2DMS_ARRAY_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX2DMS_ARRAY_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9181,9 +8330,6 @@ impl Default for D3D12_TEX2DMS_ARRAY_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX2DMS_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX2DMS_ARRAY_UAV {
@@ -9195,9 +8341,6 @@ impl Default for D3D12_TEX2DMS_ARRAY_UAV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX2DMS_ARRAY_UAV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX2DMS_DSV {
@@ -9207,9 +8350,6 @@ impl Default for D3D12_TEX2DMS_DSV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX2DMS_DSV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9221,9 +8361,6 @@ impl Default for D3D12_TEX2DMS_RTV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX2DMS_RTV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX2DMS_SRV {
@@ -9234,9 +8371,6 @@ impl Default for D3D12_TEX2DMS_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX2DMS_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX2DMS_UAV {
@@ -9246,9 +8380,6 @@ impl Default for D3D12_TEX2DMS_UAV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX2DMS_UAV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9262,9 +8393,6 @@ impl Default for D3D12_TEX2D_ARRAY_DSV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX2D_ARRAY_DSV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX2D_ARRAY_RTV {
@@ -9277,9 +8405,6 @@ impl Default for D3D12_TEX2D_ARRAY_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX2D_ARRAY_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9296,9 +8421,6 @@ impl Default for D3D12_TEX2D_ARRAY_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX2D_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX2D_ARRAY_UAV {
@@ -9312,9 +8434,6 @@ impl Default for D3D12_TEX2D_ARRAY_UAV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX2D_ARRAY_UAV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX2D_DSV {
@@ -9324,9 +8443,6 @@ impl Default for D3D12_TEX2D_DSV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX2D_DSV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9338,9 +8454,6 @@ impl Default for D3D12_TEX2D_RTV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX2D_RTV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9355,9 +8468,6 @@ impl Default for D3D12_TEX2D_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX2D_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX2D_UAV {
@@ -9368,9 +8478,6 @@ impl Default for D3D12_TEX2D_UAV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX2D_UAV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9384,9 +8491,6 @@ impl Default for D3D12_TEX3D_RTV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX3D_RTV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX3D_SRV {
@@ -9399,9 +8503,6 @@ impl Default for D3D12_TEX3D_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEX3D_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEX3D_UAV {
@@ -9413,9 +8514,6 @@ impl Default for D3D12_TEX3D_UAV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEX3D_UAV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9431,9 +8529,6 @@ impl Default for D3D12_TEXCUBE_ARRAY_SRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TEXCUBE_ARRAY_SRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TEXCUBE_SRV {
@@ -9445,9 +8540,6 @@ impl Default for D3D12_TEXCUBE_SRV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEXCUBE_SRV {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_TEXEL_ADDRESS_RANGE_BIT_COUNT: u32 = 16u32;
 #[repr(transparent)]
@@ -9475,9 +8567,6 @@ impl Default for D3D12_TEXTURE_BARRIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TEXTURE_BARRIER {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9536,10 +8625,6 @@ impl Default for D3D12_TEXTURE_COPY_LOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_TEXTURE_COPY_LOCATION {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -9552,10 +8637,6 @@ impl Default for D3D12_TEXTURE_COPY_LOCATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_TEXTURE_COPY_LOCATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9586,9 +8667,6 @@ impl Default for D3D12_THREAD_LAUNCH_OVERRIDES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_THREAD_LAUNCH_OVERRIDES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_TILED_RESOURCES_TIER(pub i32);
@@ -9609,9 +8687,6 @@ impl Default for D3D12_TILED_RESOURCE_COORDINATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TILED_RESOURCE_COORDINATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_TILED_RESOURCE_TILE_SIZE_IN_BYTES: u32 = 65536u32;
 #[repr(transparent)]
@@ -9713,9 +8788,6 @@ impl Default for D3D12_TILE_REGION_SIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_TILE_REGION_SIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_TILE_SHAPE {
@@ -9727,9 +8799,6 @@ impl Default for D3D12_TILE_SHAPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_TILE_SHAPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_TRACKED_WORKLOAD_MAX_INSTANCES: u32 = 32u32;
 #[repr(transparent)]
@@ -9767,10 +8836,6 @@ impl Default for D3D12_UNORDERED_ACCESS_VIEW_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_UNORDERED_ACCESS_VIEW_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy)]
@@ -9790,10 +8855,6 @@ impl Default for D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_UNORDERED_ACCESS_VIEW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_VARIABLE_SHADING_RATE_TIER(pub i32);
@@ -9811,9 +8872,6 @@ impl Default for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA_0 {
@@ -9827,9 +8885,6 @@ impl Default for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VERSIONED_DEVICE_REMOVED_EXTENDED_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_VERSIONED_ROOT_SIGNATURE_DESC {
@@ -9840,9 +8895,6 @@ impl Default for D3D12_VERSIONED_ROOT_SIGNATURE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VERSIONED_ROOT_SIGNATURE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9856,9 +8908,6 @@ impl Default for D3D12_VERSIONED_ROOT_SIGNATURE_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VERSIONED_ROOT_SIGNATURE_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VERTEX_BUFFER_VIEW {
@@ -9870,9 +8919,6 @@ impl Default for D3D12_VERTEX_BUFFER_VIEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VERTEX_BUFFER_VIEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_VIDEO_DECODE_MAX_ARGUMENTS: u32 = 10u32;
 pub const D3D12_VIDEO_DECODE_MAX_HISTOGRAM_COMPONENTS: u32 = 4u32;
@@ -9901,9 +8947,6 @@ impl Default for D3D12_VIEWPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIEWPORT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_VIEWPORT_AND_SCISSORRECT_MAX_INDEX: u32 = 15u32;
 pub const D3D12_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE: u32 = 16u32;
 pub const D3D12_VIEWPORT_BOUNDS_MAX: u32 = 32767u32;
@@ -9919,9 +8962,6 @@ impl Default for D3D12_VIEW_INSTANCE_LOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIEW_INSTANCE_LOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIEW_INSTANCING_DESC {
@@ -9933,9 +8973,6 @@ impl Default for D3D12_VIEW_INSTANCING_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIEW_INSTANCING_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10020,9 +9057,6 @@ impl Default for D3D12_WORK_GRAPH_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_WORK_GRAPH_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_WORK_GRAPH_FLAGS(pub i32);
@@ -10073,9 +9107,6 @@ impl Default for D3D12_WORK_GRAPH_MEMORY_REQUIREMENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_WORK_GRAPH_MEMORY_REQUIREMENTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_WRITEBUFFERIMMEDIATE_MODE(pub i32);
@@ -10092,9 +9123,6 @@ impl Default for D3D12_WRITEBUFFERIMMEDIATE_PARAMETER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_WRITEBUFFERIMMEDIATE_PARAMETER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D_HIGHEST_SHADER_MODEL: D3D_SHADER_MODEL = D3D_SHADER_MODEL(105i32);
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
@@ -81,10 +81,6 @@ impl Default for D3DADAPTER_IDENTIFIER9 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for D3DADAPTER_IDENTIFIER9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -106,10 +102,6 @@ impl Default for D3DADAPTER_IDENTIFIER9 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for D3DADAPTER_IDENTIFIER9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -123,10 +115,6 @@ impl Default for D3DAES_CTR_IV {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for D3DAES_CTR_IV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -139,10 +127,6 @@ impl Default for D3DAES_CTR_IV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for D3DAES_CTR_IV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -166,9 +150,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_CONFIGURECRYPTOSESSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_CONFIGURECRYPTOSESSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_CONFIGUREINITIALIZE {
@@ -181,9 +162,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_CONFIGUREINITIALIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_CONFIGUREINITIALIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DAUTHENTICATEDCHANNEL_CONFIGUREPROTECTION {
@@ -194,9 +172,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_CONFIGUREPROTECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_CONFIGUREPROTECTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -211,9 +186,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_CONFIGURESHAREDRESOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_CONFIGURESHAREDRESOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_CONFIGUREUNCOMPRESSEDENCRYPTION {
@@ -224,9 +196,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_CONFIGUREUNCOMPRESSEDENCRYPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_CONFIGUREUNCOMPRESSEDENCRYPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -241,9 +210,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_CONFIGURE_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_CONFIGURE_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_CONFIGURE_OUTPUT {
@@ -257,9 +223,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_CONFIGURE_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_CONFIGURE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DAUTHENTICATEDCHANNEL_D3D9: D3DAUTHENTICATEDCHANNELTYPE = D3DAUTHENTICATEDCHANNELTYPE(1i32);
 pub const D3DAUTHENTICATEDCHANNEL_DRIVER_HARDWARE: D3DAUTHENTICATEDCHANNELTYPE = D3DAUTHENTICATEDCHANNELTYPE(3i32);
@@ -277,9 +240,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0 {
@@ -291,9 +251,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0_0 {
@@ -303,9 +260,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_PROTECTION_FLAGS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -318,9 +272,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYCHANNELTYPE_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYCHANNELTYPE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_INPUT {
@@ -331,9 +282,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -348,9 +296,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYCRYPTOSESSION_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_QUERYDEVICEHANDLE_OUTPUT {
@@ -361,9 +306,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYDEVICEHANDLE_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYDEVICEHANDLE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -376,9 +318,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUIDCOUNT_OUTPUT
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUIDCOUNT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUID_INPUT {
@@ -389,9 +328,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUID_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUID_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -404,9 +340,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUID_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYEVICTIONENCRYPTIONGUID_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -421,9 +354,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYINFOBUSTYPE_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYINFOBUSTYPE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_INPUT {
@@ -435,9 +365,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -452,9 +379,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTIDCOUNT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_INPUT {
@@ -467,9 +391,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
@@ -487,10 +408,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -507,10 +424,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3DAUTHENTICATEDCHANNEL_QUERYPROTECTION_OUTPUT {
@@ -521,9 +434,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYPROTECTION_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYPROTECTION_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -536,9 +446,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESSCOU
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESSCOUNT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESS_INPUT {
@@ -549,9 +456,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESS_IN
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESS_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -566,9 +470,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESS_OU
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYRESTRICTEDSHAREDRESOURCEPROCESS_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_QUERYUNCOMPRESSEDENCRYPTIONLEVEL_OUTPUT {
@@ -579,9 +480,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYUNCOMPRESSEDENCRYPTIONLEVEL_OUTPUT
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYUNCOMPRESSEDENCRYPTIONLEVEL_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -594,9 +492,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERYUNRESTRICTEDPROTECTEDSHAREDRESOURC
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERYUNRESTRICTEDPROTECTEDSHAREDRESOURCECOUNT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DAUTHENTICATEDCHANNEL_QUERY_INPUT {
@@ -608,9 +503,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERY_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERY_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -625,9 +517,6 @@ impl Default for D3DAUTHENTICATEDCHANNEL_QUERY_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DAUTHENTICATEDCHANNEL_QUERY_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DAUTHENTICATEDCONFIGURE_CRYPTOSESSION: windows_core::GUID = windows_core::GUID::from_u128(0x6346cc54_2cfc_4ad4_8224_d15837de7700);
 pub const D3DAUTHENTICATEDCONFIGURE_ENCRYPTIONWHENACCESSIBLE: windows_core::GUID = windows_core::GUID::from_u128(0x41fff286_6ae0_4d43_9d55_a46e9efd158a);
@@ -702,9 +591,6 @@ impl Default for D3DBOX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DBOX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DBRANCH {
@@ -717,9 +603,6 @@ impl Default for D3DBRANCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DBRANCH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DBUSIMPL_MODIFIER_DAUGHTER_BOARD_CONNECTOR: D3DBUSTYPE = D3DBUSTYPE(262144i32);
 pub const D3DBUSIMPL_MODIFIER_DAUGHTER_BOARD_CONNECTOR_INSIDE_OF_NUAE: D3DBUSTYPE = D3DBUSTYPE(327680i32);
@@ -827,9 +710,6 @@ impl Default for D3DCAPS9 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DCAPS9 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DCAPS_OVERLAY: i32 = 2048i32;
 pub const D3DCAPS_READ_SCANLINE: i32 = 131072i32;
 pub const D3DCLEAR_STENCIL: i32 = 4i32;
@@ -858,9 +738,6 @@ impl Default for D3DCLIPSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DCLIPSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DCLIPSTATUS9 {
@@ -871,9 +748,6 @@ impl Default for D3DCLIPSTATUS9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DCLIPSTATUS9 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DCLIPSTATUS_EXTENTS2: i32 = 2i32;
 pub const D3DCLIPSTATUS_EXTENTS3: i32 = 4i32;
@@ -914,9 +788,6 @@ impl Default for D3DCOLORVALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DCOLORVALUE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DCOLOR_MONO: u32 = 1u32;
 pub const D3DCOLOR_RGB: u32 = 2u32;
 #[repr(C)]
@@ -932,9 +803,6 @@ impl Default for D3DCOMPOSERECTDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DCOMPOSERECTDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DCOMPOSERECTDESTINATION {
@@ -947,9 +815,6 @@ impl Default for D3DCOMPOSERECTDESTINATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DCOMPOSERECTDESTINATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1165,9 +1030,6 @@ impl Default for D3DDEVICEDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDEVICEDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDEVICEDESC7 {
@@ -1209,9 +1071,6 @@ impl Default for D3DDEVICEDESC7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDEVICEDESC7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDEVICE_CREATION_PARAMETERS {
@@ -1224,9 +1083,6 @@ impl Default for D3DDEVICE_CREATION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDEVICE_CREATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDEVINFOID_D3DTEXTUREMANAGER: u32 = 2u32;
 pub const D3DDEVINFOID_TEXTUREMANAGER: u32 = 1u32;
@@ -1245,9 +1101,6 @@ impl Default for D3DDEVINFO_D3D9BANDWIDTHTIMINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDEVINFO_D3D9BANDWIDTHTIMINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDEVINFO_D3D9CACHEUTILIZATION {
@@ -1258,9 +1111,6 @@ impl Default for D3DDEVINFO_D3D9CACHEUTILIZATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDEVINFO_D3D9CACHEUTILIZATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1276,9 +1126,6 @@ impl Default for D3DDEVINFO_D3D9INTERFACETIMINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDEVINFO_D3D9INTERFACETIMINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDEVINFO_D3D9PIPELINETIMINGS {
@@ -1292,9 +1139,6 @@ impl Default for D3DDEVINFO_D3D9PIPELINETIMINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDEVINFO_D3D9PIPELINETIMINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDEVINFO_D3D9STAGETIMINGS {
@@ -1305,9 +1149,6 @@ impl Default for D3DDEVINFO_D3D9STAGETIMINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDEVINFO_D3D9STAGETIMINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1320,9 +1161,6 @@ impl Default for D3DDEVINFO_D3DVERTEXSTATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDEVINFO_D3DVERTEXSTATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDEVINFO_RESOURCEMANAGER {
@@ -1332,9 +1170,6 @@ impl Default for D3DDEVINFO_RESOURCEMANAGER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDEVINFO_RESOURCEMANAGER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1348,9 +1183,6 @@ impl Default for D3DDEVINFO_VCACHE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDEVINFO_VCACHE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1372,9 +1204,6 @@ impl Default for D3DDISPLAYMODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDISPLAYMODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDISPLAYMODEEX {
@@ -1390,9 +1219,6 @@ impl Default for D3DDISPLAYMODEEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDISPLAYMODEEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDISPLAYMODEFILTER {
@@ -1404,9 +1230,6 @@ impl Default for D3DDISPLAYMODEFILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDISPLAYMODEFILTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1430,9 +1253,6 @@ impl Default for D3DDP_PTRSTRIDE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DDP_PTRSTRIDE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DDRAWPRIMITIVESTRIDEDDATA {
@@ -1446,9 +1266,6 @@ impl Default for D3DDRAWPRIMITIVESTRIDEDDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DDRAWPRIMITIVESTRIDEDDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DDTCAPS_DEC3N: i32 = 128i32;
 pub const D3DDTCAPS_FLOAT16_2: i32 = 256i32;
@@ -1472,9 +1289,6 @@ impl Default for D3DENCRYPTED_BLOCK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DENCRYPTED_BLOCK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DENUM_NO_DRIVERVERSION: i32 = 4i32;
 pub const D3DENUM_WHQL_LEVEL: i32 = 2i32;
 #[repr(C)]
@@ -1491,9 +1305,6 @@ impl Default for D3DEXECUTEBUFFERDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DEXECUTEBUFFERDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DEXECUTEDATA {
@@ -1509,9 +1320,6 @@ impl Default for D3DEXECUTEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DEXECUTEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DEXECUTE_CLIPPED: i32 = 1i32;
 pub const D3DEXECUTE_UNCLIPPED: i32 = 2i32;
@@ -1556,9 +1364,6 @@ impl Default for D3DFINDDEVICERESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DFINDDEVICERESULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DFINDDEVICESEARCH {
@@ -1574,9 +1379,6 @@ impl Default for D3DFINDDEVICESEARCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DFINDDEVICESEARCH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DFMT_A1: D3DFORMAT = D3DFORMAT(118u32);
 pub const D3DFMT_A16B16G16R16: D3DFORMAT = D3DFORMAT(36u32);
@@ -1703,9 +1505,6 @@ impl Default for D3DGAMMARAMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DGAMMARAMP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DGETDATA_FLUSH: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1720,9 +1519,6 @@ impl Default for D3DHVERTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHVERTEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DHVERTEX_0 {
@@ -1733,9 +1529,6 @@ impl Default for D3DHVERTEX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHVERTEX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1748,9 +1541,6 @@ impl Default for D3DHVERTEX_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DHVERTEX_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DHVERTEX_2 {
@@ -1761,9 +1551,6 @@ impl Default for D3DHVERTEX_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DHVERTEX_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1779,9 +1566,6 @@ impl Default for D3DINDEXBUFFER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DINDEXBUFFER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DINSTRUCTION {
@@ -1793,9 +1577,6 @@ impl Default for D3DINSTRUCTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DINSTRUCTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DISSUE_BEGIN: u32 = 2u32;
 pub const D3DISSUE_END: u32 = 1u32;
@@ -1824,10 +1605,6 @@ impl Default for D3DLIGHT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3DLIGHT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1851,10 +1628,6 @@ impl Default for D3DLIGHT2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3DLIGHT2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -1880,10 +1653,6 @@ impl Default for D3DLIGHT7 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3DLIGHT7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1908,10 +1677,6 @@ impl Default for D3DLIGHT9 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3DLIGHT9 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DLIGHTCAPS_DIRECTIONAL: i32 = 4i32;
 pub const D3DLIGHTCAPS_GLSPOT: i32 = 16i32;
 pub const D3DLIGHTCAPS_PARALLELPOINT: i32 = 8i32;
@@ -1933,10 +1698,6 @@ impl Default for D3DLIGHTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3DLIGHTDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DLIGHTINGCAPS {
@@ -1950,9 +1711,6 @@ impl Default for D3DLIGHTINGCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DLIGHTINGCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1965,10 +1723,6 @@ impl Default for D3DLIGHTINGELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for D3DLIGHTINGELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DLIGHTINGMODEL_MONO: i32 = 2i32;
 pub const D3DLIGHTINGMODEL_RGB: i32 = 1i32;
@@ -2002,9 +1756,6 @@ impl Default for D3DLINE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DLINE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DLINE_0 {
@@ -2016,9 +1767,6 @@ impl Default for D3DLINE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DLINE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DLINE_1 {
@@ -2029,9 +1777,6 @@ impl Default for D3DLINE_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DLINE_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DLINECAPS_ALPHACMP: i32 = 8i32;
 pub const D3DLINECAPS_ANTIALIAS: i32 = 32i32;
@@ -2051,9 +1796,6 @@ impl Default for D3DLOCKED_BOX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DLOCKED_BOX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DLOCKED_RECT {
@@ -2064,9 +1806,6 @@ impl Default for D3DLOCKED_RECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DLOCKED_RECT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DLOCK_DISCARD: i32 = 8192i32;
 pub const D3DLOCK_DONOTWAIT: i32 = 16384i32;
@@ -2091,9 +1830,6 @@ impl Default for D3DLVERTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DLVERTEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DLVERTEX_0 {
@@ -2104,9 +1840,6 @@ impl Default for D3DLVERTEX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DLVERTEX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2119,9 +1852,6 @@ impl Default for D3DLVERTEX_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DLVERTEX_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DLVERTEX_2 {
@@ -2132,9 +1862,6 @@ impl Default for D3DLVERTEX_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DLVERTEX_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2147,9 +1874,6 @@ impl Default for D3DLVERTEX_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DLVERTEX_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DLVERTEX_4 {
@@ -2160,9 +1884,6 @@ impl Default for D3DLVERTEX_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DLVERTEX_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2175,9 +1896,6 @@ impl Default for D3DLVERTEX_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DLVERTEX_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DLVERTEX_6 {
@@ -2188,9 +1906,6 @@ impl Default for D3DLVERTEX_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DLVERTEX_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2209,9 +1924,6 @@ impl Default for D3DMATERIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DMATERIAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DMATERIAL_0 {
@@ -2222,9 +1934,6 @@ impl Default for D3DMATERIAL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DMATERIAL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2237,9 +1946,6 @@ impl Default for D3DMATERIAL_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DMATERIAL_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DMATERIAL_2 {
@@ -2250,9 +1956,6 @@ impl Default for D3DMATERIAL_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DMATERIAL_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2265,9 +1968,6 @@ impl Default for D3DMATERIAL_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DMATERIAL_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DMATERIAL_4 {
@@ -2278,9 +1978,6 @@ impl Default for D3DMATERIAL_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DMATERIAL_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2296,9 +1993,6 @@ impl Default for D3DMATERIAL7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DMATERIAL7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DMATERIAL7_0 {
@@ -2309,9 +2003,6 @@ impl Default for D3DMATERIAL7_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DMATERIAL7_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2324,9 +2015,6 @@ impl Default for D3DMATERIAL7_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DMATERIAL7_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DMATERIAL7_2 {
@@ -2337,9 +2025,6 @@ impl Default for D3DMATERIAL7_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DMATERIAL7_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2352,9 +2037,6 @@ impl Default for D3DMATERIAL7_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DMATERIAL7_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DMATERIAL7_4 {
@@ -2365,9 +2047,6 @@ impl Default for D3DMATERIAL7_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DMATERIAL7_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2383,9 +2062,6 @@ impl Default for D3DMATERIAL9 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DMATERIAL9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DMATERIALCOLORSOURCE(pub i32);
@@ -2400,9 +2076,6 @@ impl Default for D3DMATRIXLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DMATRIXLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DMATRIXMULTIPLY {
@@ -2414,9 +2087,6 @@ impl Default for D3DMATRIXMULTIPLY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DMATRIXMULTIPLY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DMAX30SHADERINSTRUCTIONS: u32 = 32768u32;
 pub const D3DMAXUSERCLIPPLANES: u32 = 32u32;
@@ -2437,10 +2107,6 @@ impl Default for D3DMEMORYPRESSURE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for D3DMEMORYPRESSURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2454,10 +2120,6 @@ impl Default for D3DMEMORYPRESSURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for D3DMEMORYPRESSURE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DMIN30SHADERINSTRUCTIONS: u32 = 512u32;
 pub const D3DMP_16: D3DSHADER_MIN_PRECISION = D3DSHADER_MIN_PRECISION(1i32);
@@ -2553,9 +2215,6 @@ impl Default for D3DPICKRECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DPICKRECORD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DPMISCCAPS_BLENDOP: i32 = 2048i32;
 pub const D3DPMISCCAPS_CLIPPLANESCALEDPOINTS: i32 = 256i32;
 pub const D3DPMISCCAPS_CLIPTLVERTS: i32 = 512i32;
@@ -2587,9 +2246,6 @@ impl Default for D3DPOINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DPOINT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2652,10 +2308,6 @@ impl Default for D3DPRESENTSTATS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for D3DPRESENTSTATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2671,10 +2323,6 @@ impl Default for D3DPRESENTSTATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for D3DPRESENTSTATS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DPRESENT_BACK_BUFFERS_MAX: i32 = 3i32;
 pub const D3DPRESENT_BACK_BUFFERS_MAX_EX: i32 = 30i32;
@@ -2713,9 +2361,6 @@ impl Default for D3DPRESENT_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DPRESENT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DPRESENT_RATE_DEFAULT: u32 = 0u32;
 pub const D3DPRESENT_UPDATECOLORKEY: i32 = 128i32;
 pub const D3DPRESENT_UPDATEOVERLAYONLY: i32 = 32i32;
@@ -2743,9 +2388,6 @@ impl Default for D3DPRIMCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DPRIMCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DPRIMITIVETYPE(pub i32);
@@ -2762,9 +2404,6 @@ impl Default for D3DPROCESSVERTICES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DPROCESSVERTICES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DPROCESSVERTICES_COPY: i32 = 2i32;
 pub const D3DPROCESSVERTICES_NOCOLOR: i32 = 16i32;
@@ -2819,9 +2458,6 @@ impl Default for D3DPSHADERCAPS2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DPSHADERCAPS2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DPTADDRESSCAPS_BORDER: i32 = 8i32;
 pub const D3DPTADDRESSCAPS_CLAMP: i32 = 4i32;
@@ -2913,9 +2549,6 @@ impl Default for D3DRANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DRANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DRASTER_STATUS {
@@ -2926,9 +2559,6 @@ impl Default for D3DRASTER_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DRASTER_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2942,9 +2572,6 @@ impl Default for D3DRECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DRECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2961,9 +2588,6 @@ impl Default for D3DRECTPATCH_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DRECTPATCH_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2988,9 +2612,6 @@ impl Default for D3DRESOURCESTATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DRESOURCESTATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3273,9 +2894,6 @@ impl Default for D3DSPAN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DSPAN {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DSPC_EQ: D3DSHADER_COMPARISON = D3DSHADER_COMPARISON(2i32);
 pub const D3DSPC_GE: D3DSHADER_COMPARISON = D3DSHADER_COMPARISON(3i32);
 pub const D3DSPC_GT: D3DSHADER_COMPARISON = D3DSHADER_COMPARISON(1i32);
@@ -3363,9 +2981,6 @@ impl Default for D3DSTATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DSTATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DSTATE_0 {
@@ -3377,9 +2992,6 @@ impl Default for D3DSTATE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DSTATE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DSTATE_1 {
@@ -3390,9 +3002,6 @@ impl Default for D3DSTATE_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DSTATE_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3413,9 +3022,6 @@ impl Default for D3DSTATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DSTATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DSTATUS {
@@ -3427,9 +3033,6 @@ impl Default for D3DSTATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DSTATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DSTATUS_CLIPINTERSECTIONBACK: i32 = 131072i32;
 pub const D3DSTATUS_CLIPINTERSECTIONBOTTOM: i32 = 32768i32;
@@ -3498,9 +3101,6 @@ impl Default for D3DSURFACE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DSURFACE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3589,9 +3189,6 @@ impl Default for D3DTEXTURELOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DTEXTURELOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DTEXTUREMAGFILTER(pub i32);
@@ -3638,9 +3235,6 @@ impl Default for D3DTLVERTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DTLVERTEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DTLVERTEX_0 {
@@ -3651,9 +3245,6 @@ impl Default for D3DTLVERTEX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DTLVERTEX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3666,9 +3257,6 @@ impl Default for D3DTLVERTEX_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DTLVERTEX_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DTLVERTEX_2 {
@@ -3679,9 +3267,6 @@ impl Default for D3DTLVERTEX_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DTLVERTEX_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3694,9 +3279,6 @@ impl Default for D3DTLVERTEX_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DTLVERTEX_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DTLVERTEX_4 {
@@ -3707,9 +3289,6 @@ impl Default for D3DTLVERTEX_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DTLVERTEX_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3722,9 +3301,6 @@ impl Default for D3DTLVERTEX_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DTLVERTEX_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DTLVERTEX_6 {
@@ -3736,9 +3312,6 @@ impl Default for D3DTLVERTEX_6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DTLVERTEX_6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DTLVERTEX_7 {
@@ -3749,9 +3322,6 @@ impl Default for D3DTLVERTEX_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DTLVERTEX_7 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DTOP_ADD: D3DTEXTUREOP = D3DTEXTUREOP(7i32);
 pub const D3DTOP_ADDSIGNED: D3DTEXTUREOP = D3DTEXTUREOP(8i32);
@@ -3790,9 +3360,6 @@ impl Default for D3DTRANSFORMCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DTRANSFORMCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DTRANSFORMCAPS_CLIP: i32 = 1i32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3813,9 +3380,6 @@ impl Default for D3DTRANSFORMDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DTRANSFORMDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3DTRANSFORMSTATETYPE(pub i32);
@@ -3834,9 +3398,6 @@ impl Default for D3DTRIANGLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DTRIANGLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DTRIANGLE_0 {
@@ -3847,9 +3408,6 @@ impl Default for D3DTRIANGLE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DTRIANGLE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3862,9 +3420,6 @@ impl Default for D3DTRIANGLE_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DTRIANGLE_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DTRIANGLE_2 {
@@ -3875,9 +3430,6 @@ impl Default for D3DTRIANGLE_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DTRIANGLE_2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DTRIFLAG_EDGEENABLE1: i32 = 256i32;
 pub const D3DTRIFLAG_EDGEENABLE2: i32 = 512i32;
@@ -3897,9 +3449,6 @@ impl Default for D3DTRIPATCH_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DTRIPATCH_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DTSS_ALPHAARG0: D3DTEXTURESTAGESTATETYPE = D3DTEXTURESTAGESTATETYPE(27i32);
 pub const D3DTSS_ALPHAARG1: D3DTEXTURESTAGESTATETYPE = D3DTEXTURESTAGESTATETYPE(5i32);
@@ -3990,9 +3539,6 @@ impl Default for D3DVERTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVERTEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DVERTEX_0 {
@@ -4003,9 +3549,6 @@ impl Default for D3DVERTEX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DVERTEX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4018,9 +3561,6 @@ impl Default for D3DVERTEX_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVERTEX_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DVERTEX_2 {
@@ -4031,9 +3571,6 @@ impl Default for D3DVERTEX_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DVERTEX_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4046,9 +3583,6 @@ impl Default for D3DVERTEX_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVERTEX_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DVERTEX_4 {
@@ -4059,9 +3593,6 @@ impl Default for D3DVERTEX_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DVERTEX_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4074,9 +3605,6 @@ impl Default for D3DVERTEX_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVERTEX_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DVERTEX_6 {
@@ -4088,9 +3616,6 @@ impl Default for D3DVERTEX_6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVERTEX_6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3DVERTEX_7 {
@@ -4101,9 +3626,6 @@ impl Default for D3DVERTEX_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DVERTEX_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4121,9 +3643,6 @@ impl Default for D3DVERTEXBUFFERDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVERTEXBUFFERDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DVERTEXBUFFER_DESC {
@@ -4139,9 +3658,6 @@ impl Default for D3DVERTEXBUFFER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVERTEXBUFFER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DVERTEXELEMENT9 {
@@ -4156,9 +3672,6 @@ impl Default for D3DVERTEXELEMENT9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DVERTEXELEMENT9 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DVERTEXTEXTURESAMPLER0: u32 = 257u32;
 pub const D3DVERTEXTEXTURESAMPLER1: u32 = 258u32;
@@ -4187,9 +3700,6 @@ impl Default for D3DVIEWPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVIEWPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DVIEWPORT2 {
@@ -4210,9 +3720,6 @@ impl Default for D3DVIEWPORT2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVIEWPORT2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DVIEWPORT7 {
@@ -4228,9 +3735,6 @@ impl Default for D3DVIEWPORT7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVIEWPORT7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DVIEWPORT9 {
@@ -4245,9 +3749,6 @@ impl Default for D3DVIEWPORT9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DVIEWPORT9 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DVIS_INSIDE_BOTTOM: u32 = 0u32;
 pub const D3DVIS_INSIDE_FAR: u32 = 0u32;
@@ -4293,9 +3794,6 @@ impl Default for D3DVOLUME_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3DVOLUME_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3DVOP_CLIP: u32 = 4u32;
 pub const D3DVOP_EXTENTS: u32 = 8u32;
 pub const D3DVOP_LIGHT: u32 = 1024u32;
@@ -4319,9 +3817,6 @@ impl Default for D3DVSHADERCAPS2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DVSHADERCAPS2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3DVS_ADDRESSMODE_SHIFT: u32 = 13u32;
 #[repr(transparent)]
@@ -4369,9 +3864,6 @@ impl Default for D3D_OMAC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D_OMAC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D_OMAC_SIZE: u32 = 16u32;
 pub const D3D_SDK_VERSION: u32 = 32u32;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/mod.rs
@@ -24,9 +24,6 @@ impl Default for D3D9ON12_ARGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D9ON12_ARGS {
-    type TypeKind = windows_core::CloneType;
-}
 windows_core::imp::define_interface!(IDirect3DDevice9On12, IDirect3DDevice9On12_Vtbl, 0xe7fda234_b589_4049_940d_8878977531c8);
 windows_core::imp::interface_hierarchy!(IDirect3DDevice9On12, windows_core::IUnknown);
 impl IDirect3DDevice9On12 {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/mod.rs
@@ -104,9 +104,6 @@ impl Default for COMPOSITION_FRAME_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMPOSITION_FRAME_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COMPOSITION_STATS {
@@ -119,9 +116,6 @@ impl Default for COMPOSITION_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COMPOSITION_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COMPOSITION_STATS_MAX_TARGETS: u32 = 256u32;
 #[repr(C)]
@@ -138,9 +132,6 @@ impl Default for COMPOSITION_TARGET_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMPOSITION_TARGET_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COMPOSITION_TARGET_STATS {
@@ -154,9 +145,6 @@ impl Default for COMPOSITION_TARGET_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COMPOSITION_TARGET_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -206,10 +194,6 @@ impl Default for DCOMPOSITION_FRAME_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for DCOMPOSITION_FRAME_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DCOMPOSITION_MAX_WAITFORCOMPOSITORCLOCK_OBJECTS: u32 = 32u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -228,9 +212,6 @@ impl Default for DCompositionInkTrailPoint {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DCompositionInkTrailPoint {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IDCompositionAffineTransform2DEffect, IDCompositionAffineTransform2DEffect_Vtbl, 0x0b74b9e8_cdd6_492f_bbbc_5ed32157026d);
 impl core::ops::Deref for IDCompositionAffineTransform2DEffect {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
@@ -61,10 +61,6 @@ impl Default for ACCESSRECTLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ACCESSRECTLIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ACCESSRECT_BROKEN: i32 = 4i32;
 pub const ACCESSRECT_NOTHOLDINGWIN16LOCK: i32 = 2i32;
 pub const ACCESSRECT_VRAMSTYLE: i32 = 1i32;
@@ -82,10 +78,6 @@ impl Default for ATTACHLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ATTACHLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CCHDEVICENAME: u32 = 32u32;
 pub const CLSID_DirectDraw: windows_core::GUID = windows_core::GUID::from_u128(0xd7b70ee0_4340_11cf_b063_0020afc2cd35);
@@ -136,10 +128,6 @@ impl Default for DBLNODE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DBLNODE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DCICOMMAND: u32 = 3075u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -152,9 +140,6 @@ impl Default for DD32BITDRIVERDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD32BITDRIVERDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDABLT_SRCOVERDEST: i32 = 1i32;
 pub const DDAL_IMPLICIT: i32 = 1i32;
@@ -170,9 +155,6 @@ impl Default for DDARGB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDARGB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDBD_1: i32 = 16384i32;
 pub const DDBD_16: i32 = 1024i32;
@@ -194,9 +176,6 @@ impl Default for DDBLTBATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDBLTBATCH {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DDBLTFAST_DESTCOLORKEY: u32 = 2u32;
 pub const DDBLTFAST_DONOTWAIT: u32 = 32u32;
@@ -239,9 +218,6 @@ impl Default for DDBLTFX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDBLTFX {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union DDBLTFX_0 {
     pub dwZDestConst: u32,
@@ -256,9 +232,6 @@ impl Default for DDBLTFX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDBLTFX_0 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 pub union DDBLTFX_1 {
@@ -275,9 +248,6 @@ impl Default for DDBLTFX_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDBLTFX_1 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union DDBLTFX_2 {
     pub dwAlphaDestConst: u32,
@@ -293,9 +263,6 @@ impl Default for DDBLTFX_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDBLTFX_2 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union DDBLTFX_3 {
     pub dwAlphaSrcConst: u32,
@@ -310,9 +277,6 @@ impl Default for DDBLTFX_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDBLTFX_3 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 pub union DDBLTFX_4 {
@@ -330,9 +294,6 @@ impl Default for DDBLTFX_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDBLTFX_4 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DDBLTFX_ARITHSTRETCHY: i32 = 1i32;
 pub const DDBLTFX_MIRRORLEFTRIGHT: i32 = 2i32;
@@ -384,9 +345,6 @@ impl Default for DDBOBNEXTFIELDINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDBOBNEXTFIELDINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDCAPS2_AUTOFLIPOVERLAY: i32 = 8i32;
 pub const DDCAPS2_CANAUTOGENMIPMAP: i32 = 1073741824i32;
@@ -482,9 +440,6 @@ impl Default for DDCAPS_DX1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDCAPS_DX1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDCAPS_DX3 {
@@ -544,9 +499,6 @@ impl Default for DDCAPS_DX3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDCAPS_DX3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -612,9 +564,6 @@ impl Default for DDCAPS_DX5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDCAPS_DX5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -682,9 +631,6 @@ impl Default for DDCAPS_DX6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDCAPS_DX6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DDCAPS_DX7 {
@@ -751,9 +697,6 @@ impl Default for DDCAPS_DX7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDCAPS_DX7 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DDCAPS_GDI: i32 = 1024i32;
 pub const DDCAPS_NOHARDWARE: i32 = 33554432i32;
 pub const DDCAPS_OVERLAY: i32 = 2048i32;
@@ -810,9 +753,6 @@ impl Default for DDCOLORCONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDCOLORCONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDCOLORKEY {
@@ -823,9 +763,6 @@ impl Default for DDCOLORKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDCOLORKEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDCOLOR_BRIGHTNESS: i32 = 1i32;
 pub const DDCOLOR_COLORENABLE: i32 = 64i32;
@@ -849,9 +786,6 @@ impl Default for DDCOMPBUFFERINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDCOMPBUFFERINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -913,9 +847,6 @@ impl Default for DDCORECAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDCORECAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DDCREATEDRIVEROBJECT: u32 = 10u32;
 pub const DDCREATE_EMULATIONONLY: i32 = 2i32;
 pub const DDCREATE_HARDWAREONLY: i32 = 1i32;
@@ -936,9 +867,6 @@ impl Default for DDDEVICEIDENTIFIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDDEVICEIDENTIFIER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDDEVICEIDENTIFIER2 {
@@ -957,9 +885,6 @@ impl Default for DDDEVICEIDENTIFIER2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDDEVICEIDENTIFIER2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DDEDM_REFRESHRATES: i32 = 1i32;
 pub const DDEDM_STANDARDVGAMODES: i32 = 2i32;
 pub const DDEM_MODEFAILED: i32 = 2i32;
@@ -976,9 +901,6 @@ impl Default for DDENABLEIRQINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDENABLEIRQINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDENUMOVERLAYZ_BACKTOFRONT: i32 = 0i32;
 pub const DDENUMOVERLAYZ_FRONTTOBACK: i32 = 1i32;
@@ -1005,9 +927,6 @@ impl Default for DDFLIPOVERLAYINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDFLIPOVERLAYINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDFLIPVIDEOPORTINFO {
@@ -1020,9 +939,6 @@ impl Default for DDFLIPVIDEOPORTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDFLIPVIDEOPORTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDFLIP_DONOTWAIT: i32 = 32i32;
 pub const DDFLIP_EVEN: i32 = 2i32;
@@ -1086,9 +1002,6 @@ impl Default for DDGAMMARAMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDGAMMARAMP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DDGBS_CANBLT: i32 = 1i32;
 pub const DDGBS_ISBLTDONE: i32 = 2i32;
 pub const DDGDI_GETHOSTIDENTIFIER: i32 = 1i32;
@@ -1103,9 +1016,6 @@ impl Default for DDGETCURRENTAUTOFLIPININFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDGETCURRENTAUTOFLIPININFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDGETCURRENTAUTOFLIPOUTINFO {
@@ -1117,9 +1027,6 @@ impl Default for DDGETCURRENTAUTOFLIPOUTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDGETCURRENTAUTOFLIPOUTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDGETIRQINFO {
@@ -1129,9 +1036,6 @@ impl Default for DDGETIRQINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDGETIRQINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1143,9 +1047,6 @@ impl Default for DDGETPOLARITYININFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDGETPOLARITYININFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDGETPOLARITYOUTINFO {
@@ -1156,9 +1057,6 @@ impl Default for DDGETPOLARITYOUTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDGETPOLARITYOUTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDGETPREVIOUSAUTOFLIPININFO {
@@ -1168,9 +1066,6 @@ impl Default for DDGETPREVIOUSAUTOFLIPININFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDGETPREVIOUSAUTOFLIPININFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1183,9 +1078,6 @@ impl Default for DDGETPREVIOUSAUTOFLIPOUTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDGETPREVIOUSAUTOFLIPOUTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDGETTRANSFERSTATUSOUTINFO {
@@ -1195,9 +1087,6 @@ impl Default for DDGETTRANSFERSTATUSOUTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDGETTRANSFERSTATUSOUTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDGFS_CANFLIP: i32 = 1i32;
 pub const DDGFS_ISFLIPDONE: i32 = 2i32;
@@ -1215,10 +1104,6 @@ impl Default for DDHALDDRAWFNS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHALDDRAWFNS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1249,10 +1134,6 @@ impl Default for DDHALINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHALINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DDHALINFO_GETDRIVERINFO2: i32 = 8i32;
 pub const DDHALINFO_GETDRIVERINFOSET: i32 = 4i32;
 pub const DDHALINFO_ISPRIMARYDISPLAY: i32 = 1i32;
@@ -1276,9 +1157,6 @@ impl Default for DDHALMODEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDHALMODEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1294,10 +1172,6 @@ impl Default for DDHAL_ADDATTACHEDSURFACEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_ADDATTACHEDSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDHAL_APP_DLLNAME: windows_core::PCSTR = windows_core::s!("DDRAW.DLL");
 #[repr(C)]
@@ -1319,10 +1193,6 @@ impl Default for DDHAL_BEGINMOCOMPFRAMEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_BEGINMOCOMPFRAMEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1354,10 +1224,6 @@ impl Default for DDHAL_BLTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_BLTDATA {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1392,10 +1258,6 @@ impl Default for DDHAL_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1412,10 +1274,6 @@ impl Default for DDHAL_CANCREATESURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_CANCREATESURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1430,10 +1288,6 @@ impl Default for DDHAL_CANCREATEVPORTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_CANCREATEVPORTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDHAL_CB32_CANCREATESURFACE: i32 = 32i32;
 pub const DDHAL_CB32_CREATEPALETTE: i32 = 64i32;
@@ -1463,10 +1317,6 @@ impl Default for DDHAL_COLORCONTROLDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_COLORCONTROLDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DDHAL_COLOR_COLORCONTROL: i32 = 1i32;
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1489,10 +1339,6 @@ impl Default for DDHAL_CREATEMOCOMPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_CREATEMOCOMPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1509,10 +1355,6 @@ impl Default for DDHAL_CREATEPALETTEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_CREATEPALETTEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1531,10 +1373,6 @@ impl Default for DDHAL_CREATESURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_CREATESURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1549,10 +1387,6 @@ impl Default for DDHAL_CREATESURFACEEXDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_CREATESURFACEEXDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDHAL_CREATESURFACEEX_SWAPHANDLES: i32 = 1i32;
 #[repr(C)]
@@ -1570,10 +1404,6 @@ impl Default for DDHAL_CREATEVPORTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_CREATEVPORTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDHAL_D3DBUFCB32_CANCREATED3DBUF: i32 = 1i32;
 pub const DDHAL_D3DBUFCB32_CREATED3DBUF: i32 = 2i32;
@@ -1603,10 +1433,6 @@ impl Default for DDHAL_DDCALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DDCALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1620,10 +1446,6 @@ impl Default for DDHAL_DDCOLORCONTROLCALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DDCOLORCONTROLCALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1643,10 +1465,6 @@ impl Default for DDHAL_DDEXEBUFCALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DDEXEBUFCALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1661,10 +1479,6 @@ impl Default for DDHAL_DDKERNELCALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DDKERNELCALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1683,10 +1497,6 @@ impl Default for DDHAL_DDMISCELLANEOUS2CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DDMISCELLANEOUS2CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1703,10 +1513,6 @@ impl Default for DDHAL_DDMISCELLANEOUSCALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DDMISCELLANEOUSCALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1731,10 +1537,6 @@ impl Default for DDHAL_DDMOTIONCOMPCALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DDMOTIONCOMPCALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1749,10 +1551,6 @@ impl Default for DDHAL_DDPALETTECALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DDPALETTECALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1780,10 +1578,6 @@ impl Default for DDHAL_DDSURFACECALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DDSURFACECALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1814,10 +1608,6 @@ impl Default for DDHAL_DDVIDEOPORTCALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DDVIDEOPORTCALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1832,10 +1622,6 @@ impl Default for DDHAL_DESTROYDDLOCALDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DESTROYDDLOCALDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1849,10 +1635,6 @@ impl Default for DDHAL_DESTROYDRIVERDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DESTROYDRIVERDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1869,10 +1651,6 @@ impl Default for DDHAL_DESTROYMOCOMPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DESTROYMOCOMPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1887,10 +1665,6 @@ impl Default for DDHAL_DESTROYPALETTEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DESTROYPALETTEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1907,10 +1681,6 @@ impl Default for DDHAL_DESTROYSURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DESTROYSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1925,10 +1695,6 @@ impl Default for DDHAL_DESTROYVPORTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DESTROYVPORTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDHAL_DRIVER_DLLNAME: windows_core::PCSTR = windows_core::s!("DDRAW16.DLL");
 pub const DDHAL_DRIVER_HANDLED: i32 = 1i32;
@@ -1950,10 +1716,6 @@ impl Default for DDHAL_DRVSETCOLORKEYDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_DRVSETCOLORKEYDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1970,10 +1732,6 @@ impl Default for DDHAL_ENDMOCOMPFRAMEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_ENDMOCOMPFRAMEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDHAL_EXEBUFCB32_CANCREATEEXEBUF: i32 = 1i32;
 pub const DDHAL_EXEBUFCB32_CREATEEXEBUF: i32 = 2i32;
@@ -1999,10 +1757,6 @@ impl Default for DDHAL_FLIPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_FLIPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2018,10 +1772,6 @@ impl Default for DDHAL_FLIPTOGDISURFACEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_FLIPTOGDISURFACEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2039,10 +1789,6 @@ impl Default for DDHAL_FLIPVPORTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_FLIPVPORTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2062,10 +1808,6 @@ impl Default for DDHAL_GETAVAILDRIVERMEMORYDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETAVAILDRIVERMEMORYDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2081,10 +1823,6 @@ impl Default for DDHAL_GETBLTSTATUSDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETBLTSTATUSDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2103,9 +1841,6 @@ impl Default for DDHAL_GETDRIVERINFODATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDHAL_GETDRIVERINFODATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DDHAL_GETDRIVERSTATEDATA {
@@ -2120,9 +1855,6 @@ impl Default for DDHAL_GETDRIVERSTATEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDHAL_GETDRIVERSTATEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDHAL_GETDRIVERSTATEDATA_0 {
@@ -2132,9 +1864,6 @@ impl Default for DDHAL_GETDRIVERSTATEDATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDHAL_GETDRIVERSTATEDATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2152,10 +1881,6 @@ impl Default for DDHAL_GETFLIPSTATUSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETFLIPSTATUSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DDHAL_GETHEAPALIGNMENTDATA {
@@ -2169,9 +1894,6 @@ impl Default for DDHAL_GETHEAPALIGNMENTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDHAL_GETHEAPALIGNMENTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2191,10 +1913,6 @@ impl Default for DDHAL_GETINTERNALMOCOMPDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETINTERNALMOCOMPDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2216,10 +1934,6 @@ impl Default for DDHAL_GETMOCOMPCOMPBUFFDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETMOCOMPCOMPBUFFDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2237,10 +1951,6 @@ impl Default for DDHAL_GETMOCOMPFORMATSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETMOCOMPFORMATSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2257,10 +1967,6 @@ impl Default for DDHAL_GETMOCOMPGUIDSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETMOCOMPGUIDSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2275,10 +1981,6 @@ impl Default for DDHAL_GETSCANLINEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETSCANLINEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2300,10 +2002,6 @@ impl Default for DDHAL_GETVPORTBANDWIDTHDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETVPORTBANDWIDTHDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2321,10 +2019,6 @@ impl Default for DDHAL_GETVPORTCONNECTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETVPORTCONNECTDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2341,10 +2035,6 @@ impl Default for DDHAL_GETVPORTFIELDDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETVPORTFIELDDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2359,10 +2049,6 @@ impl Default for DDHAL_GETVPORTFLIPSTATUSDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETVPORTFLIPSTATUSDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2382,10 +2068,6 @@ impl Default for DDHAL_GETVPORTINPUTFORMATDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETVPORTINPUTFORMATDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2401,10 +2083,6 @@ impl Default for DDHAL_GETVPORTLINEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETVPORTLINEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2425,10 +2103,6 @@ impl Default for DDHAL_GETVPORTOUTPUTFORMATDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETVPORTOUTPUTFORMATDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2444,10 +2118,6 @@ impl Default for DDHAL_GETVPORTSIGNALDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_GETVPORTSIGNALDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDHAL_KERNEL_SYNCSURFACEDATA: i32 = 1i32;
 pub const DDHAL_KERNEL_SYNCVIDEOPORTDATA: i32 = 2i32;
@@ -2469,10 +2139,6 @@ impl Default for DDHAL_LOCKDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_LOCKDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDHAL_MISC2CB32_ALPHABLT: i32 = 1i32;
 pub const DDHAL_MISC2CB32_CREATESURFACEEX: i32 = 2i32;
@@ -2520,10 +2186,6 @@ impl Default for DDHAL_QUERYMOCOMPSTATUSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_QUERYMOCOMPSTATUSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2546,10 +2208,6 @@ impl Default for DDHAL_RENDERMOCOMPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_RENDERMOCOMPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2564,10 +2222,6 @@ impl Default for DDHAL_SETCLIPLISTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_SETCLIPLISTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2585,10 +2239,6 @@ impl Default for DDHAL_SETCOLORKEYDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_SETCOLORKEYDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2608,10 +2258,6 @@ impl Default for DDHAL_SETENTRIESDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_SETENTRIESDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2627,10 +2273,6 @@ impl Default for DDHAL_SETEXCLUSIVEMODEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_SETEXCLUSIVEMODEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2648,10 +2290,6 @@ impl Default for DDHAL_SETMODEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_SETMODEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2671,10 +2309,6 @@ impl Default for DDHAL_SETOVERLAYPOSITIONDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_SETOVERLAYPOSITIONDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2691,10 +2325,6 @@ impl Default for DDHAL_SETPALETTEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_SETPALETTEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDHAL_SURFCB32_ADDATTACHEDSURFACE: i32 = 128i32;
 pub const DDHAL_SURFCB32_BLT: i32 = 32i32;
@@ -2736,10 +2366,6 @@ impl Default for DDHAL_SYNCSURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_SYNCSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2761,10 +2387,6 @@ impl Default for DDHAL_SYNCVIDEOPORTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_SYNCVIDEOPORTDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2779,10 +2401,6 @@ impl Default for DDHAL_UNLOCKDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_UNLOCKDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2801,10 +2419,6 @@ impl Default for DDHAL_UPDATENONLOCALHEAPDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_UPDATENONLOCALHEAPDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2831,10 +2445,6 @@ impl Default for DDHAL_UPDATEOVERLAYDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_UPDATEOVERLAYDATA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2855,10 +2465,6 @@ impl Default for DDHAL_UPDATEVPORTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_UPDATEVPORTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDHAL_VPORT32_CANCREATEVIDEOPORT: i32 = 1i32;
 pub const DDHAL_VPORT32_COLORCONTROL: i32 = 32768i32;
@@ -2893,10 +2499,6 @@ impl Default for DDHAL_VPORTCOLORDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_VPORTCOLORDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2913,10 +2515,6 @@ impl Default for DDHAL_WAITFORVERTICALBLANKDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_WAITFORVERTICALBLANKDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2935,10 +2533,6 @@ impl Default for DDHAL_WAITFORVPORTSYNCDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDHAL_WAITFORVPORTSYNCDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDIRQ_BUSMASTER: i32 = 2i32;
 pub const DDIRQ_DISPLAY_VSYNC: i32 = 1i32;
@@ -2975,9 +2569,6 @@ impl Default for DDKERNELCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDKERNELCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DDKERNELCAPS_AUTOFLIP: i32 = 2i32;
 pub const DDKERNELCAPS_CAPTURE_INVERTED: i32 = 512i32;
 pub const DDKERNELCAPS_CAPTURE_NONLOCALVIDMEM: i32 = 128i32;
@@ -2998,9 +2589,6 @@ impl Default for DDLOCKININFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDLOCKININFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDLOCKOUTINFO {
@@ -3010,9 +2598,6 @@ impl Default for DDLOCKOUTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDLOCKOUTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDLOCK_DISCARDCONTENTS: i32 = 8192i32;
 pub const DDLOCK_DONOTWAIT: i32 = 16384i32;
@@ -3042,10 +2627,6 @@ impl Default for DDMCBUFFERINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDMCBUFFERINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DDMCCOMPBUFFERINFO {
@@ -3061,9 +2642,6 @@ impl Default for DDMCCOMPBUFFERINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDMCCOMPBUFFERINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDMCQUERY_READ: u32 = 1u32;
 #[repr(C)]
@@ -3083,9 +2661,6 @@ impl Default for DDMDL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDMDL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDMOCOMPBUFFERINFO {
@@ -3099,9 +2674,6 @@ impl Default for DDMOCOMPBUFFERINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDMOCOMPBUFFERINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDMODEINFO_MAXREFRESH: u32 = 16u32;
 pub const DDMODEINFO_MODEX: u32 = 2u32;
@@ -3130,9 +2702,6 @@ impl Default for DDMONITORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDMONITORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DDMORESURFACECAPS {
@@ -3145,9 +2714,6 @@ impl Default for DDMORESURFACECAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDMORESURFACECAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DDMORESURFACECAPS_0 {
@@ -3158,9 +2724,6 @@ impl Default for DDMORESURFACECAPS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDMORESURFACECAPS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDNEWCALLBACKFNS: u32 = 12u32;
 #[repr(C)]
@@ -3177,9 +2740,6 @@ impl Default for DDNONLOCALVIDMEMCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDNONLOCALVIDMEMCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3241,9 +2801,6 @@ impl Default for DDNTCORECAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDNTCORECAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DDOPTSURFACEDESC {
@@ -3259,9 +2816,6 @@ impl Default for DDOPTSURFACEDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDOPTSURFACEDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDOSCAPS {
@@ -3271,9 +2825,6 @@ impl Default for DDOSCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDOSCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDOSDCAPS_MONOLITHICMIPMAP: i32 = 4i32;
 pub const DDOSDCAPS_OPTCOMPRESSED: i32 = 1i32;
@@ -3314,9 +2865,6 @@ impl Default for DDOVERLAYFX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDOVERLAYFX {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union DDOVERLAYFX_0 {
     pub dwAlphaDestConst: u32,
@@ -3332,9 +2880,6 @@ impl Default for DDOVERLAYFX_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDOVERLAYFX_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union DDOVERLAYFX_1 {
     pub dwAlphaSrcConst: u32,
@@ -3349,9 +2894,6 @@ impl Default for DDOVERLAYFX_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDOVERLAYFX_1 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DDOVERZ_INSERTINBACKOF: i32 = 5i32;
 pub const DDOVERZ_INSERTINFRONTOF: i32 = 4i32;
@@ -3434,9 +2976,6 @@ impl Default for DDPIXELFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDPIXELFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDPIXELFORMAT_0 {
@@ -3453,9 +2992,6 @@ impl Default for DDPIXELFORMAT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDPIXELFORMAT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDPIXELFORMAT_1 {
@@ -3471,9 +3007,6 @@ impl Default for DDPIXELFORMAT_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDPIXELFORMAT_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDPIXELFORMAT_2 {
@@ -3488,9 +3021,6 @@ impl Default for DDPIXELFORMAT_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDPIXELFORMAT_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDPIXELFORMAT_2_0 {
@@ -3501,9 +3031,6 @@ impl Default for DDPIXELFORMAT_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDPIXELFORMAT_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3518,9 +3045,6 @@ impl Default for DDPIXELFORMAT_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDPIXELFORMAT_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDPIXELFORMAT_4 {
@@ -3534,9 +3058,6 @@ impl Default for DDPIXELFORMAT_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDPIXELFORMAT_4 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDRAWICLIP_INMASTERSPRITELIST: i32 = 4i32;
 pub const DDRAWICLIP_ISINITIALIZED: i32 = 2i32;
@@ -3657,10 +3178,6 @@ impl Default for DDRAWI_DDMOTIONCOMP_INT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDMOTIONCOMP_INT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -3687,10 +3204,6 @@ impl Default for DDRAWI_DDMOTIONCOMP_LCL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDMOTIONCOMP_LCL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3709,10 +3222,6 @@ impl Default for DDRAWI_DDRAWCLIPPER_GBL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWCLIPPER_GBL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3727,10 +3236,6 @@ impl Default for DDRAWI_DDRAWCLIPPER_INT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWCLIPPER_INT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -3750,10 +3255,6 @@ impl Default for DDRAWI_DDRAWCLIPPER_LCL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWCLIPPER_LCL {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DDRAWI_DDRAWDATANOTFETCHED: i32 = 67108864i32;
 #[repr(C)]
@@ -3777,10 +3278,6 @@ impl Default for DDRAWI_DDRAWPALETTE_GBL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWPALETTE_GBL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -3793,10 +3290,6 @@ impl Default for DDRAWI_DDRAWPALETTE_GBL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWPALETTE_GBL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -3812,10 +3305,6 @@ impl Default for DDRAWI_DDRAWPALETTE_INT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWPALETTE_INT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -3837,10 +3326,6 @@ impl Default for DDRAWI_DDRAWPALETTE_LCL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWPALETTE_LCL {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -3865,10 +3350,6 @@ impl Default for DDRAWI_DDRAWSURFACE_GBL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_GBL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -3883,10 +3364,6 @@ impl Default for DDRAWI_DDRAWSURFACE_GBL_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_GBL_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -3899,10 +3376,6 @@ impl Default for DDRAWI_DDRAWSURFACE_GBL_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_GBL_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -3917,10 +3390,6 @@ impl Default for DDRAWI_DDRAWSURFACE_GBL_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_GBL_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -3933,10 +3402,6 @@ impl Default for DDRAWI_DDRAWSURFACE_GBL_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_GBL_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3966,9 +3431,6 @@ impl Default for DDRAWI_DDRAWSURFACE_GBL_MORE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_GBL_MORE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDRAWI_DDRAWSURFACE_GBL_MORE_0 {
@@ -3979,9 +3441,6 @@ impl Default for DDRAWI_DDRAWSURFACE_GBL_MORE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_GBL_MORE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -3997,10 +3456,6 @@ impl Default for DDRAWI_DDRAWSURFACE_INT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_INT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -4040,10 +3495,6 @@ impl Default for DDRAWI_DDRAWSURFACE_LCL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_LCL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -4057,10 +3508,6 @@ impl Default for DDRAWI_DDRAWSURFACE_LCL_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_LCL_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -4073,10 +3520,6 @@ impl Default for DDRAWI_DDRAWSURFACE_LCL_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_LCL_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -4120,10 +3563,6 @@ impl Default for DDRAWI_DDRAWSURFACE_MORE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDRAWSURFACE_MORE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4139,10 +3578,6 @@ impl Default for DDRAWI_DDVIDEOPORT_INT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDVIDEOPORT_INT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -4176,10 +3611,6 @@ impl Default for DDRAWI_DDVIDEOPORT_LCL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DDVIDEOPORT_LCL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -4262,10 +3693,6 @@ impl Default for DDRAWI_DIRECTDRAW_GBL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DIRECTDRAW_GBL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4280,10 +3707,6 @@ impl Default for DDRAWI_DIRECTDRAW_INT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DIRECTDRAW_INT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -4321,10 +3744,6 @@ impl Default for DDRAWI_DIRECTDRAW_LCL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DDRAWI_DIRECTDRAW_LCL {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DDRAWI_DISPLAYDRV: i32 = 32i32;
 pub const DDRAWI_DRIVERINFO2: i32 = 536870912i32;
@@ -4372,9 +3791,6 @@ impl Default for DDRGBA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDRGBA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDSCAPS {
@@ -4384,9 +3800,6 @@ impl Default for DDSCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDSCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4401,9 +3814,6 @@ impl Default for DDSCAPS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDSCAPS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDSCAPS2_0 {
@@ -4414,9 +3824,6 @@ impl Default for DDSCAPS2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDSCAPS2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDSCAPS2_ADDITIONALPRIMARY: i32 = -2147483648i32;
 pub const DDSCAPS2_COMMANDBUFFER: i32 = 64i32;
@@ -4475,9 +3882,6 @@ impl Default for DDSCAPSEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDSCAPSEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDSCAPSEX_0 {
@@ -4488,9 +3892,6 @@ impl Default for DDSCAPSEX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDSCAPSEX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDSCAPS_3DDEVICE: i32 = 8192i32;
 pub const DDSCAPS_ALLOCONLOAD: i32 = 67108864i32;
@@ -4570,9 +3971,6 @@ impl Default for DDSETSTATEININFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDSETSTATEININFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDSETSTATEOUTINFO {
@@ -4584,9 +3982,6 @@ impl Default for DDSETSTATEOUTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDSETSTATEOUTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDSETSURFACEDESC_PRESERVEDC: i32 = 1i32;
 pub const DDSETSURFACEDESC_RECREATEDC: i32 = 0i32;
@@ -4601,9 +3996,6 @@ impl Default for DDSKIPNEXTFIELDINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDSKIPNEXTFIELDINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDSKIP_ENABLENEXT: u32 = 2u32;
 pub const DDSKIP_SKIPNEXT: u32 = 1u32;
@@ -4624,9 +4016,6 @@ impl Default for DDSTEREOMODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDSTEREOMODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4660,9 +4049,6 @@ impl Default for DDSURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DDSURFACEDESC {
@@ -4688,9 +4074,6 @@ impl Default for DDSURFACEDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDSURFACEDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDSURFACEDESC_0 {
@@ -4701,9 +4084,6 @@ impl Default for DDSURFACEDESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDSURFACEDESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4716,9 +4096,6 @@ impl Default for DDSURFACEDESC_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDSURFACEDESC_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4746,9 +4123,6 @@ impl Default for DDSURFACEDESC2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDSURFACEDESC2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDSURFACEDESC2_0 {
@@ -4760,9 +4134,6 @@ impl Default for DDSURFACEDESC2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDSURFACEDESC2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDSURFACEDESC2_1 {
@@ -4773,9 +4144,6 @@ impl Default for DDSURFACEDESC2_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDSURFACEDESC2_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4789,9 +4157,6 @@ impl Default for DDSURFACEDESC2_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDSURFACEDESC2_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDSURFACEDESC2_3 {
@@ -4803,9 +4168,6 @@ impl Default for DDSURFACEDESC2_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDSURFACEDESC2_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DDSURFACEDESC2_4 {
@@ -4816,9 +4178,6 @@ impl Default for DDSURFACEDESC2_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDSURFACEDESC2_4 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDSVCAPS_RESERVED1: i32 = 1i32;
 pub const DDSVCAPS_RESERVED2: i32 = 2i32;
@@ -4840,9 +4199,6 @@ impl Default for DDTRANSFERININFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDTRANSFERININFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDTRANSFEROUTINFO {
@@ -4852,9 +4208,6 @@ impl Default for DDTRANSFEROUTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDTRANSFEROUTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDTRANSFER_CANCEL: u32 = 128u32;
 pub const DDTRANSFER_HALFLINES: u32 = 256u32;
@@ -4874,9 +4227,6 @@ impl Default for DDVERSIONDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDVERSIONDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DDVERSIONINFO: u32 = 13u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4894,9 +4244,6 @@ impl Default for DDVIDEOPORTBANDWIDTH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDVIDEOPORTBANDWIDTH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4926,9 +4273,6 @@ impl Default for DDVIDEOPORTCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDVIDEOPORTCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDVIDEOPORTCONNECT {
@@ -4942,9 +4286,6 @@ impl Default for DDVIDEOPORTCONNECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDVIDEOPORTCONNECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4962,9 +4303,6 @@ impl Default for DDVIDEOPORTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDVIDEOPORTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4985,9 +4323,6 @@ impl Default for DDVIDEOPORTDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDVIDEOPORTDESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5011,9 +4346,6 @@ impl Default for DDVIDEOPORTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDVIDEOPORTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDVIDEOPORTNOTIFY {
@@ -5026,9 +4358,6 @@ impl Default for DDVIDEOPORTNOTIFY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDVIDEOPORTNOTIFY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5045,9 +4374,6 @@ impl Default for DDVIDEOPORTSTATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDVIDEOPORTSTATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DDVPBCAPS_DESTINATION: i32 = 2i32;
 pub const DDVPBCAPS_SOURCE: i32 = 1i32;
@@ -5162,9 +4488,6 @@ impl Default for DD_ADDATTACHEDSURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_ADDATTACHEDSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_ATTACHLIST {
@@ -5175,9 +4498,6 @@ impl Default for DD_ATTACHLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_ATTACHLIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5195,9 +4515,6 @@ impl Default for DD_BEGINMOCOMPFRAMEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_BEGINMOCOMPFRAMEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 pub struct DD_BLTDATA {
@@ -5229,9 +4546,6 @@ impl Default for DD_BLTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_BLTDATA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5254,10 +4568,6 @@ impl Default for DD_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DD_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_CANCREATESURFACEDATA {
@@ -5272,9 +4582,6 @@ impl Default for DD_CANCREATESURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_CANCREATESURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_CANCREATEVPORTDATA {
@@ -5288,9 +4595,6 @@ impl Default for DD_CANCREATEVPORTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_CANCREATEVPORTDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_CLIPPER_GLOBAL {
@@ -5301,9 +4605,6 @@ impl Default for DD_CLIPPER_GLOBAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_CLIPPER_GLOBAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_CLIPPER_LOCAL {
@@ -5313,9 +4614,6 @@ impl Default for DD_CLIPPER_LOCAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_CLIPPER_LOCAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5328,9 +4626,6 @@ impl Default for DD_COLORCONTROLCALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_COLORCONTROLCALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5346,9 +4641,6 @@ impl Default for DD_COLORCONTROLDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_COLORCONTROLDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5368,9 +4660,6 @@ impl Default for DD_CREATEMOCOMPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_CREATEMOCOMPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5388,10 +4677,6 @@ impl Default for DD_CREATEPALETTEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DD_CREATEPALETTEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_CREATESURFACEDATA {
@@ -5407,9 +4692,6 @@ impl Default for DD_CREATESURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_CREATESURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_CREATESURFACEEXDATA {
@@ -5422,9 +4704,6 @@ impl Default for DD_CREATESURFACEEXDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_CREATESURFACEEXDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5439,9 +4718,6 @@ impl Default for DD_CREATEVPORTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_CREATEVPORTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5459,9 +4735,6 @@ impl Default for DD_D3DBUFCALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_D3DBUFCALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_DESTROYDDLOCALDATA {
@@ -5474,9 +4747,6 @@ impl Default for DD_DESTROYDDLOCALDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_DESTROYDDLOCALDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_DESTROYMOCOMPDATA {
@@ -5488,9 +4758,6 @@ impl Default for DD_DESTROYMOCOMPDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_DESTROYMOCOMPDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5505,9 +4772,6 @@ impl Default for DD_DESTROYPALETTEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_DESTROYPALETTEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_DESTROYSURFACEDATA {
@@ -5520,9 +4784,6 @@ impl Default for DD_DESTROYSURFACEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_DESTROYSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5537,9 +4798,6 @@ impl Default for DD_DESTROYVPORTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_DESTROYVPORTDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_DIRECTDRAW_GLOBAL {
@@ -5553,9 +4811,6 @@ impl Default for DD_DIRECTDRAW_GLOBAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_DIRECTDRAW_GLOBAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_DIRECTDRAW_LOCAL {
@@ -5565,9 +4820,6 @@ impl Default for DD_DIRECTDRAW_LOCAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_DIRECTDRAW_LOCAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5583,9 +4835,6 @@ impl Default for DD_DRVSETCOLORKEYDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_DRVSETCOLORKEYDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_ENDMOCOMPFRAMEDATA {
@@ -5599,9 +4848,6 @@ impl Default for DD_ENDMOCOMPFRAMEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_ENDMOCOMPFRAMEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5620,9 +4866,6 @@ impl Default for DD_FLIPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_FLIPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_FLIPTOGDISURFACEDATA {
@@ -5636,9 +4879,6 @@ impl Default for DD_FLIPTOGDISURFACEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_FLIPTOGDISURFACEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5655,9 +4895,6 @@ impl Default for DD_FLIPVPORTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_FLIPVPORTDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_FREEDRIVERMEMORYDATA {
@@ -5670,9 +4907,6 @@ impl Default for DD_FREEDRIVERMEMORYDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_FREEDRIVERMEMORYDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5689,9 +4923,6 @@ impl Default for DD_GETAVAILDRIVERMEMORYDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETAVAILDRIVERMEMORYDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETBLTSTATUSDATA {
@@ -5705,9 +4936,6 @@ impl Default for DD_GETBLTSTATUSDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETBLTSTATUSDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5726,9 +4954,6 @@ impl Default for DD_GETDRIVERINFODATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETDRIVERINFODATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DD_GETDRIVERSTATEDATA {
@@ -5743,9 +4968,6 @@ impl Default for DD_GETDRIVERSTATEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETDRIVERSTATEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DD_GETDRIVERSTATEDATA_0 {
@@ -5756,9 +4978,6 @@ impl Default for DD_GETDRIVERSTATEDATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETDRIVERSTATEDATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5774,9 +4993,6 @@ impl Default for DD_GETFLIPSTATUSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETFLIPSTATUSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DD_GETHEAPALIGNMENTDATA {
@@ -5790,9 +5006,6 @@ impl Default for DD_GETHEAPALIGNMENTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETHEAPALIGNMENTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5809,9 +5022,6 @@ impl Default for DD_GETINTERNALMOCOMPDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETINTERNALMOCOMPDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5830,9 +5040,6 @@ impl Default for DD_GETMOCOMPCOMPBUFFDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETMOCOMPCOMPBUFFDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETMOCOMPFORMATSDATA {
@@ -5847,9 +5054,6 @@ impl Default for DD_GETMOCOMPFORMATSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETMOCOMPFORMATSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETMOCOMPGUIDSDATA {
@@ -5863,9 +5067,6 @@ impl Default for DD_GETMOCOMPGUIDSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETMOCOMPGUIDSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETSCANLINEDATA {
@@ -5878,9 +5079,6 @@ impl Default for DD_GETSCANLINEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETSCANLINEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5900,9 +5098,6 @@ impl Default for DD_GETVPORTBANDWIDTHDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETVPORTBANDWIDTHDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETVPORTCONNECTDATA {
@@ -5918,9 +5113,6 @@ impl Default for DD_GETVPORTCONNECTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETVPORTCONNECTDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETVPORTFIELDDATA {
@@ -5935,9 +5127,6 @@ impl Default for DD_GETVPORTFIELDDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETVPORTFIELDDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETVPORTFLIPSTATUSDATA {
@@ -5950,9 +5139,6 @@ impl Default for DD_GETVPORTFLIPSTATUSDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETVPORTFLIPSTATUSDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5970,9 +5156,6 @@ impl Default for DD_GETVPORTINPUTFORMATDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETVPORTINPUTFORMATDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETVPORTLINEDATA {
@@ -5986,9 +5169,6 @@ impl Default for DD_GETVPORTLINEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETVPORTLINEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6007,9 +5187,6 @@ impl Default for DD_GETVPORTOUTPUTFORMATDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_GETVPORTOUTPUTFORMATDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_GETVPORTSIGNALDATA {
@@ -6023,9 +5200,6 @@ impl Default for DD_GETVPORTSIGNALDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_GETVPORTSIGNALDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6044,9 +5218,6 @@ impl Default for DD_HALINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_HALINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DD_HALINFO_V4 {
@@ -6061,9 +5232,6 @@ impl Default for DD_HALINFO_V4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_HALINFO_V4 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DD_HAL_VERSION: u32 = 256u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6077,9 +5245,6 @@ impl Default for DD_KERNELCALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_KERNELCALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6099,9 +5264,6 @@ impl Default for DD_LOCKDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_LOCKDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_MAPMEMORYDATA {
@@ -6115,9 +5277,6 @@ impl Default for DD_MAPMEMORYDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_MAPMEMORYDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6134,9 +5293,6 @@ impl Default for DD_MISCELLANEOUS2CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_MISCELLANEOUS2CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_MISCELLANEOUSCALLBACKS {
@@ -6148,9 +5304,6 @@ impl Default for DD_MISCELLANEOUSCALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_MISCELLANEOUSCALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6170,9 +5323,6 @@ impl Default for DD_MORECAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_MORECAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DD_MORESURFACECAPS {
@@ -6185,9 +5335,6 @@ impl Default for DD_MORESURFACECAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_MORESURFACECAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DD_MORESURFACECAPS_0 {
@@ -6198,9 +5345,6 @@ impl Default for DD_MORESURFACECAPS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_MORESURFACECAPS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6223,9 +5367,6 @@ impl Default for DD_MOTIONCOMPCALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_MOTIONCOMPCALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DD_MOTIONCOMP_LOCAL {
@@ -6246,9 +5387,6 @@ impl Default for DD_MOTIONCOMP_LOCAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_MOTIONCOMP_LOCAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_NONLOCALVIDMEMCAPS {
@@ -6264,9 +5402,6 @@ impl Default for DD_NONLOCALVIDMEMCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_NONLOCALVIDMEMCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_NTCALLBACKS {
@@ -6281,9 +5416,6 @@ impl Default for DD_NTCALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_NTCALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_NTPRIVATEDRIVERCAPS {
@@ -6294,9 +5426,6 @@ impl Default for DD_NTPRIVATEDRIVERCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_NTPRIVATEDRIVERCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -6313,10 +5442,6 @@ impl Default for DD_PALETTECALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DD_PALETTECALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_PALETTE_GLOBAL {
@@ -6326,9 +5451,6 @@ impl Default for DD_PALETTE_GLOBAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_PALETTE_GLOBAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6340,9 +5462,6 @@ impl Default for DD_PALETTE_LOCAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_PALETTE_LOCAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6357,9 +5476,6 @@ impl Default for DD_QUERYMOCOMPSTATUSDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_QUERYMOCOMPSTATUSDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6380,9 +5496,6 @@ impl Default for DD_RENDERMOCOMPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_RENDERMOCOMPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DD_RUNTIME_VERSION: i32 = 2306i32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6396,9 +5509,6 @@ impl Default for DD_SETCLIPLISTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_SETCLIPLISTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6414,9 +5524,6 @@ impl Default for DD_SETCOLORKEYDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_SETCOLORKEYDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -6436,10 +5543,6 @@ impl Default for DD_SETENTRIESDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DD_SETENTRIESDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_SETEXCLUSIVEMODEDATA {
@@ -6453,9 +5556,6 @@ impl Default for DD_SETEXCLUSIVEMODEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_SETEXCLUSIVEMODEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6473,9 +5573,6 @@ impl Default for DD_SETOVERLAYPOSITIONDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_SETOVERLAYPOSITIONDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_SETPALETTEDATA {
@@ -6491,9 +5588,6 @@ impl Default for DD_SETPALETTEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_SETPALETTEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_STEREOMODE {
@@ -6508,9 +5602,6 @@ impl Default for DD_STEREOMODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_STEREOMODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6537,9 +5628,6 @@ impl Default for DD_SURFACECALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_SURFACECALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DD_SURFACE_GLOBAL {
@@ -6561,9 +5649,6 @@ impl Default for DD_SURFACE_GLOBAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_SURFACE_GLOBAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DD_SURFACE_GLOBAL_0 {
@@ -6574,9 +5659,6 @@ impl Default for DD_SURFACE_GLOBAL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_SURFACE_GLOBAL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6590,9 +5672,6 @@ impl Default for DD_SURFACE_GLOBAL_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_SURFACE_GLOBAL_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DD_SURFACE_GLOBAL_2 {
@@ -6604,9 +5683,6 @@ impl Default for DD_SURFACE_GLOBAL_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_SURFACE_GLOBAL_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_SURFACE_INT {
@@ -6616,9 +5692,6 @@ impl Default for DD_SURFACE_INT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_SURFACE_INT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6639,9 +5712,6 @@ impl Default for DD_SURFACE_LOCAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_SURFACE_LOCAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DD_SURFACE_LOCAL_0 {
@@ -6653,9 +5723,6 @@ impl Default for DD_SURFACE_LOCAL_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_SURFACE_LOCAL_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DD_SURFACE_LOCAL_1 {
@@ -6666,9 +5733,6 @@ impl Default for DD_SURFACE_LOCAL_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_SURFACE_LOCAL_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6683,9 +5747,6 @@ impl Default for DD_SURFACE_MORE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_SURFACE_MORE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6707,9 +5768,6 @@ impl Default for DD_SYNCSURFACEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_SYNCSURFACEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_SYNCVIDEOPORTDATA {
@@ -6728,9 +5786,6 @@ impl Default for DD_SYNCVIDEOPORTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_SYNCVIDEOPORTDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_UNLOCKDATA {
@@ -6743,9 +5798,6 @@ impl Default for DD_UNLOCKDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_UNLOCKDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6762,9 +5814,6 @@ impl Default for DD_UPDATENONLOCALHEAPDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_UPDATENONLOCALHEAPDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 pub struct DD_UPDATEOVERLAYDATA {
@@ -6788,9 +5837,6 @@ impl Default for DD_UPDATEOVERLAYDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_UPDATEOVERLAYDATA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_UPDATEVPORTDATA {
@@ -6809,9 +5855,6 @@ impl Default for DD_UPDATEVPORTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_UPDATEVPORTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DD_VERSION: i32 = 512i32;
 #[repr(C)]
@@ -6841,9 +5884,6 @@ impl Default for DD_VIDEOPORTCALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_VIDEOPORTCALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_VIDEOPORT_LOCAL {
@@ -6863,9 +5903,6 @@ impl Default for DD_VIDEOPORT_LOCAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_VIDEOPORT_LOCAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_VPORTCOLORDATA {
@@ -6880,9 +5917,6 @@ impl Default for DD_VPORTCOLORDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_VPORTCOLORDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6899,9 +5933,6 @@ impl Default for DD_WAITFORVERTICALBLANKDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DD_WAITFORVERTICALBLANKDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DD_WAITFORVPORTSYNCDATA {
@@ -6917,9 +5948,6 @@ impl Default for DD_WAITFORVPORTSYNCDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DD_WAITFORVPORTSYNCDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DELETED_LASTONE: u32 = 1u32;
 pub const DELETED_NOTFOUND: u32 = 2u32;
@@ -6953,9 +5981,6 @@ impl Default for DXAPI_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXAPI_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXERR_GENERIC: u32 = 2147500037u32;
 pub const DXERR_OUTOFCAPS: u32 = 2289434984u32;
 pub const DXERR_UNSUPPORTED: u32 = 2147500033u32;
@@ -6968,9 +5993,6 @@ impl Default for DX_IRQDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DX_IRQDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DX_OK: u32 = 0u32;
 pub const GUID_ColorControlCallbacks: windows_core::GUID = windows_core::GUID::from_u128(0xefd60cc2_49e7_11d0_889d_00aa00bbb76a);
@@ -7014,9 +6036,6 @@ impl Default for HEAPALIAS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HEAPALIAS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HEAPALIASINFO {
@@ -7029,9 +6048,6 @@ impl Default for HEAPALIASINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HEAPALIASINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HEAPALIASINFO_MAPPEDDUMMY: i32 = 2i32;
 pub const HEAPALIASINFO_MAPPEDREAL: i32 = 1i32;
@@ -7053,9 +6069,6 @@ impl Default for HEAPALIGNMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HEAPALIGNMENT {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IDDVideoPortContainer, IDDVideoPortContainer_Vtbl, 0x6c142760_a733_11ce_a521_0020af0be560);
 windows_core::imp::interface_hierarchy!(IDDVideoPortContainer, windows_core::IUnknown);
@@ -11179,9 +10192,6 @@ impl Default for IUNKNOWN_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IUNKNOWN_LIST {
-    type TypeKind = windows_core::CloneType;
-}
 pub type LPCLIPPERCALLBACK = Option<unsafe extern "system" fn(lpddclipper: Option<IDirectDrawClipper>, hwnd: super::super::Foundation::HWND, code: u32, lpcontext: *mut core::ffi::c_void) -> u32>;
 pub type LPDD32BITDRIVERINIT = Option<unsafe extern "system" fn(dwcontext: u32) -> u32>;
 pub type LPDDENUMCALLBACKA = Option<unsafe extern "system" fn(param0: *mut windows_core::GUID, param1: windows_core::PCSTR, param2: windows_core::PCSTR, param3: *mut core::ffi::c_void) -> super::super::Foundation::BOOL>;
@@ -11474,9 +10484,6 @@ impl Default for PROCESS_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const REGSTR_KEY_DDHW_DESCRIPTION: windows_core::PCSTR = windows_core::s!("Description");
 pub const REGSTR_KEY_DDHW_DRIVERNAME: windows_core::PCSTR = windows_core::s!("DriverName");
 pub const REGSTR_PATH_DDHW: windows_core::PCSTR = windows_core::s!("Hardware\\DirectDrawDrivers");
@@ -11492,9 +10499,6 @@ impl Default for SURFACEALIGNMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SURFACEALIGNMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SURFACEALIGNMENT_0 {
@@ -11505,9 +10509,6 @@ impl Default for SURFACEALIGNMENT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SURFACEALIGNMENT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11522,9 +10523,6 @@ impl Default for SURFACEALIGNMENT_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SURFACEALIGNMENT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SURFACEALIGNMENT_0_1 {
@@ -11537,9 +10535,6 @@ impl Default for SURFACEALIGNMENT_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SURFACEALIGNMENT_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SURFACEALIGN_DISCARDABLE: i32 = 1i32;
 #[repr(C)]
@@ -11557,9 +10552,6 @@ impl Default for VIDEOMEMORY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEOMEMORY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIDEOMEMORY_0 {
@@ -11571,9 +10563,6 @@ impl Default for VIDEOMEMORY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEOMEMORY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIDEOMEMORY_1 {
@@ -11584,9 +10573,6 @@ impl Default for VIDEOMEMORY_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEOMEMORY_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11609,9 +10595,6 @@ impl Default for VIDEOMEMORYINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEOMEMORYINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct VIDMEM {
@@ -11627,9 +10610,6 @@ impl Default for VIDMEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDMEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIDMEM_0 {
@@ -11641,9 +10621,6 @@ impl Default for VIDMEM_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDMEM_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIDMEM_1 {
@@ -11654,9 +10631,6 @@ impl Default for VIDMEM_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDMEM_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11679,9 +10653,6 @@ impl Default for VIDMEMINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDMEMINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIDMEM_HEAPDISABLED: i32 = 32i32;
 pub const VIDMEM_ISHEAP: i32 = 4i32;
@@ -11715,9 +10686,6 @@ impl Default for VMEMHEAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VMEMHEAP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VMEMHEAP_ALIGNMENT: i32 = 4i32;
 pub const VMEMHEAP_LINEAR: i32 = 1i32;
 pub const VMEMHEAP_RECTANGULAR: i32 = 2i32;
@@ -11733,9 +10701,6 @@ impl Default for VMEML {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VMEML {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11760,8 +10725,5 @@ impl Default for VMEMR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VMEMR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const _FACDD: u32 = 2166u32;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
@@ -70,9 +70,6 @@ impl Default for DWRITE_BITMAP_DATA_BGRA32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_BITMAP_DATA_BGRA32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DWRITE_BREAK_CONDITION(pub i32);
@@ -92,9 +89,6 @@ impl Default for DWRITE_CARET_METRICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_CARET_METRICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_CLUSTER_METRICS {
@@ -106,9 +100,6 @@ impl Default for DWRITE_CLUSTER_METRICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_CLUSTER_METRICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DWRITE_COLOR_COMPOSITE_CLEAR: DWRITE_COLOR_COMPOSITE_MODE = DWRITE_COLOR_COMPOSITE_MODE(0i32);
 pub const DWRITE_COLOR_COMPOSITE_COLOR_BURN: DWRITE_COLOR_COMPOSITE_MODE = DWRITE_COLOR_COMPOSITE_MODE(18i32);
@@ -154,9 +145,6 @@ impl Default for DWRITE_COLOR_F {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_COLOR_F {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct DWRITE_COLOR_GLYPH_RUN {
@@ -172,9 +160,6 @@ impl Default for DWRITE_COLOR_GLYPH_RUN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_COLOR_GLYPH_RUN {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct DWRITE_COLOR_GLYPH_RUN1 {
@@ -186,9 +171,6 @@ impl Default for DWRITE_COLOR_GLYPH_RUN1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_COLOR_GLYPH_RUN1 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -216,9 +198,6 @@ impl Default for DWRITE_FILE_FRAGMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_FILE_FRAGMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -278,9 +257,6 @@ impl Default for DWRITE_FONT_AXIS_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_FONT_AXIS_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DWRITE_FONT_AXIS_TAG(pub u32);
@@ -299,9 +275,6 @@ impl Default for DWRITE_FONT_AXIS_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_FONT_AXIS_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -330,9 +303,6 @@ impl Default for DWRITE_FONT_FEATURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_FONT_FEATURE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -455,9 +425,6 @@ impl Default for DWRITE_FONT_METRICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_FONT_METRICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_FONT_METRICS1 {
@@ -481,9 +448,6 @@ impl Default for DWRITE_FONT_METRICS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_FONT_METRICS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_FONT_PROPERTY {
@@ -495,9 +459,6 @@ impl Default for DWRITE_FONT_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_FONT_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -628,10 +589,6 @@ impl Default for DWRITE_GLYPH_IMAGE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_GLYPH_IMAGE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DWRITE_GLYPH_IMAGE_FORMATS(pub i32);
@@ -694,9 +651,6 @@ impl Default for DWRITE_GLYPH_METRICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_GLYPH_METRICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_GLYPH_OFFSET {
@@ -707,9 +661,6 @@ impl Default for DWRITE_GLYPH_OFFSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_GLYPH_OFFSET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -735,9 +686,6 @@ impl Default for DWRITE_GLYPH_RUN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_GLYPH_RUN {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_GLYPH_RUN_DESCRIPTION {
@@ -751,9 +699,6 @@ impl Default for DWRITE_GLYPH_RUN_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_GLYPH_RUN_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -778,9 +723,6 @@ impl Default for DWRITE_HIT_TEST_METRICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_HIT_TEST_METRICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DWRITE_INFORMATIONAL_STRING_COPYRIGHT_NOTICE: DWRITE_INFORMATIONAL_STRING_ID = DWRITE_INFORMATIONAL_STRING_ID(1i32);
 pub const DWRITE_INFORMATIONAL_STRING_DESCRIPTION: DWRITE_INFORMATIONAL_STRING_ID = DWRITE_INFORMATIONAL_STRING_ID(7i32);
@@ -823,9 +765,6 @@ impl Default for DWRITE_INLINE_OBJECT_METRICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_INLINE_OBJECT_METRICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_JUSTIFICATION_OPPORTUNITY {
@@ -839,9 +778,6 @@ impl Default for DWRITE_JUSTIFICATION_OPPORTUNITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_JUSTIFICATION_OPPORTUNITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_LINE_BREAKPOINT {
@@ -851,9 +787,6 @@ impl Default for DWRITE_LINE_BREAKPOINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_LINE_BREAKPOINT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -870,9 +803,6 @@ impl Default for DWRITE_LINE_METRICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_LINE_METRICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_LINE_METRICS1 {
@@ -884,9 +814,6 @@ impl Default for DWRITE_LINE_METRICS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_LINE_METRICS1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -901,9 +828,6 @@ impl Default for DWRITE_LINE_SPACING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_LINE_SPACING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -931,9 +855,6 @@ impl Default for DWRITE_MATRIX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_MATRIX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -972,9 +893,6 @@ impl Default for DWRITE_OVERHANG_METRICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_OVERHANG_METRICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1028,9 +946,6 @@ impl Default for DWRITE_PAINT_COLOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_PAINT_COLOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy)]
@@ -1043,10 +958,6 @@ impl Default for DWRITE_PAINT_ELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -1069,10 +980,6 @@ impl Default for DWRITE_PAINT_ELEMENT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1086,10 +993,6 @@ impl Default for DWRITE_PAINT_ELEMENT_0_6 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1101,10 +1004,6 @@ impl Default for DWRITE_PAINT_ELEMENT_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -1118,10 +1017,6 @@ impl Default for DWRITE_PAINT_ELEMENT_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1133,10 +1028,6 @@ impl Default for DWRITE_PAINT_ELEMENT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -1157,10 +1048,6 @@ impl Default for DWRITE_PAINT_ELEMENT_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1180,10 +1067,6 @@ impl Default for DWRITE_PAINT_ELEMENT_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1196,10 +1079,6 @@ impl Default for DWRITE_PAINT_ELEMENT_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -1217,10 +1096,6 @@ impl Default for DWRITE_PAINT_ELEMENT_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for DWRITE_PAINT_ELEMENT_0_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1257,9 +1132,6 @@ impl Default for DWRITE_PANOSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_PANOSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_PANOSE_2 {
@@ -1278,9 +1150,6 @@ impl Default for DWRITE_PANOSE_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_PANOSE_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1301,9 +1170,6 @@ impl Default for DWRITE_PANOSE_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_PANOSE_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_PANOSE_3 {
@@ -1323,9 +1189,6 @@ impl Default for DWRITE_PANOSE_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_PANOSE_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_PANOSE_0 {
@@ -1344,9 +1207,6 @@ impl Default for DWRITE_PANOSE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_PANOSE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1763,9 +1623,6 @@ impl Default for DWRITE_SCRIPT_ANALYSIS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_SCRIPT_ANALYSIS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_SCRIPT_PROPERTIES {
@@ -1779,9 +1636,6 @@ impl Default for DWRITE_SCRIPT_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_SCRIPT_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1831,9 +1685,6 @@ impl Default for DWRITE_SHAPING_GLYPH_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_SHAPING_GLYPH_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_SHAPING_TEXT_PROPERTIES {
@@ -1843,9 +1694,6 @@ impl Default for DWRITE_SHAPING_TEXT_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_SHAPING_TEXT_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DWRITE_STANDARD_FONT_AXIS_COUNT: u32 = 5u32;
 #[repr(C)]
@@ -1863,9 +1711,6 @@ impl Default for DWRITE_STRIKETHROUGH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_STRIKETHROUGH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DWRITE_TEXTURE_ALIASED_1x1: DWRITE_TEXTURE_TYPE = DWRITE_TEXTURE_TYPE(0i32);
 pub const DWRITE_TEXTURE_CLEARTYPE_3x1: DWRITE_TEXTURE_TYPE = DWRITE_TEXTURE_TYPE(1i32);
@@ -1902,9 +1747,6 @@ impl Default for DWRITE_TEXT_METRICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_TEXT_METRICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_TEXT_METRICS1 {
@@ -1915,9 +1757,6 @@ impl Default for DWRITE_TEXT_METRICS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_TEXT_METRICS1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1930,9 +1769,6 @@ impl Default for DWRITE_TEXT_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_TEXT_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_TRIMMING {
@@ -1944,9 +1780,6 @@ impl Default for DWRITE_TRIMMING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_TRIMMING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1965,9 +1798,6 @@ impl Default for DWRITE_TYPOGRAPHIC_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_TYPOGRAPHIC_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_UNDERLINE {
@@ -1985,9 +1815,6 @@ impl Default for DWRITE_UNDERLINE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWRITE_UNDERLINE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWRITE_UNICODE_RANGE {
@@ -1998,9 +1825,6 @@ impl Default for DWRITE_UNICODE_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWRITE_UNICODE_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dwm/mod.rs
@@ -265,10 +265,6 @@ impl Default for DWM_BLURBEHIND {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DWM_BLURBEHIND {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DWM_CLOAKED_APP: u32 = 1u32;
 pub const DWM_CLOAKED_INHERITED: u32 = 4u32;
 pub const DWM_CLOAKED_SHELL: u32 = 2u32;
@@ -291,9 +287,6 @@ impl Default for DWM_PRESENT_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWM_PRESENT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -392,9 +385,6 @@ impl Default for DWM_THUMBNAIL_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWM_THUMBNAIL_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DWM_TIMING_INFO {
@@ -444,9 +434,6 @@ impl Default for DWM_TIMING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWM_TIMING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DWM_TNP_OPACITY: u32 = 4u32;
 pub const DWM_TNP_RECTDESTINATION: u32 = 1u32;
 pub const DWM_TNP_RECTSOURCE: u32 = 2u32;
@@ -484,9 +471,6 @@ impl Default for MilMatrix3x2D {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MilMatrix3x2D {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct UNSIGNED_RATIO {
@@ -497,9 +481,6 @@ impl Default for UNSIGNED_RATIO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UNSIGNED_RATIO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const c_DwmMaxAdapters: u32 = 16u32;
 pub const c_DwmMaxMonitors: u32 = 16u32;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/Common/mod.rs
@@ -178,9 +178,6 @@ impl Default for DXGI_GAMMA_CONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_GAMMA_CONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_GAMMA_CONTROL_CAPABILITIES {
@@ -195,9 +192,6 @@ impl Default for DXGI_GAMMA_CONTROL_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_GAMMA_CONTROL_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_JPEG_AC_HUFFMAN_TABLE {
@@ -208,9 +202,6 @@ impl Default for DXGI_JPEG_AC_HUFFMAN_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_JPEG_AC_HUFFMAN_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -223,9 +214,6 @@ impl Default for DXGI_JPEG_DC_HUFFMAN_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_JPEG_DC_HUFFMAN_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_JPEG_QUANTIZATION_TABLE {
@@ -235,9 +223,6 @@ impl Default for DXGI_JPEG_QUANTIZATION_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_JPEG_QUANTIZATION_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -253,9 +238,6 @@ impl Default for DXGI_MODE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_MODE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -289,9 +271,6 @@ impl Default for DXGI_RATIONAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_RATIONAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_RGB {
@@ -304,9 +283,6 @@ impl Default for DXGI_RGB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_RGB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_SAMPLE_DESC {
@@ -317,9 +293,6 @@ impl Default for DXGI_SAMPLE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_SAMPLE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN: u32 = 4294967295u32;
 pub const _FACDXGI: u32 = 2170u32;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
@@ -64,9 +64,6 @@ impl Default for DXGI_ADAPTER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_ADAPTER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_ADAPTER_DESC1 {
@@ -85,9 +82,6 @@ impl Default for DXGI_ADAPTER_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_ADAPTER_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -110,9 +104,6 @@ impl Default for DXGI_ADAPTER_DESC2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_ADAPTER_DESC2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_ADAPTER_DESC3 {
@@ -133,9 +124,6 @@ impl Default for DXGI_ADAPTER_DESC3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_ADAPTER_DESC3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -319,9 +307,6 @@ impl Default for DXGI_DECODE_SWAP_CHAIN_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_DECODE_SWAP_CHAIN_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_DISPLAY_COLOR_SPACE {
@@ -332,9 +317,6 @@ impl Default for DXGI_DISPLAY_COLOR_SPACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_DISPLAY_COLOR_SPACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -434,9 +416,6 @@ impl Default for DXGI_FRAME_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_FRAME_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_FRAME_STATISTICS_MEDIA {
@@ -452,9 +431,6 @@ impl Default for DXGI_FRAME_STATISTICS_MEDIA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_FRAME_STATISTICS_MEDIA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -526,9 +502,6 @@ impl Default for DXGI_HDR_METADATA_HDR10 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_HDR_METADATA_HDR10 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_HDR_METADATA_HDR10PLUS {
@@ -538,9 +511,6 @@ impl Default for DXGI_HDR_METADATA_HDR10PLUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_HDR_METADATA_HDR10PLUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -560,9 +530,6 @@ impl Default for DXGI_INFO_QUEUE_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_INFO_QUEUE_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_INFO_QUEUE_FILTER_DESC {
@@ -578,9 +545,6 @@ impl Default for DXGI_INFO_QUEUE_FILTER_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_INFO_QUEUE_FILTER_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_INFO_QUEUE_MESSAGE {
@@ -595,9 +559,6 @@ impl Default for DXGI_INFO_QUEUE_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_INFO_QUEUE_MESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -632,9 +593,6 @@ impl Default for DXGI_MAPPED_RECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_MAPPED_RECT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGI_MAP_DISCARD: DXGI_MAP_FLAGS = DXGI_MAP_FLAGS(4u32);
 #[repr(transparent)]
@@ -690,9 +648,6 @@ impl Default for DXGI_MATRIX_3X2_F {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_MATRIX_3X2_F {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXGI_MAX_SWAP_CHAIN_BUFFERS: u32 = 16u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -716,10 +671,6 @@ impl Default for DXGI_MODE_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for DXGI_MODE_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGI_MSG_DXGIGetDebugInterface1_InvalidFlags: DXGI_Message_Id = DXGI_Message_Id(231i32);
 pub const DXGI_MSG_DXGIGetDebugInterface1_NULL_ppDebug: DXGI_Message_Id = DXGI_Message_Id(230i32);
@@ -1192,10 +1143,6 @@ impl Default for DXGI_OUTDUPL_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for DXGI_OUTDUPL_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DXGI_OUTDUPL_FLAG(pub i32);
@@ -1249,9 +1196,6 @@ impl Default for DXGI_OUTDUPL_FRAME_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_OUTDUPL_FRAME_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_OUTDUPL_MOVE_RECT {
@@ -1263,9 +1207,6 @@ impl Default for DXGI_OUTDUPL_MOVE_RECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_OUTDUPL_MOVE_RECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXGI_OUTDUPL_POINTER_POSITION {
@@ -1276,9 +1217,6 @@ impl Default for DXGI_OUTDUPL_POINTER_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_OUTDUPL_POINTER_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1293,9 +1231,6 @@ impl Default for DXGI_OUTDUPL_POINTER_SHAPE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_OUTDUPL_POINTER_SHAPE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1318,10 +1253,6 @@ impl Default for DXGI_OUTPUT_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for DXGI_OUTPUT_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
@@ -1347,10 +1278,6 @@ impl Default for DXGI_OUTPUT_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for DXGI_OUTPUT_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1479,9 +1406,6 @@ impl Default for DXGI_PRESENT_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_PRESENT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXGI_PRESENT_RESTART: DXGI_PRESENT = DXGI_PRESENT(4u32);
 pub const DXGI_PRESENT_RESTRICT_TO_OUTPUT: DXGI_PRESENT = DXGI_PRESENT(64u32);
 pub const DXGI_PRESENT_STEREO_PREFER_RIGHT: DXGI_PRESENT = DXGI_PRESENT(16u32);
@@ -1500,9 +1424,6 @@ impl Default for DXGI_QUERY_VIDEO_MEMORY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_QUERY_VIDEO_MEMORY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1537,9 +1458,6 @@ impl Default for DXGI_RGBA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXGI_RGBA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DXGI_SCALING(pub i32);
@@ -1555,9 +1473,6 @@ impl Default for DXGI_SHARED_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXGI_SHARED_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXGI_SHARED_RESOURCE_READ: DXGI_SHARED_RESOURCE_RW = DXGI_SHARED_RESOURCE_RW(2147483648u32);
 #[repr(transparent)]
@@ -1611,10 +1526,6 @@ impl Default for DXGI_SURFACE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for DXGI_SURFACE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1673,10 +1584,6 @@ impl Default for DXGI_SWAP_CHAIN_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for DXGI_SWAP_CHAIN_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1698,10 +1605,6 @@ impl Default for DXGI_SWAP_CHAIN_DESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for DXGI_SWAP_CHAIN_DESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1766,10 +1669,6 @@ impl Default for DXGI_SWAP_CHAIN_FULLSCREEN_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for DXGI_SWAP_CHAIN_FULLSCREEN_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
@@ -2213,9 +2213,6 @@ impl Default for ABC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ABC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ABCFLOAT {
@@ -2228,9 +2225,6 @@ impl Default for ABCFLOAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ABCFLOAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ABORTDOC: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2241,9 +2235,6 @@ impl Default for ABORTPATH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ABORTPATH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ABSOLUTE: u32 = 1u32;
 pub const AC_SRC_ALPHA: u32 = 1u32;
@@ -2275,9 +2266,6 @@ impl Default for AXESLISTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AXESLISTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AXESLISTW {
@@ -2289,9 +2277,6 @@ impl Default for AXESLISTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AXESLISTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2305,9 +2290,6 @@ impl Default for AXISINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AXISINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AXISINFOW {
@@ -2319,9 +2301,6 @@ impl Default for AXISINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AXISINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2372,9 +2351,6 @@ impl Default for BITMAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BITMAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BITMAPCOREHEADER {
@@ -2389,9 +2365,6 @@ impl Default for BITMAPCOREHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BITMAPCOREHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BITMAPCOREINFO {
@@ -2402,9 +2375,6 @@ impl Default for BITMAPCOREINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BITMAPCOREINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -2420,9 +2390,6 @@ impl Default for BITMAPFILEHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BITMAPFILEHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BITMAPINFO {
@@ -2433,9 +2400,6 @@ impl Default for BITMAPINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BITMAPINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2456,9 +2420,6 @@ impl Default for BITMAPINFOHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BITMAPINFOHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2488,9 +2449,6 @@ impl Default for BITMAPV4HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BITMAPV4HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2525,9 +2483,6 @@ impl Default for BITMAPV5HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BITMAPV5HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BITSPIXEL: GET_DEVICE_CAPS_INDEX = GET_DEVICE_CAPS_INDEX(12u32);
 pub const BI_BITFIELDS: BI_COMPRESSION = BI_COMPRESSION(3u32);
 #[repr(transparent)]
@@ -2555,9 +2510,6 @@ impl Default for BLENDFUNCTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BLENDFUNCTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BLTALIGNMENT: GET_DEVICE_CAPS_INDEX = GET_DEVICE_CAPS_INDEX(119u32);
 #[repr(transparent)]
@@ -2658,9 +2610,6 @@ impl Default for CIEXYZ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CIEXYZ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CIEXYZTRIPLE {
@@ -2672,9 +2621,6 @@ impl Default for CIEXYZTRIPLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CIEXYZTRIPLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLEARTYPE_NATURAL_QUALITY: u32 = 6u32;
 pub const CLEARTYPE_QUALITY: FONT_QUALITY = FONT_QUALITY(5u8);
@@ -2717,9 +2663,6 @@ impl Default for COLORADJUSTMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLORADJUSTMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COLORMATCHTOTARGET_EMBEDED: u32 = 1u32;
 pub const COLORMGMTCAPS: GET_DEVICE_CAPS_INDEX = GET_DEVICE_CAPS_INDEX(121u32);
@@ -2870,9 +2813,6 @@ impl Default for DESIGNVECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DESIGNVECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DESKTOPHORZRES: GET_DEVICE_CAPS_INDEX = GET_DEVICE_CAPS_INDEX(118u32);
 pub const DESKTOPVERTRES: GET_DEVICE_CAPS_INDEX = GET_DEVICE_CAPS_INDEX(117u32);
 pub const DEVICEDATA: u32 = 19u32;
@@ -2914,9 +2854,6 @@ impl Default for DEVMODEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVMODEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVMODEA_0 {
@@ -2927,9 +2864,6 @@ impl Default for DEVMODEA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVMODEA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2948,9 +2882,6 @@ impl Default for DEVMODEA_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVMODEA_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVMODEA_0_1 {
@@ -2963,9 +2894,6 @@ impl Default for DEVMODEA_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVMODEA_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVMODEA_1 {
@@ -2976,9 +2904,6 @@ impl Default for DEVMODEA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVMODEA_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3016,9 +2941,6 @@ impl Default for DEVMODEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVMODEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVMODEW_0 {
@@ -3029,9 +2951,6 @@ impl Default for DEVMODEW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVMODEW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3050,9 +2969,6 @@ impl Default for DEVMODEW_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVMODEW_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVMODEW_0_1 {
@@ -3065,9 +2981,6 @@ impl Default for DEVMODEW_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVMODEW_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVMODEW_1 {
@@ -3078,9 +2991,6 @@ impl Default for DEVMODEW_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVMODEW_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3224,9 +3134,6 @@ impl Default for DIBSECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIBSECTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DIB_PAL_COLORS: DIB_USAGE = DIB_USAGE(1u32);
 pub const DIB_RGB_COLORS: DIB_USAGE = DIB_USAGE(0u32);
 #[repr(transparent)]
@@ -3272,9 +3179,6 @@ impl Default for DISPLAY_DEVICEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPLAY_DEVICEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPLAY_DEVICEW {
@@ -3289,9 +3193,6 @@ impl Default for DISPLAY_DEVICEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPLAY_DEVICEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DISPLAY_DEVICE_ACC_DRIVER: DISPLAY_DEVICE_STATE_FLAGS = DISPLAY_DEVICE_STATE_FLAGS(64u32);
 pub const DISPLAY_DEVICE_ACTIVE: DISPLAY_DEVICE_STATE_FLAGS = DISPLAY_DEVICE_STATE_FLAGS(1u32);
@@ -3678,9 +3579,6 @@ impl Default for DRAWTEXTPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRAWTEXTPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DRAW_CAPTION_FLAGS(pub u32);
@@ -3865,9 +3763,6 @@ impl Default for EMR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRALPHABLEND {
@@ -3895,9 +3790,6 @@ impl Default for EMRALPHABLEND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRALPHABLEND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRANGLEARC {
@@ -3912,9 +3804,6 @@ impl Default for EMRANGLEARC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRANGLEARC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRARC {
@@ -3927,9 +3816,6 @@ impl Default for EMRARC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRARC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3956,9 +3842,6 @@ impl Default for EMRBITBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRBITBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRCOLORCORRECTPALETTE {
@@ -3972,9 +3855,6 @@ impl Default for EMRCOLORCORRECTPALETTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRCOLORCORRECTPALETTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3991,9 +3871,6 @@ impl Default for EMRCOLORMATCHTOTARGET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRCOLORMATCHTOTARGET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRCREATEBRUSHINDIRECT {
@@ -4005,9 +3882,6 @@ impl Default for EMRCREATEBRUSHINDIRECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRCREATEBRUSHINDIRECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4025,9 +3899,6 @@ impl Default for EMRCREATEDIBPATTERNBRUSHPT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRCREATEDIBPATTERNBRUSHPT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRCREATEMONOBRUSH {
@@ -4044,9 +3915,6 @@ impl Default for EMRCREATEMONOBRUSH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRCREATEMONOBRUSH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRCREATEPALETTE {
@@ -4058,9 +3926,6 @@ impl Default for EMRCREATEPALETTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRCREATEPALETTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4074,9 +3939,6 @@ impl Default for EMRCREATEPEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRCREATEPEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRELLIPSE {
@@ -4087,9 +3949,6 @@ impl Default for EMRELLIPSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRELLIPSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4104,9 +3963,6 @@ impl Default for EMREOF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMREOF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMREXCLUDECLIPRECT {
@@ -4117,9 +3973,6 @@ impl Default for EMREXCLUDECLIPRECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMREXCLUDECLIPRECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4132,9 +3985,6 @@ impl Default for EMREXTCREATEFONTINDIRECTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMREXTCREATEFONTINDIRECTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4152,9 +4002,6 @@ impl Default for EMREXTCREATEPEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMREXTCREATEPEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMREXTESCAPE {
@@ -4167,9 +4014,6 @@ impl Default for EMREXTESCAPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMREXTESCAPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4184,9 +4028,6 @@ impl Default for EMREXTFLOODFILL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMREXTFLOODFILL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMREXTSELECTCLIPRGN {
@@ -4199,9 +4040,6 @@ impl Default for EMREXTSELECTCLIPRGN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMREXTSELECTCLIPRGN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4218,9 +4056,6 @@ impl Default for EMREXTTEXTOUTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMREXTTEXTOUTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRFILLPATH {
@@ -4231,9 +4066,6 @@ impl Default for EMRFILLPATH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRFILLPATH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4249,9 +4081,6 @@ impl Default for EMRFILLRGN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRFILLRGN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRFORMAT {
@@ -4264,9 +4093,6 @@ impl Default for EMRFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4283,9 +4109,6 @@ impl Default for EMRFRAMERGN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRFRAMERGN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRGDICOMMENT {
@@ -4297,9 +4120,6 @@ impl Default for EMRGDICOMMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRGDICOMMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4314,9 +4134,6 @@ impl Default for EMRGLSBOUNDEDRECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRGLSBOUNDEDRECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRGLSRECORD {
@@ -4328,9 +4145,6 @@ impl Default for EMRGLSRECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRGLSRECORD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4347,9 +4161,6 @@ impl Default for EMRGRADIENTFILL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRGRADIENTFILL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRINVERTRGN {
@@ -4363,9 +4174,6 @@ impl Default for EMRINVERTRGN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRINVERTRGN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRLINETO {
@@ -4376,9 +4184,6 @@ impl Default for EMRLINETO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRLINETO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4412,9 +4217,6 @@ impl Default for EMRMASKBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRMASKBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRMODIFYWORLDTRANSFORM {
@@ -4426,9 +4228,6 @@ impl Default for EMRMODIFYWORLDTRANSFORM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRMODIFYWORLDTRANSFORM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4444,9 +4243,6 @@ impl Default for EMRNAMEDESCAPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRNAMEDESCAPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMROFFSETCLIPRGN {
@@ -4457,9 +4253,6 @@ impl Default for EMROFFSETCLIPRGN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMROFFSETCLIPRGN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4491,9 +4284,6 @@ impl Default for EMRPLGBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRPLGBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRPOLYDRAW {
@@ -4507,9 +4297,6 @@ impl Default for EMRPOLYDRAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRPOLYDRAW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4525,9 +4312,6 @@ impl Default for EMRPOLYDRAW16 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRPOLYDRAW16 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRPOLYLINE {
@@ -4541,9 +4325,6 @@ impl Default for EMRPOLYLINE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRPOLYLINE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRPOLYLINE16 {
@@ -4556,9 +4337,6 @@ impl Default for EMRPOLYLINE16 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRPOLYLINE16 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4575,9 +4353,6 @@ impl Default for EMRPOLYPOLYLINE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRPOLYPOLYLINE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRPOLYPOLYLINE16 {
@@ -4592,9 +4367,6 @@ impl Default for EMRPOLYPOLYLINE16 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRPOLYPOLYLINE16 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4612,9 +4384,6 @@ impl Default for EMRPOLYTEXTOUTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRPOLYTEXTOUTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRRESIZEPALETTE {
@@ -4627,9 +4396,6 @@ impl Default for EMRRESIZEPALETTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRRESIZEPALETTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRRESTOREDC {
@@ -4640,9 +4406,6 @@ impl Default for EMRRESTOREDC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRRESTOREDC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4655,9 +4418,6 @@ impl Default for EMRROUNDRECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRROUNDRECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4673,9 +4433,6 @@ impl Default for EMRSCALEVIEWPORTEXTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSCALEVIEWPORTEXTEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSELECTCLIPPATH {
@@ -4686,9 +4443,6 @@ impl Default for EMRSELECTCLIPPATH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRSELECTCLIPPATH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4701,9 +4455,6 @@ impl Default for EMRSELECTOBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSELECTOBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSELECTPALETTE {
@@ -4714,9 +4465,6 @@ impl Default for EMRSELECTPALETTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRSELECTPALETTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4729,9 +4477,6 @@ impl Default for EMRSETARCDIRECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSETARCDIRECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSETCOLORADJUSTMENT {
@@ -4743,9 +4488,6 @@ impl Default for EMRSETCOLORADJUSTMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSETCOLORADJUSTMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSETCOLORSPACE {
@@ -4756,9 +4498,6 @@ impl Default for EMRSETCOLORSPACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRSETCOLORSPACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4784,9 +4523,6 @@ impl Default for EMRSETDIBITSTODEVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSETDIBITSTODEVICE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSETICMPROFILE {
@@ -4801,9 +4537,6 @@ impl Default for EMRSETICMPROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSETICMPROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSETMAPPERFLAGS {
@@ -4815,9 +4548,6 @@ impl Default for EMRSETMAPPERFLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSETMAPPERFLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSETMITERLIMIT {
@@ -4828,9 +4558,6 @@ impl Default for EMRSETMITERLIMIT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRSETMITERLIMIT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4846,9 +4573,6 @@ impl Default for EMRSETPALETTEENTRIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSETPALETTEENTRIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSETPIXELV {
@@ -4861,9 +4585,6 @@ impl Default for EMRSETPIXELV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSETPIXELV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSETTEXTCOLOR {
@@ -4874,9 +4595,6 @@ impl Default for EMRSETTEXTCOLOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRSETTEXTCOLOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4889,9 +4607,6 @@ impl Default for EMRSETVIEWPORTEXTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSETVIEWPORTEXTEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSETVIEWPORTORGEX {
@@ -4903,9 +4618,6 @@ impl Default for EMRSETVIEWPORTORGEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSETVIEWPORTORGEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSETWORLDTRANSFORM {
@@ -4916,9 +4628,6 @@ impl Default for EMRSETWORLDTRANSFORM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRSETWORLDTRANSFORM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4947,9 +4656,6 @@ impl Default for EMRSTRETCHBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSTRETCHBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRSTRETCHDIBITS {
@@ -4975,9 +4681,6 @@ impl Default for EMRSTRETCHDIBITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMRSTRETCHDIBITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMRTEXT {
@@ -4992,9 +4695,6 @@ impl Default for EMRTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5022,9 +4722,6 @@ impl Default for EMRTRANSPARENTBLT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMRTRANSPARENTBLT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EMR_ABORTPATH: ENHANCED_METAFILE_RECORD_TYPE = ENHANCED_METAFILE_RECORD_TYPE(68u32);
 pub const EMR_ALPHABLEND: ENHANCED_METAFILE_RECORD_TYPE = ENHANCED_METAFILE_RECORD_TYPE(114u32);
@@ -5186,9 +4883,6 @@ impl Default for ENHMETAHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENHMETAHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENHMETARECORD {
@@ -5200,9 +4894,6 @@ impl Default for ENHMETARECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENHMETARECORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENHMETA_SIGNATURE: u32 = 1179469088u32;
 pub const ENHMETA_STOCK_OBJECT: u32 = 2147483648u32;
@@ -5219,9 +4910,6 @@ impl Default for ENUMLOGFONTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENUMLOGFONTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENUMLOGFONTEXA {
@@ -5235,9 +4923,6 @@ impl Default for ENUMLOGFONTEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENUMLOGFONTEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENUMLOGFONTEXDVA {
@@ -5249,9 +4934,6 @@ impl Default for ENUMLOGFONTEXDVA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENUMLOGFONTEXDVA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENUMLOGFONTEXDVW {
@@ -5262,9 +4944,6 @@ impl Default for ENUMLOGFONTEXDVW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENUMLOGFONTEXDVW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5279,9 +4958,6 @@ impl Default for ENUMLOGFONTEXW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENUMLOGFONTEXW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENUMLOGFONTW {
@@ -5293,9 +4969,6 @@ impl Default for ENUMLOGFONTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENUMLOGFONTW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENUMPAPERBINS: u32 = 31u32;
 pub const ENUMPAPERMETRICS: u32 = 34u32;
@@ -5479,9 +5152,6 @@ impl Default for EXTLOGFONTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXTLOGFONTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXTLOGFONTW {
@@ -5501,9 +5171,6 @@ impl Default for EXTLOGFONTW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXTLOGFONTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXTLOGPEN {
@@ -5520,9 +5187,6 @@ impl Default for EXTLOGPEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXTLOGPEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXTLOGPEN32 {
@@ -5538,9 +5202,6 @@ impl Default for EXTLOGPEN32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXTLOGPEN32 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EXTTEXTOUT: u32 = 512u32;
 pub const EXT_DEVICE_CAPS: u32 = 4099u32;
@@ -5629,9 +5290,6 @@ impl Default for FIXED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FIXED {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FIXED_PITCH: FONT_PITCH = FONT_PITCH(1u8);
 pub const FLI_GLYPHS: i32 = 262144i32;
@@ -5785,9 +5443,6 @@ impl Default for GCP_RESULTSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GCP_RESULTSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GCP_RESULTSW {
@@ -5805,9 +5460,6 @@ impl Default for GCP_RESULTSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GCP_RESULTSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GCP_SYMSWAPOFF: GET_CHARACTER_PLACEMENT_FLAGS = GET_CHARACTER_PLACEMENT_FLAGS(8388608u32);
 pub const GCP_USEKERNING: GET_CHARACTER_PLACEMENT_FLAGS = GET_CHARACTER_PLACEMENT_FLAGS(8u32);
@@ -5950,9 +5602,6 @@ impl Default for GLYPHMETRICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GLYPHMETRICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GLYPHSET {
@@ -5966,9 +5615,6 @@ impl Default for GLYPHSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GLYPHSET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GM_ADVANCED: GRAPHICS_MODE = GRAPHICS_MODE(2i32);
 pub const GM_COMPATIBLE: GRAPHICS_MODE = GRAPHICS_MODE(1i32);
@@ -5992,9 +5638,6 @@ impl Default for GRADIENT_RECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GRADIENT_RECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GRADIENT_TRIANGLE {
@@ -6006,9 +5649,6 @@ impl Default for GRADIENT_TRIANGLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GRADIENT_TRIANGLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6027,9 +5667,6 @@ impl Default for HANDLETABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HANDLETABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HANGEUL_CHARSET: FONT_CHARSET = FONT_CHARSET(129u8);
 pub const HANGUL_CHARSET: FONT_CHARSET = FONT_CHARSET(129u8);
@@ -6370,9 +6007,6 @@ impl Default for KERNINGPAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERNINGPAIR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LAYOUT_BITMAPORIENTATIONPRESERVED: DC_LAYOUT = DC_LAYOUT(8u32);
 pub const LAYOUT_BTT: u32 = 2u32;
 pub const LAYOUT_RTL: DC_LAYOUT = DC_LAYOUT(1u32);
@@ -6410,9 +6044,6 @@ impl Default for LOGBRUSH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOGBRUSH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LOGBRUSH32 {
@@ -6424,9 +6055,6 @@ impl Default for LOGBRUSH32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LOGBRUSH32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6451,9 +6079,6 @@ impl Default for LOGFONTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOGFONTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LOGFONTW {
@@ -6477,9 +6102,6 @@ impl Default for LOGFONTW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOGFONTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LOGPALETTE {
@@ -6492,9 +6114,6 @@ impl Default for LOGPALETTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOGPALETTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LOGPEN {
@@ -6506,9 +6125,6 @@ impl Default for LOGPEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LOGPEN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LOGPIXELSX: GET_DEVICE_CAPS_INDEX = GET_DEVICE_CAPS_INDEX(88u32);
 pub const LOGPIXELSY: GET_DEVICE_CAPS_INDEX = GET_DEVICE_CAPS_INDEX(90u32);
@@ -6541,9 +6157,6 @@ impl Default for MAT2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MAT2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MAXSTRETCHBLTMODE: u32 = 4u32;
 pub const MERGECOPY: ROP_CODE = ROP_CODE(12583114u32);
 pub const MERGEPAINT: ROP_CODE = ROP_CODE(12255782u32);
@@ -6564,9 +6177,6 @@ impl Default for METAHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for METAHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct METARECORD {
@@ -6578,9 +6188,6 @@ impl Default for METARECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for METARECORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const META_ANIMATEPALETTE: u32 = 1078u32;
 pub const META_ARC: u32 = 2071u32;
@@ -6682,9 +6289,6 @@ impl Default for MONITORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONITORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONITORINFOEXA {
@@ -6696,9 +6300,6 @@ impl Default for MONITORINFOEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONITORINFOEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONITORINFOEXW {
@@ -6709,9 +6310,6 @@ impl Default for MONITORINFOEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MONITORINFOEXW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MONITOR_DEFAULTTONEAREST: MONITOR_FROM_FLAGS = MONITOR_FROM_FLAGS(2u32);
 pub const MONITOR_DEFAULTTONULL: MONITOR_FROM_FLAGS = MONITOR_FROM_FLAGS(0u32);
@@ -6758,9 +6356,6 @@ impl Default for NEWTEXTMETRICA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NEWTEXTMETRICA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NEWTEXTMETRICW {
@@ -6793,9 +6388,6 @@ impl Default for NEWTEXTMETRICW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NEWTEXTMETRICW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NEWTRANSPARENT: u32 = 3u32;
 pub const NEXTBAND: u32 = 3u32;
@@ -6883,9 +6475,6 @@ impl Default for OUTLINETEXTMETRICA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OUTLINETEXTMETRICA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OUTLINETEXTMETRICW {
@@ -6927,9 +6516,6 @@ impl Default for OUTLINETEXTMETRICW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OUTLINETEXTMETRICW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OUT_CHARACTER_PRECIS: FONT_OUTPUT_PRECISION = FONT_OUTPUT_PRECISION(2u8);
 pub const OUT_DEFAULT_PRECIS: FONT_OUTPUT_PRECISION = FONT_OUTPUT_PRECISION(0u8);
 pub const OUT_DEVICE_PRECIS: FONT_OUTPUT_PRECISION = FONT_OUTPUT_PRECISION(5u8);
@@ -6956,9 +6542,6 @@ impl Default for PAINTSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PAINTSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PALETTEENTRY {
@@ -6971,9 +6554,6 @@ impl Default for PALETTEENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PALETTEENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6993,9 +6573,6 @@ impl Default for PANOSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PANOSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PANOSE_COUNT: u32 = 10u32;
 pub const PAN_ANY: u32 = 0u32;
@@ -7188,9 +6765,6 @@ impl Default for PELARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PELARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PEN_STYLE(pub i32);
@@ -7243,9 +6817,6 @@ impl Default for POINTFX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POINTFX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const POLYFILL_LAST: u32 = 2u32;
 pub const POLYGONALCAPS: GET_DEVICE_CAPS_INDEX = GET_DEVICE_CAPS_INDEX(32u32);
 #[repr(C)]
@@ -7264,9 +6835,6 @@ impl Default for POLYTEXTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLYTEXTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLYTEXTW {
@@ -7282,9 +6850,6 @@ impl Default for POLYTEXTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLYTEXTW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POSTSCRIPT_DATA: u32 = 37u32;
 pub const POSTSCRIPT_IDENTIFY: u32 = 4117u32;
@@ -7369,9 +6934,6 @@ impl Default for RASTERIZER_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASTERIZER_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RASTER_FONTTYPE: u32 = 1u32;
 pub const RC_BANDING: u32 = 2u32;
 pub const RC_BIGFONT: u32 = 1024u32;
@@ -7454,9 +7016,6 @@ impl Default for RGBQUAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RGBQUAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RGBTRIPLE {
@@ -7469,9 +7028,6 @@ impl Default for RGBTRIPLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RGBTRIPLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RGNDATA {
@@ -7482,9 +7038,6 @@ impl Default for RGNDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RGNDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7499,9 +7052,6 @@ impl Default for RGNDATAHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RGNDATAHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RGN_AND: RGN_COMBINE_MODE = RGN_COMBINE_MODE(1i32);
 #[repr(transparent)]
@@ -7683,9 +7233,6 @@ impl Default for TEXTMETRICA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TEXTMETRICA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TEXTMETRICW {
@@ -7714,9 +7261,6 @@ impl Default for TEXTMETRICW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TEXTMETRICW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7812,9 +7356,6 @@ impl Default for TRIVERTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRIVERTEX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TRUETYPE_FONTTYPE: u32 = 4u32;
 pub const TTDELETE_DONTREMOVEFONT: u32 = 1u32;
 #[repr(C)]
@@ -7828,9 +7369,6 @@ impl Default for TTEMBEDINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TTEMBEDINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TTEMBED_EMBEDEUDC: TTEMBED_FLAGS = TTEMBED_FLAGS(32u32);
 pub const TTEMBED_EUDCEMBEDDED: u32 = 2u32;
@@ -7909,9 +7447,6 @@ impl Default for TTLOADINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TTLOADINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TTLOAD_EMBEDDED_FONT_STATUS(pub u32);
@@ -7965,9 +7500,6 @@ impl Default for TTPOLYCURVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TTPOLYCURVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TTPOLYGONHEADER {
@@ -7979,9 +7511,6 @@ impl Default for TTPOLYGONHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TTPOLYGONHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7999,9 +7528,6 @@ impl Default for TTVALIDATIONTESTSPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TTVALIDATIONTESTSPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TTVALIDATIONTESTSPARAMSEX {
@@ -8017,9 +7543,6 @@ impl Default for TTVALIDATIONTESTSPARAMSEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TTVALIDATIONTESTSPARAMSEX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TT_AVAILABLE: u32 = 1u32;
 pub const TT_ENABLED: u32 = 2u32;
@@ -8050,9 +7573,6 @@ impl Default for WCRANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WCRANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WGLSWAP {
@@ -8063,9 +7583,6 @@ impl Default for WGLSWAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WGLSWAP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WGL_FONT_LINES: u32 = 0u32;
 pub const WGL_FONT_POLYGONS: u32 = 1u32;
@@ -8121,7 +7638,4 @@ impl Default for XFORM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XFORM {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/GdiPlus/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/GdiPlus/mod.rs
@@ -3399,9 +3399,6 @@ impl Default for BitmapData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BitmapData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Blur {
@@ -3411,9 +3408,6 @@ impl Default for Blur {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for Blur {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BlurEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0x633c80a4_1843_482b_9ef2_be2834c5fdd4);
 #[repr(C)]
@@ -3427,9 +3421,6 @@ impl Default for BlurParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BlurParams {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BrightnessContrast {
@@ -3439,9 +3430,6 @@ impl Default for BrightnessContrast {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BrightnessContrast {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BrightnessContrastEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0xd3a1dbe1_8ec4_4c17_9f4c_ea97ad1c343d);
 #[repr(C)]
@@ -3454,9 +3442,6 @@ impl Default for BrightnessContrastParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BrightnessContrastParams {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3488,9 +3473,6 @@ impl Default for CharacterRange {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CharacterRange {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CodecIImageBytes: windows_core::GUID = windows_core::GUID::from_u128(0x025d1823_6c7d_447b_bbdb_a3cbc3dfa2fc);
 #[repr(C)]
@@ -3654,9 +3636,6 @@ impl Default for Color {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Color {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ColorAdjustType(pub i32);
@@ -3677,9 +3656,6 @@ impl Default for ColorBalance {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ColorBalance {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ColorBalanceEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0x537e597d_251e_48da_9664_29ca496b70f8);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3692,9 +3668,6 @@ impl Default for ColorBalanceParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ColorBalanceParams {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3714,9 +3687,6 @@ impl Default for ColorCurve {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ColorCurve {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ColorCurveEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0xdd6a0022_58e4_4a67_9d9b_d48eb881a53d);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3730,9 +3700,6 @@ impl Default for ColorCurveParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ColorCurveParams {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ColorLUT {
@@ -3742,9 +3709,6 @@ impl Default for ColorLUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ColorLUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ColorLUTEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0xa7ce72a9_0f7f_40d7_b3cc_d0c02d5c3212);
 #[repr(C)]
@@ -3760,9 +3724,6 @@ impl Default for ColorLUTParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ColorLUTParams {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ColorMap {
@@ -3774,9 +3735,6 @@ impl Default for ColorMap {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ColorMap {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ColorMatrix {
@@ -3787,9 +3745,6 @@ impl Default for ColorMatrix {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ColorMatrix {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ColorMatrixEffect {
@@ -3799,9 +3754,6 @@ impl Default for ColorMatrixEffect {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ColorMatrixEffect {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ColorMatrixEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0x718f2615_7933_40e3_a511_5f68fe14dd74);
 #[repr(transparent)]
@@ -3826,9 +3778,6 @@ impl Default for ColorPalette {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ColorPalette {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3954,9 +3903,6 @@ impl Default for ENHMETAHEADER3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENHMETAHEADER3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Effect {
@@ -3970,9 +3916,6 @@ impl Default for Effect {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for Effect {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EmfPlusRecordTotal: EmfPlusRecordType = EmfPlusRecordType(16443i32);
 #[repr(transparent)]
@@ -4195,9 +4138,6 @@ impl Default for EncoderParameter {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EncoderParameter {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct EncoderParameterValueType(pub i32);
@@ -4220,9 +4160,6 @@ impl Default for EncoderParameters {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EncoderParameters {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EncoderQuality: windows_core::GUID = windows_core::GUID::from_u128(0x1d5be4b5_fa4a_452d_9cdd_5db35105e7eb);
 pub const EncoderRenderMethod: windows_core::GUID = windows_core::GUID::from_u128(0x6d42c53a_229a_4825_8bb7_5c99e2b9a8b8);
@@ -4360,9 +4297,6 @@ impl Default for GdiplusStartupInput {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GdiplusStartupInput {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GdiplusStartupInputEx {
@@ -4373,9 +4307,6 @@ impl Default for GdiplusStartupInputEx {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GdiplusStartupInputEx {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GdiplusStartupNoSetRound: GdiplusStartupParams = GdiplusStartupParams(1i32);
 #[repr(C)]
@@ -4388,9 +4319,6 @@ impl Default for GdiplusStartupOutput {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GdiplusStartupOutput {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4413,9 +4341,6 @@ impl Default for GpAdjustableArrowCap {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpAdjustableArrowCap {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpBitmap(pub u8);
@@ -4423,9 +4348,6 @@ impl Default for GpBitmap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpBitmap {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4435,9 +4357,6 @@ impl Default for GpBrush {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpBrush {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpCachedBitmap(pub u8);
@@ -4445,9 +4364,6 @@ impl Default for GpCachedBitmap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpCachedBitmap {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4457,9 +4373,6 @@ impl Default for GpCustomLineCap {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpCustomLineCap {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpFont(pub u8);
@@ -4467,9 +4380,6 @@ impl Default for GpFont {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpFont {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4479,9 +4389,6 @@ impl Default for GpFontCollection {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpFontCollection {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpFontFamily(pub u8);
@@ -4489,9 +4396,6 @@ impl Default for GpFontFamily {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpFontFamily {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4501,9 +4405,6 @@ impl Default for GpGraphics {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpGraphics {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpHatch(pub u8);
@@ -4511,9 +4412,6 @@ impl Default for GpHatch {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpHatch {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4523,9 +4421,6 @@ impl Default for GpImage {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpImage {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpImageAttributes(pub u8);
@@ -4533,9 +4428,6 @@ impl Default for GpImageAttributes {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpImageAttributes {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4545,9 +4437,6 @@ impl Default for GpInstalledFontCollection {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpInstalledFontCollection {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpLineGradient(pub u8);
@@ -4555,9 +4444,6 @@ impl Default for GpLineGradient {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpLineGradient {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4567,9 +4453,6 @@ impl Default for GpMetafile {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpMetafile {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpPath(pub u8);
@@ -4577,9 +4460,6 @@ impl Default for GpPath {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpPath {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4589,9 +4469,6 @@ impl Default for GpPathGradient {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpPathGradient {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpPathIterator(pub u8);
@@ -4599,9 +4476,6 @@ impl Default for GpPathIterator {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpPathIterator {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4611,9 +4485,6 @@ impl Default for GpPen {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpPen {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpPrivateFontCollection(pub u8);
@@ -4621,9 +4492,6 @@ impl Default for GpPrivateFontCollection {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpPrivateFontCollection {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4633,9 +4501,6 @@ impl Default for GpRegion {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpRegion {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpSolidFill(pub u8);
@@ -4644,9 +4509,6 @@ impl Default for GpSolidFill {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GpSolidFill {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GpStringFormat(pub u8);
@@ -4654,9 +4516,6 @@ impl Default for GpStringFormat {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpStringFormat {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4668,9 +4527,6 @@ impl Default for GpTexture {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GpTexture {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4759,9 +4615,6 @@ impl Default for HueSaturationLightness {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HueSaturationLightness {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HueSaturationLightnessEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0x8b2dd6c3_eb07_4d87_a5f0_7108e26a9c5f);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4774,9 +4627,6 @@ impl Default for HueSaturationLightnessParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HueSaturationLightnessParams {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IImageBytes, IImageBytes_Vtbl, 0x025d1823_6c7d_447b_bbdb_a3cbc3dfa2fc);
 windows_core::imp::interface_hierarchy!(IImageBytes, windows_core::IUnknown);
@@ -4870,9 +4720,6 @@ impl Default for ImageCodecInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ImageCodecInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ImageFlags(pub i32);
@@ -4918,9 +4765,6 @@ impl Default for ImageItemData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ImageItemData {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4970,9 +4814,6 @@ impl Default for Levels {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Levels {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LevelsEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0x99c354ec_2a31_4f3a_8c34_17a803b33a25);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4985,9 +4826,6 @@ impl Default for LevelsParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LevelsParams {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5068,10 +4906,6 @@ impl Default for MetafileHeader {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for MetafileHeader {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -5084,10 +4918,6 @@ impl Default for MetafileHeader_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for MetafileHeader_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5133,9 +4963,6 @@ impl Default for PWMFRect16 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PWMFRect16 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5216,9 +5043,6 @@ impl Default for Point {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Point {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PointF {
@@ -5229,9 +5053,6 @@ impl Default for PointF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PointF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -5252,9 +5073,6 @@ impl Default for PropertyItem {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PropertyItem {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PropertyNotFound: Status = Status(19i32);
 pub const PropertyNotSupported: Status = Status(20i32);
@@ -5522,9 +5340,6 @@ impl Default for Rect {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Rect {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RectF {
@@ -5538,9 +5353,6 @@ impl Default for RectF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RectF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RedEyeCorrection {
@@ -5550,9 +5362,6 @@ impl Default for RedEyeCorrection {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RedEyeCorrection {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RedEyeCorrectionEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0x74d29d05_69a4_4266_9549_3cc52836b632);
 #[repr(C)]
@@ -5565,9 +5374,6 @@ impl Default for RedEyeCorrectionParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RedEyeCorrectionParams {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -5604,9 +5410,6 @@ impl Default for Sharpen {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Sharpen {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SharpenEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0x63cbf3ee_c526_402c_8f71_62c540bf5142);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5619,9 +5422,6 @@ impl Default for SharpenParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SharpenParams {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Size {
@@ -5633,9 +5433,6 @@ impl Default for Size {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Size {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SizeF {
@@ -5646,9 +5443,6 @@ impl Default for SizeF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SizeF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5721,9 +5515,6 @@ impl Default for Tint {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Tint {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TintEffectGuid: windows_core::GUID = windows_core::GUID::from_u128(0x1077af00_2848_4441_9489_44ad4c2d7a2c);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5735,9 +5526,6 @@ impl Default for TintParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TintParams {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5772,9 +5560,6 @@ impl Default for WmfPlaceableFileHeader {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WmfPlaceableFileHeader {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WmfRecordTypeAbortDoc: EmfPlusRecordType = EmfPlusRecordType(65618i32);
 pub const WmfRecordTypeAnimatePalette: EmfPlusRecordType = EmfPlusRecordType(66614i32);

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
@@ -5429,9 +5429,6 @@ impl Default for WICBitmapPattern {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WICBitmapPattern {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WICBitmapPlane {
@@ -5445,9 +5442,6 @@ impl Default for WICBitmapPlane {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WICBitmapPlane {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WICBitmapPlaneDescription {
@@ -5459,9 +5453,6 @@ impl Default for WICBitmapPlaneDescription {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WICBitmapPlaneDescription {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WICBitmapTransformFlipHorizontal: WICBitmapTransformOptions = WICBitmapTransformOptions(8i32);
 pub const WICBitmapTransformFlipVertical: WICBitmapTransformOptions = WICBitmapTransformOptions(16i32);
@@ -5524,10 +5515,6 @@ impl Default for WICDdsFormatInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for WICDdsFormatInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5546,10 +5533,6 @@ impl Default for WICDdsParameters {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for WICDdsParameters {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WICDdsTexture1D: WICDdsDimension = WICDdsDimension(0i32);
 pub const WICDdsTexture2D: WICDdsDimension = WICDdsDimension(1i32);
@@ -5632,10 +5615,6 @@ impl Default for WICImageParameters {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for WICImageParameters {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WICJpegChrominanceProperties(pub i32);
@@ -5660,9 +5639,6 @@ impl Default for WICJpegFrameHeader {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WICJpegFrameHeader {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5689,9 +5665,6 @@ impl Default for WICJpegScanHeader {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WICJpegScanHeader {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5732,9 +5705,6 @@ impl Default for WICMetadataHeader {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WICMetadataHeader {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WICMetadataPattern {
@@ -5748,9 +5718,6 @@ impl Default for WICMetadataPattern {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WICMetadataPattern {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WICMetadataReader: WICComponentType = WICComponentType(8i32);
 pub const WICMetadataWriter: WICComponentType = WICComponentType(16i32);
@@ -5885,9 +5852,6 @@ impl Default for WICRawCapabilitiesInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WICRawCapabilitiesInfo {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WICRawCapabilityFullySupported: WICRawCapabilities = WICRawCapabilities(2i32);
 pub const WICRawCapabilityGetSupported: WICRawCapabilities = WICRawCapabilities(1i32);
 pub const WICRawCapabilityNotSupported: WICRawCapabilities = WICRawCapabilities(0i32);
@@ -5932,9 +5896,6 @@ impl Default for WICRawToneCurve {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WICRawToneCurve {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WICRawToneCurvePoint {
@@ -5945,9 +5906,6 @@ impl Default for WICRawToneCurvePoint {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WICRawToneCurvePoint {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5961,9 +5919,6 @@ impl Default for WICRect {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WICRect {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
@@ -2098,10 +2098,6 @@ impl Default for EMRPIXELFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for EMRPIXELFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GLU_AUTO_LOAD_MATRIX: u32 = 100200u32;
 pub const GLU_BEGIN: u32 = 100100u32;
 pub const GLU_CCW: u32 = 100121u32;
@@ -2262,9 +2258,6 @@ impl Default for GLYPHMETRICSFLOAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GLYPHMETRICSFLOAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GL_2D: u32 = 1536u32;
 pub const GL_2_BYTES: u32 = 5127u32;
@@ -2912,9 +2905,6 @@ impl Default for LAYERPLANEDESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LAYERPLANEDESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PFD_DEPTH_DONTCARE: PFD_FLAGS = PFD_FLAGS(536870912u32);
 pub const PFD_DIRECT3D_ACCELERATED: PFD_FLAGS = PFD_FLAGS(16384u32);
 pub const PFD_DOUBLEBUFFER: PFD_FLAGS = PFD_FLAGS(1u32);
@@ -3033,9 +3023,6 @@ impl Default for PIXELFORMATDESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PIXELFORMATDESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POINTFLOAT {
@@ -3046,7 +3033,4 @@ impl Default for POINTFLOAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POINTFLOAT {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
@@ -1554,9 +1554,6 @@ impl Default for ADDJOB_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADDJOB_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADDJOB_INFO_1W {
@@ -1567,9 +1564,6 @@ impl Default for ADDJOB_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADDJOB_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ALREADY_REGISTERED: PrintAsyncNotifyError = PrintAsyncNotifyError(15i32);
 pub const ALREADY_UNREGISTERED: PrintAsyncNotifyError = PrintAsyncNotifyError(14i32);
@@ -1599,9 +1593,6 @@ impl Default for ATTRIBUTE_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATTRIBUTE_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ATTRIBUTE_INFO_2 {
@@ -1618,9 +1609,6 @@ impl Default for ATTRIBUTE_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATTRIBUTE_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1640,9 +1628,6 @@ impl Default for ATTRIBUTE_INFO_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATTRIBUTE_INFO_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1668,9 +1653,6 @@ impl Default for ATTRIBUTE_INFO_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATTRIBUTE_INFO_4 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BIDI_ACCESS_ADMINISTRATOR: u32 = 1u32;
 pub const BIDI_ACCESS_USER: u32 = 2u32;
 pub const BIDI_ACTION_ENUM_SCHEMA: windows_core::PCWSTR = windows_core::w!("EnumSchema");
@@ -1691,9 +1673,6 @@ impl Default for BIDI_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BIDI_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union BIDI_DATA_0 {
@@ -1707,9 +1686,6 @@ impl Default for BIDI_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BIDI_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BIDI_ENUM: BIDI_TYPE = BIDI_TYPE(6i32);
 pub const BIDI_FLOAT: BIDI_TYPE = BIDI_TYPE(2i32);
@@ -1728,9 +1704,6 @@ impl Default for BIDI_REQUEST_CONTAINER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BIDI_REQUEST_CONTAINER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct BIDI_REQUEST_DATA {
@@ -1742,9 +1715,6 @@ impl Default for BIDI_REQUEST_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BIDI_REQUEST_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1759,9 +1729,6 @@ impl Default for BIDI_RESPONSE_CONTAINER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BIDI_RESPONSE_CONTAINER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct BIDI_RESPONSE_DATA {
@@ -1774,9 +1741,6 @@ impl Default for BIDI_RESPONSE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BIDI_RESPONSE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BIDI_STRING: BIDI_TYPE = BIDI_TYPE(4i32);
 pub const BIDI_TEXT: BIDI_TYPE = BIDI_TYPE(5i32);
@@ -1793,9 +1757,6 @@ impl Default for BINARY_CONTAINER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BINARY_CONTAINER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BOOKLET_EDGE_LEFT: u32 = 0u32;
 pub const BOOKLET_EDGE_RIGHT: u32 = 1u32;
@@ -1816,9 +1777,6 @@ impl Default for BranchOfficeJobData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BranchOfficeJobData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union BranchOfficeJobData_0 {
@@ -1833,9 +1791,6 @@ impl Default for BranchOfficeJobData_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BranchOfficeJobData_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct BranchOfficeJobDataContainer {
@@ -1846,9 +1801,6 @@ impl Default for BranchOfficeJobDataContainer {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BranchOfficeJobDataContainer {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1871,9 +1823,6 @@ impl Default for BranchOfficeJobDataError {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BranchOfficeJobDataError {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BranchOfficeJobDataPipelineFailed {
@@ -1885,9 +1834,6 @@ impl Default for BranchOfficeJobDataPipelineFailed {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BranchOfficeJobDataPipelineFailed {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1906,9 +1852,6 @@ impl Default for BranchOfficeJobDataPrinted {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BranchOfficeJobDataPrinted {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BranchOfficeJobDataRendered {
@@ -1925,9 +1868,6 @@ impl Default for BranchOfficeJobDataRendered {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BranchOfficeJobDataRendered {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BranchOfficeLogOfflineFileFull {
@@ -1937,9 +1877,6 @@ impl Default for BranchOfficeLogOfflineFileFull {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BranchOfficeLogOfflineFileFull {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CC_BIG5: i32 = -10i32;
 pub const CC_CP437: i32 = -1i32;
@@ -2008,10 +1945,6 @@ impl Default for COMPROPSHEETUI {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for COMPROPSHEETUI {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONFIG_INFO_DATA_1 {
@@ -2022,9 +1955,6 @@ impl Default for CONFIG_INFO_DATA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONFIG_INFO_DATA_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COPYFILE_EVENT_ADD_PRINTER_CONNECTION: u32 = 3u32;
 pub const COPYFILE_EVENT_DELETE_PRINTER: u32 = 2u32;
@@ -2046,9 +1976,6 @@ impl Default for CORE_PRINTER_DRIVERA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CORE_PRINTER_DRIVERA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CORE_PRINTER_DRIVERW {
@@ -2061,9 +1988,6 @@ impl Default for CORE_PRINTER_DRIVERW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CORE_PRINTER_DRIVERW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CPSFUNC_ADD_HPROPSHEETPAGE: u32 = 0u32;
 pub const CPSFUNC_ADD_PCOMPROPSHEETUI: u32 = 3u32;
@@ -2119,10 +2043,6 @@ impl Default for CPSUICBPARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for CPSUICBPARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -2135,10 +2055,6 @@ impl Default for CPSUICBPARAM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for CPSUICBPARAM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CPSUICB_ACTION_ITEMS_APPLIED: u32 = 4u32;
 pub const CPSUICB_ACTION_NONE: u32 = 0u32;
@@ -2168,9 +2084,6 @@ impl Default for CPSUIDATABLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CPSUIDATABLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CPSUIF_ABOUT_CALLBACK: u32 = 4u32;
 pub const CPSUIF_ICONID_AS_HICON: u32 = 2u32;
 pub const CPSUIF_UPDATE_PERMISSION: u32 = 1u32;
@@ -2196,9 +2109,6 @@ impl Default for CUSTOMSIZEPARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CUSTOMSIZEPARAM {
-    type TypeKind = windows_core::CopyType;
-}
 pub const Compression_Fast: EXpsCompressionOptions = EXpsCompressionOptions(3i32);
 pub const Compression_Normal: EXpsCompressionOptions = EXpsCompressionOptions(1i32);
 pub const Compression_NotCompressed: EXpsCompressionOptions = EXpsCompressionOptions(0i32);
@@ -2213,9 +2123,6 @@ impl Default for DATATYPES_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DATATYPES_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DATATYPES_INFO_1W {
@@ -2225,9 +2132,6 @@ impl Default for DATATYPES_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DATATYPES_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2243,9 +2147,6 @@ impl Default for DATA_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DATA_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEF_PRIORITY: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2260,9 +2161,6 @@ impl Default for DELETE_PORT_DATA_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DELETE_PORT_DATA_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICEPROPERTYHEADER {
@@ -2275,9 +2173,6 @@ impl Default for DEVICEPROPERTYHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICEPROPERTYHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2296,10 +2191,6 @@ impl Default for DEVQUERYPRINT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DEVQUERYPRINT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DF_BKSP_OK: u32 = 64u32;
 pub const DF_NOITALIC: u32 = 1u32;
@@ -2467,10 +2358,6 @@ impl Default for DLGPAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for DLGPAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -2483,10 +2370,6 @@ impl Default for DLGPAGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for DLGPAGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMPUB_BOOKLET_EDGE: u32 = 21u32;
 pub const DMPUB_COLOR: u32 = 6u32;
@@ -2537,10 +2420,6 @@ impl Default for DOCEVENT_CREATEDCPRE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DOCEVENT_CREATEDCPRE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOCEVENT_ESCAPE {
@@ -2552,9 +2431,6 @@ impl Default for DOCEVENT_ESCAPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOCEVENT_ESCAPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2569,9 +2445,6 @@ impl Default for DOCEVENT_FILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOCEVENT_FILTER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOCUMENTEVENT_ABORTDOC: u32 = 9u32;
 pub const DOCUMENTEVENT_CREATEDCPOST: u32 = 2u32;
@@ -2627,10 +2500,6 @@ impl Default for DOCUMENTPROPERTYHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DOCUMENTPROPERTYHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOC_INFO_1A {
@@ -2643,9 +2512,6 @@ impl Default for DOC_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOC_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOC_INFO_1W {
@@ -2657,9 +2523,6 @@ impl Default for DOC_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOC_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2675,9 +2538,6 @@ impl Default for DOC_INFO_2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOC_INFO_2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOC_INFO_2W {
@@ -2692,9 +2552,6 @@ impl Default for DOC_INFO_2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOC_INFO_2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOC_INFO_3A {
@@ -2707,9 +2564,6 @@ impl Default for DOC_INFO_3A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOC_INFO_3A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2724,9 +2578,6 @@ impl Default for DOC_INFO_3W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOC_INFO_3W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOC_INFO_INTERNAL {
@@ -2740,9 +2591,6 @@ impl Default for DOC_INFO_INTERNAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOC_INFO_INTERNAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOC_INFO_INTERNAL_LEVEL: u32 = 100u32;
 pub const DPD_DELETE_ALL_FILES: u32 = 4u32;
@@ -2767,9 +2615,6 @@ impl Default for DRIVER_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVER_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVER_INFO_1W {
@@ -2779,9 +2624,6 @@ impl Default for DRIVER_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVER_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2798,9 +2640,6 @@ impl Default for DRIVER_INFO_2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVER_INFO_2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVER_INFO_2W {
@@ -2815,9 +2654,6 @@ impl Default for DRIVER_INFO_2W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVER_INFO_2W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2838,9 +2674,6 @@ impl Default for DRIVER_INFO_3A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVER_INFO_3A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVER_INFO_3W {
@@ -2859,9 +2692,6 @@ impl Default for DRIVER_INFO_3W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVER_INFO_3W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2883,9 +2713,6 @@ impl Default for DRIVER_INFO_4A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVER_INFO_4A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVER_INFO_4W {
@@ -2906,9 +2733,6 @@ impl Default for DRIVER_INFO_4W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVER_INFO_4W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVER_INFO_5A {
@@ -2927,9 +2751,6 @@ impl Default for DRIVER_INFO_5A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVER_INFO_5A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVER_INFO_5W {
@@ -2947,9 +2768,6 @@ impl Default for DRIVER_INFO_5W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVER_INFO_5W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2977,9 +2795,6 @@ impl Default for DRIVER_INFO_6A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVER_INFO_6A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVER_INFO_6W {
@@ -3005,9 +2820,6 @@ impl Default for DRIVER_INFO_6W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVER_INFO_6W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3043,9 +2855,6 @@ impl Default for DRIVER_INFO_8A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVER_INFO_8A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVER_INFO_8W {
@@ -3080,9 +2889,6 @@ impl Default for DRIVER_INFO_8W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVER_INFO_8W {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DRIVER_KERNELMODE: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3094,9 +2900,6 @@ impl Default for DRIVER_UPGRADE_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVER_UPGRADE_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3119,9 +2922,6 @@ impl Default for DRIVER_UPGRADE_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVER_UPGRADE_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRIVER_USERMODE: u32 = 2u32;
 pub const DSPRINT_PENDING: u32 = 2147483648u32;
@@ -3247,9 +3047,6 @@ impl Default for EXTCHKBOX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXTCHKBOX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -3268,10 +3065,6 @@ impl Default for EXTPUSH {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for EXTPUSH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -3285,10 +3078,6 @@ impl Default for EXTPUSH_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for EXTPUSH_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -3301,10 +3090,6 @@ impl Default for EXTPUSH_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for EXTPUSH_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3340,9 +3125,6 @@ impl Default for EXTTEXTMETRIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXTTEXTMETRIC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3398,9 +3180,6 @@ impl Default for FORM_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FORM_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FORM_INFO_1W {
@@ -3413,9 +3192,6 @@ impl Default for FORM_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FORM_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3436,9 +3212,6 @@ impl Default for FORM_INFO_2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FORM_INFO_2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FORM_INFO_2W {
@@ -3458,9 +3231,6 @@ impl Default for FORM_INFO_2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FORM_INFO_2W {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FORM_PRINTER: u32 = 2u32;
 pub const FORM_USER: u32 = 0u32;
 pub const FinalPageCount: PageCountType = PageCountType(0i32);
@@ -3476,9 +3246,6 @@ impl Default for GLYPHRUN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GLYPHRUN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GPD_OEMCUSTOMDATA: u32 = 1u32;
 pub const GUID_DEVINTERFACE_IPPUSB_PRINT: windows_core::GUID = windows_core::GUID::from_u128(0xf2f40381_f46d_4e51_bce7_62de6cf2d098);
@@ -4808,9 +4575,6 @@ impl Default for INSERTPSUIPAGE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INSERTPSUIPAGE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INSPSUIPAGE_MODE_AFTER: u32 = 1u32;
 pub const INSPSUIPAGE_MODE_BEFORE: u32 = 0u32;
 pub const INSPSUIPAGE_MODE_FIRST_CHILD: u32 = 2u32;
@@ -4828,9 +4592,6 @@ impl Default for INVOC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INVOC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IOCTL_USBPRINT_ADD_CHILD_DEVICE: u32 = 2228316u32;
 pub const IOCTL_USBPRINT_ADD_MSIPP_COMPAT_ID: u32 = 2228308u32;
@@ -10864,9 +10625,6 @@ impl Default for ImgErrorInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ImgErrorInfo {
-    type TypeKind = windows_core::CloneType;
-}
 pub const IntermediatePageCount: PageCountType = PageCountType(1i32);
 pub const JOB_ACCESS_ADMINISTER: u32 = 16u32;
 pub const JOB_ACCESS_READ: u32 = 32u32;
@@ -10902,9 +10660,6 @@ impl Default for JOB_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOB_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOB_INFO_1W {
@@ -10926,9 +10681,6 @@ impl Default for JOB_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOB_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
@@ -10964,10 +10716,6 @@ impl Default for JOB_INFO_2A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
-impl windows_core::TypeKind for JOB_INFO_2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11002,10 +10750,6 @@ impl Default for JOB_INFO_2W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
-impl windows_core::TypeKind for JOB_INFO_2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOB_INFO_3 {
@@ -11017,9 +10761,6 @@ impl Default for JOB_INFO_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOB_INFO_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
@@ -11056,10 +10797,6 @@ impl Default for JOB_INFO_4A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
-impl windows_core::TypeKind for JOB_INFO_4A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11094,10 +10831,6 @@ impl Default for JOB_INFO_4W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
-impl windows_core::TypeKind for JOB_INFO_4W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JOB_NOTIFY_FIELD_BYTES_PRINTED: u32 = 23u32;
 pub const JOB_NOTIFY_FIELD_DATATYPE: u32 = 5u32;
@@ -11155,10 +10888,6 @@ impl Default for KERNDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Devices_Display")]
-impl windows_core::TypeKind for KERNDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LOCAL_ONLY_REGISTRATION: PrintAsyncNotifyError = PrintAsyncNotifyError(23i32);
 pub const LPR: u32 = 2u32;
 #[repr(C)]
@@ -11172,9 +10901,6 @@ impl Default for MAPTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MAPTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MAX_ADDRESS_STR_LEN: u32 = 13u32;
 pub const MAX_CHANNEL_COUNT_EXCEEDED: PrintAsyncNotifyError = PrintAsyncNotifyError(22i32);
@@ -11209,9 +10935,6 @@ impl Default for MESSAGEBOX_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MESSAGEBOX_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MIN_PRIORITY: u32 = 1u32;
 #[repr(C)]
 #[cfg(all(feature = "Win32_Devices_Communication", feature = "Win32_System_Power"))]
@@ -11240,10 +10963,6 @@ impl Default for MONITOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Devices_Communication", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for MONITOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Devices_Communication", feature = "Win32_System_Power"))]
@@ -11279,10 +10998,6 @@ impl Default for MONITOR2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Devices_Communication", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for MONITOR2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Devices_Communication", feature = "Win32_System_Power"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11295,10 +11010,6 @@ impl Default for MONITOREX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Devices_Communication", feature = "Win32_System_Power"))]
-impl windows_core::TypeKind for MONITOREX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
@@ -11316,10 +11027,6 @@ impl Default for MONITORINIT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for MONITORINIT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11341,9 +11048,6 @@ impl Default for MONITORREG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONITORREG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONITORUI {
@@ -11357,9 +11061,6 @@ impl Default for MONITORUI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONITORUI {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONITOR_INFO_1A {
@@ -11370,9 +11071,6 @@ impl Default for MONITOR_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONITOR_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONITOR_INFO_1W {
@@ -11382,9 +11080,6 @@ impl Default for MONITOR_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MONITOR_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11398,9 +11093,6 @@ impl Default for MONITOR_INFO_2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONITOR_INFO_2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONITOR_INFO_2W {
@@ -11412,9 +11104,6 @@ impl Default for MONITOR_INFO_2W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MONITOR_INFO_2W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MS_PRINT_JOB_OUTPUT_FILE: windows_core::PCWSTR = windows_core::w!("MsPrintJobOutputFile");
 pub const MTYPE_ADD: u32 = 64u32;
@@ -11454,9 +11143,6 @@ impl Default for MXDC_ESCAPE_HEADER_T {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MXDC_ESCAPE_HEADER_T {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MXDC_GET_FILENAME_DATA_T {
@@ -11467,9 +11153,6 @@ impl Default for MXDC_GET_FILENAME_DATA_T {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MXDC_GET_FILENAME_DATA_T {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MXDC_IMAGETYPE_JPEGHIGH_COMPRESSION: MXDC_IMAGE_TYPE_ENUMS = MXDC_IMAGE_TYPE_ENUMS(1i32);
 pub const MXDC_IMAGETYPE_JPEGLOW_COMPRESSION: MXDC_IMAGE_TYPE_ENUMS = MXDC_IMAGE_TYPE_ENUMS(3i32);
@@ -11495,9 +11178,6 @@ impl Default for MXDC_PRINTTICKET_DATA_T {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MXDC_PRINTTICKET_DATA_T {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MXDC_PRINTTICKET_ESCAPE_T {
@@ -11508,9 +11188,6 @@ impl Default for MXDC_PRINTTICKET_ESCAPE_T {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MXDC_PRINTTICKET_ESCAPE_T {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MXDC_RESOURCE_DICTIONARY: MXDC_S0_PAGE_ENUMS = MXDC_S0_PAGE_ENUMS(5i32);
 pub const MXDC_RESOURCE_ICC_PROFILE: MXDC_S0_PAGE_ENUMS = MXDC_S0_PAGE_ENUMS(6i32);
@@ -11533,9 +11210,6 @@ impl Default for MXDC_S0PAGE_DATA_T {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MXDC_S0PAGE_DATA_T {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MXDC_S0PAGE_PASSTHROUGH_ESCAPE_T {
@@ -11547,9 +11221,6 @@ impl Default for MXDC_S0PAGE_PASSTHROUGH_ESCAPE_T {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MXDC_S0PAGE_PASSTHROUGH_ESCAPE_T {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MXDC_S0PAGE_RESOURCE_ESCAPE_T {
@@ -11560,9 +11231,6 @@ impl Default for MXDC_S0PAGE_RESOURCE_ESCAPE_T {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MXDC_S0PAGE_RESOURCE_ESCAPE_T {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11580,9 +11248,6 @@ impl Default for MXDC_XPS_S0PAGE_RESOURCE_T {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MXDC_XPS_S0PAGE_RESOURCE_T {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NORMAL_PRINT: u32 = 0u32;
 #[repr(transparent)]
@@ -11603,9 +11268,6 @@ impl Default for NOTIFICATION_CONFIG_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NOTIFICATION_CONFIG_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NOTIFICATION_CONFIG_ASYNC_CHANNEL: NOTIFICATION_CONFIG_FLAGS = NOTIFICATION_CONFIG_FLAGS(8i32);
 pub const NOTIFICATION_CONFIG_CREATE_EVENT: NOTIFICATION_CONFIG_FLAGS = NOTIFICATION_CONFIG_FLAGS(1i32);
@@ -11648,10 +11310,6 @@ impl Default for OEMCUIPPARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for OEMCUIPPARAM {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OEMCUIP_DOCPROP: u32 = 1u32;
 pub const OEMCUIP_PRNPROP: u32 = 2u32;
 #[repr(C)]
@@ -11674,10 +11332,6 @@ impl Default for OEMDMPARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for OEMDMPARAM {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OEMDM_CONVERT: u32 = 3u32;
 pub const OEMDM_DEFAULT: u32 = 2u32;
 pub const OEMDM_MERGE: u32 = 4u32;
@@ -11696,9 +11350,6 @@ impl Default for OEMFONTINSTPARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OEMFONTINSTPARAM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OEMGDS_FREEMEM: u32 = 32769u32;
 pub const OEMGDS_JOBTIMEOUT: u32 = 32770u32;
@@ -11740,9 +11391,6 @@ impl Default for OEMUIOBJ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OEMUIOBJ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OEMUIPROCS {
@@ -11753,9 +11401,6 @@ impl Default for OEMUIPROCS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OEMUIPROCS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -11779,10 +11424,6 @@ impl Default for OEMUIPSPARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for OEMUIPSPARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OEM_DMEXTRAHEADER {
@@ -11794,9 +11435,6 @@ impl Default for OEM_DMEXTRAHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OEM_DMEXTRAHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OEM_MODE_PUBLISHER: u32 = 1u32;
 #[repr(C)]
@@ -11812,9 +11450,6 @@ impl Default for OIEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OIEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OIEXTF_ANSI_STRING: u32 = 1u32;
 pub const OPTCF_HIDE: u32 = 1u32;
@@ -11833,9 +11468,6 @@ impl Default for OPTCOMBO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPTCOMBO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPTIF_CALLBACK: i32 = 4i32;
 pub const OPTIF_CHANGED: i32 = 8i32;
@@ -11881,10 +11513,6 @@ impl Default for OPTITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for OPTITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -11898,10 +11526,6 @@ impl Default for OPTITEM_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for OPTITEM_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -11914,10 +11538,6 @@ impl Default for OPTITEM_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for OPTITEM_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11934,9 +11554,6 @@ impl Default for OPTPARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPTPARAM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPTPF_DISABLED: u32 = 2u32;
 pub const OPTPF_HIDE: u32 = 1u32;
@@ -11966,9 +11583,6 @@ impl Default for OPTTYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPTTYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OTS_LBCB_INCL_ITEM_NONE: u32 = 8u32;
 pub const OTS_LBCB_NO_ICON16_IN_ITEM: u32 = 16u32;
@@ -12054,9 +11668,6 @@ impl Default for PORT_DATA_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PORT_DATA_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PORT_DATA_2 {
@@ -12080,9 +11691,6 @@ impl Default for PORT_DATA_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PORT_DATA_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PORT_DATA_LIST_1 {
@@ -12095,9 +11703,6 @@ impl Default for PORT_DATA_LIST_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PORT_DATA_LIST_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PORT_INFO_1A {
@@ -12108,9 +11713,6 @@ impl Default for PORT_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PORT_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PORT_INFO_1W {
@@ -12120,9 +11722,6 @@ impl Default for PORT_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PORT_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12138,9 +11737,6 @@ impl Default for PORT_INFO_2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PORT_INFO_2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PORT_INFO_2W {
@@ -12155,9 +11751,6 @@ impl Default for PORT_INFO_2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PORT_INFO_2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PORT_INFO_3A {
@@ -12170,9 +11763,6 @@ impl Default for PORT_INFO_3A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PORT_INFO_3A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PORT_INFO_3W {
@@ -12184,9 +11774,6 @@ impl Default for PORT_INFO_3W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PORT_INFO_3W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PORT_STATUS_DOOR_OPEN: u32 = 7u32;
 pub const PORT_STATUS_NO_TONER: u32 = 6u32;
@@ -12314,9 +11901,6 @@ impl Default for PRINTER_CONNECTION_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_CONNECTION_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_CONNECTION_INFO_1W {
@@ -12327,9 +11911,6 @@ impl Default for PRINTER_CONNECTION_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTER_CONNECTION_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRINTER_CONNECTION_MISMATCH: u32 = 32u32;
 pub const PRINTER_CONNECTION_NO_UI: u32 = 64u32;
@@ -12351,10 +11932,6 @@ impl Default for PRINTER_DEFAULTSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTER_DEFAULTSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12368,10 +11945,6 @@ impl Default for PRINTER_DEFAULTSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTER_DEFAULTSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRINTER_DELETE: PRINTER_ACCESS_RIGHTS = PRINTER_ACCESS_RIGHTS(65536u32);
 pub const PRINTER_DRIVER_CATEGORY_3D: u32 = 4096u32;
@@ -12424,9 +11997,6 @@ impl Default for PRINTER_ENUM_VALUESA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_ENUM_VALUESA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_ENUM_VALUESW {
@@ -12440,9 +12010,6 @@ impl Default for PRINTER_ENUM_VALUESW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTER_ENUM_VALUESW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRINTER_ERROR_INFORMATION: u32 = 2147483648u32;
 pub const PRINTER_ERROR_JAM: u32 = 2u32;
@@ -12464,9 +12031,6 @@ impl Default for PRINTER_EVENT_ATTRIBUTES_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTER_EVENT_ATTRIBUTES_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRINTER_EVENT_CACHE_DELETE: u32 = 6u32;
 pub const PRINTER_EVENT_CACHE_REFRESH: u32 = 5u32;
@@ -12491,9 +12055,6 @@ impl Default for PRINTER_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_INFO_1A {
@@ -12507,9 +12068,6 @@ impl Default for PRINTER_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_INFO_1W {
@@ -12522,9 +12080,6 @@ impl Default for PRINTER_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTER_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
@@ -12558,10 +12113,6 @@ impl Default for PRINTER_INFO_2A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
-impl windows_core::TypeKind for PRINTER_INFO_2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12594,10 +12145,6 @@ impl Default for PRINTER_INFO_2W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security"))]
-impl windows_core::TypeKind for PRINTER_INFO_2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12609,10 +12156,6 @@ impl Default for PRINTER_INFO_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for PRINTER_INFO_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12626,9 +12169,6 @@ impl Default for PRINTER_INFO_4A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_INFO_4A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_INFO_4W {
@@ -12640,9 +12180,6 @@ impl Default for PRINTER_INFO_4W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTER_INFO_4W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12658,9 +12195,6 @@ impl Default for PRINTER_INFO_5A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_INFO_5A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_INFO_5W {
@@ -12675,9 +12209,6 @@ impl Default for PRINTER_INFO_5W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_INFO_5W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_INFO_6 {
@@ -12687,9 +12218,6 @@ impl Default for PRINTER_INFO_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTER_INFO_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12702,9 +12230,6 @@ impl Default for PRINTER_INFO_7A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_INFO_7A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_INFO_7W {
@@ -12715,9 +12240,6 @@ impl Default for PRINTER_INFO_7W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTER_INFO_7W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -12731,10 +12253,6 @@ impl Default for PRINTER_INFO_8A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTER_INFO_8A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12746,10 +12264,6 @@ impl Default for PRINTER_INFO_8W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTER_INFO_8W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -12763,10 +12277,6 @@ impl Default for PRINTER_INFO_9A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTER_INFO_9A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12778,10 +12288,6 @@ impl Default for PRINTER_INFO_9W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTER_INFO_9W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRINTER_NOTIFY_CATEGORY_3D: u32 = 8192u32;
 pub const PRINTER_NOTIFY_CATEGORY_ALL: u32 = 4096u32;
@@ -12827,9 +12333,6 @@ impl Default for PRINTER_NOTIFY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_NOTIFY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PRINTER_NOTIFY_INFO_DATA {
@@ -12844,9 +12347,6 @@ impl Default for PRINTER_NOTIFY_INFO_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_NOTIFY_INFO_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PRINTER_NOTIFY_INFO_DATA_0 {
@@ -12858,9 +12358,6 @@ impl Default for PRINTER_NOTIFY_INFO_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_NOTIFY_INFO_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_NOTIFY_INFO_DATA_0_0 {
@@ -12871,9 +12368,6 @@ impl Default for PRINTER_NOTIFY_INFO_DATA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTER_NOTIFY_INFO_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRINTER_NOTIFY_INFO_DATA_COMPACT: u32 = 1u32;
 pub const PRINTER_NOTIFY_INFO_DISCARDED: u32 = 1u32;
@@ -12889,9 +12383,6 @@ impl Default for PRINTER_NOTIFY_INIT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_NOTIFY_INIT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_NOTIFY_OPTIONS {
@@ -12904,9 +12395,6 @@ impl Default for PRINTER_NOTIFY_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTER_NOTIFY_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRINTER_NOTIFY_OPTIONS_REFRESH: u32 = 1u32;
 #[repr(C)]
@@ -12924,9 +12412,6 @@ impl Default for PRINTER_NOTIFY_OPTIONS_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_NOTIFY_OPTIONS_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PRINTER_NOTIFY_STATUS_ENDPOINT: u32 = 1u32;
 pub const PRINTER_NOTIFY_STATUS_INFO: u32 = 4u32;
 pub const PRINTER_NOTIFY_STATUS_POLL: u32 = 2u32;
@@ -12943,9 +12428,6 @@ impl Default for PRINTER_OPTIONSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTER_OPTIONSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTER_OPTIONSW {
@@ -12956,9 +12438,6 @@ impl Default for PRINTER_OPTIONSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTER_OPTIONSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRINTER_OPTION_CACHE: PRINTER_OPTION_FLAGS = PRINTER_OPTION_FLAGS(2i32);
 pub const PRINTER_OPTION_CLIENT_CHANGE: PRINTER_OPTION_FLAGS = PRINTER_OPTION_FLAGS(4i32);
@@ -13074,10 +12553,6 @@ impl Default for PRINTIFI32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTIFI32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13096,10 +12571,6 @@ impl Default for PRINTPROCESSOROPENDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTPROCESSOROPENDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTPROCESSOR_CAPS_1 {
@@ -13112,9 +12583,6 @@ impl Default for PRINTPROCESSOR_CAPS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTPROCESSOR_CAPS_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13134,9 +12602,6 @@ impl Default for PRINTPROCESSOR_CAPS_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTPROCESSOR_CAPS_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTPROCESSOR_INFO_1A {
@@ -13147,9 +12612,6 @@ impl Default for PRINTPROCESSOR_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTPROCESSOR_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINTPROCESSOR_INFO_1W {
@@ -13159,9 +12621,6 @@ impl Default for PRINTPROCESSOR_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINTPROCESSOR_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13280,9 +12739,6 @@ impl Default for PRINTPROVIDOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINTPROVIDOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PRINT_APP_BIDI_NOTIFY_CHANNEL: windows_core::GUID = windows_core::GUID::from_u128(0x2abad223_b994_4aca_82fc_4571b1b585ac);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13303,9 +12759,6 @@ impl Default for PRINT_EXECUTION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRINT_EXECUTION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRINT_FEATURE_OPTION {
@@ -13316,9 +12769,6 @@ impl Default for PRINT_FEATURE_OPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINT_FEATURE_OPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRINT_PORT_MONITOR_NOTIFY_CHANNEL: windows_core::GUID = windows_core::GUID::from_u128(0x25df3b0e_74a9_47f5_80ce_79b4b1eb5c58);
 #[repr(C)]
@@ -13336,10 +12786,6 @@ impl Default for PROPSHEETUI_GETICON_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for PROPSHEETUI_GETICON_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13359,9 +12805,6 @@ impl Default for PROPSHEETUI_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROPSHEETUI_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -13379,10 +12822,6 @@ impl Default for PROPSHEETUI_INFO_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for PROPSHEETUI_INFO_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -13395,10 +12834,6 @@ impl Default for PROPSHEETUI_INFO_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for PROPSHEETUI_INFO_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROPSHEETUI_INFO_VERSION: u32 = 256u32;
 pub const PROPSHEETUI_REASON_BEFORE_INIT: u32 = 5u32;
@@ -13422,9 +12857,6 @@ impl Default for PROVIDOR_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROVIDOR_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROVIDOR_INFO_1W {
@@ -13437,9 +12869,6 @@ impl Default for PROVIDOR_INFO_1W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROVIDOR_INFO_1W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROVIDOR_INFO_2A {
@@ -13449,9 +12878,6 @@ impl Default for PROVIDOR_INFO_2A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROVIDOR_INFO_2A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13463,9 +12889,6 @@ impl Default for PROVIDOR_INFO_2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROVIDOR_INFO_2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSCRIPT5_PRIVATE_DEVMODE {
@@ -13476,9 +12899,6 @@ impl Default for PSCRIPT5_PRIVATE_DEVMODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSCRIPT5_PRIVATE_DEVMODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13493,9 +12913,6 @@ impl Default for PSPINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSPINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PSUIHDRF_DEFTITLE: u32 = 16u32;
 pub const PSUIHDRF_EXACT_PTITLE: u32 = 32u32;
@@ -13523,9 +12940,6 @@ impl Default for PUBLISHERINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PUBLISHERINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PUSHBUTTON_TYPE_CALLBACK: u32 = 1u32;
 pub const PUSHBUTTON_TYPE_DLGPROC: u32 = 0u32;
@@ -13571,9 +12985,6 @@ impl Default for PrintNamedProperty {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PrintNamedProperty {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PrintPropertiesCollection {
@@ -13585,9 +12996,6 @@ impl Default for PrintPropertiesCollection {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PrintPropertiesCollection {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PrintPropertyValue {
@@ -13598,9 +13006,6 @@ impl Default for PrintPropertyValue {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PrintPropertyValue {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -13616,9 +13021,6 @@ impl Default for PrintPropertyValue_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PrintPropertyValue_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PrintPropertyValue_0_0 {
@@ -13629,9 +13031,6 @@ impl Default for PrintPropertyValue_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PrintPropertyValue_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PrintSchemaAsyncOperation: windows_core::GUID = windows_core::GUID::from_u128(0x43b2f83d_10f2_48ab_831b_55fdbdbd34a4);
 #[repr(transparent)]
@@ -13694,9 +13093,6 @@ impl Default for SETRESULT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SETRESULT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SHIMOPTS(pub i32);
@@ -13711,9 +13107,6 @@ impl Default for SHOWUIPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHOWUIPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SIMULATE_CAPS_1 {
@@ -13727,9 +13120,6 @@ impl Default for SIMULATE_CAPS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIMULATE_CAPS_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13747,9 +13137,6 @@ impl Default for SPLCLIENT_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPLCLIENT_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPLCLIENT_INFO_2_W2K {
@@ -13759,9 +13146,6 @@ impl Default for SPLCLIENT_INFO_2_W2K {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPLCLIENT_INFO_2_W2K {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -13775,10 +13159,6 @@ impl Default for SPLCLIENT_INFO_2_WINXP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SPLCLIENT_INFO_2_WINXP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13790,10 +13170,6 @@ impl Default for SPLCLIENT_INFO_2_WINXP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SPLCLIENT_INFO_2_WINXP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13813,9 +13189,6 @@ impl Default for SPLCLIENT_INFO_3_VISTA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPLCLIENT_INFO_3_VISTA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13837,9 +13210,6 @@ impl Default for SPLCLIENT_INFO_INTERNAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPLCLIENT_INFO_INTERNAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPLCLIENT_INFO_INTERNAL_LEVEL: u32 = 100u32;
 pub const SPLDS_ASSET_NUMBER: windows_core::PCWSTR = windows_core::w!("assetNumber");
@@ -13951,9 +13321,6 @@ impl Default for TRANSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TRANSDATA_0 {
@@ -13965,9 +13332,6 @@ impl Default for TRANSDATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSDATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TTDOWNLOAD_BITMAP: u32 = 2u32;
 pub const TTDOWNLOAD_DONTCARE: u32 = 0u32;
@@ -14006,9 +13370,6 @@ impl Default for UFF_FILEHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UFF_FILEHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UFF_FONTDIRECTORY {
@@ -14028,9 +13389,6 @@ impl Default for UFF_FONTDIRECTORY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UFF_FONTDIRECTORY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UFF_VERSION_NUMBER: u32 = 65537u32;
 pub const UFM_CART: u32 = 2u32;
@@ -14074,9 +13432,6 @@ impl Default for UNIDRVINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UNIDRVINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UNIDRV_PRIVATE_DEVMODE {
@@ -14087,9 +13442,6 @@ impl Default for UNIDRV_PRIVATE_DEVMODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UNIDRV_PRIVATE_DEVMODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14110,9 +13462,6 @@ impl Default for UNIFM_HDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UNIFM_HDR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const UNIFM_VERSION_1_0: u32 = 65536u32;
 pub const UNIRECTIONAL_NOTIFICATION_LOST: PrintAsyncNotifyError = PrintAsyncNotifyError(5i32);
 #[repr(C)]
@@ -14126,9 +13475,6 @@ impl Default for UNI_CODEPAGEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UNI_CODEPAGEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14149,9 +13495,6 @@ impl Default for UNI_GLYPHSETDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UNI_GLYPHSETDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UNI_GLYPHSETDATA_VERSION_1_0: u32 = 65536u32;
 pub const UNKNOWN_PROTOCOL: u32 = 0u32;
@@ -14175,9 +13518,6 @@ impl Default for USERDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USERDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIDTHRUN {
@@ -14190,9 +13530,6 @@ impl Default for WIDTHRUN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIDTHRUN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIDTHTABLE {
@@ -14204,9 +13541,6 @@ impl Default for WIDTHTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIDTHTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WM_FI_FILENAME: u32 = 900u32;
 #[repr(transparent)]
@@ -14260,9 +13594,6 @@ impl Default for _SPLCLIENT_INFO_2_V3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _SPLCLIENT_INFO_2_V3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const kADT_ASCII: EATTRIBUTE_DATATYPE = EATTRIBUTE_DATATYPE(5i32);
 pub const kADT_BINARY: EATTRIBUTE_DATATYPE = EATTRIBUTE_DATATYPE(7i32);

--- a/crates/libs/windows/src/Windows/Win32/Management/MobileDeviceManagementRegistration/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Management/MobileDeviceManagementRegistration/mod.rs
@@ -142,9 +142,6 @@ impl Default for MANAGEMENT_REGISTRATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MANAGEMENT_REGISTRATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MANAGEMENT_SERVICE_INFO {
@@ -155,9 +152,6 @@ impl Default for MANAGEMENT_SERVICE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MANAGEMENT_SERVICE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MDM_REGISTRATION_FACILITY_CODE: u32 = 25u32;
 pub const MENROLL_E_CERTAUTH_FAILED_TO_FIND_CERT: windows_core::HRESULT = windows_core::HRESULT(0x80180028_u32 as _);

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
@@ -23,9 +23,6 @@ impl Default for APOInitBaseStruct {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APOInitBaseStruct {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 #[derive(Clone, Debug, PartialEq)]
@@ -41,10 +38,6 @@ impl Default for APOInitSystemEffects {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for APOInitSystemEffects {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
@@ -66,10 +59,6 @@ impl Default for APOInitSystemEffects2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for APOInitSystemEffects2 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -88,10 +77,6 @@ impl Default for APOInitSystemEffects3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
-impl windows_core::TypeKind for APOInitSystemEffects3 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -116,9 +101,6 @@ impl Default for APO_CONNECTION_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APO_CONNECTION_DESCRIPTOR {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct APO_CONNECTION_PROPERTY {
@@ -132,9 +114,6 @@ impl Default for APO_CONNECTION_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APO_CONNECTION_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct APO_CONNECTION_PROPERTY_V2 {
@@ -145,9 +124,6 @@ impl Default for APO_CONNECTION_PROPERTY_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APO_CONNECTION_PROPERTY_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -186,10 +162,6 @@ impl Default for APO_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for APO_NOTIFICATION {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub union APO_NOTIFICATION_0 {
@@ -212,10 +184,6 @@ impl Default for APO_NOTIFICATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for APO_NOTIFICATION_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub struct APO_NOTIFICATION_DESCRIPTOR {
     pub r#type: APO_NOTIFICATION_TYPE,
@@ -230,9 +198,6 @@ impl Default for APO_NOTIFICATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APO_NOTIFICATION_DESCRIPTOR {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 pub union APO_NOTIFICATION_DESCRIPTOR_0 {
@@ -250,9 +215,6 @@ impl Default for APO_NOTIFICATION_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APO_NOTIFICATION_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -286,9 +248,6 @@ impl Default for APO_REG_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APO_REG_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AUDIOMEDIATYPE_EQUAL_FORMAT_DATA: u32 = 4u32;
 pub const AUDIOMEDIATYPE_EQUAL_FORMAT_TYPES: u32 = 2u32;
 pub const AUDIOMEDIATYPE_EQUAL_FORMAT_USER_DATA: u32 = 8u32;
@@ -301,9 +260,6 @@ impl Default for AUDIO_ENDPOINT_PROPERTY_CHANGE_APO_NOTIFICATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIO_ENDPOINT_PROPERTY_CHANGE_APO_NOTIFICATION_DESCRIPTOR {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
@@ -319,10 +275,6 @@ impl Default for AUDIO_ENDPOINT_PROPERTY_CHANGE_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for AUDIO_ENDPOINT_PROPERTY_CHANGE_NOTIFICATION {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AUDIO_ENDPOINT_VOLUME_APO_NOTIFICATION_DESCRIPTOR {
@@ -332,9 +284,6 @@ impl Default for AUDIO_ENDPOINT_VOLUME_APO_NOTIFICATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIO_ENDPOINT_VOLUME_APO_NOTIFICATION_DESCRIPTOR {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -347,9 +296,6 @@ impl Default for AUDIO_ENDPOINT_VOLUME_CHANGE_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIO_ENDPOINT_VOLUME_CHANGE_NOTIFICATION {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AUDIO_ENDPOINT_VOLUME_CHANGE_NOTIFICATION2 {
@@ -360,9 +306,6 @@ impl Default for AUDIO_ENDPOINT_VOLUME_CHANGE_NOTIFICATION2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIO_ENDPOINT_VOLUME_CHANGE_NOTIFICATION2 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const AUDIO_FLOW_PULL: AUDIO_FLOW_TYPE = AUDIO_FLOW_TYPE(0i32);
 pub const AUDIO_FLOW_PUSH: AUDIO_FLOW_TYPE = AUDIO_FLOW_TYPE(1i32);
@@ -380,9 +323,6 @@ impl Default for AUDIO_MICROPHONE_BOOST_APO_NOTIFICATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIO_MICROPHONE_BOOST_APO_NOTIFICATION_DESCRIPTOR {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -402,9 +342,6 @@ impl Default for AUDIO_MICROPHONE_BOOST_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIO_MICROPHONE_BOOST_NOTIFICATION {
-    type TypeKind = windows_core::CloneType;
-}
 pub const AUDIO_MIN_CHANNELS: u32 = 1u32;
 pub const AUDIO_MIN_FRAMERATE: f64 = 10f64;
 #[repr(C)]
@@ -419,9 +356,6 @@ impl Default for AUDIO_SYSTEMEFFECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIO_SYSTEMEFFECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AUDIO_SYSTEMEFFECTS_PROPERTY_CHANGE_APO_NOTIFICATION_DESCRIPTOR {
@@ -432,9 +366,6 @@ impl Default for AUDIO_SYSTEMEFFECTS_PROPERTY_CHANGE_APO_NOTIFICATION_DESCRIPTOR
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIO_SYSTEMEFFECTS_PROPERTY_CHANGE_APO_NOTIFICATION_DESCRIPTOR {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
@@ -451,10 +382,6 @@ impl Default for AUDIO_SYSTEMEFFECTS_PROPERTY_CHANGE_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for AUDIO_SYSTEMEFFECTS_PROPERTY_CHANGE_NOTIFICATION {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -478,9 +405,6 @@ impl Default for AUDIO_VOLUME_NOTIFICATION_DATA2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIO_VOLUME_NOTIFICATION_DATA2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 #[derive(Clone, Debug, PartialEq)]
@@ -494,10 +418,6 @@ impl Default for AudioFXExtensionParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for AudioFXExtensionParams {
-    type TypeKind = windows_core::CloneType;
 }
 pub const BUFFER_INVALID: APO_BUFFER_FLAGS = APO_BUFFER_FLAGS(0i32);
 pub const BUFFER_SILENT: APO_BUFFER_FLAGS = APO_BUFFER_FLAGS(2i32);
@@ -1391,9 +1311,6 @@ impl Default for UNCOMPRESSEDAUDIOFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UNCOMPRESSEDAUDIOFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const eAudioConstriction14_14: EAudioConstriction = EAudioConstriction(3i32);
 pub const eAudioConstriction44_16: EAudioConstriction = EAudioConstriction(2i32);

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
@@ -17,9 +17,6 @@ impl Default for CONNECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONNECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONNECTIONLIST {
@@ -30,9 +27,6 @@ impl Default for CONNECTIONLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONNECTIONLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONN_DST_ATTENUATION: u32 = 1u32;
 pub const CONN_DST_CENTER: u32 = 18u32;
@@ -130,9 +124,6 @@ impl Default for DLSHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DLSHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DLSID {
@@ -145,9 +136,6 @@ impl Default for DLSID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DLSID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DLSID_GMInHardware: windows_core::GUID = windows_core::GUID::from_u128(0x178f2f24_c364_11d1_a760_0000f875ac12);
 pub const DLSID_GSInHardware: windows_core::GUID = windows_core::GUID::from_u128(0x178f2f25_c364_11d1_a760_0000f875ac12);
@@ -168,9 +156,6 @@ impl Default for DLSVERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DLSVERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DLS_CDL_ADD: u32 = 4u32;
 pub const DLS_CDL_AND: u32 = 1u32;
@@ -203,9 +188,6 @@ impl Default for DMUS_ARTICPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_ARTICPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_ARTICULATION {
@@ -216,9 +198,6 @@ impl Default for DMUS_ARTICULATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_ARTICULATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -232,9 +211,6 @@ impl Default for DMUS_ARTICULATION2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_ARTICULATION2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_BUFFERDESC {
@@ -247,9 +223,6 @@ impl Default for DMUS_BUFFERDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_BUFFERDESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMUS_CLOCKF_GLOBAL: u32 = 1u32;
 #[repr(C)]
@@ -265,9 +238,6 @@ impl Default for DMUS_CLOCKINFO7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_CLOCKINFO7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_CLOCKINFO8 {
@@ -281,9 +251,6 @@ impl Default for DMUS_CLOCKINFO8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_CLOCKINFO8 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -301,9 +268,6 @@ impl Default for DMUS_COPYRIGHT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_COPYRIGHT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DMUS_DEFAULT_SIZE_OFFSETTABLE: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -317,9 +281,6 @@ impl Default for DMUS_DOWNLOADINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_DOWNLOADINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMUS_DOWNLOADINFO_INSTRUMENT: u32 = 1u32;
 pub const DMUS_DOWNLOADINFO_INSTRUMENT2: u32 = 3u32;
@@ -344,9 +305,6 @@ impl Default for DMUS_EVENTHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_EVENTHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DMUS_EVENT_STRUCTURED: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -360,9 +318,6 @@ impl Default for DMUS_EXTENSIONCHUNK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_EXTENSIONCHUNK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -378,9 +333,6 @@ impl Default for DMUS_INSTRUMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_INSTRUMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMUS_INSTRUMENT_GM_INSTRUMENT: u32 = 1u32;
 #[repr(C)]
@@ -398,9 +350,6 @@ impl Default for DMUS_LFOPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_LFOPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DMUS_MAX_DESCRIPTION: u32 = 128u32;
 pub const DMUS_MAX_DRIVER: u32 = 128u32;
 pub const DMUS_MIN_DATA_SIZE: u32 = 4u32;
@@ -414,9 +363,6 @@ impl Default for DMUS_MSCPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_MSCPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_NOTERANGE {
@@ -428,9 +374,6 @@ impl Default for DMUS_NOTERANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_NOTERANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_OFFSETTABLE {
@@ -440,9 +383,6 @@ impl Default for DMUS_OFFSETTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_OFFSETTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMUS_PC_AUDIOPATH: u32 = 1024u32;
 pub const DMUS_PC_DIRECTSOUND: u32 = 128u32;
@@ -475,9 +415,6 @@ impl Default for DMUS_PEGPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_PEGPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_PORTCAPS {
@@ -498,9 +435,6 @@ impl Default for DMUS_PORTCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_PORTCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_PORTPARAMS7 {
@@ -517,9 +451,6 @@ impl Default for DMUS_PORTPARAMS7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_PORTPARAMS7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -538,9 +469,6 @@ impl Default for DMUS_PORTPARAMS8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_PORTPARAMS8 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMUS_PORTPARAMS_AUDIOCHANNELS: u32 = 4u32;
 pub const DMUS_PORTPARAMS_CHANNELGROUPS: u32 = 2u32;
@@ -573,9 +501,6 @@ impl Default for DMUS_REGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_REGION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_SYNTHSTATS {
@@ -592,9 +517,6 @@ impl Default for DMUS_SYNTHSTATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_SYNTHSTATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -613,9 +535,6 @@ impl Default for DMUS_SYNTHSTATS8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_SYNTHSTATS8 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMUS_SYNTHSTATS_CPU_PER_VOICE: u32 = 4u32;
 pub const DMUS_SYNTHSTATS_FREE_MEMORY: u32 = 32u32;
@@ -639,9 +558,6 @@ impl Default for DMUS_VEGPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_VEGPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_VOICE_STATE {
@@ -652,9 +568,6 @@ impl Default for DMUS_VOICE_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_VOICE_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMUS_VOLUME_MAX: u32 = 2000u32;
 pub const DMUS_VOLUME_MIN: i32 = -20000i32;
@@ -671,9 +584,6 @@ impl Default for DMUS_WAVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_WAVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_WAVEARTDL {
@@ -688,9 +598,6 @@ impl Default for DMUS_WAVEARTDL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_WAVEARTDL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_WAVEDATA {
@@ -702,9 +609,6 @@ impl Default for DMUS_WAVEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMUS_WAVEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DMUS_WAVEDL {
@@ -714,9 +618,6 @@ impl Default for DMUS_WAVEDL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_WAVEDL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -730,9 +631,6 @@ impl Default for DMUS_WAVES_REVERB_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMUS_WAVES_REVERB_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSBUSID_BACK_CENTER: u32 = 8u32;
 pub const DSBUSID_BACK_LEFT: u32 = 4u32;
@@ -782,9 +680,6 @@ impl Default for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_1_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_1_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_A: DSPROPERTY_DIRECTSOUNDDEVICE = DSPROPERTY_DIRECTSOUNDDEVICE(5i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -801,9 +696,6 @@ impl Default for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_A_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_A_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_W: DSPROPERTY_DIRECTSOUNDDEVICE = DSPROPERTY_DIRECTSOUNDDEVICE(6i32);
 #[repr(C)]
@@ -822,9 +714,6 @@ impl Default for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_W_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_W_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1: DSPROPERTY_DIRECTSOUNDDEVICE = DSPROPERTY_DIRECTSOUNDDEVICE(3i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -836,9 +725,6 @@ impl Default for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_1_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A: DSPROPERTY_DIRECTSOUNDDEVICE = DSPROPERTY_DIRECTSOUNDDEVICE(7i32);
 #[repr(C)]
@@ -852,9 +738,6 @@ impl Default for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_A_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W: DSPROPERTY_DIRECTSOUNDDEVICE = DSPROPERTY_DIRECTSOUNDDEVICE(8i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -866,9 +749,6 @@ impl Default for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSPROPERTY_DIRECTSOUNDDEVICE_ENUMERATE_W_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_A: DSPROPERTY_DIRECTSOUNDDEVICE = DSPROPERTY_DIRECTSOUNDDEVICE(1i32);
 #[repr(C)]
@@ -883,9 +763,6 @@ impl Default for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_A_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_A_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_W: DSPROPERTY_DIRECTSOUNDDEVICE = DSPROPERTY_DIRECTSOUNDDEVICE(4i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -898,9 +775,6 @@ impl Default for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_W_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING_W_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSPROPSETID_DirectSoundDevice: windows_core::GUID = windows_core::GUID::from_u128(0x84624f82_25ec_11d1_a4d8_00c04fc28aca);
 #[repr(C)]
@@ -918,9 +792,6 @@ impl Default for DVAudInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVAudInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DV_AUDIOMODE: u32 = 3840u32;
 pub const DV_AUDIOQU: u32 = 117440512u32;
@@ -2200,9 +2071,6 @@ impl Default for INSTHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INSTHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub type LPFNDIRECTSOUNDDEVICEENUMERATECALLBACK1 = Option<unsafe extern "system" fn(param0: *mut DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_1_DATA, param1: *mut core::ffi::c_void) -> super::super::super::Foundation::BOOL>;
 pub type LPFNDIRECTSOUNDDEVICEENUMERATECALLBACKA = Option<unsafe extern "system" fn(param0: *mut DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_A_DATA, param1: *mut core::ffi::c_void) -> super::super::super::Foundation::BOOL>;
 pub type LPFNDIRECTSOUNDDEVICEENUMERATECALLBACKW = Option<unsafe extern "system" fn(param0: *mut DSPROPERTY_DIRECTSOUNDDEVICE_DESCRIPTION_W_DATA, param1: *mut core::ffi::c_void) -> super::super::super::Foundation::BOOL>;
@@ -2217,9 +2085,6 @@ impl Default for MDEVICECAPSEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MDEVICECAPSEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIDILOCALE {
@@ -2230,9 +2095,6 @@ impl Default for MIDILOCALE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIDILOCALE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Multimedia")]
@@ -2251,10 +2113,6 @@ impl Default for MIDIOPENDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Multimedia")]
-impl windows_core::TypeKind for MIDIOPENDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POOLCUE {
@@ -2264,9 +2122,6 @@ impl Default for POOLCUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POOLCUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2278,9 +2133,6 @@ impl Default for POOLTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POOLTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POOL_CUE_NULL: i32 = -1i32;
 pub const REFRESH_F_LASTBUFFER: u32 = 1u32;
@@ -2298,9 +2150,6 @@ impl Default for RGNHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RGNHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RGNRANGE {
@@ -2311,9 +2160,6 @@ impl Default for RGNRANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RGNRANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SIZE_DVINFO: u32 = 32u32;
 #[repr(C)]
@@ -2329,9 +2175,6 @@ impl Default for WAVELINK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAVELINK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WAVELINK_CHANNEL_LEFT: i32 = 1i32;
 pub const WAVELINK_CHANNEL_RIGHT: i32 = 2i32;
 #[repr(C)]
@@ -2346,9 +2189,6 @@ impl Default for WLOOP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLOOP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLOOP_TYPE_FORWARD: u32 = 0u32;
 pub const WLOOP_TYPE_RELEASE: u32 = 2u32;
@@ -2366,7 +2206,4 @@ impl Default for WSMPL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMPL {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/mod.rs
@@ -94,10 +94,6 @@ impl Default for DS3DBUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for DS3DBUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -116,10 +112,6 @@ impl Default for DS3DLISTENER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D")]
-impl windows_core::TypeKind for DS3DLISTENER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS3DMODE_DISABLE: u32 = 2u32;
 pub const DS3DMODE_HEADRELATIVE: u32 = 1u32;
@@ -152,9 +144,6 @@ impl Default for DSBCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSBCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSBCAPS_CTRL3D: u32 = 16u32;
 pub const DSBCAPS_CTRLFREQUENCY: u32 = 32u32;
@@ -199,9 +188,6 @@ impl Default for DSBPOSITIONNOTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSBPOSITIONNOTIFY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSBSIZE_FX_MIN: u32 = 150u32;
 pub const DSBSIZE_MAX: u32 = 268435455u32;
 pub const DSBSIZE_MIN: u32 = 4u32;
@@ -226,9 +212,6 @@ impl Default for DSBUFFERDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSBUFFERDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSBUFFERDESC1 {
@@ -242,9 +225,6 @@ impl Default for DSBUFFERDESC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSBUFFERDESC1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSBVOLUME_MAX: u32 = 0u32;
 pub const DSBVOLUME_MIN: i32 = -10000i32;
@@ -281,9 +261,6 @@ impl Default for DSCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSCAPS_CERTIFIED: u32 = 64u32;
 pub const DSCAPS_CONTINUOUSRATE: u32 = 16u32;
 pub const DSCAPS_EMULDRIVER: u32 = 32u32;
@@ -308,9 +285,6 @@ impl Default for DSCBCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSCBCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSCBCAPS_CTRLFX: u32 = 512u32;
 pub const DSCBCAPS_WAVEMAPPED: u32 = 2147483648u32;
 pub const DSCBLOCK_ENTIREBUFFER: u32 = 1u32;
@@ -333,9 +307,6 @@ impl Default for DSCBUFFERDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSCBUFFERDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSCBUFFERDESC1 {
@@ -350,9 +321,6 @@ impl Default for DSCBUFFERDESC1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSCBUFFERDESC1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSCCAPS {
@@ -365,9 +333,6 @@ impl Default for DSCCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSCCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSCCAPS_CERTIFIED: u32 = 64u32;
 pub const DSCCAPS_EMULDRIVER: u32 = 32u32;
@@ -387,9 +352,6 @@ impl Default for DSCEFFECTDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSCEFFECTDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSCFXAec {
@@ -402,9 +364,6 @@ impl Default for DSCFXAec {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSCFXAec {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSCFXNoiseSuppress {
@@ -414,9 +373,6 @@ impl Default for DSCFXNoiseSuppress {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSCFXNoiseSuppress {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSCFXR_LOCHARDWARE: u32 = 16u32;
 pub const DSCFXR_LOCSOFTWARE: u32 = 32u32;
@@ -446,9 +402,6 @@ impl Default for DSEFFECTDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSEFFECTDESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSFXCHORUS_DELAY_MAX: f32 = 20f32;
 pub const DSFXCHORUS_DELAY_MIN: f32 = 0f32;
@@ -497,9 +450,6 @@ impl Default for DSFXChorus {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSFXChorus {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSFXCompressor {
@@ -514,9 +464,6 @@ impl Default for DSFXCompressor {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSFXCompressor {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSFXDISTORTION_EDGE_MAX: f32 = 100f32;
 pub const DSFXDISTORTION_EDGE_MIN: f32 = 0f32;
@@ -542,9 +489,6 @@ impl Default for DSFXDistortion {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSFXDistortion {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSFXECHO_FEEDBACK_MAX: f32 = 100f32;
 pub const DSFXECHO_FEEDBACK_MIN: f32 = 0f32;
 pub const DSFXECHO_LEFTDELAY_MAX: f32 = 2000f32;
@@ -568,9 +512,6 @@ impl Default for DSFXEcho {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSFXEcho {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSFXFLANGER_DELAY_MAX: f32 = 4f32;
 pub const DSFXFLANGER_DELAY_MIN: f32 = 0f32;
@@ -607,9 +548,6 @@ impl Default for DSFXFlanger {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSFXFlanger {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSFXGARGLE_RATEHZ_MAX: u32 = 1000u32;
 pub const DSFXGARGLE_RATEHZ_MIN: u32 = 1u32;
 pub const DSFXGARGLE_WAVE_SQUARE: u32 = 1u32;
@@ -624,9 +562,6 @@ impl Default for DSFXGargle {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSFXGargle {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -649,9 +584,6 @@ impl Default for DSFXI3DL2Reverb {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSFXI3DL2Reverb {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSFXPARAMEQ_BANDWIDTH_MAX: f32 = 36f32;
 pub const DSFXPARAMEQ_BANDWIDTH_MIN: f32 = 1f32;
 pub const DSFXPARAMEQ_CENTER_MAX: f32 = 16000f32;
@@ -669,9 +601,6 @@ impl Default for DSFXParamEq {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSFXParamEq {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSFXR_FAILED: i32 = 4i32;
 pub const DSFXR_LOCHARDWARE: i32 = 1i32;
@@ -692,9 +621,6 @@ impl Default for DSFXWavesReverb {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSFXWavesReverb {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSFX_I3DL2REVERB_DECAYHFRATIO_DEFAULT: f32 = 0.83f32;
 pub const DSFX_I3DL2REVERB_DECAYHFRATIO_MAX: f32 = 2f32;

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/mod.rs
@@ -11,9 +11,6 @@ impl Default for AUDIO_ENDPOINT_SHARED_CREATE_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIO_ENDPOINT_SHARED_CREATE_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEVINTERFACE_AUDIOENDPOINTPLUGIN: windows_core::GUID = windows_core::GUID::from_u128(0x9f2f7b66_65ac_4fa6_8ae4_123c78b89313);
 pub const DEVPKEY_AudioEndpointPlugin2_FactoryCLSID: super::super::super::Foundation::PROPERTYKEY = super::super::super::Foundation::PROPERTYKEY { fmtid: windows_core::GUID::from_u128(0x12d83bd7_cf12_46be_8540_812710d3021c), pid: 4 };
 pub const DEVPKEY_AudioEndpointPlugin_DataFlow: super::super::super::Foundation::PROPERTYKEY = super::super::super::Foundation::PROPERTYKEY { fmtid: windows_core::GUID::from_u128(0x12d83bd7_cf12_46be_8540_812710d3021c), pid: 2 };

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/mod.rs
@@ -47,9 +47,6 @@ impl Default for FXECHO_INITDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FXECHO_INITDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FXECHO_MAX_DELAY: f32 = 2000f32;
 pub const FXECHO_MAX_FEEDBACK: f32 = 1f32;
 pub const FXECHO_MAX_WETDRYMIX: f32 = 1f32;
@@ -67,9 +64,6 @@ impl Default for FXECHO_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FXECHO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FXEQ: windows_core::GUID = windows_core::GUID::from_u128(0xf5e01117_d6c4_485a_a3f5_695196f3dbfa);
 pub const FXEQ_DEFAULT_BANDWIDTH: f32 = 1f32;
@@ -107,9 +101,6 @@ impl Default for FXEQ_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FXEQ_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FXEcho: windows_core::GUID = windows_core::GUID::from_u128(0x5039d740_f736_449a_84d3_a56202557b87);
 pub const FXLOUDNESS_DEFAULT_MOMENTARY_MS: u32 = 400u32;
 pub const FXLOUDNESS_DEFAULT_SHORTTERM_MS: u32 = 3000u32;
@@ -130,9 +121,6 @@ impl Default for FXMASTERINGLIMITER_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FXMASTERINGLIMITER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FXMasteringLimiter: windows_core::GUID = windows_core::GUID::from_u128(0xc4137916_2be1_46fd_8599_441536f49856);
 pub const FXREVERB_DEFAULT_DIFFUSION: f32 = 0.9f32;
 pub const FXREVERB_DEFAULT_ROOMSIZE: f32 = 0.6f32;
@@ -150,9 +138,6 @@ impl Default for FXREVERB_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FXREVERB_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FXReverb: windows_core::GUID = windows_core::GUID::from_u128(0x7d9aca56_cb68_4807_b632_b137352e8596);
 pub const HRTF_DEFAULT_UNITY_GAIN_DISTANCE: f32 = 1f32;
@@ -172,9 +157,6 @@ impl Default for HrtfApoInit {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HrtfApoInit {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HrtfDirectivity {
@@ -185,9 +167,6 @@ impl Default for HrtfDirectivity {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HrtfDirectivity {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -200,9 +179,6 @@ impl Default for HrtfDirectivityCardioid {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HrtfDirectivityCardioid {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HrtfDirectivityCone {
@@ -214,9 +190,6 @@ impl Default for HrtfDirectivityCone {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HrtfDirectivityCone {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -235,9 +208,6 @@ impl Default for HrtfDistanceDecay {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HrtfDistanceDecay {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HrtfDistanceDecayType(pub i32);
@@ -254,9 +224,6 @@ impl Default for HrtfOrientation {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HrtfOrientation {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HrtfPosition {
@@ -268,9 +235,6 @@ impl Default for HrtfPosition {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HrtfPosition {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IXAPO, IXAPO_Vtbl, 0xa410b984_9839_4819_a0be_2856ae6b3adb);
 windows_core::imp::interface_hierarchy!(IXAPO, windows_core::IUnknown);
@@ -1399,9 +1363,6 @@ impl Default for XAPO_LOCKFORPROCESS_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XAPO_LOCKFORPROCESS_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const XAPO_MAX_CHANNELS: u32 = 64u32;
 pub const XAPO_MAX_FRAMERATE: u32 = 200000u32;
 pub const XAPO_MIN_CHANNELS: u32 = 1u32;
@@ -1417,9 +1378,6 @@ impl Default for XAPO_PROCESS_BUFFER_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XAPO_PROCESS_BUFFER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1439,9 +1397,6 @@ impl Default for XAPO_REGISTRATION_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XAPO_REGISTRATION_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XAPO_REGISTRATION_STRING_LENGTH: u32 = 256u32;
 pub const XAUDIO2D_DLL: windows_core::PCWSTR = windows_core::w!("xaudio2_9d.dll");
@@ -1491,9 +1446,6 @@ impl Default for XAUDIO2FX_REVERB_I3DL2_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XAUDIO2FX_REVERB_I3DL2_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XAUDIO2FX_REVERB_MAX_7POINT1_REAR_DELAY: u32 = 20u32;
 pub const XAUDIO2FX_REVERB_MAX_7POINT1_SIDE_DELAY: u32 = 5u32;
@@ -1569,9 +1521,6 @@ impl Default for XAUDIO2FX_REVERB_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XAUDIO2FX_REVERB_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct XAUDIO2FX_VOLUMEMETER_LEVELS {
@@ -1583,9 +1532,6 @@ impl Default for XAUDIO2FX_VOLUMEMETER_LEVELS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XAUDIO2FX_VOLUMEMETER_LEVELS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XAUDIO2_1024_QUANTUM: u32 = 32768u32;
 pub const XAUDIO2_ANY_PROCESSOR: u32 = 4294967295u32;
@@ -1607,9 +1553,6 @@ impl Default for XAUDIO2_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XAUDIO2_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct XAUDIO2_BUFFER_WMA {
@@ -1620,9 +1563,6 @@ impl Default for XAUDIO2_BUFFER_WMA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XAUDIO2_BUFFER_WMA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XAUDIO2_COMMIT_ALL: u32 = 0u32;
 pub const XAUDIO2_COMMIT_NOW: u32 = 0u32;
@@ -1640,9 +1580,6 @@ impl Default for XAUDIO2_DEBUG_CONFIGURATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XAUDIO2_DEBUG_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XAUDIO2_DEBUG_ENGINE: u32 = 1u32;
 pub const XAUDIO2_DEFAULT_CHANNELS: u32 = 0u32;
@@ -1665,9 +1602,6 @@ impl Default for XAUDIO2_EFFECT_CHAIN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XAUDIO2_EFFECT_CHAIN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 pub struct XAUDIO2_EFFECT_DESCRIPTOR {
     pub pEffect: core::mem::ManuallyDrop<Option<windows_core::IUnknown>>,
@@ -1678,9 +1612,6 @@ impl Default for XAUDIO2_EFFECT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XAUDIO2_EFFECT_DESCRIPTOR {
-    type TypeKind = windows_core::CloneType;
 }
 pub const XAUDIO2_END_OF_STREAM: u32 = 64u32;
 pub const XAUDIO2_E_DEVICE_INVALIDATED: windows_core::HRESULT = windows_core::HRESULT(0x88960004_u32 as _);
@@ -1698,9 +1629,6 @@ impl Default for XAUDIO2_FILTER_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XAUDIO2_FILTER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1755,9 +1683,6 @@ impl Default for XAUDIO2_PERFORMANCE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XAUDIO2_PERFORMANCE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const XAUDIO2_PLAY_TAILS: u32 = 32u32;
 pub const XAUDIO2_QUANTUM_DENOMINATOR: u32 = 100u32;
 pub const XAUDIO2_QUANTUM_NUMERATOR: u32 = 1u32;
@@ -1770,9 +1695,6 @@ impl Default for XAUDIO2_SEND_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XAUDIO2_SEND_DESCRIPTOR {
-    type TypeKind = windows_core::CloneType;
 }
 pub const XAUDIO2_SEND_USEFILTER: u32 = 128u32;
 pub const XAUDIO2_STOP_ENGINE_WHEN_IDLE: u32 = 8192u32;
@@ -1790,9 +1712,6 @@ impl Default for XAUDIO2_VOICE_DETAILS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XAUDIO2_VOICE_DETAILS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const XAUDIO2_VOICE_NOPITCH: u32 = 2u32;
 pub const XAUDIO2_VOICE_NOSAMPLESPLAYED: u32 = 256u32;
 pub const XAUDIO2_VOICE_NOSRC: u32 = 4u32;
@@ -1807,9 +1726,6 @@ impl Default for XAUDIO2_VOICE_SENDS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XAUDIO2_VOICE_SENDS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct XAUDIO2_VOICE_STATE {
@@ -1821,8 +1737,5 @@ impl Default for XAUDIO2_VOICE_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XAUDIO2_VOICE_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XAUDIO2_VOICE_USEFILTER: u32 = 8u32;

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
@@ -883,10 +883,6 @@ impl Default for ACMDRIVERDETAILSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for ACMDRIVERDETAILSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -913,10 +909,6 @@ impl Default for ACMDRIVERDETAILSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for ACMDRIVERDETAILSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACMDRIVERDETAILS_COPYRIGHT_CHARS: u32 = 80u32;
 pub const ACMDRIVERDETAILS_FEATURES_CHARS: u32 = 512u32;
@@ -946,9 +938,6 @@ impl Default for ACMDRVFORMATSUGGEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMDRVFORMATSUGGEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct ACMDRVOPENDESCA {
@@ -967,9 +956,6 @@ impl Default for ACMDRVOPENDESCA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMDRVOPENDESCA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct ACMDRVOPENDESCW {
@@ -987,9 +973,6 @@ impl Default for ACMDRVOPENDESCW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACMDRVOPENDESCW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1021,9 +1004,6 @@ impl Default for ACMDRVSTREAMHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMDRVSTREAMHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct ACMDRVSTREAMINSTANCE {
@@ -1043,9 +1023,6 @@ impl Default for ACMDRVSTREAMINSTANCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMDRVSTREAMINSTANCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct ACMDRVSTREAMSIZE {
@@ -1058,9 +1035,6 @@ impl Default for ACMDRVSTREAMSIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACMDRVSTREAMSIZE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACMERR_BASE: u32 = 512u32;
 pub const ACMERR_BUSY: u32 = 513u32;
@@ -1092,9 +1066,6 @@ impl Default for ACMFILTERCHOOSEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMFILTERCHOOSEA {
-    type TypeKind = windows_core::CopyType;
-}
 pub type ACMFILTERCHOOSEHOOKPROCA = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> u32>;
 pub type ACMFILTERCHOOSEHOOKPROCW = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> u32>;
 #[repr(C, packed(1))]
@@ -1122,9 +1093,6 @@ impl Default for ACMFILTERCHOOSEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMFILTERCHOOSEW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ACMFILTERCHOOSE_STYLEF_CONTEXTHELP: i32 = 128i32;
 pub const ACMFILTERCHOOSE_STYLEF_ENABLEHOOK: i32 = 8i32;
 pub const ACMFILTERCHOOSE_STYLEF_ENABLETEMPLATE: i32 = 16i32;
@@ -1147,9 +1115,6 @@ impl Default for ACMFILTERDETAILSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMFILTERDETAILSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct ACMFILTERDETAILSW {
@@ -1165,9 +1130,6 @@ impl Default for ACMFILTERDETAILSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACMFILTERDETAILSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACMFILTERDETAILS_FILTER_CHARS: u32 = 128u32;
 pub type ACMFILTERENUMCBA = Option<unsafe extern "system" fn(hadid: HACMDRIVERID, pafd: *mut ACMFILTERDETAILSA, dwinstance: usize, fdwsupport: u32) -> super::super::Foundation::BOOL>;
@@ -1188,9 +1150,6 @@ impl Default for ACMFILTERTAGDETAILSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMFILTERTAGDETAILSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct ACMFILTERTAGDETAILSW {
@@ -1206,9 +1165,6 @@ impl Default for ACMFILTERTAGDETAILSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACMFILTERTAGDETAILSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACMFILTERTAGDETAILS_FILTERTAG_CHARS: u32 = 48u32;
 pub type ACMFILTERTAGENUMCBA = Option<unsafe extern "system" fn(hadid: HACMDRIVERID, paftd: *mut ACMFILTERTAGDETAILSA, dwinstance: usize, fdwsupport: u32) -> super::super::Foundation::BOOL>;
@@ -1238,9 +1194,6 @@ impl Default for ACMFORMATCHOOSEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMFORMATCHOOSEA {
-    type TypeKind = windows_core::CopyType;
-}
 pub type ACMFORMATCHOOSEHOOKPROCA = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> u32>;
 pub type ACMFORMATCHOOSEHOOKPROCW = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> u32>;
 #[repr(C, packed(1))]
@@ -1268,9 +1221,6 @@ impl Default for ACMFORMATCHOOSEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMFORMATCHOOSEW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ACMFORMATCHOOSE_STYLEF_CONTEXTHELP: i32 = 128i32;
 pub const ACMFORMATCHOOSE_STYLEF_ENABLEHOOK: i32 = 8i32;
 pub const ACMFORMATCHOOSE_STYLEF_ENABLETEMPLATE: i32 = 16i32;
@@ -1293,9 +1243,6 @@ impl Default for ACMFORMATDETAILSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMFORMATDETAILSA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ACMFORMATDETAILS_FORMAT_CHARS: u32 = 128u32;
 pub type ACMFORMATENUMCBA = Option<unsafe extern "system" fn(hadid: HACMDRIVERID, pafd: *mut ACMFORMATDETAILSA, dwinstance: usize, fdwsupport: u32) -> super::super::Foundation::BOOL>;
 pub type ACMFORMATENUMCBW = Option<unsafe extern "system" fn(hadid: HACMDRIVERID, pafd: *mut tACMFORMATDETAILSW, dwinstance: usize, fdwsupport: u32) -> super::super::Foundation::BOOL>;
@@ -1315,9 +1262,6 @@ impl Default for ACMFORMATTAGDETAILSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACMFORMATTAGDETAILSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct ACMFORMATTAGDETAILSW {
@@ -1333,9 +1277,6 @@ impl Default for ACMFORMATTAGDETAILSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACMFORMATTAGDETAILSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACMFORMATTAGDETAILS_FORMATTAG_CHARS: u32 = 48u32;
 pub type ACMFORMATTAGENUMCBA = Option<unsafe extern "system" fn(hadid: HACMDRIVERID, paftd: *mut ACMFORMATTAGDETAILSA, dwinstance: usize, fdwsupport: u32) -> super::super::Foundation::BOOL>;
@@ -1372,10 +1313,6 @@ impl Default for ACMSTREAMHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ACMSTREAMHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -1398,10 +1335,6 @@ impl Default for ACMSTREAMHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ACMSTREAMHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACMSTREAMHEADER_STATUSF_DONE: i32 = 65536i32;
 pub const ACMSTREAMHEADER_STATUSF_INQUEUE: i32 = 1048576i32;
@@ -1500,9 +1433,6 @@ impl Default for AMBISONICS_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMBISONICS_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AMBISONICS_PARAM_VERSION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -1619,9 +1549,6 @@ impl Default for AUDIOCLIENT_ACTIVATION_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIOCLIENT_ACTIVATION_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AUDIOCLIENT_ACTIVATION_PARAMS_0 {
@@ -1631,9 +1558,6 @@ impl Default for AUDIOCLIENT_ACTIVATION_PARAMS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIOCLIENT_ACTIVATION_PARAMS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1650,9 +1574,6 @@ impl Default for AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AUDIOCLOCK_CHARACTERISTIC_FIXED_FREQ: u32 = 1u32;
 #[repr(transparent)]
@@ -1705,9 +1626,6 @@ impl Default for AUDIO_EFFECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIO_EFFECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct AUDIO_EFFECT_STATE(pub i32);
@@ -1737,9 +1655,6 @@ impl Default for AUDIO_VOLUME_NOTIFICATION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIO_VOLUME_NOTIFICATION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct AUXCAPS2A {
@@ -1758,9 +1673,6 @@ impl Default for AUXCAPS2A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUXCAPS2A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1781,9 +1693,6 @@ impl Default for AUXCAPS2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUXCAPS2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct AUXCAPSA {
@@ -1800,9 +1709,6 @@ impl Default for AUXCAPSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUXCAPSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct AUXCAPSW {
@@ -1818,9 +1724,6 @@ impl Default for AUXCAPSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUXCAPSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AUXCAPS_AUXIN: u32 = 2u32;
 pub const AUXCAPS_CDAUDIO: u32 = 1u32;
@@ -1850,9 +1753,6 @@ impl Default for AudioClient3ActivationParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AudioClient3ActivationParams {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AudioClientProperties {
@@ -1866,9 +1766,6 @@ impl Default for AudioClientProperties {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AudioClientProperties {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AudioExtensionParams {
@@ -1881,9 +1778,6 @@ impl Default for AudioExtensionParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AudioExtensionParams {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1995,9 +1889,6 @@ impl Default for DIRECTX_AUDIO_ACTIVATION_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIRECTX_AUDIO_ACTIVATION_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DRVM_MAPPER: u32 = 8192u32;
 pub const DRVM_MAPPER_STATUS: u32 = 8192u32;
 pub const DRV_MAPPER_PREFERRED_INPUT_GET: u32 = 16384u32;
@@ -2024,9 +1915,6 @@ impl Default for ECHOWAVEFILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ECHOWAVEFILTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7340,9 +7228,6 @@ impl Default for MIDIEVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDIEVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIDIHDR {
@@ -7361,9 +7246,6 @@ impl Default for MIDIHDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDIHDR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIDIINCAPS2A {
@@ -7380,9 +7262,6 @@ impl Default for MIDIINCAPS2A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIDIINCAPS2A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7401,9 +7280,6 @@ impl Default for MIDIINCAPS2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDIINCAPS2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIDIINCAPSA {
@@ -7418,9 +7294,6 @@ impl Default for MIDIINCAPSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDIINCAPSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIDIINCAPSW {
@@ -7434,9 +7307,6 @@ impl Default for MIDIINCAPSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIDIINCAPSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7459,9 +7329,6 @@ impl Default for MIDIOUTCAPS2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDIOUTCAPS2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIDIOUTCAPS2W {
@@ -7483,9 +7350,6 @@ impl Default for MIDIOUTCAPS2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDIOUTCAPS2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIDIOUTCAPSA {
@@ -7503,9 +7367,6 @@ impl Default for MIDIOUTCAPSA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIDIOUTCAPSA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7525,9 +7386,6 @@ impl Default for MIDIOUTCAPSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDIOUTCAPSW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MIDIPATCHSIZE: u32 = 128u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7540,9 +7398,6 @@ impl Default for MIDIPROPTEMPO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDIPROPTEMPO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIDIPROPTIMEDIV {
@@ -7553,9 +7408,6 @@ impl Default for MIDIPROPTIMEDIV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIDIPROPTIMEDIV {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIDIPROP_GET: i32 = 1073741824i32;
 pub const MIDIPROP_SET: i32 = -2147483648i32;
@@ -7572,9 +7424,6 @@ impl Default for MIDISTRMBUFFVER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIDISTRMBUFFVER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIDISTRM_ERROR: i32 = -2i32;
 pub const MIDI_CACHE_ALL: u32 = 1u32;
@@ -7636,9 +7485,6 @@ impl Default for MIXERCAPS2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCAPS2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERCAPS2W {
@@ -7657,9 +7503,6 @@ impl Default for MIXERCAPS2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCAPS2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERCAPSA {
@@ -7675,9 +7518,6 @@ impl Default for MIXERCAPSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCAPSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERCAPSW {
@@ -7692,9 +7532,6 @@ impl Default for MIXERCAPSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERCAPSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7714,9 +7551,6 @@ impl Default for MIXERCONTROLA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union MIXERCONTROLA_0 {
@@ -7729,9 +7563,6 @@ impl Default for MIXERCONTROLA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERCONTROLA_0_0 {
@@ -7742,9 +7573,6 @@ impl Default for MIXERCONTROLA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERCONTROLA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7757,9 +7585,6 @@ impl Default for MIXERCONTROLA_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLA_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union MIXERCONTROLA_1 {
@@ -7771,9 +7596,6 @@ impl Default for MIXERCONTROLA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERCONTROLA_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7790,9 +7612,6 @@ impl Default for MIXERCONTROLDETAILS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLDETAILS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union MIXERCONTROLDETAILS_0 {
@@ -7804,9 +7623,6 @@ impl Default for MIXERCONTROLDETAILS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLDETAILS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERCONTROLDETAILS_BOOLEAN {
@@ -7816,9 +7632,6 @@ impl Default for MIXERCONTROLDETAILS_BOOLEAN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERCONTROLDETAILS_BOOLEAN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7832,9 +7645,6 @@ impl Default for MIXERCONTROLDETAILS_LISTTEXTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLDETAILS_LISTTEXTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERCONTROLDETAILS_LISTTEXTW {
@@ -7847,9 +7657,6 @@ impl Default for MIXERCONTROLDETAILS_LISTTEXTW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLDETAILS_LISTTEXTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERCONTROLDETAILS_SIGNED {
@@ -7860,9 +7667,6 @@ impl Default for MIXERCONTROLDETAILS_SIGNED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLDETAILS_SIGNED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERCONTROLDETAILS_UNSIGNED {
@@ -7872,9 +7676,6 @@ impl Default for MIXERCONTROLDETAILS_UNSIGNED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERCONTROLDETAILS_UNSIGNED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7894,9 +7695,6 @@ impl Default for MIXERCONTROLW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union MIXERCONTROLW_0 {
@@ -7909,9 +7707,6 @@ impl Default for MIXERCONTROLW_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLW_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERCONTROLW_0_0 {
@@ -7922,9 +7717,6 @@ impl Default for MIXERCONTROLW_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERCONTROLW_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7937,9 +7729,6 @@ impl Default for MIXERCONTROLW_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERCONTROLW_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union MIXERCONTROLW_1 {
@@ -7951,9 +7740,6 @@ impl Default for MIXERCONTROLW_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERCONTROLW_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIXERCONTROL_CONTROLF_DISABLED: i32 = -2147483648i32;
 pub const MIXERCONTROL_CONTROLF_MULTIPLE: i32 = 2i32;
@@ -8035,9 +7821,6 @@ impl Default for MIXERLINEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERLINEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERLINEA_0 {
@@ -8052,9 +7835,6 @@ impl Default for MIXERLINEA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERLINEA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8071,9 +7851,6 @@ impl Default for MIXERLINECONTROLSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERLINECONTROLSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union MIXERLINECONTROLSA_0 {
@@ -8084,9 +7861,6 @@ impl Default for MIXERLINECONTROLSA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERLINECONTROLSA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8103,9 +7877,6 @@ impl Default for MIXERLINECONTROLSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERLINECONTROLSW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union MIXERLINECONTROLSW_0 {
@@ -8116,9 +7887,6 @@ impl Default for MIXERLINECONTROLSW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERLINECONTROLSW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8142,9 +7910,6 @@ impl Default for MIXERLINEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIXERLINEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MIXERLINEW_0 {
@@ -8159,9 +7924,6 @@ impl Default for MIXERLINEW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIXERLINEW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8252,9 +8014,6 @@ impl Default for PCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PKEY_AudioEndpointLogo_IconEffects: super::super::Foundation::PROPERTYKEY = super::super::Foundation::PROPERTYKEY { fmtid: windows_core::GUID::from_u128(0xf1ab780d_2010_4ed3_a3a6_8b87f0f0c476), pid: 0 };
 pub const PKEY_AudioEndpointLogo_IconPath: super::super::Foundation::PROPERTYKEY = super::super::Foundation::PROPERTYKEY { fmtid: windows_core::GUID::from_u128(0xf1ab780d_2010_4ed3_a3a6_8b87f0f0c476), pid: 1 };
@@ -8429,9 +8188,6 @@ impl Default for SpatialAudioClientActivationParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SpatialAudioClientActivationParams {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 pub struct SpatialAudioHrtfActivationParams {
     pub ObjectFormat: *const WAVEFORMATEX,
@@ -8450,9 +8206,6 @@ impl Default for SpatialAudioHrtfActivationParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SpatialAudioHrtfActivationParams {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C, packed(1))]
 pub struct SpatialAudioHrtfActivationParams2 {
@@ -8474,9 +8227,6 @@ impl Default for SpatialAudioHrtfActivationParams2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SpatialAudioHrtfActivationParams2 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct SpatialAudioHrtfDirectivity {
@@ -8487,9 +8237,6 @@ impl Default for SpatialAudioHrtfDirectivity {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SpatialAudioHrtfDirectivity {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8502,9 +8249,6 @@ impl Default for SpatialAudioHrtfDirectivityCardioid {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SpatialAudioHrtfDirectivityCardioid {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct SpatialAudioHrtfDirectivityCone {
@@ -8516,9 +8260,6 @@ impl Default for SpatialAudioHrtfDirectivityCone {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SpatialAudioHrtfDirectivityCone {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8534,9 +8275,6 @@ impl Default for SpatialAudioHrtfDirectivityUnion {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SpatialAudioHrtfDirectivityUnion {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SpatialAudioHrtfDirectivity_Cardioid: SpatialAudioHrtfDirectivityType = SpatialAudioHrtfDirectivityType(1i32);
 pub const SpatialAudioHrtfDirectivity_Cone: SpatialAudioHrtfDirectivityType = SpatialAudioHrtfDirectivityType(2i32);
@@ -8554,9 +8292,6 @@ impl Default for SpatialAudioHrtfDistanceDecay {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SpatialAudioHrtfDistanceDecay {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8591,9 +8326,6 @@ impl Default for SpatialAudioMetadataItemsInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SpatialAudioMetadataItemsInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SpatialAudioMetadataWriterOverflowMode(pub i32);
@@ -8615,9 +8347,6 @@ impl Default for SpatialAudioObjectRenderStreamActivationParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SpatialAudioObjectRenderStreamActivationParams {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C, packed(1))]
 pub struct SpatialAudioObjectRenderStreamActivationParams2 {
     pub ObjectFormat: *const WAVEFORMATEX,
@@ -8633,9 +8362,6 @@ impl Default for SpatialAudioObjectRenderStreamActivationParams2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SpatialAudioObjectRenderStreamActivationParams2 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C, packed(1))]
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
@@ -8656,10 +8382,6 @@ impl Default for SpatialAudioObjectRenderStreamForMetadataActivationParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SpatialAudioObjectRenderStreamForMetadataActivationParams {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C, packed(1))]
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
@@ -8682,10 +8404,6 @@ impl Default for SpatialAudioObjectRenderStreamForMetadataActivationParams2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SpatialAudioObjectRenderStreamForMetadataActivationParams2 {
-    type TypeKind = windows_core::CloneType;
-}
 pub const Speakers: EndpointFormFactor = EndpointFormFactor(1i32);
 pub const Subunit: PartType = PartType(1i32);
 pub const UnknownDigitalPassthrough: EndpointFormFactor = EndpointFormFactor(7i32);
@@ -8701,9 +8419,6 @@ impl Default for VOLUMEWAVEFILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUMEWAVEFILTER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WAVECAPS_LRVOLUME: u32 = 8u32;
 pub const WAVECAPS_PITCH: u32 = 1u32;
@@ -8724,9 +8439,6 @@ impl Default for WAVEFILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAVEFILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WAVEFORMAT {
@@ -8740,9 +8452,6 @@ impl Default for WAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8760,9 +8469,6 @@ impl Default for WAVEFORMATEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAVEFORMATEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WAVEFORMATEXTENSIBLE {
@@ -8776,9 +8482,6 @@ impl Default for WAVEFORMATEXTENSIBLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAVEFORMATEXTENSIBLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WAVEFORMATEXTENSIBLE_0 {
@@ -8790,9 +8493,6 @@ impl Default for WAVEFORMATEXTENSIBLE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WAVEFORMATEXTENSIBLE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8810,9 +8510,6 @@ impl Default for WAVEHDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WAVEHDR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8833,9 +8530,6 @@ impl Default for WAVEINCAPS2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAVEINCAPS2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WAVEINCAPS2W {
@@ -8855,9 +8549,6 @@ impl Default for WAVEINCAPS2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAVEINCAPS2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WAVEINCAPSA {
@@ -8874,9 +8565,6 @@ impl Default for WAVEINCAPSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAVEINCAPSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WAVEINCAPSW {
@@ -8892,9 +8580,6 @@ impl Default for WAVEINCAPSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WAVEINCAPSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WAVEIN_MAPPER_STATUS_DEVICE: u32 = 0u32;
 pub const WAVEIN_MAPPER_STATUS_FORMAT: u32 = 2u32;
@@ -8919,9 +8604,6 @@ impl Default for WAVEOUTCAPS2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAVEOUTCAPS2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WAVEOUTCAPS2W {
@@ -8942,9 +8624,6 @@ impl Default for WAVEOUTCAPS2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAVEOUTCAPS2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WAVEOUTCAPSA {
@@ -8962,9 +8641,6 @@ impl Default for WAVEOUTCAPSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAVEOUTCAPSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WAVEOUTCAPSW {
@@ -8981,9 +8657,6 @@ impl Default for WAVEOUTCAPSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WAVEOUTCAPSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WAVEOUT_MAPPER_STATUS_DEVICE: u32 = 0u32;
 pub const WAVEOUT_MAPPER_STATUS_FORMAT: u32 = 2u32;
@@ -9057,7 +8730,4 @@ impl Default for tACMFORMATDETAILSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for tACMFORMATDETAILSW {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/mod.rs
@@ -4682,9 +4682,6 @@ impl Default for MACINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MACINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MDSP_READ: u32 = 1u32;
 pub const MDSP_SEEK_BOF: u32 = 1u32;
 pub const MDSP_SEEK_CUR: u32 = 2u32;
@@ -4705,9 +4702,6 @@ impl Default for MTP_COMMAND_DATA_IN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MTP_COMMAND_DATA_IN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MTP_COMMAND_DATA_OUT {
@@ -4721,9 +4715,6 @@ impl Default for MTP_COMMAND_DATA_OUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MTP_COMMAND_DATA_OUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MTP_COMMAND_MAX_PARAMS: u32 = 5u32;
 pub const MTP_NEXTPHASE_NO_DATA: u32 = 3u32;
@@ -4745,9 +4736,6 @@ impl Default for OPAQUECOMMAND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPAQUECOMMAND {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RSA_KEY_LEN: u32 = 64u32;
 pub const SAC_CERT_V1: u32 = 2u32;
@@ -4774,9 +4762,6 @@ impl Default for WMDMDATETIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMDMDATETIME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4869,9 +4854,6 @@ impl Default for WMDMDetermineMaxPropStringLen {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMDMDetermineMaxPropStringLen {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WMDMDevice: windows_core::GUID = windows_core::GUID::from_u128(0x807b3cdf_357a_11d3_8471_00c04f79dbc0);
 pub const WMDMDeviceEnum: windows_core::GUID = windows_core::GUID::from_u128(0x430e35af_3971_11d3_8474_00c04f79dbc0);
 #[repr(C)]
@@ -4886,9 +4868,6 @@ impl Default for WMDMID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMDMID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMDMID_LENGTH: u32 = 128u32;
 pub const WMDMLogger: windows_core::GUID = windows_core::GUID::from_u128(0x110a3202_5a79_11d3_8d78_444553540000);
@@ -4907,9 +4886,6 @@ impl Default for WMDMMetadataView {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMDMMetadataView {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WMDMRIGHTS {
@@ -4925,9 +4901,6 @@ impl Default for WMDMRIGHTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMDMRIGHTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMDMStorage: windows_core::GUID = windows_core::GUID::from_u128(0x807b3ce0_357a_11d3_8471_00c04f79dbc0);
 pub const WMDMStorageEnum: windows_core::GUID = windows_core::GUID::from_u128(0xeb401a3b_3af7_11d3_8474_00c04f79dbc0);
@@ -5119,10 +5092,6 @@ impl Default for WMDM_FORMAT_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for WMDM_FORMAT_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WMDM_GET_FORMAT_SUPPORT_AUDIO: u32 = 1u32;
 pub const WMDM_GET_FORMAT_SUPPORT_FILE: u32 = 4u32;
 pub const WMDM_GET_FORMAT_SUPPORT_VIDEO: u32 = 2u32;
@@ -5161,10 +5130,6 @@ impl Default for WMDM_PROP_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for WMDM_PROP_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
 pub struct WMDM_PROP_DESC {
@@ -5184,10 +5149,6 @@ impl Default for WMDM_PROP_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for WMDM_PROP_DESC {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
 pub union WMDM_PROP_DESC_0 {
@@ -5206,10 +5167,6 @@ impl Default for WMDM_PROP_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for WMDM_PROP_DESC_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5222,10 +5179,6 @@ impl Default for WMDM_PROP_VALUES_ENUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for WMDM_PROP_VALUES_ENUM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
@@ -5245,10 +5198,6 @@ impl Default for WMDM_PROP_VALUES_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for WMDM_PROP_VALUES_RANGE {
-    type TypeKind = windows_core::CloneType;
 }
 pub const WMDM_RIGHTS_COPY_TO_CD: u32 = 8u32;
 pub const WMDM_RIGHTS_COPY_TO_NON_SDMI_DEVICE: u32 = 2u32;
@@ -5351,9 +5300,6 @@ impl Default for WMFILECAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMFILECAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const g_wszAudioWAVECodec: windows_core::PCWSTR = windows_core::w!("WMDM/AudioWAVECodec");
 pub const g_wszVideoFourCCCodec: windows_core::PCWSTR = windows_core::w!("WMDM/VideoFourCCCodec");

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Tv/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Tv/mod.rs
@@ -22,9 +22,6 @@ impl Default for ATSC_FILTER_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATSC_FILTER_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ATSC_MGT_PID: u32 = 8187u32;
 pub const ATSC_MGT_TID: u32 = 199u32;
 pub const ATSC_PIT_TID: u32 = 208u32;
@@ -65,9 +62,6 @@ impl Default for BDA_DEBUG_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_DEBUG_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BDA_DEBUG_DATA_AVAILABLE: windows_core::GUID = windows_core::GUID::from_u128(0x69c24f54_9983_497e_b415_282be4c555fb);
 pub const BDA_DEBUG_DATA_TYPE_STRING: windows_core::GUID = windows_core::GUID::from_u128(0xa806e767_de5c_430c_80bf_a21ebe06c748);
 #[repr(transparent)]
@@ -86,9 +80,6 @@ impl Default for BDA_EVENT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -109,9 +100,6 @@ impl Default for BDA_TRANSPORT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_TRANSPORT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BSKYB_TERRESTRIAL_TV_NETWORK_TYPE: windows_core::GUID = windows_core::GUID::from_u128(0x9e9e46c6_3aba_4f08_ad0e_cc5ac8148c2b);
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -122,9 +110,6 @@ impl Default for BadSampleInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BadSampleInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const Bda_DigitalStandard_ATSC: BDA_DigitalSignalStandard = BDA_DigitalSignalStandard(8i32);
 pub const Bda_DigitalStandard_DVB_C: BDA_DigitalSignalStandard = BDA_DigitalSignalStandard(4i32);
@@ -196,9 +181,6 @@ impl Default for CAPTURE_STREAMTIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CAPTURE_STREAMTIME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLSID_CPCAFiltersCategory: windows_core::GUID = windows_core::GUID::from_u128(0xc4c4c4fc_0049_4e2b_98fb_9537f6ce516d);
 pub const CLSID_DTFilterEncProperties: windows_core::GUID = windows_core::GUID::from_u128(0xc4c4c482_0049_4e2b_98fb_9537f6ce516d);
@@ -281,9 +263,6 @@ impl Default for ChannelChangeInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ChannelChangeInfo {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ChannelChangeSpanningEvent_End: ChannelChangeSpanningEvent_State = ChannelChangeSpanningEvent_State(2i32);
 pub const ChannelChangeSpanningEvent_Start: ChannelChangeSpanningEvent_State = ChannelChangeSpanningEvent_State(0i32);
 #[repr(transparent)]
@@ -302,9 +281,6 @@ impl Default for ChannelInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ChannelInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ChannelInfo_0 {
@@ -317,9 +293,6 @@ impl Default for ChannelInfo_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ChannelInfo_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ChannelInfo_0_2 {
@@ -330,9 +303,6 @@ impl Default for ChannelInfo_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ChannelInfo_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ChannelInfo_0_1 {
@@ -342,9 +312,6 @@ impl Default for ChannelInfo_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ChannelInfo_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -357,9 +324,6 @@ impl Default for ChannelInfo_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ChannelInfo_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ChannelTuneRequest: windows_core::GUID = windows_core::GUID::from_u128(0x0369b4e5_45b6_11d3_b650_00c04f79498e);
 #[repr(transparent)]
@@ -378,9 +342,6 @@ impl Default for ChannelTypeInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ChannelTypeInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ChannelTypeNone: ChannelType = ChannelType(0i32);
 pub const ChannelTypeOther: ChannelType = ChannelType(1i32);
@@ -544,9 +505,6 @@ impl Default for DSHOW_STREAM_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSHOW_STREAM_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DSMCC_ELEMENT {
@@ -560,9 +518,6 @@ impl Default for DSMCC_ELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSMCC_ELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -588,9 +543,6 @@ impl Default for DSMCC_FILTER_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSMCC_FILTER_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DSMCC_SECTION {
@@ -614,9 +566,6 @@ impl Default for DSMCC_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSMCC_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union DSMCC_SECTION_0 {
@@ -628,9 +577,6 @@ impl Default for DSMCC_SECTION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSMCC_SECTION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DSMCC_SECTION_1 {
@@ -641,9 +587,6 @@ impl Default for DSMCC_SECTION_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSMCC_SECTION_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DTFilter: windows_core::GUID = windows_core::GUID::from_u128(0xc4c4c4f2_0049_4e2b_98fb_9537f6ce516d);
 pub const DTV_CardStatus_Error: u32 = 2u32;
@@ -670,9 +613,6 @@ impl Default for DVBScramblingControlSpanningEvent {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVBScramblingControlSpanningEvent {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DVBTLocator: windows_core::GUID = windows_core::GUID::from_u128(0x9cd64701_bdf3_4d14_8e03_f12983d86664);
 pub const DVBTLocator2: windows_core::GUID = windows_core::GUID::from_u128(0xefe3fa02_45d7_4920_be96_53fa7f35b0e6);
 pub const DVBTuneRequest: windows_core::GUID = windows_core::GUID::from_u128(0x15d6504a_5494_499c_886c_973c9e53b9f1);
@@ -693,9 +633,6 @@ impl Default for DVB_EIT_FILTER_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVB_EIT_FILTER_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVB_EIT_OTHER_TID: u32 = 79u32;
 pub const DVB_EIT_PID: u32 = 18u32;
@@ -755,10 +692,6 @@ impl Default for DVR_STREAM_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_MediaFoundation")]
-impl windows_core::TypeKind for DVR_STREAM_DESC {
-    type TypeKind = windows_core::CloneType;
-}
 pub const DigitalCableLocator: windows_core::GUID = windows_core::GUID::from_u128(0x03c06416_d127_407a_ab4c_fdd279abbe5d);
 pub const DigitalCableTuneRequest: windows_core::GUID = windows_core::GUID::from_u128(0x26ec0b63_aa90_458a_8df4_5659f2c8a18a);
 pub const DigitalCableTuningSpace: windows_core::GUID = windows_core::GUID::from_u128(0xd9bb4cee_b87a_47f1_ac92_b08d9c7813fc);
@@ -782,9 +715,6 @@ impl Default for DualMonoInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DualMonoInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DvbParentalRatingDescriptor {
@@ -796,9 +726,6 @@ impl Default for DvbParentalRatingDescriptor {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DvbParentalRatingDescriptor {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DvbParentalRatingParam {
@@ -809,9 +736,6 @@ impl Default for DvbParentalRatingParam {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DvbParentalRatingParam {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ECHOSTAR_SATELLITE_TV_NETWORK_TYPE: windows_core::GUID = windows_core::GUID::from_u128(0xc4f6b31b_c6bf_4759_886f_a7386dca27a0);
 pub const ENCDEC_CPEVENT: EncDecEvents = EncDecEvents(0i32);
@@ -33689,10 +33613,6 @@ impl Default for KSEVENTDATA_BDA_RF_TUNER_SCAN_S {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSEVENTDATA_BDA_RF_TUNER_SCAN_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSEVENTSETID_BdaCAEvent: windows_core::GUID = windows_core::GUID::from_u128(0x488c4ccc_b768_4129_8eb1_b00a071f9068);
 pub const KSEVENTSETID_BdaDiseqCEvent: windows_core::GUID = windows_core::GUID::from_u128(0x8b19bbf0_4184_43ac_ad3c_0c889be4c212);
 pub const KSEVENTSETID_BdaEvent: windows_core::GUID = windows_core::GUID::from_u128(0xae7e55b2_96d7_4e29_908f_62f95b2a1679);
@@ -33851,10 +33771,6 @@ impl Default for KSM_BDA_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -33868,10 +33784,6 @@ impl Default for KSM_BDA_CAS_CAPTURETOKEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_CAS_CAPTURETOKEN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -33888,10 +33800,6 @@ impl Default for KSM_BDA_CAS_CLOSEMMIDIALOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_CAS_CLOSEMMIDIALOG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -33910,10 +33818,6 @@ impl Default for KSM_BDA_CAS_ENTITLEMENTTOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_CAS_ENTITLEMENTTOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -33928,10 +33832,6 @@ impl Default for KSM_BDA_CAS_OPENBROADCASTMMI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_CAS_OPENBROADCASTMMI {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -33948,10 +33848,6 @@ impl Default for KSM_BDA_DEBUG_LEVEL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_DEBUG_LEVEL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -33964,10 +33860,6 @@ impl Default for KSM_BDA_DRM_SETDRM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_DRM_SETDRM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -33983,10 +33875,6 @@ impl Default for KSM_BDA_EVENT_COMPLETE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_EVENT_COMPLETE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34001,10 +33889,6 @@ impl Default for KSM_BDA_GDDS_SERVICEFROMTUNEXML {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_GDDS_SERVICEFROMTUNEXML {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34017,10 +33901,6 @@ impl Default for KSM_BDA_GDDS_TUNEXMLFROMIDX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_GDDS_TUNEXMLFROMIDX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -34037,10 +33917,6 @@ impl Default for KSM_BDA_GPNV_GETVALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_GPNV_GETVALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34053,10 +33929,6 @@ impl Default for KSM_BDA_GPNV_NAMEINDEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_GPNV_NAMEINDEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -34075,10 +33947,6 @@ impl Default for KSM_BDA_GPNV_SETVALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_GPNV_SETVALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34094,10 +33962,6 @@ impl Default for KSM_BDA_ISDBCAS_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_ISDBCAS_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34112,10 +33976,6 @@ impl Default for KSM_BDA_PIN {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_PIN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34128,10 +33988,6 @@ impl Default for KSM_BDA_PIN_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_PIN_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -34147,10 +34003,6 @@ impl Default for KSM_BDA_PIN_PAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_PIN_PAIR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34163,10 +34015,6 @@ impl Default for KSM_BDA_PIN_PAIR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_PIN_PAIR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -34181,10 +34029,6 @@ impl Default for KSM_BDA_PIN_PAIR_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_PIN_PAIR_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34197,10 +34041,6 @@ impl Default for KSM_BDA_SCAN_CAPABILTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_SCAN_CAPABILTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -34217,10 +34057,6 @@ impl Default for KSM_BDA_SCAN_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_SCAN_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34235,10 +34071,6 @@ impl Default for KSM_BDA_SCAN_START {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_SCAN_START {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34251,10 +34083,6 @@ impl Default for KSM_BDA_TS_SELECTOR_SETTSID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_TS_SELECTOR_SETTSID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -34270,10 +34098,6 @@ impl Default for KSM_BDA_TUNER_TUNEREQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_TUNER_TUNEREQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34287,10 +34111,6 @@ impl Default for KSM_BDA_USERACTIVITY_USEREASON {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_USERACTIVITY_USEREASON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34303,10 +34123,6 @@ impl Default for KSM_BDA_WMDRMTUNER_GETPIDPROTECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_WMDRMTUNER_GETPIDPROTECTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -34324,10 +34140,6 @@ impl Default for KSM_BDA_WMDRMTUNER_PURCHASEENTITLEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_WMDRMTUNER_PURCHASEENTITLEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34342,10 +34154,6 @@ impl Default for KSM_BDA_WMDRMTUNER_SETPIDPROTECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_WMDRMTUNER_SETPIDPROTECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34359,10 +34167,6 @@ impl Default for KSM_BDA_WMDRMTUNER_SYNCVALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_WMDRMTUNER_SYNCVALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34375,10 +34179,6 @@ impl Default for KSM_BDA_WMDRM_LICENSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_WMDRM_LICENSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -34394,10 +34194,6 @@ impl Default for KSM_BDA_WMDRM_RENEWLICENSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSM_BDA_WMDRM_RENEWLICENSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSNODE_BDA_8PSK_DEMODULATOR: windows_core::GUID = windows_core::GUID::from_u128(0xe957a0e7_dd98_4a3c_810b_3525157ab62e);
 pub const KSNODE_BDA_8VSB_DEMODULATOR: windows_core::GUID = windows_core::GUID::from_u128(0x71985f4f_1ca1_11d3_9cc8_00c04f7971e0);
@@ -34536,10 +34332,6 @@ impl Default for KSPROPERTY_BDA_RF_TUNER_CAPS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSPROPERTY_BDA_RF_TUNER_CAPS_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_BDA_RF_TUNER_FREQUENCY: KSPROPERTY_BDA_FREQUENCY_FILTER = KSPROPERTY_BDA_FREQUENCY_FILTER(0i32);
 pub const KSPROPERTY_BDA_RF_TUNER_FREQUENCY_MULTIPLIER: KSPROPERTY_BDA_FREQUENCY_FILTER = KSPROPERTY_BDA_FREQUENCY_FILTER(5i32);
 pub const KSPROPERTY_BDA_RF_TUNER_POLARITY: KSPROPERTY_BDA_FREQUENCY_FILTER = KSPROPERTY_BDA_FREQUENCY_FILTER(1i32);
@@ -34561,10 +34353,6 @@ impl Default for KSPROPERTY_BDA_RF_TUNER_SCAN_STATUS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSPROPERTY_BDA_RF_TUNER_SCAN_STATUS_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_BDA_RF_TUNER_STANDARD: KSPROPERTY_BDA_FREQUENCY_FILTER = KSPROPERTY_BDA_FREQUENCY_FILTER(8i32);
 pub const KSPROPERTY_BDA_RF_TUNER_STANDARD_MODE: KSPROPERTY_BDA_FREQUENCY_FILTER = KSPROPERTY_BDA_FREQUENCY_FILTER(9i32);
 #[repr(C)]
@@ -34580,10 +34368,6 @@ impl Default for KSPROPERTY_BDA_RF_TUNER_STANDARD_MODE_S {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSPROPERTY_BDA_RF_TUNER_STANDARD_MODE_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34597,10 +34381,6 @@ impl Default for KSPROPERTY_BDA_RF_TUNER_STANDARD_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSPROPERTY_BDA_RF_TUNER_STANDARD_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_BDA_RF_TUNER_TRANSPONDER: KSPROPERTY_BDA_FREQUENCY_FILTER = KSPROPERTY_BDA_FREQUENCY_FILTER(3i32);
 pub const KSPROPERTY_BDA_ROLL_OFF: KSPROPERTY_BDA_DIGITAL_DEMODULATOR = KSPROPERTY_BDA_DIGITAL_DEMODULATOR(9i32);
@@ -34662,10 +34442,6 @@ impl Default for KSP_BDA_NODE_PIN {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSP_BDA_NODE_PIN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34679,10 +34455,6 @@ impl Default for KSP_NODE_ESPID {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KSP_NODE_ESPID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 #[derive(Clone, Copy)]
@@ -34694,10 +34466,6 @@ impl Default for KS_DATARANGE_BDA_ANTENNA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KS_DATARANGE_BDA_ANTENNA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
@@ -34711,10 +34479,6 @@ impl Default for KS_DATARANGE_BDA_TRANSPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_KernelStreaming")]
-impl windows_core::TypeKind for KS_DATARANGE_BDA_TRANSPORT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LIC_BadLicense: LicenseEventBlockReason = LicenseEventBlockReason(0i32);
 pub const LIC_Expired: LicenseEventBlockReason = LicenseEventBlockReason(2i32);
@@ -34737,9 +34501,6 @@ impl Default for LONG_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LONG_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union LONG_SECTION_0 {
@@ -34750,9 +34511,6 @@ impl Default for LONG_SECTION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LONG_SECTION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -34765,9 +34523,6 @@ impl Default for LONG_SECTION_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LONG_SECTION_1 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LanguageComponentType: windows_core::GUID = windows_core::GUID::from_u128(0x1be49f30_0e1b_11d3_9d8e_00c04f72d980);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -34779,9 +34534,6 @@ impl Default for LanguageInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LanguageInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LastReservedDeviceDispid: SegDispidList = SegDispidList(16383i32);
 pub const LastReservedDeviceEvent: SegEventidList = SegEventidList(16383i32);
@@ -34833,9 +34585,6 @@ impl Default for MPEG2_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG2_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MPEG2_FILTER2 {
@@ -34848,9 +34597,6 @@ impl Default for MPEG2_FILTER2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG2_FILTER2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MPEG2_FILTER2_0 {
@@ -34861,9 +34607,6 @@ impl Default for MPEG2_FILTER2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPEG2_FILTER2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -34891,9 +34634,6 @@ impl Default for MPEG2_FILTER2_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG2_FILTER2_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MPEG2_FILTER_VERSION_1_SIZE: u32 = 124u32;
 pub const MPEG2_FILTER_VERSION_2_SIZE: u32 = 133u32;
 #[repr(C, packed(1))]
@@ -34905,9 +34645,6 @@ impl Default for MPEG_BCS_DEMUX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPEG_BCS_DEMUX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MPEG_CAT_PID: u32 = 1u32;
 pub const MPEG_CAT_TID: u32 = 1u32;
@@ -34922,9 +34659,6 @@ impl Default for MPEG_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MPEG_CONTEXT_0 {
@@ -34935,9 +34669,6 @@ impl Default for MPEG_CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPEG_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MPEG_CONTEXT_BCS_DEMUX: MPEG_CONTEXT_TYPE = MPEG_CONTEXT_TYPE(0i32);
 #[repr(transparent)]
@@ -34959,9 +34690,6 @@ impl Default for MPEG_DATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG_DATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MPEG_DATE_AND_TIME {
@@ -34973,9 +34701,6 @@ impl Default for MPEG_DATE_AND_TIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG_DATE_AND_TIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MPEG_HEADER_BITS {
@@ -34985,9 +34710,6 @@ impl Default for MPEG_HEADER_BITS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPEG_HEADER_BITS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -34999,9 +34721,6 @@ impl Default for MPEG_HEADER_BITS_MIDL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG_HEADER_BITS_MIDL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MPEG_HEADER_VERSION_BITS {
@@ -35011,9 +34730,6 @@ impl Default for MPEG_HEADER_VERSION_BITS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPEG_HEADER_VERSION_BITS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -35025,9 +34741,6 @@ impl Default for MPEG_HEADER_VERSION_BITS_MIDL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG_HEADER_VERSION_BITS_MIDL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MPEG_PACKET_LIST {
@@ -35038,9 +34751,6 @@ impl Default for MPEG_PACKET_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPEG_PACKET_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MPEG_PAT_PID: u32 = 0u32;
 pub const MPEG_PAT_TID: u32 = 0u32;
@@ -35066,9 +34776,6 @@ impl Default for MPEG_RQST_PACKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG_RQST_PACKET {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MPEG_RQST_START_MPE_STREAM: MPEG_REQUEST_TYPE = MPEG_REQUEST_TYPE(8i32);
 pub const MPEG_RQST_UNKNOWN: MPEG_REQUEST_TYPE = MPEG_REQUEST_TYPE(0i32);
 pub const MPEG_SECTION_IS_CURRENT: MPEG_CURRENT_NEXT_BIT = MPEG_CURRENT_NEXT_BIT(1i32);
@@ -35088,9 +34795,6 @@ impl Default for MPEG_SERVICE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG_SERVICE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MPEG_SERVICE_RESPONSE {
@@ -35101,9 +34805,6 @@ impl Default for MPEG_SERVICE_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPEG_SERVICE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -35117,9 +34818,6 @@ impl Default for MPEG_STREAM_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPEG_STREAM_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -35135,9 +34833,6 @@ impl Default for MPEG_STREAM_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG_STREAM_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MPEG_TIME {
@@ -35149,9 +34844,6 @@ impl Default for MPEG_TIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPEG_TIME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MPEG_TSDT_PID: u32 = 2u32;
 pub const MPEG_TSDT_TID: u32 = 3u32;
@@ -35165,9 +34857,6 @@ impl Default for MPEG_WINSOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG_WINSOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MPE_ELEMENT {
@@ -35179,9 +34868,6 @@ impl Default for MPE_ELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPE_ELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSEventBinder: windows_core::GUID = windows_core::GUID::from_u128(0x577faa18_4518_445e_8f70_1473f8cf4ba4);
 pub const MSVIDCTL_ALT: MSVidCtlButtonstate = MSVidCtlButtonstate(4i32);
@@ -35301,9 +34987,6 @@ impl Default for Mpeg2TableSampleHdr {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Mpeg2TableSampleHdr {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OCUR_PAIRING_PROTOCOL_VERSION: u32 = 2u32;
 pub const PARENTAL_CONTROL_ATTRIB_DIALOGUE: u32 = 515u32;
 pub const PARENTAL_CONTROL_ATTRIB_FANTASY: u32 = 516u32;
@@ -35325,9 +35008,6 @@ impl Default for PBDAParentalControl {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PBDAParentalControl {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PBDA_ALWAYS_TUNE_IN_MUX: windows_core::GUID = windows_core::GUID::from_u128(0x1e1d7141_583f_4ac2_b019_1f430eda0f4c);
 pub const PBDA_PAIRING_PROTOCOL_VERSION: u32 = 3u32;
 #[repr(C)]
@@ -35344,9 +35024,6 @@ impl Default for PBDA_TAG_ATTRIBUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PBDA_TAG_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PIC_SEQ_SAMPLE {
@@ -35356,9 +35033,6 @@ impl Default for PIC_SEQ_SAMPLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PIC_SEQ_SAMPLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -35371,9 +35045,6 @@ impl Default for PIDListSpanningEvent {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PIDListSpanningEvent {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct PID_BITS {
@@ -35384,9 +35055,6 @@ impl Default for PID_BITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PID_BITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct PID_BITS_MIDL {
@@ -35396,9 +35064,6 @@ impl Default for PID_BITS_MIDL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PID_BITS_MIDL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PINNAME_BDA_ANALOG_AUDIO: windows_core::GUID = windows_core::GUID::from_u128(0xd28a580a_9b1f_4b0c_9c33_9bf0a8ea636b);
 pub const PINNAME_BDA_ANALOG_VIDEO: windows_core::GUID = windows_core::GUID::from_u128(0x5c0c8281_5667_486c_8482_63e31f01a6e9);
@@ -35433,9 +35098,6 @@ impl Default for ProgramElement {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ProgramElement {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ProtType(pub i32);
@@ -35450,9 +35112,6 @@ impl Default for RATING_ATTRIBUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RATING_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct RATING_INFO {
@@ -35463,9 +35122,6 @@ impl Default for RATING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RATING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -35480,9 +35136,6 @@ impl Default for RATING_SYSTEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RATING_SYSTEM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RECORDING_STARTED: CPRecordingStatus = CPRecordingStatus(1i32);
 pub const RECORDING_STOPPED: CPRecordingStatus = CPRecordingStatus(0i32);
@@ -35517,9 +35170,6 @@ impl Default for SAMPLE_LIVE_STREAM_TIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SAMPLE_LIVE_STREAM_TIME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SAMPLE_SEQ_CONTENT_B_FRAME: u32 = 3u32;
 pub const SAMPLE_SEQ_CONTENT_I_FRAME: u32 = 1u32;
 pub const SAMPLE_SEQ_CONTENT_NONREF_FRAME: u32 = 3u32;
@@ -35539,9 +35189,6 @@ impl Default for SAMPLE_SEQ_OFFSET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SAMPLE_SEQ_OFFSET {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SAMPLE_SEQ_PICTURE_HEADER: u32 = 3u32;
 pub const SAMPLE_SEQ_SEEK_POINT: u32 = 2u32;
 pub const SAMPLE_SEQ_SEQUENCE_HEADER: u32 = 1u32;
@@ -35558,9 +35205,6 @@ impl Default for SBE2_STREAM_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SBE2_STREAM_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SBE2_STREAM_DESC_EVENT: windows_core::GUID = windows_core::GUID::from_u128(0x2313a4ed_bf2d_454f_ad8a_d95ba7f91fee);
 pub const SBE2_STREAM_DESC_VERSION: u32 = 1u32;
@@ -35580,9 +35224,6 @@ impl Default for SBE_PIN_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SBE_PIN_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCTE_EAS_IB_PID: u32 = 8187u32;
 pub const SCTE_EAS_OOB_PID: u32 = 8188u32;
 pub const SCTE_EAS_TID: u32 = 216u32;
@@ -35598,9 +35239,6 @@ impl Default for SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union SECTION_0 {
@@ -35611,9 +35249,6 @@ impl Default for SECTION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECTION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SID_DRMSecureServiceChannel: windows_core::GUID = windows_core::GUID::from_u128(0xc4c4c4c4_0049_4e2b_98fb_9537f6ce516d);
 pub const SID_MSVidCtl_CurrentAudioEndpoint: windows_core::GUID = windows_core::GUID::from_u128(0xcf9a88f4_abcf_4ed8_9b74_7db33445459e);
@@ -35637,9 +35272,6 @@ impl Default for STREAMBUFFER_ATTRIBUTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STREAMBUFFER_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -35696,9 +35328,6 @@ impl Default for SpanningEventDescriptor {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SpanningEventDescriptor {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SpanningEventEmmMessage {
@@ -35721,9 +35350,6 @@ impl Default for SpanningEventEmmMessage {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SpanningEventEmmMessage {
-    type TypeKind = windows_core::CopyType;
-}
 pub const System5: EnTvRat_System = EnTvRat_System(5i32);
 pub const System6: EnTvRat_System = EnTvRat_System(6i32);
 pub const SystemTuningSpaces: windows_core::GUID = windows_core::GUID::from_u128(0xd02aac50_027e_11d3_9d8e_00c04f72d980);
@@ -35738,9 +35364,6 @@ impl Default for TID_EXTENSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TID_EXTENSION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TIFLoad: windows_core::GUID = windows_core::GUID::from_u128(0x14eb8748_1753_4393_95ae_4f7e7a87aad6);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -35754,9 +35377,6 @@ impl Default for TRANSPORT_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSPORT_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TRANSPORT_PROPERTIES_0 {
@@ -35768,9 +35388,6 @@ impl Default for TRANSPORT_PROPERTIES_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSPORT_PROPERTIES_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSPORT_PROPERTIES_0_0 {
@@ -35780,9 +35397,6 @@ impl Default for TRANSPORT_PROPERTIES_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSPORT_PROPERTIES_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TenthsSecondsMode: PositionModeList = PositionModeList(1i32);
 pub const TuneRequest: windows_core::GUID = windows_core::GUID::from_u128(0xb46e0d38_ab35_4a06_a137_70576b01b39f);
@@ -35832,9 +35446,6 @@ impl Default for UDCR_TAG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UDCR_TAG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const US_TV: EnTvRat_System = EnTvRat_System(1i32);
 pub const US_TV_14: EnTvRat_US_TV = EnTvRat_US_TV(5i32);
 pub const US_TV_G: EnTvRat_US_TV = EnTvRat_US_TV(3i32);
@@ -35881,9 +35492,6 @@ impl Default for VA_OPTIONAL_VIDEO_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VA_OPTIONAL_VIDEO_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VA_PRIMARIES_H264_GENERIC_FILM: VA_COLOR_PRIMARIES = VA_COLOR_PRIMARIES(8i32);
 pub const VA_PRIMARIES_ITU_R_BT_470_SYSTEM_B_G: VA_COLOR_PRIMARIES = VA_COLOR_PRIMARIES(5i32);
 pub const VA_PRIMARIES_ITU_R_BT_470_SYSTEM_M: VA_COLOR_PRIMARIES = VA_COLOR_PRIMARIES(4i32);
@@ -35924,9 +35532,6 @@ impl Default for WMDRMProtectionInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMDRMProtectionInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XDSCodec: windows_core::GUID = windows_core::GUID::from_u128(0xc4c4c4f3_0049_4e2b_98fb_9537f6ce516d);
 pub const XDSToRat: windows_core::GUID = windows_core::GUID::from_u128(0xc5c5c5f0_3abc_11d6_b25b_00c04fa0c026);

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/mod.rs
@@ -67,9 +67,6 @@ impl Default for ALLOCATOR_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ALLOCATOR_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AMAP_3D_TARGET: VMRSurfaceAllocationFlags = VMRSurfaceAllocationFlags(2i32);
 pub const AMAP_ALLOW_SYSMEM: VMRSurfaceAllocationFlags = VMRSurfaceAllocationFlags(4i32);
 pub const AMAP_DIRECTED_FLIP: VMRSurfaceAllocationFlags = VMRSurfaceAllocationFlags(16i32);
@@ -94,9 +91,6 @@ impl Default for AMCOPPCommand {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMCOPPCommand {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMCOPPSignature {
@@ -106,9 +100,6 @@ impl Default for AMCOPPSignature {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMCOPPSignature {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -124,9 +115,6 @@ impl Default for AMCOPPStatusInput {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMCOPPStatusInput {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMCOPPStatusOutput {
@@ -138,9 +126,6 @@ impl Default for AMCOPPStatusOutput {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMCOPPStatusOutput {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AMCOPYPROTECT_RestrictDuplication: u32 = 1u32;
 pub const AMDDS_ALL: u32 = 255u32;
@@ -377,9 +362,6 @@ impl Default for AMVABUFFERINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMVABUFFERINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMVABeginFrameInfo {
@@ -393,9 +375,6 @@ impl Default for AMVABeginFrameInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMVABeginFrameInfo {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
@@ -414,10 +393,6 @@ impl Default for AMVACompBufferInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for AMVACompBufferInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMVAEndFrameInfo {
@@ -429,9 +404,6 @@ impl Default for AMVAEndFrameInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMVAEndFrameInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMVAInternalMemInfo {
@@ -441,9 +413,6 @@ impl Default for AMVAInternalMemInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMVAInternalMemInfo {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
@@ -459,10 +428,6 @@ impl Default for AMVAUncompBufferInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for AMVAUncompBufferInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 #[derive(Clone, Copy)]
@@ -476,10 +441,6 @@ impl Default for AMVAUncompDataInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for AMVAUncompDataInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AMVA_QUERYRENDERSTATUSF_READ: u32 = 1u32;
 pub const AMVA_TYPEINDEX_OUTPUTFRAME: u32 = 4294967295u32;
@@ -505,9 +466,6 @@ impl Default for AMVPDATAINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMVPDATAINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMVPDIMINFO {
@@ -522,9 +480,6 @@ impl Default for AMVPDIMINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMVPDIMINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMVPSIZE {
@@ -535,9 +490,6 @@ impl Default for AMVPSIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMVPSIZE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AMVP_BEST_BANDWIDTH: AMVP_SELECT_FORMAT_BY = AMVP_SELECT_FORMAT_BY(1i32);
 pub const AMVP_DO_NOT_CARE: AMVP_SELECT_FORMAT_BY = AMVP_SELECT_FORMAT_BY(0i32);
@@ -564,9 +516,6 @@ impl Default for AM_AC3_ALTERNATE_AUDIO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_AC3_ALTERNATE_AUDIO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AM_AC3_ALTERNATE_AUDIO_1: u32 = 1u32;
 pub const AM_AC3_ALTERNATE_AUDIO_2: u32 = 2u32;
 pub const AM_AC3_ALTERNATE_AUDIO_BOTH: u32 = 3u32;
@@ -580,9 +529,6 @@ impl Default for AM_AC3_BIT_STREAM_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_AC3_BIT_STREAM_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AM_AC3_DIALOGUE_LEVEL {
@@ -592,9 +538,6 @@ impl Default for AM_AC3_DIALOGUE_LEVEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_AC3_DIALOGUE_LEVEL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -607,9 +550,6 @@ impl Default for AM_AC3_DOWNMIX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_AC3_DOWNMIX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AM_AC3_ERROR_CONCEALMENT {
@@ -621,9 +561,6 @@ impl Default for AM_AC3_ERROR_CONCEALMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_AC3_ERROR_CONCEALMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AM_AC3_ROOM_TYPE {
@@ -633,9 +570,6 @@ impl Default for AM_AC3_ROOM_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_AC3_ROOM_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AM_AC3_SERVICE_COMMENTARY: u32 = 5u32;
 pub const AM_AC3_SERVICE_DIALOG_ONLY: u32 = 4u32;
@@ -677,9 +611,6 @@ impl Default for AM_COLCON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_COLCON {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AM_CONTENTPROPERTY_AUTHOR: u32 = 2u32;
 pub const AM_CONTENTPROPERTY_COPYRIGHT: u32 = 4u32;
 pub const AM_CONTENTPROPERTY_DESCRIPTION: u32 = 8u32;
@@ -693,9 +624,6 @@ impl Default for AM_COPY_MACROVISION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_COPY_MACROVISION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -725,9 +653,6 @@ impl Default for AM_DVDCOPY_BUSKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_DVDCOPY_BUSKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AM_DVDCOPY_CHLGKEY {
@@ -739,9 +664,6 @@ impl Default for AM_DVDCOPY_CHLGKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_DVDCOPY_CHLGKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AM_DVDCOPY_DISCKEY {
@@ -752,9 +674,6 @@ impl Default for AM_DVDCOPY_DISCKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_DVDCOPY_DISCKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AM_DVDCOPY_SET_COPY_STATE {
@@ -764,9 +683,6 @@ impl Default for AM_DVDCOPY_SET_COPY_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_DVDCOPY_SET_COPY_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -780,9 +696,6 @@ impl Default for AM_DVDCOPY_TITLEKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_DVDCOPY_TITLEKEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AM_DVD_ADAPT_GRAPH: AM_DVD_GRAPH_FLAGS = AM_DVD_GRAPH_FLAGS(16384i32);
 pub const AM_DVD_CGMS_COPY_ONCE: u32 = 16u32;
@@ -803,9 +716,6 @@ impl Default for AM_DVD_ChangeRate {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_DVD_ChangeRate {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AM_DVD_DO_NOT_CLEAR: AM_DVD_GRAPH_FLAGS = AM_DVD_GRAPH_FLAGS(512i32);
 pub const AM_DVD_EVR_ONLY: AM_DVD_GRAPH_FLAGS = AM_DVD_GRAPH_FLAGS(4096i32);
@@ -835,9 +745,6 @@ impl Default for AM_DVD_RENDERSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_DVD_RENDERSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AM_DVD_SECTOR_NOT_PROTECTED: u32 = 0u32;
 pub const AM_DVD_SECTOR_PROTECTED: u32 = 32u32;
 pub const AM_DVD_SECTOR_PROTECT_MASK: u32 = 32u32;
@@ -863,9 +770,6 @@ impl Default for AM_DVD_YUV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_DVD_YUV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AM_DvdKaraokeData {
@@ -876,9 +780,6 @@ impl Default for AM_DvdKaraokeData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_DvdKaraokeData {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AM_EXSEEK_BUFFERING: AMExtendedSeekingCapabilities = AMExtendedSeekingCapabilities(32i32);
 pub const AM_EXSEEK_CANSCAN: AMExtendedSeekingCapabilities = AMExtendedSeekingCapabilities(2i32);
@@ -897,9 +798,6 @@ impl Default for AM_ExactRateChange {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_ExactRateChange {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -920,9 +818,6 @@ impl Default for AM_FRAMESTEP_STEP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_FRAMESTEP_STEP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AM_GBF_NODDSURFACELOCK: u32 = 8u32;
 pub const AM_GBF_NOTASYNCPOINT: u32 = 2u32;
@@ -1037,10 +932,6 @@ impl Default for AM_MPEGSTREAMTYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_MediaFoundation")]
-impl windows_core::TypeKind for AM_MPEGSTREAMTYPE {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_MediaFoundation")]
 #[derive(Clone, Debug, PartialEq)]
@@ -1054,10 +945,6 @@ impl Default for AM_MPEGSYSTEMTYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_MediaFoundation")]
-impl windows_core::TypeKind for AM_MPEGSYSTEMTYPE {
-    type TypeKind = windows_core::CloneType;
 }
 pub const AM_MPEG_AUDIO_DUAL_LEFT: u32 = 1u32;
 pub const AM_MPEG_AUDIO_DUAL_MERGE: u32 = 0u32;
@@ -1130,9 +1017,6 @@ impl Default for AM_PROPERTY_SPHLI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_PROPERTY_SPHLI {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AM_PROPERTY_SPPAL {
@@ -1142,9 +1026,6 @@ impl Default for AM_PROPERTY_SPPAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_PROPERTY_SPPAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1169,9 +1050,6 @@ impl Default for AM_QueryRate {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_QueryRate {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AM_RATE_ChangeRate: AM_PROPERTY_DVD_RATE_CHANGE = AM_PROPERTY_DVD_RATE_CHANGE(1i32);
 pub const AM_RATE_CorrectTS: AM_PROPERTY_TS_RATE_CHANGE = AM_PROPERTY_TS_RATE_CHANGE(8i32);
@@ -1212,10 +1090,6 @@ impl Default for AM_SAMPLE2_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_MediaFoundation")]
-impl windows_core::TypeKind for AM_SAMPLE2_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AM_SAMPLE_DATADISCONTINUITY: AM_SAMPLE_PROPERTY_FLAGS = AM_SAMPLE_PROPERTY_FLAGS(4i32);
 pub const AM_SAMPLE_ENDOFSTREAM: AM_SAMPLE_PROPERTY_FLAGS = AM_SAMPLE_PROPERTY_FLAGS(512i32);
@@ -1268,9 +1142,6 @@ impl Default for AM_STREAM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_STREAM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AM_STREAM_INFO_DISCARDING: AM_STREAM_INFO_FLAGS = AM_STREAM_INFO_FLAGS(4i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1289,9 +1160,6 @@ impl Default for AM_SimpleRateChange {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AM_SimpleRateChange {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AM_UseNewCSSKey: u32 = 1u32;
 pub const AM_VIDEO_FLAG_B_SAMPLE: i32 = 32i32;
@@ -1326,9 +1194,6 @@ impl Default for AM_WST_PAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_WST_PAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct AM_WST_SERVICE(pub i32);
@@ -1360,9 +1225,6 @@ impl Default for ANALOGVIDEOINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ANALOGVIDEOINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ANNEX_A_DSM_CC: MPEG2StreamType = MPEG2StreamType(8i32);
 pub const ATSCCT_AC3: ATSCComponentTypeFlags = ATSCComponentTypeFlags(1i32);
 #[repr(transparent)]
@@ -1387,9 +1249,6 @@ impl Default for AUDIO_STREAM_CONFIG_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIO_STREAM_CONFIG_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct AVIEXTHEADER {
@@ -1402,9 +1261,6 @@ impl Default for AVIEXTHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVIEXTHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1425,9 +1281,6 @@ impl Default for AVIFIELDINDEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVIFIELDINDEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct AVIFIELDINDEX_0 {
@@ -1439,9 +1292,6 @@ impl Default for AVIFIELDINDEX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVIFIELDINDEX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AVIF_COPYRIGHTED: u32 = 131072u32;
 pub const AVIF_HASINDEX: u32 = 16u32;
@@ -1470,9 +1320,6 @@ impl Default for AVIINDEXENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVIINDEXENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct AVIMAINHEADER {
@@ -1495,9 +1342,6 @@ impl Default for AVIMAINHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVIMAINHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct AVIMETAINDEX {
@@ -1516,9 +1360,6 @@ impl Default for AVIMETAINDEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVIMETAINDEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct AVIOLDINDEX {
@@ -1530,9 +1371,6 @@ impl Default for AVIOLDINDEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVIOLDINDEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1546,9 +1384,6 @@ impl Default for AVIOLDINDEX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVIOLDINDEX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1564,10 +1399,6 @@ impl Default for AVIPALCHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for AVIPALCHANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AVISF_DISABLED: u32 = 1u32;
 pub const AVISF_VIDEO_PALCHANGES: u32 = 65536u32;
@@ -1590,9 +1421,6 @@ impl Default for AVISTDINDEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVISTDINDEX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AVISTDINDEX_DELTAFRAME: u32 = 2147483648u32;
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1604,9 +1432,6 @@ impl Default for AVISTDINDEX_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVISTDINDEX_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1633,9 +1458,6 @@ impl Default for AVISTREAMHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVISTREAMHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AVISTREAMHEADER_0 {
@@ -1648,9 +1470,6 @@ impl Default for AVISTREAMHEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVISTREAMHEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1670,9 +1489,6 @@ impl Default for AVISUPERINDEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVISUPERINDEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct AVISUPERINDEX_0 {
@@ -1684,9 +1500,6 @@ impl Default for AVISUPERINDEX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVISUPERINDEX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1711,9 +1524,6 @@ impl Default for AVIStreamHeader {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVIStreamHeader {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct AVITCDLINDEX {
@@ -1733,9 +1543,6 @@ impl Default for AVITCDLINDEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVITCDLINDEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct AVITCDLINDEX_ENTRY {
@@ -1749,9 +1556,6 @@ impl Default for AVITCDLINDEX_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVITCDLINDEX_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1770,9 +1574,6 @@ impl Default for AVITIMECODEINDEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVITIMECODEINDEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1794,9 +1595,6 @@ impl Default for AVITIMEDINDEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVITIMEDINDEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct AVITIMEDINDEX_ENTRY {
@@ -1808,9 +1606,6 @@ impl Default for AVITIMEDINDEX_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVITIMEDINDEX_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AVI_HEADERSIZE: u32 = 2048u32;
 pub const AVI_INDEX_IS_DATA: u32 = 128u32;
@@ -1871,9 +1666,6 @@ impl Default for BDANODE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDANODE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BDA_BCC_RATE_1_2: BinaryConvolutionCodeRate = BinaryConvolutionCodeRate(1i32);
 pub const BDA_BCC_RATE_1_3: BinaryConvolutionCodeRate = BinaryConvolutionCodeRate(10i32);
 pub const BDA_BCC_RATE_1_4: BinaryConvolutionCodeRate = BinaryConvolutionCodeRate(9i32);
@@ -1903,9 +1695,6 @@ impl Default for BDA_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_CAS_CHECK_ENTITLEMENTTOKEN {
@@ -1917,9 +1706,6 @@ impl Default for BDA_CAS_CHECK_ENTITLEMENTTOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_CAS_CHECK_ENTITLEMENTTOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_CAS_CLOSEMMIDATA {
@@ -1929,9 +1715,6 @@ impl Default for BDA_CAS_CLOSEMMIDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_CAS_CLOSEMMIDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1943,9 +1726,6 @@ impl Default for BDA_CAS_CLOSE_MMIDIALOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_CAS_CLOSE_MMIDIALOG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1961,9 +1741,6 @@ impl Default for BDA_CAS_OPENMMIDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_CAS_OPENMMIDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_CAS_REQUESTTUNERDATA {
@@ -1977,9 +1754,6 @@ impl Default for BDA_CAS_REQUESTTUNERDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_CAS_REQUESTTUNERDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_CA_MODULE_UI {
@@ -1991,9 +1765,6 @@ impl Default for BDA_CA_MODULE_UI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_CA_MODULE_UI {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_CHANGES_COMPLETE: BDA_CHANGE_STATE = BDA_CHANGE_STATE(0i32);
 pub const BDA_CHANGES_PENDING: BDA_CHANGE_STATE = BDA_CHANGE_STATE(1i32);
@@ -2038,9 +1809,6 @@ impl Default for BDA_DISEQC_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_DISEQC_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_DISEQC_SEND {
@@ -2052,9 +1820,6 @@ impl Default for BDA_DISEQC_SEND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_DISEQC_SEND {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2068,9 +1833,6 @@ impl Default for BDA_DRM_DRMSTATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_DRM_DRMSTATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2095,9 +1857,6 @@ impl Default for BDA_DVBT2_L1_SIGNALLING_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_DVBT2_L1_SIGNALLING_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BDA_DrmPairingError(pub i32);
@@ -2121,9 +1880,6 @@ impl Default for BDA_ETHERNET_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_ETHERNET_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_ETHERNET_ADDRESS_LIST {
@@ -2134,9 +1890,6 @@ impl Default for BDA_ETHERNET_ADDRESS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_ETHERNET_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_EVENT_ACCESS_DENIED: BDA_EVENT_ID = BDA_EVENT_ID(15i32);
 pub const BDA_EVENT_ACCESS_GRANTED: BDA_EVENT_ID = BDA_EVENT_ID(14i32);
@@ -2239,9 +1992,6 @@ impl Default for BDA_GDDS_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_GDDS_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_GDDS_DATATYPE {
@@ -2252,9 +2002,6 @@ impl Default for BDA_GDDS_DATATYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_GDDS_DATATYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_GUARD_19_128: GuardInterval = GuardInterval(6i32);
 pub const BDA_GUARD_19_256: GuardInterval = GuardInterval(7i32);
@@ -2282,9 +2029,6 @@ impl Default for BDA_IPv4_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_IPv4_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_IPv4_ADDRESS_LIST {
@@ -2296,9 +2040,6 @@ impl Default for BDA_IPv4_ADDRESS_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_IPv4_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_IPv6_ADDRESS {
@@ -2308,9 +2049,6 @@ impl Default for BDA_IPv6_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_IPv6_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2322,9 +2060,6 @@ impl Default for BDA_IPv6_ADDRESS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_IPv6_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2345,9 +2080,6 @@ impl Default for BDA_ISDBCAS_EMG_REQ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_ISDBCAS_EMG_REQ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct BDA_ISDBCAS_REQUESTHEADER {
@@ -2360,9 +2092,6 @@ impl Default for BDA_ISDBCAS_REQUESTHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_ISDBCAS_REQUESTHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2377,9 +2106,6 @@ impl Default for BDA_ISDBCAS_RESPONSEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_ISDBCAS_RESPONSEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_LNB_SOURCE_A: LNB_Source = LNB_Source(1i32);
 pub const BDA_LNB_SOURCE_B: LNB_Source = LNB_Source(2i32);
@@ -2441,9 +2167,6 @@ impl Default for BDA_MUX_PIDLISTITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_MUX_PIDLISTITEM {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BDA_NO_MULTICAST: BDA_MULTICAST_MODE = BDA_MULTICAST_MODE(2i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2457,9 +2180,6 @@ impl Default for BDA_PID_MAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_PID_MAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_PID_UNMAP {
@@ -2470,9 +2190,6 @@ impl Default for BDA_PID_UNMAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_PID_UNMAP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_PILOT_MAX: Pilot = Pilot(3i32);
 pub const BDA_PILOT_NOT_DEFINED: Pilot = Pilot(0i32);
@@ -2499,9 +2216,6 @@ impl Default for BDA_PROGRAM_PID_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_PROGRAM_PID_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BDA_PROMISCUOUS_MULTICAST: BDA_MULTICAST_MODE = BDA_MULTICAST_MODE(0i32);
 pub const BDA_RANGE_NOT_DEFINED: BDA_Range = BDA_Range(0i32);
 pub const BDA_RANGE_NOT_SET: BDA_Range = BDA_Range(-1i32);
@@ -2515,9 +2229,6 @@ impl Default for BDA_RATING_PINRESET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_RATING_PINRESET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_ROLL_OFF_20: RollOff = RollOff(1i32);
 pub const BDA_ROLL_OFF_25: RollOff = RollOff(2i32);
@@ -2538,9 +2249,6 @@ impl Default for BDA_SCAN_CAPABILTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_SCAN_CAPABILTIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_SCAN_MOD_1024QAM: ScanModulationTypes = ScanModulationTypes(262144i32);
 pub const BDA_SCAN_MOD_112QAM: ScanModulationTypes = ScanModulationTypes(32i32);
@@ -2584,9 +2292,6 @@ impl Default for BDA_SCAN_START {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_SCAN_START {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_SCAN_STATE {
@@ -2599,9 +2304,6 @@ impl Default for BDA_SCAN_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_SCAN_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_SIGNAL_ACTIVE: BDA_SIGNAL_STATE = BDA_SIGNAL_STATE(2i32);
 pub const BDA_SIGNAL_INACTIVE: BDA_SIGNAL_STATE = BDA_SIGNAL_STATE(1i32);
@@ -2619,9 +2321,6 @@ impl Default for BDA_SIGNAL_TIMEOUTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_SIGNAL_TIMEOUTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_SIGNAL_UNAVAILABLE: BDA_SIGNAL_STATE = BDA_SIGNAL_STATE(0i32);
 pub const BDA_SPECTRAL_INVERSION_AUTOMATIC: SpectralInversion = SpectralInversion(1i32);
@@ -2642,9 +2341,6 @@ impl Default for BDA_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_TABLE_SECTION {
@@ -2657,9 +2353,6 @@ impl Default for BDA_TABLE_SECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_TABLE_SECTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2674,9 +2367,6 @@ impl Default for BDA_TEMPLATE_CONNECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_TEMPLATE_CONNECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_TEMPLATE_PIN_JOINT {
@@ -2687,9 +2377,6 @@ impl Default for BDA_TEMPLATE_PIN_JOINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_TEMPLATE_PIN_JOINT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2705,9 +2392,6 @@ impl Default for BDA_TS_SELECTORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_TS_SELECTORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_TS_SELECTORINFO_ISDBS_EXT {
@@ -2717,9 +2401,6 @@ impl Default for BDA_TS_SELECTORINFO_ISDBS_EXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_TS_SELECTORINFO_ISDBS_EXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2734,9 +2415,6 @@ impl Default for BDA_TUNER_DIAGNOSTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_TUNER_DIAGNOSTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_TUNER_TUNERSTATE {
@@ -2748,9 +2426,6 @@ impl Default for BDA_TUNER_TUNERSTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_TUNER_TUNERSTATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_UNDEFINED_CHANNEL: BDA_Channel = BDA_Channel(-1i32);
 pub const BDA_UNITIALIZED_MPEG2STREAMTYPE: MPEG2StreamType = MPEG2StreamType(-1i32);
@@ -2765,9 +2440,6 @@ impl Default for BDA_USERACTIVITY_INTERVAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_USERACTIVITY_INTERVAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_WMDRMTUNER_PIDPROTECTION {
@@ -2778,9 +2450,6 @@ impl Default for BDA_WMDRMTUNER_PIDPROTECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_WMDRMTUNER_PIDPROTECTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2795,9 +2464,6 @@ impl Default for BDA_WMDRMTUNER_PURCHASEENTITLEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BDA_WMDRMTUNER_PURCHASEENTITLEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BDA_WMDRM_KEYINFOLIST {
@@ -2809,9 +2475,6 @@ impl Default for BDA_WMDRM_KEYINFOLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_WMDRM_KEYINFOLIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2825,9 +2488,6 @@ impl Default for BDA_WMDRM_RENEWLICENSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_WMDRM_RENEWLICENSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2847,9 +2507,6 @@ impl Default for BDA_WMDRM_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BDA_WMDRM_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BDA_XMIT_MODE_16K: TransmissionMode = TransmissionMode(7i32);
 pub const BDA_XMIT_MODE_1K: TransmissionMode = TransmissionMode(6i32);
@@ -2902,9 +2559,6 @@ impl Default for COLORKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLORKEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3151,9 +2805,6 @@ impl Default for DVD_ATR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_ATR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DVD_AUDIO_APPMODE(pub i32);
@@ -3202,9 +2853,6 @@ impl Default for DVD_AudioAttributes {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_AudioAttributes {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVD_AudioDuringFFwdRew: DVD_OPTION_FLAG = DVD_OPTION_FLAG(4i32);
 pub const DVD_AudioFormat_AC3: DVD_AUDIO_FORMAT = DVD_AUDIO_FORMAT(0i32);
@@ -3256,9 +2904,6 @@ impl Default for DVD_DECODER_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_DECODER_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVD_DEFAULT_AUDIO_STREAM: u32 = 15u32;
 pub const DVD_DIR_BACKWARD: DVD_PLAY_DIRECTION = DVD_PLAY_DIRECTION(1i32);
@@ -3316,9 +2961,6 @@ impl Default for DVD_HMSF_TIMECODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_HMSF_TIMECODE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DVD_HMSF_TimeCodeEvents: DVD_OPTION_FLAG = DVD_OPTION_FLAG(3i32);
 pub const DVD_IncreaseOutputControl: DVD_OPTION_FLAG = DVD_OPTION_FLAG(10i32);
 #[repr(transparent)]
@@ -3343,9 +2985,6 @@ impl Default for DVD_KaraokeAttributes {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_KaraokeAttributes {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVD_Karaoke_GuideMelody1: DVD_KARAOKE_CONTENTS = DVD_KARAOKE_CONTENTS(4i32);
 pub const DVD_Karaoke_GuideMelody2: DVD_KARAOKE_CONTENTS = DVD_KARAOKE_CONTENTS(8i32);
@@ -3375,9 +3014,6 @@ impl Default for DVD_MUA_Coeff {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_MUA_Coeff {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_MUA_MixingInfo {
@@ -3391,9 +3027,6 @@ impl Default for DVD_MUA_MixingInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_MUA_MixingInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVD_MaxReadBurstInKB: DVD_OPTION_FLAG = DVD_OPTION_FLAG(16i32);
 #[repr(C)]
@@ -3410,9 +3043,6 @@ impl Default for DVD_MenuAttributes {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_MenuAttributes {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVD_Mix_0to0: DVD_KARAOKE_DOWNMIX = DVD_KARAOKE_DOWNMIX(1i32);
 pub const DVD_Mix_0to1: DVD_KARAOKE_DOWNMIX = DVD_KARAOKE_DOWNMIX(256i32);
@@ -3438,9 +3068,6 @@ impl Default for DVD_MultichannelAudioAttributes {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_MultichannelAudioAttributes {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3499,9 +3126,6 @@ impl Default for DVD_PLAYBACK_LOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_PLAYBACK_LOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DVD_PLAYBACK_LOCATION2 {
@@ -3514,9 +3138,6 @@ impl Default for DVD_PLAYBACK_LOCATION2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_PLAYBACK_LOCATION2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3586,9 +3207,6 @@ impl Default for DVD_SubpictureAttributes {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_SubpictureAttributes {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DVD_TC_FLAG_25fps: DVD_TIMECODE_FLAGS = DVD_TIMECODE_FLAGS(1i32);
 pub const DVD_TC_FLAG_30fps: DVD_TIMECODE_FLAGS = DVD_TIMECODE_FLAGS(2i32);
 pub const DVD_TC_FLAG_DropFrame: DVD_TIMECODE_FLAGS = DVD_TIMECODE_FLAGS(4i32);
@@ -3602,9 +3220,6 @@ impl Default for DVD_TIMECODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_TIMECODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3635,9 +3250,6 @@ impl Default for DVD_TitleAttributes {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_TitleAttributes {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DVD_TitleAttributes_0 {
@@ -3648,9 +3260,6 @@ impl Default for DVD_TitleAttributes_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVD_TitleAttributes_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVD_Title_Album: DVD_TextStringType = DVD_TextStringType(59i32);
 pub const DVD_Title_Movie: DVD_TextStringType = DVD_TextStringType(57i32);
@@ -3695,9 +3304,6 @@ impl Default for DVD_VideoAttributes {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVD_VideoAttributes {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DVD_VideoCompression_MPEG1: DVD_VIDEO_COMPRESSION = DVD_VIDEO_COMPRESSION(1i32);
 pub const DVD_VideoCompression_MPEG2: DVD_VIDEO_COMPRESSION = DVD_VIDEO_COMPRESSION(2i32);
 pub const DVD_VideoCompression_Other: DVD_VIDEO_COMPRESSION = DVD_VIDEO_COMPRESSION(0i32);
@@ -3735,9 +3341,6 @@ impl Default for DVINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DVRESOLUTION_DC: _DVRESOLUTION = _DVRESOLUTION(1003i32);
 pub const DVRESOLUTION_FULL: _DVRESOLUTION = _DVRESOLUTION(1000i32);
 pub const DVRESOLUTION_HALF: _DVRESOLUTION = _DVRESOLUTION(1001i32);
@@ -3768,10 +3371,6 @@ impl Default for DXVA2SW_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Media_MediaFoundation"))]
-impl windows_core::TypeKind for DXVA2SW_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Etw")]
 #[derive(Clone, Copy)]
@@ -3789,10 +3388,6 @@ impl Default for DXVA2TraceVideoProcessBltData {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Etw")]
-impl windows_core::TypeKind for DXVA2TraceVideoProcessBltData {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVA2Trace_Control: windows_core::GUID = windows_core::GUID::from_u128(0xa0386e75_f70c_464c_a9ce_33c44e091623);
 pub const DXVA2Trace_DecodeDevBeginFrame: windows_core::GUID = windows_core::GUID::from_u128(0x9fd1acf6_44cb_4637_bc62_2c11a9608f90);
 #[repr(C)]
@@ -3809,10 +3404,6 @@ impl Default for DXVA2Trace_DecodeDevBeginFrameData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Etw")]
-impl windows_core::TypeKind for DXVA2Trace_DecodeDevBeginFrameData {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVA2Trace_DecodeDevCreated: windows_core::GUID = windows_core::GUID::from_u128(0xb4de17a1_c5b2_44fe_86d5_d97a648114ff);
 #[repr(C)]
@@ -3833,10 +3424,6 @@ impl Default for DXVA2Trace_DecodeDevCreatedData {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Etw")]
-impl windows_core::TypeKind for DXVA2Trace_DecodeDevCreatedData {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVA2Trace_DecodeDevDestroyed: windows_core::GUID = windows_core::GUID::from_u128(0x853ebdf2_4160_421d_8893_63dcea4f18bb);
 pub const DXVA2Trace_DecodeDevEndFrame: windows_core::GUID = windows_core::GUID::from_u128(0x9fb3cb33_47dc_4899_98c8_c0c6cd7cd3cb);
 pub const DXVA2Trace_DecodeDevExecute: windows_core::GUID = windows_core::GUID::from_u128(0x850aeb4c_d19a_4609_b3b4_bcbf0e22121e);
@@ -3856,10 +3443,6 @@ impl Default for DXVA2Trace_DecodeDevGetBufferData {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Etw")]
-impl windows_core::TypeKind for DXVA2Trace_DecodeDevGetBufferData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Etw")]
 #[derive(Clone, Copy)]
@@ -3873,10 +3456,6 @@ impl Default for DXVA2Trace_DecodeDeviceData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Etw")]
-impl windows_core::TypeKind for DXVA2Trace_DecodeDeviceData {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVA2Trace_VideoProcessBlt: windows_core::GUID = windows_core::GUID::from_u128(0x69089cc0_71ab_42d0_953a_2887bf05a8af);
 pub const DXVA2Trace_VideoProcessDevCreated: windows_core::GUID = windows_core::GUID::from_u128(0x895508c6_540d_4c87_98f8_8dcbf2dabb2a);
@@ -3899,10 +3478,6 @@ impl Default for DXVA2Trace_VideoProcessDevCreatedData {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Etw")]
-impl windows_core::TypeKind for DXVA2Trace_VideoProcessDevCreatedData {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVA2Trace_VideoProcessDevDestroyed: windows_core::GUID = windows_core::GUID::from_u128(0xf97f30b1_fb49_42c7_8ee8_88bdfa92d4e2);
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Etw")]
@@ -3917,10 +3492,6 @@ impl Default for DXVA2Trace_VideoProcessDeviceData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Etw")]
-impl windows_core::TypeKind for DXVA2Trace_VideoProcessDeviceData {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVA2_DestinationFlagMask: DXVA2_DestinationFlags = DXVA2_DestinationFlags(-65521i32);
 pub const DXVA2_DestinationFlag_Alpha_Changed: DXVA2_DestinationFlags = DXVA2_DestinationFlags(8i32);
@@ -3971,10 +3542,6 @@ impl Default for DXVA2_VIDEOPROCESSBLT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_MediaFoundation")]
-impl windows_core::TypeKind for DXVA2_VIDEOPROCESSBLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media_MediaFoundation")]
 #[derive(Clone, Copy)]
@@ -3994,10 +3561,6 @@ impl Default for DXVA2_VIDEOSAMPLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_MediaFoundation")]
-impl windows_core::TypeKind for DXVA2_VIDEOSAMPLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVA_ALPHA_BLEND_COMBINATION_BUFFER: u32 = 13u32;
 pub const DXVA_ALPHA_BLEND_COMBINATION_FUNCTION: u32 = 3u32;
@@ -4052,9 +3615,6 @@ impl Default for DXVA_COPPSetProtectionLevelCmdData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_COPPSetProtectionLevelCmdData {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVA_COPPSetSignaling: windows_core::GUID = windows_core::GUID::from_u128(0x09a631a5_d684_4c60_8e4d_d3bb0f0be3ee);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4075,9 +3635,6 @@ impl Default for DXVA_COPPSetSignalingCmdData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_COPPSetSignalingCmdData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_COPPStatusData {
@@ -4091,9 +3648,6 @@ impl Default for DXVA_COPPStatusData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_COPPStatusData {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4112,9 +3666,6 @@ impl Default for DXVA_COPPStatusDisplayData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_COPPStatusDisplayData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_COPPStatusHDCPKeyData {
@@ -4129,9 +3680,6 @@ impl Default for DXVA_COPPStatusHDCPKeyData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_COPPStatusHDCPKeyData {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4154,9 +3702,6 @@ impl Default for DXVA_COPPStatusSignalingCmdData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_COPPStatusSignalingCmdData {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVA_DCCMD_SURFACE_BUFFER: u32 = 12u32;
 pub const DXVA_DEBLOCKING_CONTROL_BUFFER: u32 = 4u32;
@@ -4362,9 +3907,6 @@ impl Default for EALocationCodeType {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EALocationCodeType {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EC_ACTIVATE: u32 = 19u32;
 pub const EC_BANDWIDTHCHANGE: u32 = 72u32;
 pub const EC_BUFFERING_DATA: u32 = 17u32;
@@ -4491,9 +4033,6 @@ impl Default for FILTER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTER_INFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FILTER_STATE(pub i32);
@@ -4527,10 +4066,6 @@ impl Default for HEAACWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for HEAACWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -4547,10 +4082,6 @@ impl Default for HEAACWAVEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for HEAACWAVEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HEVC_TEMPORAL_VIDEO_SUBSET: MPEG2StreamType = MPEG2StreamType(37i32);
 pub const HEVC_VIDEO_OR_TEMPORAL_VIDEO: MPEG2StreamType = MPEG2StreamType(36i32);
@@ -31986,9 +31517,6 @@ impl Default for KS_BDA_FRAME_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_BDA_FRAME_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LIBID_QuartzNetTypeLib: windows_core::GUID = windows_core::GUID::from_u128(0x56a868b1_0ad4_11ce_b03a_0020af0ba770);
 pub const LIBID_QuartzTypeLib: windows_core::GUID = windows_core::GUID::from_u128(0x56a868b0_0ad4_11ce_b03a_0020af0ba770);
 #[repr(transparent)]
@@ -32113,10 +31641,6 @@ impl Default for MPEG1WAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for MPEG1WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MPEG2StreamType(pub i32);
@@ -32176,9 +31700,6 @@ impl Default for MPEG2_TRANSPORT_STRIDE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPEG2_TRANSPORT_STRIDE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -32195,10 +31716,6 @@ impl Default for MPEGLAYER3WAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for MPEGLAYER3WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -32240,9 +31757,6 @@ impl Default for MP_ENVELOPE_SEGMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MP_ENVELOPE_SEGMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MP_PARAMINFO {
@@ -32258,9 +31772,6 @@ impl Default for MP_PARAMINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MP_PARAMINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -32292,9 +31803,6 @@ impl Default for MainAVIHeader {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MainAVIHeader {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MixerPref9_ARAdjustXorY: VMR9MixerPrefs = VMR9MixerPrefs(4i32);
 pub const MixerPref9_AnisotropicFiltering: VMR9MixerPrefs = VMR9MixerPrefs(64i32);
@@ -32350,9 +31858,6 @@ impl Default for NORMALIZEDRECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NORMALIZEDRECT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NotAssociated: SmartCardAssociationType = SmartCardAssociationType(0i32);
 pub const NotEntitled: EntitlementType = EntitlementType(1i32);
@@ -32444,9 +31949,6 @@ impl Default for PID_MAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PID_MAP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PID_MPEG2_SECTION_PSI_SI: MUX_PID_TYPE = MUX_PID_TYPE(1i32);
 pub const PID_OTHER: MUX_PID_TYPE = MUX_PID_TYPE(-1i32);
 pub const PINDIR_INPUT: PIN_DIRECTION = PIN_DIRECTION(0i32);
@@ -32467,10 +31969,6 @@ impl Default for PIN_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for PIN_INFO {
-    type TypeKind = windows_core::CloneType;
 }
 pub const PhysConn_Audio_1394: PhysicalConnectorType = PhysicalConnectorType(4103i32);
 pub const PhysConn_Audio_AESDigital: PhysicalConnectorType = PhysicalConnectorType(4099i32);
@@ -32524,9 +32022,6 @@ impl Default for Quality {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Quality {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct QualityMessageType(pub i32);
@@ -32541,9 +32036,6 @@ impl Default for REGFILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REGFILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct REGFILTER2 {
@@ -32556,9 +32048,6 @@ impl Default for REGFILTER2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REGFILTER2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union REGFILTER2_0 {
@@ -32569,9 +32058,6 @@ impl Default for REGFILTER2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REGFILTER2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -32584,9 +32070,6 @@ impl Default for REGFILTER2_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REGFILTER2_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REGFILTER2_0_1 {
@@ -32597,9 +32080,6 @@ impl Default for REGFILTER2_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REGFILTER2_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -32619,9 +32099,6 @@ impl Default for REGFILTERPINS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REGFILTERPINS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REGFILTERPINS2 {
@@ -32638,9 +32115,6 @@ impl Default for REGFILTERPINS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REGFILTERPINS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REGPINMEDIUM {
@@ -32653,9 +32127,6 @@ impl Default for REGPINMEDIUM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REGPINMEDIUM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REGPINTYPES {
@@ -32666,9 +32137,6 @@ impl Default for REGPINTYPES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REGPINTYPES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -32722,9 +32190,6 @@ impl Default for RIFFCHUNK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RIFFCHUNK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct RIFFLIST {
@@ -32736,9 +32201,6 @@ impl Default for RIFFLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RIFFLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ReadData: OUTPUT_STATE = OUTPUT_STATE(1i32);
 pub const RenderData: OUTPUT_STATE = OUTPUT_STATE(2i32);
@@ -32812,9 +32274,6 @@ impl Default for STREAM_ID_MAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STREAM_ID_MAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct STREAM_STATE(pub i32);
@@ -32842,9 +32301,6 @@ impl Default for SmartCardApplication {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SmartCardApplication {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -32874,9 +32330,6 @@ impl Default for TIMECODEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TIMECODEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TIMECODE_RATE_30DROP: u32 = 0u32;
 pub const TIMECODE_SMPTE_BINARY_GROUP: u32 = 7u32;
 pub const TIMECODE_SMPTE_COLOR_FRAME: u32 = 8u32;
@@ -32892,10 +32345,6 @@ impl Default for TRUECOLORINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for TRUECOLORINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -33085,9 +32534,6 @@ impl Default for VFW_FILTERLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VFW_FILTERLIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VFW_FIRST_CODE: u32 = 512u32;
 pub const VFW_S_AUDIO_NOT_RENDERED: windows_core::HRESULT = windows_core::HRESULT(0x40258_u32 as _);
 pub const VFW_S_CANT_CUE: windows_core::HRESULT = windows_core::HRESULT(0x40268_u32 as _);
@@ -33131,10 +32577,6 @@ impl Default for VIDEOINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for VIDEOINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -33148,10 +32590,6 @@ impl Default for VIDEOINFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for VIDEOINFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -33183,9 +32621,6 @@ impl Default for VIDEO_STREAM_CONFIG_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIDEO_STREAM_CONFIG_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VMR9ARMode_LetterBox: VMR9AspectRatioMode = VMR9AspectRatioMode(1i32);
 pub const VMR9ARMode_None: VMR9AspectRatioMode = VMR9AspectRatioMode(0i32);
 pub const VMR9AllocFlag_3DRenderTarget: VMR9SurfaceAllocationFlags = VMR9SurfaceAllocationFlags(1i32);
@@ -33214,10 +32649,6 @@ impl Default for VMR9AllocationInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for VMR9AllocationInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -33236,10 +32667,6 @@ impl Default for VMR9AlphaBitmap {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for VMR9AlphaBitmap {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -33267,9 +32694,6 @@ impl Default for VMR9DeinterlaceCaps {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VMR9DeinterlaceCaps {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VMR9DeinterlacePrefs(pub i32);
@@ -33286,9 +32710,6 @@ impl Default for VMR9Frequency {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VMR9Frequency {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -33322,10 +32743,6 @@ impl Default for VMR9MonitorInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for VMR9MonitorInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VMR9NormalizedRect {
@@ -33338,9 +32755,6 @@ impl Default for VMR9NormalizedRect {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VMR9NormalizedRect {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -33365,10 +32779,6 @@ impl Default for VMR9PresentationInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for VMR9PresentationInfo {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VMR9ProcAmpControl {
@@ -33383,9 +32793,6 @@ impl Default for VMR9ProcAmpControl {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VMR9ProcAmpControl {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -33404,9 +32811,6 @@ impl Default for VMR9ProcAmpControlRange {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VMR9ProcAmpControlRange {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -33435,9 +32839,6 @@ impl Default for VMR9VideoDesc {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VMR9VideoDesc {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Debug, PartialEq)]
@@ -33457,10 +32858,6 @@ impl Default for VMR9VideoStreamInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for VMR9VideoStreamInfo {
-    type TypeKind = windows_core::CloneType;
 }
 pub const VMR9_SampleFieldInterleavedEvenFirst: VMR9_SampleFormat = VMR9_SampleFormat(3i32);
 pub const VMR9_SampleFieldInterleavedOddFirst: VMR9_SampleFormat = VMR9_SampleFormat(4i32);
@@ -33490,10 +32887,6 @@ impl Default for VMRALLOCATIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for VMRALLOCATIONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -33511,10 +32904,6 @@ impl Default for VMRALPHABITMAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for VMRALPHABITMAP {
-    type TypeKind = windows_core::CloneType;
 }
 pub const VMRBITMAP_DISABLE: u32 = 1u32;
 pub const VMRBITMAP_ENTIREDDS: u32 = 4u32;
@@ -33535,9 +32924,6 @@ impl Default for VMRDeinterlaceCaps {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VMRDeinterlaceCaps {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VMRDeinterlacePrefs(pub i32);
@@ -33555,9 +32941,6 @@ impl Default for VMRFrequency {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VMRFrequency {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VMRGUID {
@@ -33568,9 +32951,6 @@ impl Default for VMRGUID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VMRGUID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -33593,10 +32973,6 @@ impl Default for VMRMONITORINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for VMRMONITORINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -33627,10 +33003,6 @@ impl Default for VMRPRESENTATIONINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for VMRPRESENTATIONINFO {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -33664,10 +33036,6 @@ impl Default for VMRVIDEOSTREAMINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_DirectDraw")]
-impl windows_core::TypeKind for VMRVIDEOSTREAMINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VMRVideoDesc {
@@ -33683,9 +33051,6 @@ impl Default for VMRVideoDesc {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VMRVideoDesc {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VMR_ARMODE_LETTER_BOX: VMR_ASPECT_RATIO_MODE = VMR_ASPECT_RATIO_MODE(1i32);
 pub const VMR_ARMODE_NONE: VMR_ASPECT_RATIO_MODE = VMR_ASPECT_RATIO_MODE(0i32);

--- a/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
@@ -106,9 +106,6 @@ impl Default for DMO_MEDIA_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DMO_MEDIA_TYPE {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct DMO_OUTPUT_DATA_BUFFER {
@@ -121,9 +118,6 @@ impl Default for DMO_OUTPUT_DATA_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMO_OUTPUT_DATA_BUFFER {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DMO_OUTPUT_DATA_BUFFERF_DISCONTINUITY: _DMO_OUTPUT_DATA_BUFFER_FLAGS = _DMO_OUTPUT_DATA_BUFFER_FLAGS(8i32);
 pub const DMO_OUTPUT_DATA_BUFFERF_INCOMPLETE: _DMO_OUTPUT_DATA_BUFFER_FLAGS = _DMO_OUTPUT_DATA_BUFFER_FLAGS(16777216i32);
@@ -145,9 +139,6 @@ impl Default for DMO_PARTIAL_MEDIATYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DMO_PARTIAL_MEDIATYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMO_PROCESS_OUTPUT_DISCARD_WHEN_NO_BUFFER: _DMO_PROCESS_OUTPUT_FLAGS = _DMO_PROCESS_OUTPUT_FLAGS(1i32);
 pub const DMO_QUALITY_STATUS_ENABLED: _DMO_QUALITY_STATUS_FLAGS = _DMO_QUALITY_STATUS_FLAGS(1i32);

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
@@ -112,9 +112,6 @@ impl Default for ALLOCATOR_PROPERTIES_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ALLOCATOR_PROPERTIES_EX {
-    type TypeKind = windows_core::CloneType;
-}
 pub const APO_CLASS_UUID: windows_core::GUID = windows_core::GUID::from_u128(0x5989fce8_9cd0_467d_8a6a_5419e31529d4);
 pub const AUDIOENDPOINT_CLASS_UUID: windows_core::GUID = windows_core::GUID::from_u128(0xc166523c_fe0c_4a94_a586_f1a80cfbbf3e);
 pub const AUDIOMODULE_MAX_DATA_SIZE: u32 = 64000u32;
@@ -136,9 +133,6 @@ impl Default for AUDIORESOURCEMANAGEMENT_RESOURCEGROUP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIORESOURCEMANAGEMENT_RESOURCEGROUP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -195,9 +189,6 @@ impl Default for CC_BYTE_PAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CC_BYTE_PAIR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CC_HW_FIELD {
@@ -210,9 +201,6 @@ impl Default for CC_HW_FIELD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CC_HW_FIELD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CC_MAX_HW_DECODE_LINES: u32 = 12u32;
 pub const CLSID_KsIBasicAudioInterfaceHandler: windows_core::GUID = windows_core::GUID::from_u128(0xb9f8ac3e_0f71_11d2_b72c_00c04fb6bd3d);
@@ -254,9 +242,6 @@ impl Default for DEVCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEVPKEY_KsAudio_Controller_DeviceInterface_Path: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x13e004d6_b066_43bd_913b_a415cd13da87), pid: 3 };
 pub const DEVPKEY_KsAudio_PacketSize_Constraints: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x13e004d6_b066_43bd_913b_a415cd13da87), pid: 2 };
 pub const DEVPKEY_KsAudio_PacketSize_Constraints2: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x9404f781_7191_409b_8b0b_80bf6ec229ae), pid: 2 };
@@ -273,9 +258,6 @@ impl Default for DS3DVECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS3DVECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DS3DVECTOR_0 {
@@ -286,9 +268,6 @@ impl Default for DS3DVECTOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS3DVECTOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -301,9 +280,6 @@ impl Default for DS3DVECTOR_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS3DVECTOR_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DS3DVECTOR_2 {
@@ -314,9 +290,6 @@ impl Default for DS3DVECTOR_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS3DVECTOR_2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS3D_HRTF_VERSION_1: KSDS3D_HRTF_FILTER_VERSION = KSDS3D_HRTF_FILTER_VERSION(0i32);
 #[repr(transparent)]
@@ -2001,9 +1974,6 @@ impl Default for INTERLEAVED_AUDIO_FORMAT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERLEAVED_AUDIO_FORMAT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IOCTL_KS_DISABLE_EVENT: u32 = 3080203u32;
 pub const IOCTL_KS_ENABLE_EVENT: u32 = 3080199u32;
 pub const IOCTL_KS_HANDSHAKE: u32 = 3080223u32;
@@ -2025,9 +1995,6 @@ impl Default for KSAC3_ALTERNATE_AUDIO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAC3_ALTERNATE_AUDIO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSAC3_ALTERNATE_AUDIO_1: u32 = 1u32;
 pub const KSAC3_ALTERNATE_AUDIO_2: u32 = 2u32;
 pub const KSAC3_ALTERNATE_AUDIO_BOTH: u32 = 3u32;
@@ -2041,9 +2008,6 @@ impl Default for KSAC3_BIT_STREAM_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAC3_BIT_STREAM_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAC3_DIALOGUE_LEVEL {
@@ -2053,9 +2017,6 @@ impl Default for KSAC3_DIALOGUE_LEVEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAC3_DIALOGUE_LEVEL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2068,9 +2029,6 @@ impl Default for KSAC3_DOWNMIX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAC3_DOWNMIX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAC3_ERROR_CONCEALMENT {
@@ -2082,9 +2040,6 @@ impl Default for KSAC3_ERROR_CONCEALMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAC3_ERROR_CONCEALMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAC3_ROOM_TYPE {
@@ -2094,9 +2049,6 @@ impl Default for KSAC3_ROOM_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAC3_ROOM_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSAC3_SERVICE_COMMENTARY: u32 = 5u32;
 pub const KSAC3_SERVICE_DIALOG_ONLY: u32 = 4u32;
@@ -2140,9 +2092,6 @@ impl Default for KSALLOCATOR_FRAMING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSALLOCATOR_FRAMING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSALLOCATOR_FRAMING_0 {
@@ -2154,9 +2103,6 @@ impl Default for KSALLOCATOR_FRAMING_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSALLOCATOR_FRAMING_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSALLOCATOR_FRAMING_1 {
@@ -2167,9 +2113,6 @@ impl Default for KSALLOCATOR_FRAMING_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSALLOCATOR_FRAMING_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2184,9 +2127,6 @@ impl Default for KSALLOCATOR_FRAMING_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSALLOCATOR_FRAMING_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSALLOCATOR_OPTIONF_COMPATIBLE: u32 = 1u32;
 pub const KSALLOCATOR_OPTIONF_SYSTEM_MEMORY: u32 = 2u32;
@@ -2209,9 +2149,6 @@ impl Default for KSATTRIBUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSATTRIBUTEID_AUDIOSIGNALPROCESSING_MODE: windows_core::GUID = windows_core::GUID::from_u128(0xe1f89eb5_5f46_419b_967b_ff6770b98401);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2223,9 +2160,6 @@ impl Default for KSATTRIBUTE_AUDIOSIGNALPROCESSING_MODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSATTRIBUTE_AUDIOSIGNALPROCESSING_MODE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSATTRIBUTE_REQUIRED: u32 = 1u32;
 pub const KSAUDDECOUTMODE_PCM_51: u32 = 2u32;
@@ -2293,9 +2227,6 @@ impl Default for KSAUDIOENGINE_BUFFER_SIZE_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIOENGINE_BUFFER_SIZE_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAUDIOENGINE_DESCRIPTOR {
@@ -2307,9 +2238,6 @@ impl Default for KSAUDIOENGINE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIOENGINE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2323,9 +2251,6 @@ impl Default for KSAUDIOENGINE_DEVICECONTROLS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIOENGINE_DEVICECONTROLS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAUDIOENGINE_VOLUMELEVEL {
@@ -2337,9 +2262,6 @@ impl Default for KSAUDIOENGINE_VOLUMELEVEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIOENGINE_VOLUMELEVEL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2355,9 +2277,6 @@ impl Default for KSAUDIOMODULE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIOMODULE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSAUDIOMODULE_NOTIFICATION {
@@ -2367,9 +2286,6 @@ impl Default for KSAUDIOMODULE_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIOMODULE_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2381,9 +2297,6 @@ impl Default for KSAUDIOMODULE_NOTIFICATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIOMODULE_NOTIFICATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2398,9 +2311,6 @@ impl Default for KSAUDIOMODULE_NOTIFICATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIOMODULE_NOTIFICATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSAUDIOMODULE_PROPERTY {
@@ -2413,9 +2323,6 @@ impl Default for KSAUDIOMODULE_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIOMODULE_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAUDIO_CHANNEL_CONFIG {
@@ -2425,9 +2332,6 @@ impl Default for KSAUDIO_CHANNEL_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIO_CHANNEL_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2439,9 +2343,6 @@ impl Default for KSAUDIO_COPY_PROTECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIO_COPY_PROTECTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSAUDIO_CPU_RESOURCES_HOST_CPU: u32 = 2147483647u32;
 pub const KSAUDIO_CPU_RESOURCES_NOT_HOST_CPU: u32 = 0u32;
@@ -2455,9 +2356,6 @@ impl Default for KSAUDIO_DYNAMIC_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIO_DYNAMIC_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2473,9 +2371,6 @@ impl Default for KSAUDIO_MICROPHONE_COORDINATES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIO_MICROPHONE_COORDINATES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2496,9 +2391,6 @@ impl Default for KSAUDIO_MIC_ARRAY_GEOMETRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIO_MIC_ARRAY_GEOMETRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSAUDIO_MIXCAP_TABLE {
@@ -2511,9 +2403,6 @@ impl Default for KSAUDIO_MIXCAP_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIO_MIXCAP_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAUDIO_MIXLEVEL {
@@ -2524,9 +2413,6 @@ impl Default for KSAUDIO_MIXLEVEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIO_MIXLEVEL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2541,9 +2427,6 @@ impl Default for KSAUDIO_MIX_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIO_MIX_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSAUDIO_MIX_CAPS_0 {
@@ -2554,9 +2437,6 @@ impl Default for KSAUDIO_MIX_CAPS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIO_MIX_CAPS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2572,9 +2452,6 @@ impl Default for KSAUDIO_PACKETSIZE_CONSTRAINTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIO_PACKETSIZE_CONSTRAINTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAUDIO_PACKETSIZE_CONSTRAINTS2 {
@@ -2589,9 +2466,6 @@ impl Default for KSAUDIO_PACKETSIZE_CONSTRAINTS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIO_PACKETSIZE_CONSTRAINTS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAUDIO_PACKETSIZE_PROCESSINGMODE_CONSTRAINT {
@@ -2604,9 +2478,6 @@ impl Default for KSAUDIO_PACKETSIZE_PROCESSINGMODE_CONSTRAINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIO_PACKETSIZE_PROCESSINGMODE_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAUDIO_POSITION {
@@ -2617,9 +2488,6 @@ impl Default for KSAUDIO_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIO_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2634,9 +2502,6 @@ impl Default for KSAUDIO_POSITIONEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSAUDIO_POSITIONEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSAUDIO_PRESENTATION_POSITION {
@@ -2647,9 +2512,6 @@ impl Default for KSAUDIO_PRESENTATION_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSAUDIO_PRESENTATION_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSAUDIO_QUALITY_ADVANCED: u32 = 3u32;
 pub const KSAUDIO_QUALITY_BASIC: u32 = 2u32;
@@ -2707,9 +2569,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS_0 {
@@ -2720,9 +2579,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_CONFIGCAPS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_MASK: u64 = 2u64;
 pub const KSCAMERA_EXTENDEDPROP_BACKGROUNDSEGMENTATION_OFF: u64 = 0u64;
@@ -2739,9 +2595,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_CAMERAOFFSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_CAMERAOFFSET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_EXTENDEDPROP_CAPS_ASYNCCONTROL: u64 = 9223372036854775808u64;
 pub const KSCAMERA_EXTENDEDPROP_CAPS_CANCELLABLE: u64 = 4611686018427387904u64;
@@ -2767,9 +2620,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPSHEADER {
@@ -2780,9 +2630,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPSHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_CONFIGCAPSHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_MANUAL: u64 = 0u64;
 #[repr(C)]
@@ -2798,9 +2645,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_SETTING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_DIGITALWINDOW_SETTING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_EXTENDEDPROP_EVCOMPENSATION {
@@ -2814,9 +2658,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_EVCOMPENSATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_EVCOMPENSATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_EXTENDEDPROP_EVCOMP_FULLSTEP: u64 = 16u64;
 pub const KSCAMERA_EXTENDEDPROP_EVCOMP_HALFSTEP: u64 = 8u64;
@@ -2848,9 +2689,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_FIELDOFVIEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_FIELDOFVIEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_EXTENDEDPROP_FILTERSCOPE: u32 = 4294967295u32;
 pub const KSCAMERA_EXTENDEDPROP_FLAG_CANCELOPERATION: u64 = 9223372036854775808u64;
@@ -2904,9 +2742,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSCAMERA_EXTENDEDPROP_HISTOGRAM_OFF: u64 = 0u64;
 pub const KSCAMERA_EXTENDEDPROP_HISTOGRAM_ON: u64 = 1u64;
 pub const KSCAMERA_EXTENDEDPROP_IRTORCHMODE_ALTERNATING_FRAME_ILLUMINATION: u64 = 4u64;
@@ -2935,9 +2770,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_METADATAINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_METADATAINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_EXTENDEDPROP_METADATA_ALIGNMENTREQUIRED: u64 = 256u64;
 pub const KSCAMERA_EXTENDEDPROP_METADATA_MEMORYTYPE_MASK: u64 = 255u64;
@@ -2979,9 +2811,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_PHOTOMODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_PHOTOMODE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSCAMERA_EXTENDEDPROP_PHOTOMODE_NORMAL: u64 = 0u64;
 pub const KSCAMERA_EXTENDEDPROP_PHOTOMODE_SEQUENCE: u64 = 1u64;
 pub const KSCAMERA_EXTENDEDPROP_PHOTOMODE_SEQUENCE_SUB_NONE: u32 = 0u32;
@@ -3003,9 +2832,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSCAMERA_EXTENDEDPROP_RELATIVEPANELOPTIMIZATION_DYNAMIC: u64 = 2u64;
 pub const KSCAMERA_EXTENDEDPROP_RELATIVEPANELOPTIMIZATION_OFF: u64 = 0u64;
 pub const KSCAMERA_EXTENDEDPROP_RELATIVEPANELOPTIMIZATION_ON: u64 = 1u64;
@@ -3026,9 +2852,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPSHEADER {
@@ -3041,9 +2864,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPSHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_ROI_CONFIGCAPSHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_EXTENDEDPROP_ROI_EXPOSURE {
@@ -3055,9 +2875,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_ROI_EXPOSURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_ROI_EXPOSURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_EXTENDEDPROP_ROI_FOCUS {
@@ -3068,9 +2885,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_ROI_FOCUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_ROI_FOCUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3085,9 +2899,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_ROI_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_ROI_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROL {
@@ -3101,9 +2912,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROLHEADER {
@@ -3116,9 +2924,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROLHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_ROI_ISPCONTROLHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_EXTENDEDPROP_ROI_WHITEBALANCE {
@@ -3129,9 +2934,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_ROI_WHITEBALANCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_ROI_WHITEBALANCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_EXTENDEDPROP_SCENEMODE_AUTO: u64 = 0u64;
 pub const KSCAMERA_EXTENDEDPROP_SCENEMODE_BACKLIT: u64 = 1024u64;
@@ -3158,9 +2960,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSCAMERA_EXTENDEDPROP_VALUE_0 {
@@ -3175,9 +2974,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_VALUE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_VALUE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_EXTENDEDPROP_VFR_OFF: u64 = 0u64;
 pub const KSCAMERA_EXTENDEDPROP_VFR_ON: u64 = 1u64;
@@ -3201,9 +2997,6 @@ impl Default for KSCAMERA_EXTENDEDPROP_VIDEOPROCSETTING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_EXTENDEDPROP_VIDEOPROCSETTING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_EXTENDEDPROP_VIDEOSTABILIZATION_AUTO: u64 = 2u64;
 pub const KSCAMERA_EXTENDEDPROP_VIDEOSTABILIZATION_OFF: u64 = 0u64;
@@ -3248,9 +3041,6 @@ impl Default for KSCAMERA_MAXVIDEOFPS_FORPHOTORES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_MAXVIDEOFPS_FORPHOTORES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_METADATA_BACKGROUNDSEGMENTATIONMASK {
@@ -3264,9 +3054,6 @@ impl Default for KSCAMERA_METADATA_BACKGROUNDSEGMENTATIONMASK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_METADATA_BACKGROUNDSEGMENTATIONMASK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3292,9 +3079,6 @@ impl Default for KSCAMERA_METADATA_CAPTURESTATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_METADATA_CAPTURESTATS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSCAMERA_METADATA_CAPTURESTATS_FLAG_EXPOSURECOMPENSATION: u32 = 2u32;
 pub const KSCAMERA_METADATA_CAPTURESTATS_FLAG_EXPOSURETIME: u32 = 1u32;
 pub const KSCAMERA_METADATA_CAPTURESTATS_FLAG_FLASH: u32 = 64u32;
@@ -3317,9 +3101,6 @@ impl Default for KSCAMERA_METADATA_DIGITALWINDOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_METADATA_DIGITALWINDOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_METADATA_FRAMEILLUMINATION {
@@ -3331,9 +3112,6 @@ impl Default for KSCAMERA_METADATA_FRAMEILLUMINATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_METADATA_FRAMEILLUMINATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_METADATA_FRAMEILLUMINATION_FLAG_ON: u32 = 1u32;
 #[repr(C)]
@@ -3347,9 +3125,6 @@ impl Default for KSCAMERA_METADATA_ITEMHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_METADATA_ITEMHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_METADATA_PHOTOCONFIRMATION {
@@ -3361,9 +3136,6 @@ impl Default for KSCAMERA_METADATA_PHOTOCONFIRMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_METADATA_PHOTOCONFIRMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3381,9 +3153,6 @@ impl Default for KSCAMERA_PERFRAMESETTING_CAP_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_PERFRAMESETTING_CAP_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_PERFRAMESETTING_CAP_ITEM_HEADER {
@@ -3395,9 +3164,6 @@ impl Default for KSCAMERA_PERFRAMESETTING_CAP_ITEM_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_PERFRAMESETTING_CAP_ITEM_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3411,9 +3177,6 @@ impl Default for KSCAMERA_PERFRAMESETTING_CUSTOM_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_PERFRAMESETTING_CUSTOM_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_PERFRAMESETTING_FRAME_HEADER {
@@ -3426,9 +3189,6 @@ impl Default for KSCAMERA_PERFRAMESETTING_FRAME_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_PERFRAMESETTING_FRAME_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3444,9 +3204,6 @@ impl Default for KSCAMERA_PERFRAMESETTING_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_PERFRAMESETTING_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_PERFRAMESETTING_ITEM_CUSTOM: KSCAMERA_PERFRAMESETTING_ITEM_TYPE = KSCAMERA_PERFRAMESETTING_ITEM_TYPE(7i32);
 pub const KSCAMERA_PERFRAMESETTING_ITEM_EXPOSURE_COMPENSATION: KSCAMERA_PERFRAMESETTING_ITEM_TYPE = KSCAMERA_PERFRAMESETTING_ITEM_TYPE(3i32);
@@ -3464,9 +3221,6 @@ impl Default for KSCAMERA_PERFRAMESETTING_ITEM_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_PERFRAMESETTING_ITEM_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCAMERA_PERFRAMESETTING_ITEM_ISO: KSCAMERA_PERFRAMESETTING_ITEM_TYPE = KSCAMERA_PERFRAMESETTING_ITEM_TYPE(4i32);
 pub const KSCAMERA_PERFRAMESETTING_ITEM_PHOTOCONFIRMATION: KSCAMERA_PERFRAMESETTING_ITEM_TYPE = KSCAMERA_PERFRAMESETTING_ITEM_TYPE(6i32);
@@ -3487,9 +3241,6 @@ impl Default for KSCAMERA_PROFILE_CONCURRENCYINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_PROFILE_CONCURRENCYINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_PROFILE_INFO {
@@ -3502,9 +3253,6 @@ impl Default for KSCAMERA_PROFILE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_PROFILE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3522,9 +3270,6 @@ impl Default for KSCAMERA_PROFILE_MEDIAINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_PROFILE_MEDIAINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_PROFILE_MEDIAINFO_1 {
@@ -3536,9 +3281,6 @@ impl Default for KSCAMERA_PROFILE_MEDIAINFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_PROFILE_MEDIAINFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_PROFILE_MEDIAINFO_0 {
@@ -3549,9 +3291,6 @@ impl Default for KSCAMERA_PROFILE_MEDIAINFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_PROFILE_MEDIAINFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3566,9 +3305,6 @@ impl Default for KSCAMERA_PROFILE_PININFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_PROFILE_PININFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSCAMERA_PROFILE_PININFO_0 {
@@ -3580,9 +3316,6 @@ impl Default for KSCAMERA_PROFILE_PININFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCAMERA_PROFILE_PININFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCAMERA_PROFILE_PININFO_0_0 {
@@ -3593,9 +3326,6 @@ impl Default for KSCAMERA_PROFILE_PININFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCAMERA_PROFILE_PININFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCATEGORY_ACOUSTIC_ECHO_CANCEL: windows_core::GUID = windows_core::GUID::from_u128(0xbf963d80_c559_11d0_8a2b_00a0c9255ac1);
 pub const KSCATEGORY_AUDIO: windows_core::GUID = windows_core::GUID::from_u128(0x6994ad04_93ef_11d0_a3cc_00a0c9223196);
@@ -3644,9 +3374,6 @@ impl Default for KSCLOCK_CREATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCLOCK_CREATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSCOMPONENTID {
@@ -3662,9 +3389,6 @@ impl Default for KSCOMPONENTID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSCOMPONENTID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSCOMPONENTID_USBAUDIO: windows_core::GUID = windows_core::GUID::from_u128(0x8f1275f0_26e9_4264_ba4d_39fff01d94aa);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3676,9 +3400,6 @@ impl Default for KSCORRELATED_TIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSCORRELATED_TIME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSCREATE_ITEM_FREEONSTOP: u32 = 8u32;
 pub const KSCREATE_ITEM_NOPARAMETERS: u32 = 4u32;
@@ -3701,9 +3422,6 @@ impl Default for KSDATAFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSDATAFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSDATAFORMAT_0 {
@@ -3719,9 +3437,6 @@ impl Default for KSDATAFORMAT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSDATAFORMAT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSDATAFORMAT_BIT_ATTRIBUTES: u32 = 1u32;
 pub const KSDATAFORMAT_BIT_TEMPORAL_COMPRESSION: u32 = 0u32;
@@ -3853,9 +3568,6 @@ impl Default for KSDATARANGE_AUDIO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSDATARANGE_AUDIO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSDATARANGE_BIT_ATTRIBUTES: u32 = 1u32;
 pub const KSDATARANGE_BIT_REQUIRED_ATTRIBUTES: u32 = 2u32;
 #[repr(C)]
@@ -3871,9 +3583,6 @@ impl Default for KSDATARANGE_MUSIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSDATARANGE_MUSIC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSDEGRADESETID_Standard: windows_core::GUID = windows_core::GUID::from_u128(0x9f564180_704c_11d0_a5d6_28db04c10000);
 #[repr(transparent)]
@@ -3900,9 +3609,6 @@ impl Default for KSDEVICE_PROFILE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSDEVICE_PROFILE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSDEVICE_PROFILE_INFO_0 {
@@ -3912,9 +3618,6 @@ impl Default for KSDEVICE_PROFILE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSDEVICE_PROFILE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3928,9 +3631,6 @@ impl Default for KSDEVICE_PROFILE_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSDEVICE_PROFILE_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSDEVICE_PROFILE_TYPE_CAMERA: u32 = 1u32;
 pub const KSDEVICE_PROFILE_TYPE_UNKNOWN: u32 = 0u32;
@@ -3953,9 +3653,6 @@ impl Default for KSDISPLAYCHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSDISPLAYCHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSDS3D_BUFFER_ALL {
@@ -3974,9 +3671,6 @@ impl Default for KSDS3D_BUFFER_ALL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSDS3D_BUFFER_ALL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSDS3D_BUFFER_CONE_ANGLES {
@@ -3987,9 +3681,6 @@ impl Default for KSDS3D_BUFFER_CONE_ANGLES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSDS3D_BUFFER_CONE_ANGLES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSDS3D_COEFF_COUNT: KSDS3D_HRTF_COEFF_FORMAT = KSDS3D_HRTF_COEFF_FORMAT(2i32);
 pub const KSDS3D_FILTER_METHOD_COUNT: KSDS3D_HRTF_FILTER_METHOD = KSDS3D_HRTF_FILTER_METHOD(2i32);
@@ -4009,9 +3700,6 @@ impl Default for KSDS3D_HRTF_FILTER_FORMAT_MSG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSDS3D_HRTF_FILTER_FORMAT_MSG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4039,9 +3727,6 @@ impl Default for KSDS3D_HRTF_INIT_MSG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSDS3D_HRTF_INIT_MSG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSDS3D_HRTF_PARAMS_MSG {
@@ -4056,9 +3741,6 @@ impl Default for KSDS3D_HRTF_PARAMS_MSG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSDS3D_HRTF_PARAMS_MSG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4075,9 +3757,6 @@ impl Default for KSDS3D_ITD_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSDS3D_ITD_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSDS3D_ITD_PARAMS_MSG {
@@ -4090,9 +3769,6 @@ impl Default for KSDS3D_ITD_PARAMS_MSG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSDS3D_ITD_PARAMS_MSG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4110,9 +3786,6 @@ impl Default for KSDS3D_LISTENER_ALL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSDS3D_LISTENER_ALL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSDS3D_LISTENER_ORIENTATION {
@@ -4123,9 +3796,6 @@ impl Default for KSDS3D_LISTENER_ORIENTATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSDS3D_LISTENER_ORIENTATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSDSOUND_3D_MODE_DISABLE: u32 = 2u32;
 pub const KSDSOUND_3D_MODE_HEADRELATIVE: u32 = 1u32;
@@ -4151,9 +3821,6 @@ impl Default for KSERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSEVENTDATA {
@@ -4164,9 +3831,6 @@ impl Default for KSEVENTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSEVENTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4180,9 +3844,6 @@ impl Default for KSEVENTDATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSEVENTDATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSEVENTDATA_0_2 {
@@ -4193,9 +3854,6 @@ impl Default for KSEVENTDATA_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSEVENTDATA_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4208,9 +3866,6 @@ impl Default for KSEVENTDATA_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSEVENTDATA_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSEVENTDATA_0_1 {
@@ -4222,9 +3877,6 @@ impl Default for KSEVENTDATA_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSEVENTDATA_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSEVENTF_DPC: u32 = 16u32;
 pub const KSEVENTF_EVENT_HANDLE: u32 = 1u32;
@@ -4341,9 +3993,6 @@ impl Default for KSEVENT_TIME_INTERVAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSEVENT_TIME_INTERVAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSEVENT_TIME_MARK {
@@ -4354,9 +4003,6 @@ impl Default for KSEVENT_TIME_MARK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSEVENT_TIME_MARK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4374,9 +4020,6 @@ impl Default for KSEVENT_TUNER_INITIATE_SCAN_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSEVENT_TUNER_INITIATE_SCAN_S {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4423,9 +4066,6 @@ impl Default for KSE_NODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSE_NODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSE_PIN {
@@ -4437,9 +4077,6 @@ impl Default for KSE_PIN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSE_PIN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSFILTER_FLAG_CRITICAL_PROCESSING: u32 = 2u32;
 pub const KSFILTER_FLAG_DENY_USERMODE_ACCESS: u32 = 2147483648u32;
@@ -4459,9 +4096,6 @@ impl Default for KSFRAMETIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSFRAMETIME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSFRAMETIME_VARIABLESIZE: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4476,9 +4110,6 @@ impl Default for KSGOP_USERDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSGOP_USERDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSIDENTIFIER {
@@ -4488,9 +4119,6 @@ impl Default for KSIDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSIDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4503,9 +4131,6 @@ impl Default for KSIDENTIFIER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSIDENTIFIER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSIDENTIFIER_0_0 {
@@ -4517,9 +4142,6 @@ impl Default for KSIDENTIFIER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSIDENTIFIER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSINTERFACESETID_FileIo: windows_core::GUID = windows_core::GUID::from_u128(0x8c6f932c_e771_11d0_b8ff_00a0c9223196);
 pub const KSINTERFACESETID_Media: windows_core::GUID = windows_core::GUID::from_u128(0x3a13eb40_30a7_11d0_a5d6_28db04c10000);
@@ -4551,9 +4173,6 @@ impl Default for KSINTERVAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSINTERVAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KSIOOPERATION(pub i32);
@@ -4573,9 +4192,6 @@ impl Default for KSJACK_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSJACK_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSJACK_DESCRIPTION2 {
@@ -4587,9 +4203,6 @@ impl Default for KSJACK_DESCRIPTION2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSJACK_DESCRIPTION2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSJACK_DESCRIPTION3 {
@@ -4599,9 +4212,6 @@ impl Default for KSJACK_DESCRIPTION3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSJACK_DESCRIPTION3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4625,9 +4235,6 @@ impl Default for KSJACK_SINK_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSJACK_SINK_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSMEDIUMSETID_MidiBus: windows_core::GUID = windows_core::GUID::from_u128(0x05908040_3246_11d0_a5d6_28db04c10000);
 pub const KSMEDIUMSETID_Standard: windows_core::GUID = windows_core::GUID::from_u128(0x4747b320_62ce_11cf_a5d6_28db04c10000);
@@ -4711,9 +4318,6 @@ impl Default for KSMPEGVID_RECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSMPEGVID_RECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSMULTIPLE_DATA_PROP {
@@ -4724,9 +4328,6 @@ impl Default for KSMULTIPLE_DATA_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSMULTIPLE_DATA_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4739,9 +4340,6 @@ impl Default for KSMULTIPLE_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSMULTIPLE_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSMUSICFORMAT {
@@ -4752,9 +4350,6 @@ impl Default for KSMUSICFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSMUSICFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSMUSIC_TECHNOLOGY_FMSYNTH: windows_core::GUID = windows_core::GUID::from_u128(0x252c5c80_62e9_11cf_a5d6_28db04c10000);
 pub const KSMUSIC_TECHNOLOGY_PORT: windows_core::GUID = windows_core::GUID::from_u128(0x86c92e60_62e8_11cf_a5d6_28db04c10000);
@@ -4772,9 +4367,6 @@ impl Default for KSM_NODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSM_NODE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSNAME_Allocator: windows_core::GUID = windows_core::GUID::from_u128(0x642f5d00_4791_11d0_a5d6_28db04c10000);
 pub const KSNAME_Clock: windows_core::GUID = windows_core::GUID::from_u128(0x53172480_4791_11d0_a5d6_28db04c10000);
@@ -4803,9 +4395,6 @@ impl Default for KSNODEPROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSNODEPROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -4820,10 +4409,6 @@ impl Default for KSNODEPROPERTY_AUDIO_3D_LISTENER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for KSNODEPROPERTY_AUDIO_3D_LISTENER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -4836,10 +4421,6 @@ impl Default for KSNODEPROPERTY_AUDIO_3D_LISTENER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for KSNODEPROPERTY_AUDIO_3D_LISTENER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4852,9 +4433,6 @@ impl Default for KSNODEPROPERTY_AUDIO_CHANNEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSNODEPROPERTY_AUDIO_CHANNEL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4869,9 +4447,6 @@ impl Default for KSNODEPROPERTY_AUDIO_DEV_SPECIFIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSNODEPROPERTY_AUDIO_DEV_SPECIFIC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -4887,10 +4462,6 @@ impl Default for KSNODEPROPERTY_AUDIO_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for KSNODEPROPERTY_AUDIO_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -4904,10 +4475,6 @@ impl Default for KSNODEPROPERTY_AUDIO_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for KSNODEPROPERTY_AUDIO_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSNODETYPE_1394_DA_STREAM: windows_core::GUID = windows_core::GUID::from_u128(0xdff21fe6_f70f_11d0_b917_00a0c9223196);
 pub const KSNODETYPE_1394_DV_STREAM_SOUNDTRACK: windows_core::GUID = windows_core::GUID::from_u128(0xdff21fe7_f70f_11d0_b917_00a0c9223196);
@@ -5019,9 +4586,6 @@ impl Default for KSNODE_CREATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSNODE_CREATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSNOTIFICATIONID_AudioModule: windows_core::GUID = windows_core::GUID::from_u128(0x9c2220f0_d9a6_4d5c_a036_573857fd50d2);
 pub const KSNOTIFICATIONID_SoundDetector: windows_core::GUID = windows_core::GUID::from_u128(0x6389d844_bb32_4c4c_a802_f4b4b77afead);
 #[repr(transparent)]
@@ -5037,9 +4601,6 @@ impl Default for KSPIN_CINSTANCES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPIN_CINSTANCES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5062,9 +4623,6 @@ impl Default for KSPIN_CONNECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPIN_CONNECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5105,9 +4663,6 @@ impl Default for KSPIN_MDL_CACHING_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPIN_MDL_CACHING_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSPIN_MDL_CACHING_NOTIFICATION32 {
@@ -5118,9 +4673,6 @@ impl Default for KSPIN_MDL_CACHING_NOTIFICATION32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPIN_MDL_CACHING_NOTIFICATION32 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPIN_MDL_CACHING_NOTIFY_ADDSAMPLE: KSPIN_MDL_CACHING_EVENT = KSPIN_MDL_CACHING_EVENT(3i32);
 pub const KSPIN_MDL_CACHING_NOTIFY_CLEANALL_NOWAIT: KSPIN_MDL_CACHING_EVENT = KSPIN_MDL_CACHING_EVENT(2i32);
@@ -5138,9 +4690,6 @@ impl Default for KSPIN_PHYSICALCONNECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPIN_PHYSICALCONNECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KSPPROPERTY_ALLOCATOR_MDLCACHING(pub i32);
@@ -5154,9 +4703,6 @@ impl Default for KSPRIORITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPRIORITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPRIORITY_EXCLUSIVE: u32 = 4294967295u32;
 pub const KSPRIORITY_HIGH: u32 = 2147483648u32;
@@ -5197,9 +4743,6 @@ impl Default for KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_CAPS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_CAPS_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_INTERLEAVE: KSPROPERTY_ALLOCATOR_CONTROL = KSPROPERTY_ALLOCATOR_CONTROL(3i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5210,9 +4753,6 @@ impl Default for KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_INTERLEAVE_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_ALLOCATOR_CONTROL_CAPTURE_INTERLEAVE_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_ALLOCATOR_CONTROL_HONOR_COUNT: KSPROPERTY_ALLOCATOR_CONTROL = KSPROPERTY_ALLOCATOR_CONTROL(0i32);
 pub const KSPROPERTY_ALLOCATOR_CONTROL_SURFACE_SIZE: KSPROPERTY_ALLOCATOR_CONTROL = KSPROPERTY_ALLOCATOR_CONTROL(1i32);
@@ -5226,9 +4766,6 @@ impl Default for KSPROPERTY_ALLOCATOR_CONTROL_SURFACE_SIZE_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_ALLOCATOR_CONTROL_SURFACE_SIZE_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_ATN_READER: KSPROPERTY_TIMECODE = KSPROPERTY_TIMECODE(1i32);
 #[repr(transparent)]
@@ -5381,9 +4918,6 @@ impl Default for KSPROPERTY_BOUNDS_LONG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_BOUNDS_LONG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSPROPERTY_BOUNDS_LONG_0 {
@@ -5394,9 +4928,6 @@ impl Default for KSPROPERTY_BOUNDS_LONG_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_BOUNDS_LONG_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5409,9 +4940,6 @@ impl Default for KSPROPERTY_BOUNDS_LONG_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_BOUNDS_LONG_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSPROPERTY_BOUNDS_LONGLONG {
@@ -5422,9 +4950,6 @@ impl Default for KSPROPERTY_BOUNDS_LONGLONG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_BOUNDS_LONGLONG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5437,9 +4962,6 @@ impl Default for KSPROPERTY_BOUNDS_LONGLONG_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_BOUNDS_LONGLONG_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSPROPERTY_BOUNDS_LONGLONG_1 {
@@ -5450,9 +4972,6 @@ impl Default for KSPROPERTY_BOUNDS_LONGLONG_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_BOUNDS_LONGLONG_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5534,9 +5053,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_FLASH_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_FLASH_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_CAMERACONTROL_FOCAL_LENGTH: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(18i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5550,9 +5066,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_FOCAL_LENGTH_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_FOCAL_LENGTH_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_CAMERACONTROL_FOCUS: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(6i32);
 pub const KSPROPERTY_CAMERACONTROL_FOCUS_RELATIVE: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(16i32);
@@ -5572,9 +5085,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_IMAGE_PIN_CAPABILITY_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_IMAGE_PIN_CAPABILITY_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_CAMERACONTROL_IMAGE_PIN_CAPABILITY_SEQUENCE_EXCLUSIVE_WITH_RECORD: i32 = 2i32;
 pub const KSPROPERTY_CAMERACONTROL_IRIS: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(5i32);
 pub const KSPROPERTY_CAMERACONTROL_IRIS_RELATIVE: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(15i32);
@@ -5591,9 +5101,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_NODE_FOCAL_LENGTH_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_NODE_FOCAL_LENGTH_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_CAMERACONTROL_NODE_S {
@@ -5606,9 +5113,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_NODE_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_NODE_S {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5623,9 +5127,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_NODE_S2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_NODE_S2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_CAMERACONTROL_PAN: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(0i32);
 pub const KSPROPERTY_CAMERACONTROL_PANTILT: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(9i32);
@@ -5663,9 +5164,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S_0 {
@@ -5676,9 +5174,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_REGION_OF_INTEREST_S_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_CAMERACONTROL_ROLL: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(2i32);
 pub const KSPROPERTY_CAMERACONTROL_ROLL_RELATIVE: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(12i32);
@@ -5695,9 +5190,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_CAMERACONTROL_S2 {
@@ -5711,9 +5203,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_S2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_S2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_CAMERACONTROL_SCANMODE: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(7i32);
 #[repr(C)]
@@ -5729,9 +5218,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_S_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_S_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_CAMERACONTROL_TILT: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(1i32);
 pub const KSPROPERTY_CAMERACONTROL_TILT_RELATIVE: KSPROPERTY_VIDCAP_CAMERACONTROL = KSPROPERTY_VIDCAP_CAMERACONTROL(11i32);
@@ -5752,9 +5238,6 @@ impl Default for KSPROPERTY_CAMERACONTROL_VIDEOSTABILIZATION_MODE_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_CAMERACONTROL_VIDEOSTABILIZATION_MODE_S {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5803,9 +5286,6 @@ impl Default for KSPROPERTY_CROSSBAR_ACTIVE_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_CROSSBAR_ACTIVE_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_CROSSBAR_CAN_ROUTE: KSPROPERTY_VIDCAP_CROSSBAR = KSPROPERTY_VIDCAP_CROSSBAR(2i32);
 pub const KSPROPERTY_CROSSBAR_CAPS: KSPROPERTY_VIDCAP_CROSSBAR = KSPROPERTY_VIDCAP_CROSSBAR(0i32);
 #[repr(C)]
@@ -5819,9 +5299,6 @@ impl Default for KSPROPERTY_CROSSBAR_CAPS_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_CROSSBAR_CAPS_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_CROSSBAR_INPUT_ACTIVE: KSPROPERTY_VIDCAP_CROSSBAR = KSPROPERTY_VIDCAP_CROSSBAR(4i32);
 pub const KSPROPERTY_CROSSBAR_PININFO: KSPROPERTY_VIDCAP_CROSSBAR = KSPROPERTY_VIDCAP_CROSSBAR(1i32);
@@ -5840,9 +5317,6 @@ impl Default for KSPROPERTY_CROSSBAR_PININFO_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_CROSSBAR_PININFO_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_CROSSBAR_ROUTE: KSPROPERTY_VIDCAP_CROSSBAR = KSPROPERTY_VIDCAP_CROSSBAR(3i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5856,9 +5330,6 @@ impl Default for KSPROPERTY_CROSSBAR_ROUTE_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_CROSSBAR_ROUTE_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_CURRENT_CAPTURE_SURFACE: KSPROPERTY_VIDMEM_TRANSPORT = KSPROPERTY_VIDMEM_TRANSPORT(3i32);
 #[repr(transparent)]
@@ -5878,9 +5349,6 @@ impl Default for KSPROPERTY_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5925,9 +5393,6 @@ impl Default for KSPROPERTY_DROPPEDFRAMES_CURRENT_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_DROPPEDFRAMES_CURRENT_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_DVDCOPY_CHLG_KEY: KSPROPERTY_COPYPROT = KSPROPERTY_COPYPROT(1i32);
 pub const KSPROPERTY_DVDCOPY_DEC_KEY2: KSPROPERTY_COPYPROT = KSPROPERTY_COPYPROT(3i32);
 pub const KSPROPERTY_DVDCOPY_DISC_KEY: KSPROPERTY_COPYPROT = KSPROPERTY_COPYPROT(128i32);
@@ -5959,9 +5424,6 @@ impl Default for KSPROPERTY_EXTDEVICE_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_EXTDEVICE_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSPROPERTY_EXTDEVICE_S_0 {
@@ -5975,9 +5437,6 @@ impl Default for KSPROPERTY_EXTDEVICE_S_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_EXTDEVICE_S_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_EXTDEVICE_VERSION: KSPROPERTY_EXTDEVICE = KSPROPERTY_EXTDEVICE(1i32);
 #[repr(transparent)]
@@ -6005,9 +5464,6 @@ impl Default for KSPROPERTY_EXTXPORT_NODE_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_NODE_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSPROPERTY_EXTXPORT_NODE_S_0 {
@@ -6026,9 +5482,6 @@ impl Default for KSPROPERTY_EXTXPORT_NODE_S_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_NODE_S_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSPROPERTY_EXTXPORT_NODE_S_0_1 {
@@ -6039,9 +5492,6 @@ impl Default for KSPROPERTY_EXTXPORT_NODE_S_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_NODE_S_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6056,9 +5506,6 @@ impl Default for KSPROPERTY_EXTXPORT_NODE_S_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_NODE_S_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_EXTXPORT_OUTPUT_SIGNAL_MODE: KSPROPERTY_EXTXPORT = KSPROPERTY_EXTXPORT(2i32);
 pub const KSPROPERTY_EXTXPORT_RTC_SEARCH: KSPROPERTY_EXTXPORT = KSPROPERTY_EXTXPORT(9i32);
 #[repr(C)]
@@ -6071,9 +5518,6 @@ impl Default for KSPROPERTY_EXTXPORT_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_S {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6093,9 +5537,6 @@ impl Default for KSPROPERTY_EXTXPORT_S_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_S_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSPROPERTY_EXTXPORT_S_0_1 {
@@ -6106,9 +5547,6 @@ impl Default for KSPROPERTY_EXTXPORT_S_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_S_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6122,9 +5560,6 @@ impl Default for KSPROPERTY_EXTXPORT_S_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_EXTXPORT_S_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_EXTXPORT_STATE: KSPROPERTY_EXTXPORT = KSPROPERTY_EXTXPORT(5i32);
 pub const KSPROPERTY_EXTXPORT_STATE_NOTIFY: KSPROPERTY_EXTXPORT = KSPROPERTY_EXTXPORT(6i32);
@@ -6177,9 +5612,6 @@ impl Default for KSPROPERTY_MEDIAAVAILABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_MEDIAAVAILABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KSPROPERTY_MEDIASEEKING(pub i32);
@@ -6205,9 +5637,6 @@ impl Default for KSPROPERTY_MEMBERSHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_MEMBERSHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_MEMBER_FLAG_BASICSUPPORT_MULTICHANNEL: u32 = 2u32;
 pub const KSPROPERTY_MEMBER_FLAG_BASICSUPPORT_UNIFORM: u32 = 4u32;
@@ -6240,9 +5669,6 @@ impl Default for KSPROPERTY_NETWORKCAMERACONTROL_EVENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_NETWORKCAMERACONTROL_EVENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_NETWORKCAMERACONTROL_METADATA: KSPROPERTY_NETWORKCAMERACONTROL_PROPERTY = KSPROPERTY_NETWORKCAMERACONTROL_PROPERTY(2i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6259,9 +5685,6 @@ impl Default for KSPROPERTY_NETWORKCAMERACONTROL_METADATA_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_NETWORKCAMERACONTROL_METADATA_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KSPROPERTY_NETWORKCAMERACONTROL_METADATA_TYPE(pub i32);
@@ -6277,9 +5700,6 @@ impl Default for KSPROPERTY_NETWORKCAMERACONTROL_NTPINFO_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_NETWORKCAMERACONTROL_NTPINFO_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6338,9 +5758,6 @@ impl Default for KSPROPERTY_POSITIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_POSITIONS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_PREFERRED_CAPTURE_SURFACE: KSPROPERTY_VIDMEM_TRANSPORT = KSPROPERTY_VIDMEM_TRANSPORT(2i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6379,9 +5796,6 @@ impl Default for KSPROPERTY_SELECTOR_NODE_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_SELECTOR_NODE_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_SELECTOR_NUM_SOURCES: KSPROPERTY_VIDCAP_SELECTOR = KSPROPERTY_VIDCAP_SELECTOR(1i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6396,9 +5810,6 @@ impl Default for KSPROPERTY_SELECTOR_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_SELECTOR_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_SELECTOR_SOURCE_NODE_ID: KSPROPERTY_VIDCAP_SELECTOR = KSPROPERTY_VIDCAP_SELECTOR(0i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6412,9 +5823,6 @@ impl Default for KSPROPERTY_SERIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_SERIAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_SERIALHDR {
@@ -6425,9 +5833,6 @@ impl Default for KSPROPERTY_SERIALHDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_SERIALHDR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6456,9 +5861,6 @@ impl Default for KSPROPERTY_SPHLI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_SPHLI {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSPROPERTY_SPPAL {
@@ -6468,9 +5870,6 @@ impl Default for KSPROPERTY_SPPAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_SPPAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6484,9 +5883,6 @@ impl Default for KSPROPERTY_STEPPING_LONG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_STEPPING_LONG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_STEPPING_LONGLONG {
@@ -6497,9 +5893,6 @@ impl Default for KSPROPERTY_STEPPING_LONGLONG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_STEPPING_LONGLONG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6547,9 +5940,6 @@ impl Default for KSPROPERTY_TIMECODE_NODE_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_TIMECODE_NODE_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_TIMECODE_READER: KSPROPERTY_TIMECODE = KSPROPERTY_TIMECODE(0i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6561,9 +5951,6 @@ impl Default for KSPROPERTY_TIMECODE_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_TIMECODE_S {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6595,9 +5982,6 @@ impl Default for KSPROPERTY_TUNER_CAPS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_TUNER_CAPS_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_TUNER_FREQUENCY: KSPROPERTY_TUNER = KSPROPERTY_TUNER(4i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6616,9 +6000,6 @@ impl Default for KSPROPERTY_TUNER_FREQUENCY_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_TUNER_FREQUENCY_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_TUNER_IF_MEDIUM: KSPROPERTY_TUNER = KSPROPERTY_TUNER(7i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6631,9 +6012,6 @@ impl Default for KSPROPERTY_TUNER_IF_MEDIUM_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_TUNER_IF_MEDIUM_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_TUNER_INPUT: KSPROPERTY_TUNER = KSPROPERTY_TUNER(5i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6645,9 +6023,6 @@ impl Default for KSPROPERTY_TUNER_INPUT_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_TUNER_INPUT_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_TUNER_MODE: KSPROPERTY_TUNER = KSPROPERTY_TUNER(2i32);
 #[repr(transparent)]
@@ -6674,9 +6049,6 @@ impl Default for KSPROPERTY_TUNER_MODE_CAPS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_TUNER_MODE_CAPS_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_TUNER_MODE_DSS: KSPROPERTY_TUNER_MODES = KSPROPERTY_TUNER_MODES(8i32);
 pub const KSPROPERTY_TUNER_MODE_FM_RADIO: KSPROPERTY_TUNER_MODES = KSPROPERTY_TUNER_MODES(2i32);
 #[repr(C)]
@@ -6689,9 +6061,6 @@ impl Default for KSPROPERTY_TUNER_MODE_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_TUNER_MODE_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_TUNER_MODE_TV: KSPROPERTY_TUNER_MODES = KSPROPERTY_TUNER_MODES(1i32);
 pub const KSPROPERTY_TUNER_NETWORKTYPE_SCAN_CAPS: KSPROPERTY_TUNER = KSPROPERTY_TUNER(11i32);
@@ -6708,9 +6077,6 @@ impl Default for KSPROPERTY_TUNER_NETWORKTYPE_SCAN_CAPS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_TUNER_NETWORKTYPE_SCAN_CAPS_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_TUNER_SCAN_CAPS: KSPROPERTY_TUNER = KSPROPERTY_TUNER(8i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6726,9 +6092,6 @@ impl Default for KSPROPERTY_TUNER_SCAN_CAPS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_TUNER_SCAN_CAPS_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_TUNER_SCAN_STATUS: KSPROPERTY_TUNER = KSPROPERTY_TUNER(9i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6741,9 +6104,6 @@ impl Default for KSPROPERTY_TUNER_SCAN_STATUS_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_TUNER_SCAN_STATUS_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_TUNER_STANDARD: KSPROPERTY_TUNER = KSPROPERTY_TUNER(3i32);
 pub const KSPROPERTY_TUNER_STANDARD_MODE: KSPROPERTY_TUNER = KSPROPERTY_TUNER(10i32);
@@ -6758,9 +6118,6 @@ impl Default for KSPROPERTY_TUNER_STANDARD_MODE_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_TUNER_STANDARD_MODE_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_TUNER_STANDARD_S {
@@ -6771,9 +6128,6 @@ impl Default for KSPROPERTY_TUNER_STANDARD_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_TUNER_STANDARD_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_TUNER_STATUS: KSPROPERTY_TUNER = KSPROPERTY_TUNER(6i32);
 #[repr(C)]
@@ -6790,9 +6144,6 @@ impl Default for KSPROPERTY_TUNER_STATUS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_TUNER_STATUS_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_TVAUDIO_CAPS: KSPROPERTY_VIDCAP_TVAUDIO = KSPROPERTY_VIDCAP_TVAUDIO(0i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6807,9 +6158,6 @@ impl Default for KSPROPERTY_TVAUDIO_CAPS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_TVAUDIO_CAPS_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_TVAUDIO_CURRENTLY_AVAILABLE_MODES: KSPROPERTY_VIDCAP_TVAUDIO = KSPROPERTY_VIDCAP_TVAUDIO(2i32);
 pub const KSPROPERTY_TVAUDIO_MODE: KSPROPERTY_VIDCAP_TVAUDIO = KSPROPERTY_VIDCAP_TVAUDIO(1i32);
 #[repr(C)]
@@ -6822,9 +6170,6 @@ impl Default for KSPROPERTY_TVAUDIO_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_TVAUDIO_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_TYPE_BASICSUPPORT: u32 = 512u32;
 pub const KSPROPERTY_TYPE_COPYPAYLOAD: u32 = 2147483648u32;
@@ -6860,9 +6205,6 @@ impl Default for KSPROPERTY_VBICODECFILTERING_CC_SUBSTREAMS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VBICODECFILTERING_CC_SUBSTREAMS_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_VBICODECFILTERING_NABTS_SUBSTREAMS_S {
@@ -6873,9 +6215,6 @@ impl Default for KSPROPERTY_VBICODECFILTERING_NABTS_SUBSTREAMS_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VBICODECFILTERING_NABTS_SUBSTREAMS_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_VBICODECFILTERING_SCANLINES_DISCOVERED_BIT_ARRAY: KSPROPERTY_VBICODECFILTERING = KSPROPERTY_VBICODECFILTERING(2i32);
 pub const KSPROPERTY_VBICODECFILTERING_SCANLINES_REQUESTED_BIT_ARRAY: KSPROPERTY_VBICODECFILTERING = KSPROPERTY_VBICODECFILTERING(1i32);
@@ -6890,9 +6229,6 @@ impl Default for KSPROPERTY_VBICODECFILTERING_SCANLINES_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VBICODECFILTERING_SCANLINES_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_VBICODECFILTERING_STATISTICS: KSPROPERTY_VBICODECFILTERING = KSPROPERTY_VBICODECFILTERING(5i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6905,9 +6241,6 @@ impl Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_PIN_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_PIN_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_S {
@@ -6918,9 +6251,6 @@ impl Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VBICODECFILTERING_STATISTICS_CC_S {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6933,9 +6263,6 @@ impl Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_PIN_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_PIN_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_S {
@@ -6946,9 +6273,6 @@ impl Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VBICODECFILTERING_STATISTICS_COMMON_S {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6961,9 +6285,6 @@ impl Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_PIN_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_PIN_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_S {
@@ -6974,9 +6295,6 @@ impl Default for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VBICODECFILTERING_STATISTICS_NABTS_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_VBICODECFILTERING_SUBSTREAMS_DISCOVERED_BIT_ARRAY: KSPROPERTY_VBICODECFILTERING = KSPROPERTY_VBICODECFILTERING(4i32);
 pub const KSPROPERTY_VBICODECFILTERING_SUBSTREAMS_REQUESTED_BIT_ARRAY: KSPROPERTY_VBICODECFILTERING = KSPROPERTY_VBICODECFILTERING(3i32);
@@ -7027,9 +6345,6 @@ impl Default for KSPROPERTY_VIDEOCOMPRESSION_GETINFO_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VIDEOCOMPRESSION_GETINFO_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_VIDEOCOMPRESSION_KEYFRAME_RATE: KSPROPERTY_VIDCAP_VIDEOCOMPRESSION = KSPROPERTY_VIDCAP_VIDEOCOMPRESSION(1i32);
 pub const KSPROPERTY_VIDEOCOMPRESSION_OVERRIDE_FRAME_SIZE: KSPROPERTY_VIDCAP_VIDEOCOMPRESSION = KSPROPERTY_VIDCAP_VIDEOCOMPRESSION(5i32);
 pub const KSPROPERTY_VIDEOCOMPRESSION_OVERRIDE_KEYFRAME: KSPROPERTY_VIDCAP_VIDEOCOMPRESSION = KSPROPERTY_VIDCAP_VIDEOCOMPRESSION(4i32);
@@ -7047,9 +6362,6 @@ impl Default for KSPROPERTY_VIDEOCOMPRESSION_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VIDEOCOMPRESSION_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_VIDEOCOMPRESSION_S1 {
@@ -7062,9 +6374,6 @@ impl Default for KSPROPERTY_VIDEOCOMPRESSION_S1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VIDEOCOMPRESSION_S1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_VIDEOCOMPRESSION_WINDOWSIZE: KSPROPERTY_VIDCAP_VIDEOCOMPRESSION = KSPROPERTY_VIDCAP_VIDEOCOMPRESSION(6i32);
 pub const KSPROPERTY_VIDEOCONTROL_ACTUAL_FRAME_RATE: KSPROPERTY_VIDCAP_VIDEOCONTROL = KSPROPERTY_VIDCAP_VIDEOCONTROL(1i32);
@@ -7083,9 +6392,6 @@ impl Default for KSPROPERTY_VIDEOCONTROL_ACTUAL_FRAME_RATE_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VIDEOCONTROL_ACTUAL_FRAME_RATE_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_VIDEOCONTROL_CAPS: KSPROPERTY_VIDCAP_VIDEOCONTROL = KSPROPERTY_VIDCAP_VIDEOCONTROL(0i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7098,9 +6404,6 @@ impl Default for KSPROPERTY_VIDEOCONTROL_CAPS_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VIDEOCONTROL_CAPS_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_VIDEOCONTROL_FRAME_RATES: KSPROPERTY_VIDCAP_VIDEOCONTROL = KSPROPERTY_VIDCAP_VIDEOCONTROL(2i32);
 #[repr(C)]
@@ -7116,9 +6419,6 @@ impl Default for KSPROPERTY_VIDEOCONTROL_FRAME_RATES_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VIDEOCONTROL_FRAME_RATES_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_VIDEOCONTROL_MODE: KSPROPERTY_VIDCAP_VIDEOCONTROL = KSPROPERTY_VIDCAP_VIDEOCONTROL(3i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7131,9 +6431,6 @@ impl Default for KSPROPERTY_VIDEOCONTROL_MODE_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VIDEOCONTROL_MODE_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_VIDEODECODER_CAPS: KSPROPERTY_VIDCAP_VIDEODECODER = KSPROPERTY_VIDCAP_VIDEODECODER(0i32);
 #[repr(C)]
@@ -7150,9 +6447,6 @@ impl Default for KSPROPERTY_VIDEODECODER_CAPS_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VIDEODECODER_CAPS_S {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSPROPERTY_VIDEODECODER_OUTPUT_ENABLE: KSPROPERTY_VIDCAP_VIDEODECODER = KSPROPERTY_VIDCAP_VIDEODECODER(3i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7164,9 +6458,6 @@ impl Default for KSPROPERTY_VIDEODECODER_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VIDEODECODER_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_VIDEODECODER_STANDARD: KSPROPERTY_VIDCAP_VIDEODECODER = KSPROPERTY_VIDCAP_VIDEODECODER(1i32);
 pub const KSPROPERTY_VIDEODECODER_STATUS: KSPROPERTY_VIDCAP_VIDEODECODER = KSPROPERTY_VIDCAP_VIDEODECODER(2i32);
@@ -7184,9 +6475,6 @@ impl Default for KSPROPERTY_VIDEODECODER_STATUS2_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VIDEODECODER_STATUS2_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_VIDEODECODER_STATUS_S {
@@ -7198,9 +6486,6 @@ impl Default for KSPROPERTY_VIDEODECODER_STATUS_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VIDEODECODER_STATUS_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_VIDEODECODER_VCR_TIMING: KSPROPERTY_VIDCAP_VIDEODECODER = KSPROPERTY_VIDCAP_VIDEODECODER(4i32);
 pub const KSPROPERTY_VIDEOENCODER_CAPS: KSPROPERTY_VIDCAP_VIDEOENCODER = KSPROPERTY_VIDCAP_VIDEOENCODER(0i32);
@@ -7218,9 +6503,6 @@ impl Default for KSPROPERTY_VIDEOENCODER_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VIDEOENCODER_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_VIDEOENCODER_STANDARD: KSPROPERTY_VIDCAP_VIDEOENCODER = KSPROPERTY_VIDCAP_VIDEOENCODER(1i32);
 pub const KSPROPERTY_VIDEOPROCAMP_BACKLIGHT_COMPENSATION: KSPROPERTY_VIDCAP_VIDEOPROCAMP = KSPROPERTY_VIDCAP_VIDEOPROCAMP(8i32);
@@ -7247,9 +6529,6 @@ impl Default for KSPROPERTY_VIDEOPROCAMP_NODE_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VIDEOPROCAMP_NODE_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_VIDEOPROCAMP_NODE_S2 {
@@ -7263,9 +6542,6 @@ impl Default for KSPROPERTY_VIDEOPROCAMP_NODE_S2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VIDEOPROCAMP_NODE_S2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_VIDEOPROCAMP_POWERLINE_FREQUENCY: KSPROPERTY_VIDCAP_VIDEOPROCAMP = KSPROPERTY_VIDCAP_VIDEOPROCAMP(13i32);
 #[repr(C)]
@@ -7281,9 +6557,6 @@ impl Default for KSPROPERTY_VIDEOPROCAMP_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSPROPERTY_VIDEOPROCAMP_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSPROPERTY_VIDEOPROCAMP_S2 {
@@ -7297,9 +6570,6 @@ impl Default for KSPROPERTY_VIDEOPROCAMP_S2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSPROPERTY_VIDEOPROCAMP_S2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSPROPERTY_VIDEOPROCAMP_SATURATION: KSPROPERTY_VIDCAP_VIDEOPROCAMP = KSPROPERTY_VIDCAP_VIDEOPROCAMP(3i32);
 pub const KSPROPERTY_VIDEOPROCAMP_SHARPNESS: KSPROPERTY_VIDCAP_VIDEOPROCAMP = KSPROPERTY_VIDCAP_VIDEOPROCAMP(4i32);
@@ -7402,9 +6672,6 @@ impl Default for KSP_NODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSP_NODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSP_PIN {
@@ -7417,9 +6684,6 @@ impl Default for KSP_PIN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSP_PIN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSP_PIN_0 {
@@ -7430,9 +6694,6 @@ impl Default for KSP_PIN_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSP_PIN_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7447,9 +6708,6 @@ impl Default for KSP_TIMEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSP_TIMEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSQUALITY {
@@ -7462,9 +6720,6 @@ impl Default for KSQUALITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSQUALITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSQUALITY_MANAGER {
@@ -7475,9 +6730,6 @@ impl Default for KSQUALITY_MANAGER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSQUALITY_MANAGER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7490,9 +6742,6 @@ impl Default for KSQUERYBUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSQUERYBUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7508,9 +6757,6 @@ impl Default for KSRATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSRATE_CAPABILITY {
@@ -7521,9 +6767,6 @@ impl Default for KSRATE_CAPABILITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSRATE_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSRATE_NOPRESENTATIONDURATION: u32 = 2u32;
 pub const KSRATE_NOPRESENTATIONSTART: u32 = 1u32;
@@ -7542,9 +6785,6 @@ impl Default for KSRELATIVEEVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRELATIVEEVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSRELATIVEEVENT_0 {
@@ -7555,9 +6795,6 @@ impl Default for KSRELATIVEEVENT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSRELATIVEEVENT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSRELATIVEEVENT_FLAG_HANDLE: u32 = 1u32;
 pub const KSRELATIVEEVENT_FLAG_POINTER: u32 = 2u32;
@@ -7577,9 +6814,6 @@ impl Default for KSRESOLUTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRESOLUTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSRTAUDIO_BUFFER {
@@ -7591,9 +6825,6 @@ impl Default for KSRTAUDIO_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSRTAUDIO_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7607,9 +6838,6 @@ impl Default for KSRTAUDIO_BUFFER32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRTAUDIO_BUFFER32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSRTAUDIO_BUFFER_PROPERTY {
@@ -7622,9 +6850,6 @@ impl Default for KSRTAUDIO_BUFFER_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRTAUDIO_BUFFER_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSRTAUDIO_BUFFER_PROPERTY32 {
@@ -7636,9 +6861,6 @@ impl Default for KSRTAUDIO_BUFFER_PROPERTY32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSRTAUDIO_BUFFER_PROPERTY32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7653,9 +6875,6 @@ impl Default for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION32 {
@@ -7668,9 +6887,6 @@ impl Default for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSRTAUDIO_BUFFER_PROPERTY_WITH_NOTIFICATION32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7685,9 +6901,6 @@ impl Default for KSRTAUDIO_GETREADPACKET_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRTAUDIO_GETREADPACKET_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSRTAUDIO_HWLATENCY {
@@ -7699,9 +6912,6 @@ impl Default for KSRTAUDIO_HWLATENCY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSRTAUDIO_HWLATENCY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7717,9 +6927,6 @@ impl Default for KSRTAUDIO_HWREGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRTAUDIO_HWREGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSRTAUDIO_HWREGISTER32 {
@@ -7734,9 +6941,6 @@ impl Default for KSRTAUDIO_HWREGISTER32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRTAUDIO_HWREGISTER32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSRTAUDIO_HWREGISTER_PROPERTY {
@@ -7747,9 +6951,6 @@ impl Default for KSRTAUDIO_HWREGISTER_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSRTAUDIO_HWREGISTER_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7762,9 +6963,6 @@ impl Default for KSRTAUDIO_HWREGISTER_PROPERTY32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRTAUDIO_HWREGISTER_PROPERTY32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY {
@@ -7776,9 +6974,6 @@ impl Default for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY32 {
@@ -7789,9 +6984,6 @@ impl Default for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSRTAUDIO_NOTIFICATION_EVENT_PROPERTY32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7805,9 +6997,6 @@ impl Default for KSRTAUDIO_PACKETVREGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRTAUDIO_PACKETVREGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSRTAUDIO_PACKETVREGISTER_PROPERTY {
@@ -7818,9 +7007,6 @@ impl Default for KSRTAUDIO_PACKETVREGISTER_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSRTAUDIO_PACKETVREGISTER_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7834,9 +7020,6 @@ impl Default for KSRTAUDIO_SETWRITEPACKET_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSRTAUDIO_SETWRITEPACKET_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSSOUNDDETECTORPROPERTY {
@@ -7847,9 +7030,6 @@ impl Default for KSSOUNDDETECTORPROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSSOUNDDETECTORPROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7870,9 +7050,6 @@ impl Default for KSSTREAMALLOCATOR_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSSTREAMALLOCATOR_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSSTREAMALLOCATOR_STATUS_EX {
@@ -7884,9 +7061,6 @@ impl Default for KSSTREAMALLOCATOR_STATUS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSSTREAMALLOCATOR_STATUS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSSTREAM_FAILUREEXCEPTION: u32 = 8192u32;
 #[repr(C)]
@@ -7908,10 +7082,6 @@ impl Default for KSSTREAM_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for KSSTREAM_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7931,10 +7101,6 @@ impl Default for KSSTREAM_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for KSSTREAM_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSSTREAM_HEADER_OPTIONSF_BUFFEREDTRANSFER: u32 = 1024u32;
 pub const KSSTREAM_HEADER_OPTIONSF_DATADISCONTINUITY: u32 = 4u32;
@@ -7970,9 +7136,6 @@ impl Default for KSSTREAM_METADATA_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSSTREAM_METADATA_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSSTREAM_NONPAGED_DATA: u32 = 256u32;
 pub const KSSTREAM_PAGED_DATA: u32 = 0u32;
 pub const KSSTREAM_READ: u32 = 0u32;
@@ -7989,9 +7152,6 @@ impl Default for KSSTREAM_SEGMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSSTREAM_SEGMENT {
-    type TypeKind = windows_core::CloneType;
-}
 pub const KSSTREAM_SYNCHRONOUS: u32 = 4096u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8003,9 +7163,6 @@ impl Default for KSSTREAM_UVC_METADATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSSTREAM_UVC_METADATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8021,9 +7178,6 @@ impl Default for KSSTREAM_UVC_METADATATYPE_TIMESTAMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSSTREAM_UVC_METADATATYPE_TIMESTAMP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0 {
@@ -8035,9 +7189,6 @@ impl Default for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0_0 {
@@ -8047,9 +7198,6 @@ impl Default for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSSTREAM_UVC_METADATATYPE_TIMESTAMP_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSSTREAM_UVC_SECURE_ATTRIBUTE_SIZE: u32 = 8192u32;
 pub const KSSTREAM_WRITE: u32 = 1u32;
@@ -8070,9 +7218,6 @@ impl Default for KSTELEPHONY_CALLCONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSTELEPHONY_CALLCONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSTELEPHONY_CALLINFO {
@@ -8083,9 +7228,6 @@ impl Default for KSTELEPHONY_CALLINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSTELEPHONY_CALLINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8098,9 +7240,6 @@ impl Default for KSTELEPHONY_PROVIDERCHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSTELEPHONY_PROVIDERCHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSTIME {
@@ -8112,9 +7251,6 @@ impl Default for KSTIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSTIME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSTIME_FORMAT_BYTE: windows_core::GUID = windows_core::GUID::from_u128(0x7b785571_8c82_11cf_bc0c_00aa00ac74f6);
 pub const KSTIME_FORMAT_FIELD: windows_core::GUID = windows_core::GUID::from_u128(0x7b785573_8c82_11cf_bc0c_00aa00ac74f6);
@@ -8138,9 +7274,6 @@ impl Default for KSTOPOLOGY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSTOPOLOGY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSTOPOLOGY_CONNECTION {
@@ -8154,9 +7287,6 @@ impl Default for KSTOPOLOGY_CONNECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSTOPOLOGY_CONNECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSTOPOLOGY_ENDPOINTID {
@@ -8168,9 +7298,6 @@ impl Default for KSTOPOLOGY_ENDPOINTID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSTOPOLOGY_ENDPOINTID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSTOPOLOGY_ENDPOINTIDPAIR {
@@ -8181,9 +7308,6 @@ impl Default for KSTOPOLOGY_ENDPOINTIDPAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSTOPOLOGY_ENDPOINTIDPAIR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8197,9 +7321,6 @@ impl Default for KSVPMAXPIXELRATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSVPMAXPIXELRATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KSVPSIZE_PROP {
@@ -8210,9 +7331,6 @@ impl Default for KSVPSIZE_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSVPSIZE_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8225,9 +7343,6 @@ impl Default for KSVPSURFACEPARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSVPSURFACEPARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8244,9 +7359,6 @@ impl Default for KSWAVETABLE_WAVE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSWAVETABLE_WAVE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSWAVE_BUFFER {
@@ -8259,9 +7371,6 @@ impl Default for KSWAVE_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSWAVE_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KSWAVE_BUFFER_ATTRIBUTEF_LOOPING: u32 = 1u32;
 pub const KSWAVE_BUFFER_ATTRIBUTEF_STATIC: u32 = 2u32;
 #[repr(C)]
@@ -8273,9 +7382,6 @@ impl Default for KSWAVE_COMPATCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSWAVE_COMPATCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSWAVE_COMPATCAPS_INPUT: u32 = 0u32;
 pub const KSWAVE_COMPATCAPS_OUTPUT: u32 = 1u32;
@@ -8294,9 +7400,6 @@ impl Default for KSWAVE_INPUT_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSWAVE_INPUT_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8327,9 +7430,6 @@ impl Default for KSWAVE_OUTPUT_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KSWAVE_OUTPUT_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KSWAVE_VOLUME {
@@ -8340,9 +7440,6 @@ impl Default for KSWAVE_VOLUME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KSWAVE_VOLUME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KS_AMCONTROL_COLORINFO_PRESENT: u32 = 128u32;
 pub const KS_AMCONTROL_PAD_TO_16x9: u32 = 4u32;
@@ -8373,9 +7470,6 @@ impl Default for KS_AMVPDATAINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_AMVPDATAINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KS_AMVPDIMINFO {
@@ -8390,9 +7484,6 @@ impl Default for KS_AMVPDIMINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_AMVPDIMINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KS_AMVPSIZE {
@@ -8403,9 +7494,6 @@ impl Default for KS_AMVPSIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_AMVPSIZE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KS_AMVP_BEST_BANDWIDTH: KS_AMVP_SELECTFORMATBY = KS_AMVP_SELECTFORMATBY(1i32);
 pub const KS_AMVP_DO_NOT_CARE: KS_AMVP_SELECTFORMATBY = KS_AMVP_SELECTFORMATBY(0i32);
@@ -8432,9 +7520,6 @@ impl Default for KS_AM_ExactRateChange {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_AM_ExactRateChange {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KS_AM_PROPERTY_TS_RATE_CHANGE(pub i32);
@@ -8453,9 +7538,6 @@ impl Default for KS_AM_SimpleRateChange {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_AM_SimpleRateChange {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KS_AM_UseNewCSSKey: i32 = 1i32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8470,9 +7552,6 @@ impl Default for KS_ANALOGVIDEOINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_ANALOGVIDEOINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8521,9 +7600,6 @@ impl Default for KS_BITMAPINFOHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_BITMAPINFOHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KS_BI_BITFIELDS: i32 = 3i32;
 pub const KS_BI_JPEG: i32 = 4i32;
 pub const KS_BI_RGB: i32 = 0i32;
@@ -8564,9 +7640,6 @@ impl Default for KS_COLCON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_COLCON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KS_COMPRESSION {
@@ -8579,9 +7652,6 @@ impl Default for KS_COMPRESSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_COMPRESSION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KS_COPYPROTECT_RestrictDuplication: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8592,9 +7662,6 @@ impl Default for KS_COPY_MACROVISION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_COPY_MACROVISION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8621,9 +7688,6 @@ impl Default for KS_DATAFORMAT_H264VIDEOINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DATAFORMAT_H264VIDEOINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KS_DATAFORMAT_IMAGEINFO {
@@ -8634,9 +7698,6 @@ impl Default for KS_DATAFORMAT_IMAGEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DATAFORMAT_IMAGEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8649,9 +7710,6 @@ impl Default for KS_DATAFORMAT_MPEGVIDEOINFO2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DATAFORMAT_MPEGVIDEOINFO2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KS_DATAFORMAT_VBIINFOHEADER {
@@ -8662,9 +7720,6 @@ impl Default for KS_DATAFORMAT_VBIINFOHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DATAFORMAT_VBIINFOHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8677,9 +7732,6 @@ impl Default for KS_DATAFORMAT_VIDEOINFOHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DATAFORMAT_VIDEOINFOHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KS_DATAFORMAT_VIDEOINFOHEADER2 {
@@ -8690,9 +7742,6 @@ impl Default for KS_DATAFORMAT_VIDEOINFOHEADER2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DATAFORMAT_VIDEOINFOHEADER2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8705,9 +7754,6 @@ impl Default for KS_DATAFORMAT_VIDEOINFO_PALETTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DATAFORMAT_VIDEOINFO_PALETTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KS_DATARANGE_ANALOGVIDEO {
@@ -8718,9 +7764,6 @@ impl Default for KS_DATARANGE_ANALOGVIDEO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DATARANGE_ANALOGVIDEO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8738,9 +7781,6 @@ impl Default for KS_DATARANGE_H264_VIDEO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DATARANGE_H264_VIDEO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KS_DATARANGE_IMAGE {
@@ -8752,9 +7792,6 @@ impl Default for KS_DATARANGE_IMAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DATARANGE_IMAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8772,9 +7809,6 @@ impl Default for KS_DATARANGE_MPEG1_VIDEO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DATARANGE_MPEG1_VIDEO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KS_DATARANGE_MPEG2_VIDEO {
@@ -8790,9 +7824,6 @@ impl Default for KS_DATARANGE_MPEG2_VIDEO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DATARANGE_MPEG2_VIDEO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8810,9 +7841,6 @@ impl Default for KS_DATARANGE_VIDEO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DATARANGE_VIDEO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KS_DATARANGE_VIDEO2 {
@@ -8828,9 +7856,6 @@ impl Default for KS_DATARANGE_VIDEO2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DATARANGE_VIDEO2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8848,9 +7873,6 @@ impl Default for KS_DATARANGE_VIDEO_PALETTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DATARANGE_VIDEO_PALETTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct KS_DATARANGE_VIDEO_VBI {
@@ -8866,9 +7888,6 @@ impl Default for KS_DATARANGE_VIDEO_VBI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DATARANGE_VIDEO_VBI {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8889,9 +7908,6 @@ impl Default for KS_DVDCOPY_BUSKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DVDCOPY_BUSKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KS_DVDCOPY_CHLGKEY {
@@ -8903,9 +7919,6 @@ impl Default for KS_DVDCOPY_CHLGKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DVDCOPY_CHLGKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KS_DVDCOPY_DISCKEY {
@@ -8915,9 +7928,6 @@ impl Default for KS_DVDCOPY_DISCKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DVDCOPY_DISCKEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8931,9 +7941,6 @@ impl Default for KS_DVDCOPY_REGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DVDCOPY_REGION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KS_DVDCOPY_SET_COPY_STATE {
@@ -8943,9 +7950,6 @@ impl Default for KS_DVDCOPY_SET_COPY_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DVDCOPY_SET_COPY_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8959,9 +7963,6 @@ impl Default for KS_DVDCOPY_TITLEKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DVDCOPY_TITLEKEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KS_DVD_CGMS_COPY_ONCE: u32 = 16u32;
 pub const KS_DVD_CGMS_COPY_PERMITTED: u32 = 0u32;
@@ -8987,9 +7988,6 @@ impl Default for KS_DVD_YCrCb {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_DVD_YCrCb {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KS_DVD_YUV {
@@ -9002,9 +8000,6 @@ impl Default for KS_DVD_YUV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_DVD_YUV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9025,9 +8020,6 @@ impl Default for KS_FRAME_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_FRAME_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KS_FRAME_INFO_0 {
@@ -9038,9 +8030,6 @@ impl Default for KS_FRAME_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_FRAME_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9053,9 +8042,6 @@ impl Default for KS_FRAME_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_FRAME_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KS_FRAME_INFO_1_0 {
@@ -9066,9 +8052,6 @@ impl Default for KS_FRAME_INFO_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_FRAME_INFO_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9089,9 +8072,6 @@ impl Default for KS_FRAMING_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_FRAMING_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KS_FRAMING_ITEM_0 {
@@ -9102,9 +8082,6 @@ impl Default for KS_FRAMING_ITEM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_FRAMING_ITEM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9118,9 +8095,6 @@ impl Default for KS_FRAMING_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_FRAMING_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KS_FRAMING_RANGE_WEIGHTED {
@@ -9132,9 +8106,6 @@ impl Default for KS_FRAMING_RANGE_WEIGHTED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_FRAMING_RANGE_WEIGHTED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9183,9 +8154,6 @@ impl Default for KS_H264VIDEOINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_H264VIDEOINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KS_INTERLACE_1FieldPerSample: u32 = 2u32;
 pub const KS_INTERLACE_DisplayModeBobOnly: u32 = 0u32;
 pub const KS_INTERLACE_DisplayModeBobOrWeave: u32 = 128u32;
@@ -9219,9 +8187,6 @@ impl Default for KS_MPEG1VIDEOINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_MPEG1VIDEOINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9261,9 +8226,6 @@ impl Default for KS_MPEGAUDIOINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_MPEGAUDIOINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KS_MPEGAUDIOINFO_27MhzTimebase: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9280,9 +8242,6 @@ impl Default for KS_MPEGVIDEOINFO2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_MPEGVIDEOINFO2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KS_MemoryTypeAnyHost: KS_LogicalMemoryType = KS_LogicalMemoryType(6i32);
 pub const KS_MemoryTypeDeviceHostMapped: KS_LogicalMemoryType = KS_LogicalMemoryType(3i32);
@@ -9350,9 +8309,6 @@ impl Default for KS_RGBQUAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_RGBQUAD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KS_SECURE_CAMERA_SCENARIO_ID: windows_core::GUID = windows_core::GUID::from_u128(0xae53fc6e_8d89_4488_9d2e_4d008731c5fd);
 pub const KS_SEEKING_AbsolutePositioning: KS_SEEKING_FLAGS = KS_SEEKING_FLAGS(1i32);
 #[repr(transparent)]
@@ -9390,9 +8346,6 @@ impl Default for KS_TRUECOLORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_TRUECOLORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KS_TUNER_STRATEGY(pub i32);
@@ -9429,9 +8382,6 @@ impl Default for KS_TVTUNER_CHANGE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_TVTUNER_CHANGE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KS_VBICAP_PROTECTION_MV_DETECTED: i32 = 4i32;
 pub const KS_VBICAP_PROTECTION_MV_HARDWARE: i32 = 2i32;
 pub const KS_VBICAP_PROTECTION_MV_PRESENT: i32 = 1i32;
@@ -9457,9 +8407,6 @@ impl Default for KS_VBIINFOHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_VBIINFOHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KS_VBI_FLAG_FIELD1: i32 = 1i32;
 pub const KS_VBI_FLAG_FIELD2: i32 = 2i32;
 pub const KS_VBI_FLAG_FRAME: i32 = 0i32;
@@ -9484,9 +8431,6 @@ impl Default for KS_VBI_FRAME_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_VBI_FRAME_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KS_VIDEODECODER_FLAGS(pub i32);
@@ -9509,9 +8453,6 @@ impl Default for KS_VIDEOINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_VIDEOINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KS_VIDEOINFO_0 {
@@ -9523,9 +8464,6 @@ impl Default for KS_VIDEOINFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_VIDEOINFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9541,9 +8479,6 @@ impl Default for KS_VIDEOINFOHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_VIDEOINFOHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9566,9 +8501,6 @@ impl Default for KS_VIDEOINFOHEADER2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_VIDEOINFOHEADER2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KS_VIDEOINFOHEADER2_0 {
@@ -9579,9 +8511,6 @@ impl Default for KS_VIDEOINFOHEADER2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KS_VIDEOINFOHEADER2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KS_VIDEOSTREAM_CAPTURE: u32 = 2u32;
 pub const KS_VIDEOSTREAM_CC: u32 = 256u32;
@@ -9636,9 +8565,6 @@ impl Default for KS_VIDEO_STREAM_CONFIG_CAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KS_VIDEO_STREAM_CONFIG_CAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KS_VideoControlFlag_ExternalTriggerEnable: KS_VideoControlFlags = KS_VideoControlFlags(4i32);
 pub const KS_VideoControlFlag_FlipHorizontal: KS_VideoControlFlags = KS_VideoControlFlags(1i32);
 pub const KS_VideoControlFlag_FlipVertical: KS_VideoControlFlags = KS_VideoControlFlags(2i32);
@@ -9680,9 +8606,6 @@ impl Default for LOOPEDSTREAMING_POSITION_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOOPEDSTREAMING_POSITION_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MAX_NABTS_VBI_LINES_PER_FIELD: u32 = 11u32;
 pub const MAX_RESOURCEGROUPID_LENGTH: u32 = 256u32;
 pub const MAX_SINK_DESCRIPTION_NAME_LENGTH: u32 = 32u32;
@@ -9699,9 +8622,6 @@ impl Default for MEDIUM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEDIUM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MF_MDL_SHARED_PAYLOAD_KEY {
@@ -9712,9 +8632,6 @@ impl Default for MF_MDL_SHARED_PAYLOAD_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MF_MDL_SHARED_PAYLOAD_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9727,9 +8644,6 @@ impl Default for MF_MDL_SHARED_PAYLOAD_KEY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MF_MDL_SHARED_PAYLOAD_KEY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIN_DEV_VER_FOR_FLAGS: u32 = 272u32;
 pub const MIN_DEV_VER_FOR_QI: u32 = 256u32;
@@ -9757,9 +8671,6 @@ impl Default for NABTSFEC_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NABTSFEC_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NABTS_BUFFER {
@@ -9772,9 +8683,6 @@ impl Default for NABTS_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NABTS_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NABTS_BUFFER_LINE {
@@ -9785,9 +8693,6 @@ impl Default for NABTS_BUFFER_LINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NABTS_BUFFER_LINE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NABTS_BUFFER_PICTURENUMBER_SUPPORT: u32 = 1u32;
 pub const NABTS_BYTES_PER_LINE: u32 = 36u32;
@@ -9805,9 +8710,6 @@ impl Default for OPTIMAL_WEIGHT_TOTALS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPTIMAL_WEIGHT_TOTALS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PINNAME_DISPLAYPORT_OUT: windows_core::GUID = windows_core::GUID::from_u128(0x21fbb329_1a4a_48da_a076_2318a3c59b26);
 pub const PINNAME_HDMI_OUT: windows_core::GUID = windows_core::GUID::from_u128(0x387bfc03_e7ef_4901_86e0_35b7c32b00ef);
@@ -9843,9 +8745,6 @@ impl Default for PIPE_DIMENSIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PIPE_DIMENSIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PIPE_STATE(pub i32);
@@ -9863,9 +8762,6 @@ impl Default for PIPE_TERMINATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PIPE_TERMINATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROPSETID_ALLOCATOR_CONTROL: windows_core::GUID = windows_core::GUID::from_u128(0x53171960_148e_11d2_9979_0000c0cc16ba);
 pub const PROPSETID_EXT_DEVICE: windows_core::GUID = windows_core::GUID::from_u128(0xb5730a90_1a2c_11cf_8c23_00aa006b6814);
@@ -9923,9 +8819,6 @@ impl Default for SECURE_BUFFER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURE_BUFFER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SHORT_COEFF: KSDS3D_HRTF_COEFF_FORMAT = KSDS3D_HRTF_COEFF_FORMAT(1i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9937,9 +8830,6 @@ impl Default for SOUNDDETECTOR_PATTERNHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOUNDDETECTOR_PATTERNHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPEAKER_ALL: u32 = 2147483648u32;
 pub const SPEAKER_BACK_CENTER: u32 = 256u32;
@@ -10001,9 +8891,6 @@ impl Default for TRANSPORTAUDIOPARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSPORTAUDIOPARMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSPORTBASICPARMS {
@@ -10043,9 +8930,6 @@ impl Default for TRANSPORTBASICPARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSPORTBASICPARMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSPORTSTATUS {
@@ -10068,9 +8952,6 @@ impl Default for TRANSPORTSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSPORTSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSPORTVIDEOPARMS {
@@ -10082,9 +8963,6 @@ impl Default for TRANSPORTVIDEOPARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSPORTVIDEOPARMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSPORT_STATE {
@@ -10095,9 +8973,6 @@ impl Default for TRANSPORT_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSPORT_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10115,9 +8990,6 @@ impl Default for TUNER_ANALOG_CAPS_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TUNER_ANALOG_CAPS_S {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10137,9 +9009,6 @@ impl Default for VBICAP_PROPERTIES_PROTECTION_S {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBICAP_PROPERTIES_PROTECTION_S {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VBICODECFILTERING_CC_SUBSTREAMS {
@@ -10149,9 +9018,6 @@ impl Default for VBICODECFILTERING_CC_SUBSTREAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VBICODECFILTERING_CC_SUBSTREAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10163,9 +9029,6 @@ impl Default for VBICODECFILTERING_NABTS_SUBSTREAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBICODECFILTERING_NABTS_SUBSTREAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VBICODECFILTERING_SCANLINES {
@@ -10175,9 +9038,6 @@ impl Default for VBICODECFILTERING_SCANLINES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VBICODECFILTERING_SCANLINES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10189,9 +9049,6 @@ impl Default for VBICODECFILTERING_STATISTICS_CC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBICODECFILTERING_STATISTICS_CC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VBICODECFILTERING_STATISTICS_CC_PIN {
@@ -10201,9 +9058,6 @@ impl Default for VBICODECFILTERING_STATISTICS_CC_PIN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VBICODECFILTERING_STATISTICS_CC_PIN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10228,9 +9082,6 @@ impl Default for VBICODECFILTERING_STATISTICS_COMMON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBICODECFILTERING_STATISTICS_COMMON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VBICODECFILTERING_STATISTICS_COMMON_PIN {
@@ -10247,9 +9098,6 @@ impl Default for VBICODECFILTERING_STATISTICS_COMMON_PIN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VBICODECFILTERING_STATISTICS_COMMON_PIN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10268,9 +9116,6 @@ impl Default for VBICODECFILTERING_STATISTICS_NABTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBICODECFILTERING_STATISTICS_NABTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VBICODECFILTERING_STATISTICS_NABTS_PIN {
@@ -10280,9 +9125,6 @@ impl Default for VBICODECFILTERING_STATISTICS_NABTS_PIN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VBICODECFILTERING_STATISTICS_NABTS_PIN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10294,9 +9136,6 @@ impl Default for VBICODECFILTERING_STATISTICS_TELETEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBICODECFILTERING_STATISTICS_TELETEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VBICODECFILTERING_STATISTICS_TELETEXT_PIN {
@@ -10306,9 +9145,6 @@ impl Default for VBICODECFILTERING_STATISTICS_TELETEXT_PIN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VBICODECFILTERING_STATISTICS_TELETEXT_PIN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10327,9 +9163,6 @@ impl Default for VRAM_SURFACE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VRAM_SURFACE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct VRAM_SURFACE_INFO_PROPERTY_S {
@@ -10340,9 +9173,6 @@ impl Default for VRAM_SURFACE_INFO_PROPERTY_S {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VRAM_SURFACE_INFO_PROPERTY_S {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WAVE_FORMAT_EXTENSIBLE: u32 = 65534u32;
 #[repr(C)]
@@ -10358,9 +9188,6 @@ impl Default for WNF_KSCAMERA_STREAMSTATE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WNF_KSCAMERA_STREAMSTATE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WST_BUFFER {
@@ -10372,9 +9199,6 @@ impl Default for WST_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WST_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WST_BUFFER_LINE {
@@ -10385,9 +9209,6 @@ impl Default for WST_BUFFER_LINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WST_BUFFER_LINE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WST_BYTES_PER_LINE: u32 = 42u32;
 pub const WST_TVTUNER_CHANGE_BEGIN_TUNE: i32 = 4096i32;

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
@@ -1913,9 +1913,6 @@ impl Default for AM_MEDIA_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_MEDIA_TYPE {
-    type TypeKind = windows_core::CloneType;
-}
 pub const AM_MEDIA_TYPE_REPRESENTATION: windows_core::GUID = windows_core::GUID::from_u128(0xe2e42ad2_132c_491e_a268_3c7c2dca181f);
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1928,9 +1925,6 @@ impl Default for ASF_FLAT_PICTURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ASF_FLAT_PICTURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct ASF_FLAT_SYNCHRONISED_LYRICS {
@@ -1942,9 +1936,6 @@ impl Default for ASF_FLAT_SYNCHRONISED_LYRICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ASF_FLAT_SYNCHRONISED_LYRICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1959,9 +1950,6 @@ impl Default for ASF_INDEX_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ASF_INDEX_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ASF_INDEX_IDENTIFIER {
@@ -1973,9 +1961,6 @@ impl Default for ASF_INDEX_IDENTIFIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ASF_INDEX_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ASF_MUX_STATISTICS {
@@ -1986,9 +1971,6 @@ impl Default for ASF_MUX_STATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ASF_MUX_STATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2034,9 +2016,6 @@ impl Default for AecQualityMetrics_Struct {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AecQualityMetrics_Struct {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CAC3DecMediaObject: windows_core::GUID = windows_core::GUID::from_u128(0x03d7c802_ecfa_47d9_b268_5fb3e310dee4);
 pub const CAPTION_FORMAT_ATSC: windows_core::GUID = windows_core::GUID::from_u128(0x3ed9cb31_fd10_4ade_bccc_fb9105d2f3ef);
@@ -2665,9 +2644,6 @@ impl Default for CodecAPIEventData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CodecAPIEventData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_BITSTREAM_ENCRYPTION_TYPE(pub i32);
@@ -2681,9 +2657,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ARCHITECTURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ARCHITECTURE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -2699,10 +2672,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2717,10 +2686,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_DECODER_HEAP_SIZE1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -2741,10 +2706,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_DECODE_CONVERSION_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_DECODE_CONVERSION_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2760,10 +2721,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_DECODE_FORMATS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_DECODE_FORMATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_DECODE_FORMAT_COUNT {
@@ -2775,9 +2732,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_DECODE_FORMAT_COUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_DECODE_FORMAT_COUNT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -2798,10 +2752,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_DECODE_HISTOGRAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_DECODE_HISTOGRAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILES {
@@ -2814,9 +2764,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILE_COUNT {
@@ -2827,9 +2774,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILE_COUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_DECODE_PROFILE_COUNT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2842,9 +2786,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_DECODE_PROTECTED_RESOURCES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_DECODE_PROTECTED_RESOURCES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -2867,10 +2808,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_DECODE_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_DECODE_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC {
@@ -2882,9 +2819,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2900,9 +2834,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {
@@ -2916,9 +2847,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT 
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2937,9 +2865,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_CONFIG 
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_FEATURE_DATA_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_MODE {
@@ -2955,9 +2880,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_FEATURE_DATA_VIDEO_ENCODER_HEAP_SIZE {
@@ -2970,9 +2892,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_HEAP_SIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_HEAP_SIZE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -2990,10 +2909,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_INPUT_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_INPUT_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_FEATURE_DATA_VIDEO_ENCODER_INTRA_REFRESH_MODE {
@@ -3008,9 +2923,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_INTRA_REFRESH_MODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_INTRA_REFRESH_MODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3030,9 +2942,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RESOLUTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RESOLUTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RESOLUTION_RATIOS_COUNT {
@@ -3044,9 +2953,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RESOLUTION_RATIOS_COUNT
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_OUTPUT_RESOLUTION_RATIOS_COUNT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3063,9 +2969,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_PROFILE_LEVEL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_PROFILE_LEVEL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_ENCODER_RATE_CONTROL_MODE {
@@ -3079,9 +2982,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_RATE_CONTROL_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_RATE_CONTROL_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOLUTION_SUPPORT_LIMITS {
@@ -3094,9 +2994,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOLUTION_SUPPORT_LIMITS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOLUTION_SUPPORT_LIMITS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -3117,10 +3014,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOURCE_REQUIREMENTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_RESOURCE_REQUIREMENTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -3148,10 +3041,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -3182,10 +3071,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_ENCODER_SUPPORT1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_ENCODER_SUPPORT1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3200,10 +3085,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMANDS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMANDS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_COUNT {
@@ -3214,9 +3095,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_COUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_COUNT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3231,9 +3109,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETER_COUNT {
@@ -3246,9 +3121,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETER_COUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_PARAMETER_COUNT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3265,9 +3137,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SUPPORT {
@@ -3283,9 +3152,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_EXTENSION_COMMAND_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_FEATURE_AREA_SUPPORT {
@@ -3298,9 +3164,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_FEATURE_AREA_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_FEATURE_AREA_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -3318,10 +3181,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_PROTECTED_RESOURCES {
@@ -3332,9 +3191,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_PROTECTED_RESOURCES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_PROTECTED_RESOURCES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -3357,10 +3213,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_SIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_MOTION_ESTIMATOR_SIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3377,10 +3229,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_PROCESSOR_SIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_PROCESSOR_SIZE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -3400,10 +3248,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_PROCESSOR_SIZE1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_PROCESSOR_SIZE1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_PROCESS_MAX_INPUT_STREAMS {
@@ -3415,9 +3259,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_PROCESS_MAX_INPUT_STREAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_PROCESS_MAX_INPUT_STREAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_FEATURE_DATA_VIDEO_PROCESS_PROTECTED_RESOURCES {
@@ -3428,9 +3269,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_PROCESS_PROTECTED_RESOURCES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_PROCESS_PROTECTED_RESOURCES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -3451,10 +3289,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_PROCESS_REFERENCE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_PROCESS_REFERENCE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -3481,10 +3315,6 @@ impl Default for D3D12_FEATURE_DATA_VIDEO_PROCESS_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_FEATURE_DATA_VIDEO_PROCESS_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3546,10 +3376,6 @@ impl Default for D3D12_QUERY_DATA_VIDEO_DECODE_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_QUERY_DATA_VIDEO_DECODE_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -3564,10 +3390,6 @@ impl Default for D3D12_RESOLVE_VIDEO_MOTION_VECTOR_HEAP_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_RESOLVE_VIDEO_MOTION_VECTOR_HEAP_INPUT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -3580,10 +3402,6 @@ impl Default for D3D12_RESOLVE_VIDEO_MOTION_VECTOR_HEAP_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_RESOLVE_VIDEO_MOTION_VECTOR_HEAP_OUTPUT {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3598,9 +3416,6 @@ impl Default for D3D12_RESOURCE_COORDINATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RESOURCE_COORDINATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_DECODER_DESC {
@@ -3611,9 +3426,6 @@ impl Default for D3D12_VIDEO_DECODER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_DECODER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -3633,10 +3445,6 @@ impl Default for D3D12_VIDEO_DECODER_HEAP_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_VIDEO_DECODER_HEAP_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3659,10 +3467,6 @@ impl Default for D3D12_VIDEO_DECODE_COMPRESSED_BITSTREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_DECODE_COMPRESSED_BITSTREAM {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_DECODE_CONFIGURATION {
@@ -3674,9 +3478,6 @@ impl Default for D3D12_VIDEO_DECODE_CONFIGURATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_DECODE_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3735,10 +3536,6 @@ impl Default for D3D12_VIDEO_DECODE_CONVERSION_ARGUMENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D12_VIDEO_DECODE_CONVERSION_ARGUMENTS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -3756,10 +3553,6 @@ impl Default for D3D12_VIDEO_DECODE_CONVERSION_ARGUMENTS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D12_VIDEO_DECODE_CONVERSION_ARGUMENTS1 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3810,9 +3603,6 @@ impl Default for D3D12_VIDEO_DECODE_FRAME_ARGUMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_DECODE_FRAME_ARGUMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3884,10 +3674,6 @@ impl Default for D3D12_VIDEO_DECODE_INPUT_STREAM_ARGUMENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_DECODE_INPUT_STREAM_ARGUMENTS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -3900,10 +3686,6 @@ impl Default for D3D12_VIDEO_DECODE_OUTPUT_HISTOGRAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_DECODE_OUTPUT_HISTOGRAM {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -3919,10 +3701,6 @@ impl Default for D3D12_VIDEO_DECODE_OUTPUT_STREAM_ARGUMENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D12_VIDEO_DECODE_OUTPUT_STREAM_ARGUMENTS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -3937,10 +3715,6 @@ impl Default for D3D12_VIDEO_DECODE_OUTPUT_STREAM_ARGUMENTS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D12_VIDEO_DECODE_OUTPUT_STREAM_ARGUMENTS1 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const D3D12_VIDEO_DECODE_PROFILE_AV1_12BIT_PROFILE2: windows_core::GUID = windows_core::GUID::from_u128(0x17127009_a00f_4ce1_994e_bf4081f6f3f0);
 pub const D3D12_VIDEO_DECODE_PROFILE_AV1_12BIT_PROFILE2_420: windows_core::GUID = windows_core::GUID::from_u128(0x2d80bed6_9cac_4835_9e91_327bbc4f9ee8);
@@ -3993,10 +3767,6 @@ impl Default for D3D12_VIDEO_DECODE_REFERENCE_FRAMES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_DECODE_REFERENCE_FRAMES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4066,9 +3836,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_CDEF_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_CDEF_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_AV1_CODEC_CONFIGURATION {
@@ -4079,9 +3846,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_CODEC_CONFIGURATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_CODEC_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4101,9 +3865,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_CODEC_CONFIGURATION_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_CODEC_CONFIGURATION_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4193,9 +3954,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_FRAME_SUBREGION_LAYOUT_CONFIG_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_FRAME_SUBREGION_LAYOUT_CONFIG_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4378,9 +4136,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_LEVEL_TIER_CONSTRAINTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_LEVEL_TIER_CONSTRAINTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_AV1_PICTURE_CONTROL_CODEC_DATA {
@@ -4413,9 +4168,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_PICTURE_CONTROL_CODEC_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_PICTURE_CONTROL_CODEC_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4483,9 +4235,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_TILES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_AV1_POST_ENCODE_VALUES {
@@ -4503,9 +4252,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_POST_ENCODE_VALUES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_POST_ENCODE_VALUES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4575,9 +4321,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_REFERENCE_PICTURE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_REFERENCE_PICTURE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_AV1_REFERENCE_PICTURE_WARPED_MOTION_INFO {
@@ -4589,9 +4332,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_REFERENCE_PICTURE_WARPED_MOTION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_REFERENCE_PICTURE_WARPED_MOTION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4651,9 +4391,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_RESTORATION_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_RESTORATION_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4733,9 +4470,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_SEGMENTATION_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_SEGMENTATION_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_AV1_SEGMENTATION_MAP {
@@ -4746,9 +4480,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_SEGMENTATION_MAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_SEGMENTATION_MAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4819,9 +4550,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_SEGMENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_SEGMENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_AV1_SEQUENCE_STRUCTURE {
@@ -4832,9 +4560,6 @@ impl Default for D3D12_VIDEO_ENCODER_AV1_SEQUENCE_STRUCTURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_AV1_SEQUENCE_STRUCTURE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4909,9 +4634,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_AV1_LOOP_FILTER_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_AV1_LOOP_FILTER_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_CODEC_AV1_LOOP_FILTER_DELTA_CONFIG {
@@ -4923,9 +4645,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_AV1_LOOP_FILTER_DELTA_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_AV1_LOOP_FILTER_DELTA_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4939,9 +4658,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_AV1_PICTURE_CONTROL_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_AV1_PICTURE_CONTROL_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4962,9 +4678,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_AV1_QUANTIZATION_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_AV1_QUANTIZATION_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_CODEC_AV1_QUANTIZATION_DELTA_CONFIG {
@@ -4976,9 +4689,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_AV1_QUANTIZATION_DELTA_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_AV1_QUANTIZATION_DELTA_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION {
@@ -4989,9 +4699,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5005,9 +4712,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264 {
@@ -5019,9 +4723,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5140,9 +4841,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC_CUSIZE(pub i32);
@@ -5222,9 +4920,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_0 {
@@ -5238,9 +4933,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264 {
@@ -5251,9 +4943,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5316,9 +5005,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC1 {
@@ -5342,9 +5028,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAG1_NONE: D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS1 = D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS1(0i32);
 pub const D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAG1_SEPARATE_COLOUR_PLANE_REQUIRED: D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS1 = D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS1(2i32);
@@ -5467,9 +5150,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_0 {
@@ -5481,9 +5161,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5499,9 +5176,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_H264 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_H264 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_HEVC {
@@ -5516,9 +5190,6 @@ impl Default for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_HEVC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_CODEC_PICTURE_CONTROL_SUPPORT_HEVC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -5531,10 +5202,6 @@ impl Default for D3D12_VIDEO_ENCODER_COMPRESSED_BITSTREAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_COMPRESSED_BITSTREAM {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -5553,10 +5220,6 @@ impl Default for D3D12_VIDEO_ENCODER_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -5579,10 +5242,6 @@ impl Default for D3D12_VIDEO_ENCODER_ENCODEFRAME_INPUT_ARGUMENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_ENCODEFRAME_INPUT_ARGUMENTS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -5596,10 +5255,6 @@ impl Default for D3D12_VIDEO_ENCODER_ENCODEFRAME_OUTPUT_ARGUMENTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_ENCODEFRAME_OUTPUT_ARGUMENTS {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5656,10 +5311,6 @@ impl Default for D3D12_VIDEO_ENCODER_ENCODE_OPERATION_METADATA_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_ENCODE_OPERATION_METADATA_BUFFER {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_FLAGS(pub i32);
@@ -5708,9 +5359,6 @@ impl Default for D3D12_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_CONFIG_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_CONFIG_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_CONFIG_SUPPORT_0 {
@@ -5720,9 +5368,6 @@ impl Default for D3D12_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_CONFIG_SUPPORT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_FRAME_SUBREGION_LAYOUT_CONFIG_SUPPORT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5745,9 +5390,6 @@ impl Default for D3D12_VIDEO_ENCODER_FRAME_SUBREGION_METADATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_FRAME_SUBREGION_METADATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5778,9 +5420,6 @@ impl Default for D3D12_VIDEO_ENCODER_HEAP_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_HEAP_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5829,9 +5468,6 @@ impl Default for D3D12_VIDEO_ENCODER_INTRA_REFRESH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_INTRA_REFRESH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5888,9 +5524,6 @@ impl Default for D3D12_VIDEO_ENCODER_LEVEL_SETTING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_LEVEL_SETTING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_VIDEO_ENCODER_LEVEL_SETTING_0 {
@@ -5903,9 +5536,6 @@ impl Default for D3D12_VIDEO_ENCODER_LEVEL_SETTING_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_LEVEL_SETTING_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_LEVEL_TIER_CONSTRAINTS_HEVC {
@@ -5916,9 +5546,6 @@ impl Default for D3D12_VIDEO_ENCODER_LEVEL_TIER_CONSTRAINTS_HEVC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_LEVEL_TIER_CONSTRAINTS_HEVC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5941,9 +5568,6 @@ impl Default for D3D12_VIDEO_ENCODER_OUTPUT_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_OUTPUT_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_OUTPUT_METADATA_STATISTICS {
@@ -5959,9 +5583,6 @@ impl Default for D3D12_VIDEO_ENCODER_OUTPUT_METADATA_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_OUTPUT_METADATA_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA {
@@ -5972,9 +5593,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5988,9 +5606,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6022,9 +5637,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6077,9 +5689,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_P
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_PICTURE_LIST_MODIFICATION_OPERATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_PICTURE_MARKING_OPERATION {
@@ -6093,9 +5702,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_P
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_REFERENCE_PICTURE_MARKING_OPERATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6122,9 +5728,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6158,9 +5761,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6218,10 +5818,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_PICTURE_CONTROL_FLAGS(pub i32);
@@ -6271,9 +5867,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_0 {
@@ -6286,9 +5879,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES {
@@ -6298,9 +5888,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLIC
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6315,9 +5902,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLIC
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_SUBREGIONS_LAYOUT_DATA_SLICES_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_DESC {
@@ -6328,9 +5912,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6343,9 +5924,6 @@ impl Default for D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_RATIO_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PICTURE_RESOLUTION_RATIO_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_VIDEO_ENCODER_PROFILE_DESC {
@@ -6356,9 +5934,6 @@ impl Default for D3D12_VIDEO_ENCODER_PROFILE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PROFILE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6371,9 +5946,6 @@ impl Default for D3D12_VIDEO_ENCODER_PROFILE_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_PROFILE_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6408,10 +5980,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_RATE_CONTROL_ABSOLUTE_QP_MAP {
@@ -6421,9 +5989,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_ABSOLUTE_QP_MAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_ABSOLUTE_QP_MAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6440,9 +6005,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_CBR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_CBR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6461,9 +6023,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_CBR1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_CBR1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS {
@@ -6474,9 +6033,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6496,9 +6052,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_CONFIGURATION_PARAMS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_RATE_CONTROL_CQP {
@@ -6510,9 +6063,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_CQP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_CQP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6526,9 +6076,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_CQP1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_CQP1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6599,9 +6146,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_QVBR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_QVBR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_RATE_CONTROL_QVBR1 {
@@ -6621,9 +6165,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_QVBR1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_QVBR1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_RATE_CONTROL_VBR {
@@ -6640,9 +6181,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_VBR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_VBR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6662,9 +6200,6 @@ impl Default for D3D12_VIDEO_ENCODER_RATE_CONTROL_VBR1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RATE_CONTROL_VBR1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -6677,10 +6212,6 @@ impl Default for D3D12_VIDEO_ENCODER_RECONSTRUCTED_PICTURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RECONSTRUCTED_PICTURE {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6697,9 +6228,6 @@ impl Default for D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCRIPTOR_H264 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCRIPTOR_H264 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCRIPTOR_HEVC {
@@ -6713,9 +6241,6 @@ impl Default for D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCRIPTOR_HEVC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_REFERENCE_PICTURE_DESCRIPTOR_HEVC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
@@ -6738,10 +6263,6 @@ impl Default for D3D12_VIDEO_ENCODER_RESOLVE_METADATA_INPUT_ARGUMENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RESOLVE_METADATA_INPUT_ARGUMENTS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -6753,10 +6274,6 @@ impl Default for D3D12_VIDEO_ENCODER_RESOLVE_METADATA_OUTPUT_ARGUMENTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_RESOLVE_METADATA_OUTPUT_ARGUMENTS {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -6775,10 +6292,6 @@ impl Default for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6833,9 +6346,6 @@ impl Default for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_0 {
@@ -6847,9 +6357,6 @@ impl Default for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6865,9 +6372,6 @@ impl Default for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_H264 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_H264 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_HEVC {
@@ -6879,9 +6383,6 @@ impl Default for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_HEVC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODER_SEQUENCE_GOP_STRUCTURE_HEVC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7002,10 +6503,6 @@ impl Default for D3D12_VIDEO_ENCODE_REFERENCE_FRAMES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_ENCODE_REFERENCE_FRAMES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_EXTENSION_COMMAND_DESC {
@@ -7016,9 +6513,6 @@ impl Default for D3D12_VIDEO_EXTENSION_COMMAND_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_EXTENSION_COMMAND_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -7033,10 +6527,6 @@ impl Default for D3D12_VIDEO_EXTENSION_COMMAND_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_EXTENSION_COMMAND_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7089,9 +6579,6 @@ impl Default for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_STAGE(pub i32);
@@ -7135,10 +6622,6 @@ impl Default for D3D12_VIDEO_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_VIDEO_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct D3D12_VIDEO_FRAME_CODED_INTERLACE_TYPE(pub i32);
@@ -7168,10 +6651,6 @@ impl Default for D3D12_VIDEO_MOTION_ESTIMATOR_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_VIDEO_MOTION_ESTIMATOR_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -7188,10 +6667,6 @@ impl Default for D3D12_VIDEO_MOTION_ESTIMATOR_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_MOTION_ESTIMATOR_INPUT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -7203,10 +6678,6 @@ impl Default for D3D12_VIDEO_MOTION_ESTIMATOR_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_MOTION_ESTIMATOR_OUTPUT {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7310,10 +6781,6 @@ impl Default for D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_PROCESS_ALPHA_BLENDING {
@@ -7324,9 +6791,6 @@ impl Default for D3D12_VIDEO_PROCESS_ALPHA_BLENDING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_ALPHA_BLENDING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7531,9 +6995,6 @@ impl Default for D3D12_VIDEO_PROCESS_FILTER_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_FILTER_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const D3D12_VIDEO_PROCESS_FILTER_SATURATION: D3D12_VIDEO_PROCESS_FILTER = D3D12_VIDEO_PROCESS_FILTER(3i32);
 pub const D3D12_VIDEO_PROCESS_FILTER_STEREO_ADJUSTMENT: D3D12_VIDEO_PROCESS_FILTER = D3D12_VIDEO_PROCESS_FILTER(7i32);
 #[repr(C)]
@@ -7549,10 +7010,6 @@ impl Default for D3D12_VIDEO_PROCESS_INPUT_STREAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_INPUT_STREAM {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
@@ -7571,10 +7028,6 @@ impl Default for D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -7592,10 +7045,6 @@ impl Default for D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS1 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -7624,10 +7073,6 @@ impl Default for D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7679,9 +7124,6 @@ impl Default for D3D12_VIDEO_PROCESS_INPUT_STREAM_RATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_INPUT_STREAM_RATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_PROCESS_LUMA_KEY {
@@ -7693,9 +7135,6 @@ impl Default for D3D12_VIDEO_PROCESS_LUMA_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_LUMA_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7721,10 +7160,6 @@ impl Default for D3D12_VIDEO_PROCESS_OUTPUT_STREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_OUTPUT_STREAM {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Debug, PartialEq)]
@@ -7737,10 +7172,6 @@ impl Default for D3D12_VIDEO_PROCESS_OUTPUT_STREAM_ARGUMENTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_OUTPUT_STREAM_ARGUMENTS {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
@@ -7760,10 +7191,6 @@ impl Default for D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7780,10 +7207,6 @@ impl Default for D3D12_VIDEO_PROCESS_REFERENCE_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D12")]
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_REFERENCE_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7834,9 +7257,6 @@ impl Default for D3D12_VIDEO_PROCESS_TRANSFORM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_PROCESS_TRANSFORM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7890,10 +7310,6 @@ impl Default for D3D12_VIDEO_SAMPLE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-impl windows_core::TypeKind for D3D12_VIDEO_SAMPLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3D12_VIDEO_SCALE_SUPPORT {
@@ -7904,9 +7320,6 @@ impl Default for D3D12_VIDEO_SCALE_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3D12_VIDEO_SCALE_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7960,9 +7373,6 @@ impl Default for D3D12_VIDEO_SIZE_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_VIDEO_SIZE_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -7979,10 +7389,6 @@ impl Default for D3DCONTENTPROTECTIONCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for D3DCONTENTPROTECTIONCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7999,10 +7405,6 @@ impl Default for D3DCONTENTPROTECTIONCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for D3DCONTENTPROTECTIONCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct D3DOVERLAYCAPS {
@@ -8014,9 +7416,6 @@ impl Default for D3DOVERLAYCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for D3DOVERLAYCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -8032,9 +7431,6 @@ impl Default for DEVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_INFO {
-    type TypeKind = windows_core::CloneType;
-}
 pub const DEVPKEY_DeviceInterface_IsVirtualCamera: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x6edc630d_c2e3_43b7_b2d1_20525a1af120), pid: 3 };
 pub const DEVPKEY_DeviceInterface_IsWindowsCameraEffectAvailable: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x6edc630d_c2e3_43b7_b2d1_20525a1af120), pid: 4 };
 pub const DEVPKEY_DeviceInterface_VirtualCameraAssociatedCameras: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x6edc630d_c2e3_43b7_b2d1_20525a1af120), pid: 5 };
@@ -8049,9 +7445,6 @@ impl Default for DIRTYRECT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIRTYRECT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSATTRIB_CAPTURE_STREAMTIME: windows_core::GUID = windows_core::GUID::from_u128(0x0c1a5614_30cd_4f40_bcbf_d03e52306207);
 pub const DSATTRIB_CC_CONTAINER_INFO: windows_core::GUID = windows_core::GUID::from_u128(0xe7e050fb_dd5d_40dd_9915_35dcb81bdc8a);
@@ -8073,9 +7466,6 @@ impl Default for DXVA2_AES_CTR_IV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_AES_CTR_IV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA2_AYUVSample16 {
@@ -8089,9 +7479,6 @@ impl Default for DXVA2_AYUVSample16 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_AYUVSample16 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA2_AYUVSample8 {
@@ -8104,9 +7491,6 @@ impl Default for DXVA2_AYUVSample8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA2_AYUVSample8 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVA2_BitStreamDateBufferType: DXVA2_BufferfType = DXVA2_BufferfType(6i32);
 #[repr(transparent)]
@@ -8138,9 +7522,6 @@ impl Default for DXVA2_ConfigPictureDecode {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_ConfigPictureDecode {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVA2_DECODE_GET_DRIVER_HANDLE: u32 = 1829u32;
 pub const DXVA2_DECODE_SPECIFY_ENCRYPTED_BLOCKS: u32 = 1828u32;
 pub const DXVA2_DeblockingControlBufferType: DXVA2_BufferfType = DXVA2_BufferfType(3i32);
@@ -8164,9 +7545,6 @@ impl Default for DXVA2_DecodeBufferDesc {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_DecodeBufferDesc {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA2_DecodeExecuteParams {
@@ -8178,9 +7556,6 @@ impl Default for DXVA2_DecodeExecuteParams {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA2_DecodeExecuteParams {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8195,9 +7570,6 @@ impl Default for DXVA2_DecodeExtensionData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA2_DecodeExtensionData {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8248,9 +7620,6 @@ impl Default for DXVA2_ExtendedFormat {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_ExtendedFormat {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DXVA2_ExtendedFormat_0 {
@@ -8262,9 +7631,6 @@ impl Default for DXVA2_ExtendedFormat_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_ExtendedFormat_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA2_ExtendedFormat_0_0 {
@@ -8274,9 +7640,6 @@ impl Default for DXVA2_ExtendedFormat_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA2_ExtendedFormat_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVA2_FilmGrainBuffer: DXVA2_BufferfType = DXVA2_BufferfType(8i32);
 #[repr(transparent)]
@@ -8294,9 +7657,6 @@ impl Default for DXVA2_FilterValues {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_FilterValues {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DXVA2_Fixed32 {
@@ -8306,9 +7666,6 @@ impl Default for DXVA2_Fixed32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA2_Fixed32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8321,9 +7678,6 @@ impl Default for DXVA2_Fixed32_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_Fixed32_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA2_Fixed32_0_0 {
@@ -8335,9 +7689,6 @@ impl Default for DXVA2_Fixed32_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_Fixed32_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA2_Frequency {
@@ -8348,9 +7699,6 @@ impl Default for DXVA2_Frequency {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA2_Frequency {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVA2_InverseQuantizationMatrixBufferType: DXVA2_BufferfType = DXVA2_BufferfType(4i32);
 pub const DXVA2_MacroBlockControlBufferType: DXVA2_BufferfType = DXVA2_BufferfType(1i32);
@@ -8432,9 +7780,6 @@ impl Default for DXVA2_ProcAmpValues {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_ProcAmpValues {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVA2_ProcAmp_Brightness: DXVA2_ProcAmp = DXVA2_ProcAmp(1i32);
 pub const DXVA2_ProcAmp_Contrast: DXVA2_ProcAmp = DXVA2_ProcAmp(2i32);
 pub const DXVA2_ProcAmp_Hue: DXVA2_ProcAmp = DXVA2_ProcAmp(4i32);
@@ -8487,9 +7832,6 @@ impl Default for DXVA2_ValueRange {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_ValueRange {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DXVA2_VideoChromaSubSampling(pub i32);
@@ -8522,10 +7864,6 @@ impl Default for DXVA2_VideoDesc {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVA2_VideoDesc {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8577,9 +7915,6 @@ impl Default for DXVA2_VideoProcessBltParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA2_VideoProcessBltParams {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVA2_VideoProcess_AlphaBlend: DXVA2_VideoProcess = DXVA2_VideoProcess(8i32);
 pub const DXVA2_VideoProcess_AlphaBlendExtended: DXVA2_VideoProcess = DXVA2_VideoProcess(256i32);
 pub const DXVA2_VideoProcess_Constriction: DXVA2_VideoProcess = DXVA2_VideoProcess(512i32);
@@ -8619,10 +7954,6 @@ impl Default for DXVA2_VideoProcessorCaps {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVA2_VideoProcessorCaps {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVA2_VideoProcessorRenderTarget: DXVA2_VideoRenderTargetType = DXVA2_VideoRenderTargetType(1i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8651,10 +7982,6 @@ impl Default for DXVA2_VideoSample {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVA2_VideoSample {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DXVA2_VideoSoftwareRenderTarget: DXVA2_VideoRenderTargetType = DXVA2_VideoRenderTargetType(2i32);
 pub const DXVA2_VideoTransFuncMask: DXVA2_VideoTransferFunction = DXVA2_VideoTransferFunction(31i32);
@@ -8690,9 +8017,6 @@ impl Default for DXVABufferInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVABufferInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8710,10 +8034,6 @@ impl Default for DXVACompBufferInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVACompBufferInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVAHDControlGuid: windows_core::GUID = windows_core::GUID::from_u128(0xa0386e75_f70c_464c_a9ce_33c44e091623);
 pub const DXVAHDETWGUID_CREATEVIDEOPROCESSOR: windows_core::GUID = windows_core::GUID::from_u128(0x681e3d1e_5674_4fb3_a503_2f2055e91f60);
@@ -8734,9 +8054,6 @@ impl Default for DXVAHDETW_CREATEVIDEOPROCESSOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHDETW_CREATEVIDEOPROCESSOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVAHDETW_DESTROYVIDEOPROCESSOR {
@@ -8746,9 +8063,6 @@ impl Default for DXVAHDETW_DESTROYVIDEOPROCESSOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHDETW_DESTROYVIDEOPROCESSOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -8768,10 +8082,6 @@ impl Default for DXVAHDETW_VIDEOPROCESSBLTHD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVAHDETW_VIDEOPROCESSBLTHD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -8796,10 +8106,6 @@ impl Default for DXVAHDETW_VIDEOPROCESSBLTHD_STREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVAHDETW_VIDEOPROCESSBLTHD_STREAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVAHDETW_VIDEOPROCESSBLTSTATE {
@@ -8812,9 +8118,6 @@ impl Default for DXVAHDETW_VIDEOPROCESSBLTSTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHDETW_VIDEOPROCESSBLTSTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8829,9 +8132,6 @@ impl Default for DXVAHDETW_VIDEOPROCESSSTREAMSTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHDETW_VIDEOPROCESSSTREAMSTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -8860,10 +8160,6 @@ impl Default for DXVAHDSW_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVAHDSW_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DXVAHD_ALPHA_FILL_MODE(pub i32);
@@ -8886,9 +8182,6 @@ impl Default for DXVAHD_BLT_STATE_ALPHA_FILL_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_BLT_STATE_ALPHA_FILL_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVAHD_BLT_STATE_BACKGROUND_COLOR: DXVAHD_BLT_STATE = DXVAHD_BLT_STATE(1i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8900,9 +8193,6 @@ impl Default for DXVAHD_BLT_STATE_BACKGROUND_COLOR_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_BLT_STATE_BACKGROUND_COLOR_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVAHD_BLT_STATE_CONSTRICTION: DXVAHD_BLT_STATE = DXVAHD_BLT_STATE(4i32);
 #[repr(C)]
@@ -8916,9 +8206,6 @@ impl Default for DXVAHD_BLT_STATE_CONSTRICTION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_BLT_STATE_CONSTRICTION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE: DXVAHD_BLT_STATE = DXVAHD_BLT_STATE(2i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8929,9 +8216,6 @@ impl Default for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8944,9 +8228,6 @@ impl Default for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0_0 {
@@ -8956,9 +8237,6 @@ impl Default for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_BLT_STATE_OUTPUT_COLOR_SPACE_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVAHD_BLT_STATE_PRIVATE: DXVAHD_BLT_STATE = DXVAHD_BLT_STATE(1000i32);
 #[repr(C)]
@@ -8973,9 +8251,6 @@ impl Default for DXVAHD_BLT_STATE_PRIVATE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_BLT_STATE_PRIVATE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVAHD_BLT_STATE_TARGET_RECT: DXVAHD_BLT_STATE = DXVAHD_BLT_STATE(0i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8988,9 +8263,6 @@ impl Default for DXVAHD_BLT_STATE_TARGET_RECT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_BLT_STATE_TARGET_RECT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DXVAHD_COLOR {
@@ -9001,9 +8273,6 @@ impl Default for DXVAHD_COLOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_COLOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9018,9 +8287,6 @@ impl Default for DXVAHD_COLOR_RGBA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_COLOR_RGBA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVAHD_COLOR_YCbCrA {
@@ -9033,9 +8299,6 @@ impl Default for DXVAHD_COLOR_YCbCrA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_COLOR_YCbCrA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9053,9 +8316,6 @@ impl Default for DXVAHD_CONTENT_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_CONTENT_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVAHD_CUSTOM_RATE_DATA {
@@ -9068,9 +8328,6 @@ impl Default for DXVAHD_CUSTOM_RATE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_CUSTOM_RATE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9131,9 +8388,6 @@ impl Default for DXVAHD_FILTER_RANGE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_FILTER_RANGE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVAHD_FILTER_SATURATION: DXVAHD_FILTER = DXVAHD_FILTER(3i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9187,9 +8441,6 @@ impl Default for DXVAHD_RATIONAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_RATIONAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Debug, PartialEq)]
@@ -9209,10 +8460,6 @@ impl Default for DXVAHD_STREAM_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVAHD_STREAM_DATA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DXVAHD_STREAM_STATE(pub i32);
@@ -9228,9 +8475,6 @@ impl Default for DXVAHD_STREAM_STATE_ALPHA_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_ALPHA_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVAHD_STREAM_STATE_ASPECT_RATIO: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(9i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9243,9 +8487,6 @@ impl Default for DXVAHD_STREAM_STATE_ASPECT_RATIO_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_ASPECT_RATIO_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVAHD_STREAM_STATE_D3DFORMAT: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(0i32);
 #[repr(C)]
@@ -9260,10 +8501,6 @@ impl Default for DXVAHD_STREAM_STATE_D3DFORMAT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_D3DFORMAT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVAHD_STREAM_STATE_DESTINATION_RECT: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(5i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9275,9 +8512,6 @@ impl Default for DXVAHD_STREAM_STATE_DESTINATION_RECT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_DESTINATION_RECT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVAHD_STREAM_STATE_FILTER_ANAMORPHIC_SCALING: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(106i32);
 pub const DXVAHD_STREAM_STATE_FILTER_BRIGHTNESS: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(100i32);
@@ -9292,9 +8526,6 @@ impl Default for DXVAHD_STREAM_STATE_FILTER_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_FILTER_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVAHD_STREAM_STATE_FILTER_EDGE_ENHANCEMENT: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(105i32);
 pub const DXVAHD_STREAM_STATE_FILTER_HUE: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(102i32);
@@ -9311,9 +8542,6 @@ impl Default for DXVAHD_STREAM_STATE_FRAME_FORMAT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_FRAME_FORMAT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(2i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9324,9 +8552,6 @@ impl Default for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9339,9 +8564,6 @@ impl Default for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0_0 {
@@ -9351,9 +8573,6 @@ impl Default for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_INPUT_COLOR_SPACE_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVAHD_STREAM_STATE_LUMA_KEY: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(8i32);
 #[repr(C)]
@@ -9368,9 +8587,6 @@ impl Default for DXVAHD_STREAM_STATE_LUMA_KEY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_LUMA_KEY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVAHD_STREAM_STATE_OUTPUT_RATE: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(3i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9384,9 +8600,6 @@ impl Default for DXVAHD_STREAM_STATE_OUTPUT_RATE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_OUTPUT_RATE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVAHD_STREAM_STATE_PALETTE: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(7i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9398,9 +8611,6 @@ impl Default for DXVAHD_STREAM_STATE_PALETTE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_PALETTE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVAHD_STREAM_STATE_PRIVATE: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(1000i32);
 #[repr(C)]
@@ -9414,9 +8624,6 @@ impl Default for DXVAHD_STREAM_STATE_PRIVATE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_PRIVATE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVAHD_STREAM_STATE_PRIVATE_IVTC: windows_core::GUID = windows_core::GUID::from_u128(0x9c601e3c_0f33_414c_a739_99540ee42da5);
 #[repr(C)]
@@ -9432,9 +8639,6 @@ impl Default for DXVAHD_STREAM_STATE_PRIVATE_IVTC_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_PRIVATE_IVTC_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DXVAHD_STREAM_STATE_SOURCE_RECT: DXVAHD_STREAM_STATE = DXVAHD_STREAM_STATE(4i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9446,9 +8650,6 @@ impl Default for DXVAHD_STREAM_STATE_SOURCE_RECT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_STREAM_STATE_SOURCE_RECT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9470,9 +8671,6 @@ impl Default for DXVAHD_VPCAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVAHD_VPCAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -9496,10 +8694,6 @@ impl Default for DXVAHD_VPDEVCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVAHD_VPDEVCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9514,10 +8708,6 @@ impl Default for DXVAUncompDataInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVAUncompDataInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_AYUVsample2 {
@@ -9530,9 +8720,6 @@ impl Default for DXVA_AYUVsample2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_AYUVsample2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -9553,9 +8740,6 @@ impl Default for DXVA_BufferDescription {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_BufferDescription {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_COPPCommand {
@@ -9570,9 +8754,6 @@ impl Default for DXVA_COPPCommand {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_COPPCommand {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_COPPSignature {
@@ -9582,9 +8763,6 @@ impl Default for DXVA_COPPSignature {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_COPPSignature {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9600,9 +8778,6 @@ impl Default for DXVA_COPPStatusInput {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_COPPStatusInput {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_COPPStatusOutput {
@@ -9614,9 +8789,6 @@ impl Default for DXVA_COPPStatusOutput {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_COPPStatusOutput {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -9644,9 +8816,6 @@ impl Default for DXVA_ConfigPictureDecode {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_ConfigPictureDecode {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_DeinterlaceBlt {
@@ -9663,9 +8832,6 @@ impl Default for DXVA_DeinterlaceBlt {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_DeinterlaceBlt {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9684,9 +8850,6 @@ impl Default for DXVA_DeinterlaceBltEx {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_DeinterlaceBltEx {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -9708,10 +8871,6 @@ impl Default for DXVA_DeinterlaceBltEx32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DXVA_DeinterlaceBltEx32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9731,10 +8890,6 @@ impl Default for DXVA_DeinterlaceCaps {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVA_DeinterlaceCaps {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_DeinterlaceQueryAvailableModes {
@@ -9746,9 +8901,6 @@ impl Default for DXVA_DeinterlaceQueryAvailableModes {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_DeinterlaceQueryAvailableModes {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
@@ -9763,10 +8915,6 @@ impl Default for DXVA_DeinterlaceQueryModeCaps {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVA_DeinterlaceQueryModeCaps {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9798,9 +8946,6 @@ impl Default for DXVA_ExtendedFormat {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_ExtendedFormat {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_Frequency {
@@ -9811,9 +8956,6 @@ impl Default for DXVA_Frequency {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_Frequency {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9871,9 +9013,6 @@ impl Default for DXVA_PictureParameters {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_PictureParameters {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_ProcAmpControlBlt {
@@ -9891,9 +9030,6 @@ impl Default for DXVA_ProcAmpControlBlt {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_ProcAmpControlBlt {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9909,10 +9045,6 @@ impl Default for DXVA_ProcAmpControlCaps {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVA_ProcAmpControlCaps {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9930,10 +9062,6 @@ impl Default for DXVA_ProcAmpControlQueryRange {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVA_ProcAmpControlQueryRange {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVA_ProcAmp_Brightness: DXVA_ProcAmpControlProp = DXVA_ProcAmpControlProp(1i32);
 pub const DXVA_ProcAmp_Contrast: DXVA_ProcAmpControlProp = DXVA_ProcAmpControlProp(2i32);
@@ -9992,10 +9120,6 @@ impl Default for DXVA_VideoDesc {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for DXVA_VideoDesc {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DXVA_VideoLighting(pub i32);
@@ -10046,9 +9170,6 @@ impl Default for DXVA_VideoPropertyRange {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DXVA_VideoPropertyRange {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DXVA_VideoSample {
@@ -10061,9 +9182,6 @@ impl Default for DXVA_VideoSample {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DXVA_VideoSample {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -10083,10 +9201,6 @@ impl Default for DXVA_VideoSample2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DXVA_VideoSample2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -10109,10 +9223,6 @@ impl Default for DXVA_VideoSample2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DXVA_VideoSample2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10131,10 +9241,6 @@ impl Default for DXVA_VideoSample32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DXVA_VideoSample32 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DXVA_VideoTransFuncMask: DXVA_VideoTransferFunction = DXVA_VideoTransferFunction(-134217728i32);
 pub const DXVA_VideoTransFuncShift: DXVA_VideoTransferFunction = DXVA_VideoTransferFunction(27i32);
@@ -10182,9 +9288,6 @@ impl Default for DigitalWindowSetting {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DigitalWindowSetting {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DistanceToFocalPlane: MFDepthMeasurement = MFDepthMeasurement(0i32);
 pub const DistanceToOpticalCenter: MFDepthMeasurement = MFDepthMeasurement(1i32);
@@ -40339,9 +39442,6 @@ impl Default for MACROBLOCK_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MACROBLOCK_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MACROBLOCK_FLAG_DIRTY: u32 = 2u32;
 pub const MACROBLOCK_FLAG_HAS_MOTION_VECTOR: u32 = 16u32;
 pub const MACROBLOCK_FLAG_HAS_QP: u32 = 32u32;
@@ -40704,9 +39804,6 @@ impl Default for MFARGB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFARGB {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MFASFINDEXER_APPROX_SEEK_TIME_UNKNOWN: u64 = 18446744073709551615u64;
 pub const MFASFINDEXER_NO_FIXED_INTERVAL: u32 = 4294967295u32;
 pub const MFASFINDEXER_PER_ENTRY_BYTES_DYNAMIC: u32 = 65535u32;
@@ -40802,9 +39899,6 @@ impl Default for MFAYUVSample {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFAYUVSample {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MFAudioConstriction(pub i32);
@@ -40818,9 +39912,6 @@ impl Default for MFAudioDecoderDegradationInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFAudioDecoderDegradationInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFAudioFormat_AAC: windows_core::GUID = windows_core::GUID::from_u128(0x00001610_0000_0010_8000_00aa00389b71);
 pub const MFAudioFormat_AAC_HDCP: windows_core::GUID = windows_core::GUID::from_u128(0x419bce76_8b72_400f_adeb_84b57d63484d);
@@ -40881,9 +39972,6 @@ impl Default for MFBYTESTREAM_BUFFERING_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFBYTESTREAM_BUFFERING_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MFBYTESTREAM_DOES_NOT_USE_NETWORK: u32 = 2048u32;
 pub const MFBYTESTREAM_HAS_SLOW_SEEK: u32 = 256u32;
 pub const MFBYTESTREAM_IS_DIRECTORY: u32 = 128u32;
@@ -40924,9 +40012,6 @@ impl Default for MFCLOCK_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFCLOCK_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -40977,9 +40062,6 @@ impl Default for MFCONTENTPROTECTIONDEVICE_INPUT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFCONTENTPROTECTIONDEVICE_INPUT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFCONTENTPROTECTIONDEVICE_OUTPUT_DATA {
@@ -40996,9 +40078,6 @@ impl Default for MFCONTENTPROTECTIONDEVICE_OUTPUT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFCONTENTPROTECTIONDEVICE_OUTPUT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFCONTENTPROTECTIONDEVICE_REALTIMECLIENT_DATA {
@@ -41010,9 +40089,6 @@ impl Default for MFCONTENTPROTECTIONDEVICE_REALTIMECLIENT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFCONTENTPROTECTIONDEVICE_REALTIMECLIENT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFCONTENTPROTECTIONDEVICE_REALTIMECLIENT_DATA_FUNCTIONID: u32 = 67108864u32;
 #[repr(C)]
@@ -41027,9 +40103,6 @@ impl Default for MFCameraExtrinsic_CalibratedTransform {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFCameraExtrinsic_CalibratedTransform {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFCameraExtrinsics {
@@ -41040,9 +40113,6 @@ impl Default for MFCameraExtrinsics {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFCameraExtrinsics {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -41057,9 +40127,6 @@ impl Default for MFCameraIntrinsic_CameraModel {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFCameraIntrinsic_CameraModel {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFCameraIntrinsic_DistortionModel {
@@ -41073,9 +40140,6 @@ impl Default for MFCameraIntrinsic_DistortionModel {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFCameraIntrinsic_DistortionModel {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -41094,9 +40158,6 @@ impl Default for MFCameraIntrinsic_DistortionModel6KT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFCameraIntrinsic_DistortionModel6KT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFCameraIntrinsic_DistortionModelArcTan {
@@ -41110,9 +40171,6 @@ impl Default for MFCameraIntrinsic_DistortionModelArcTan {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFCameraIntrinsic_DistortionModelArcTan {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -41129,9 +40187,6 @@ impl Default for MFCameraIntrinsic_PinholeCameraModel {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFCameraIntrinsic_PinholeCameraModel {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -41195,9 +40250,6 @@ impl Default for MFExtendedCameraIntrinsic_IntrinsicModel {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFExtendedCameraIntrinsic_IntrinsicModel {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MFFLACBytestreamHandler: windows_core::GUID = windows_core::GUID::from_u128(0x0e41cfb8_0506_40f4_a516_77cc23642d91);
 pub const MFFLACSinkClassFactory: windows_core::GUID = windows_core::GUID::from_u128(0x7d39c56f_6075_47c9_9bae_8cf9e531b5f5);
 #[repr(C)]
@@ -41213,9 +40265,6 @@ impl Default for MFFOLDDOWN_MATRIX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFFOLDDOWN_MATRIX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -41237,9 +40286,6 @@ impl Default for MFINPUTTRUSTAUTHORITY_ACCESS_ACTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFINPUTTRUSTAUTHORITY_ACCESS_ACTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFINPUTTRUSTAUTHORITY_ACCESS_PARAMS {
@@ -41256,9 +40302,6 @@ impl Default for MFINPUTTRUSTAUTHORITY_ACCESS_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFINPUTTRUSTAUTHORITY_ACCESS_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFImageFormat_JPEG: windows_core::GUID = windows_core::GUID::from_u128(0x19e4a5aa_5662_4fc5_a0c0_1758028e1057);
 pub const MFImageFormat_RGB32: windows_core::GUID = windows_core::GUID::from_u128(0x00000016_0000_0010_8000_00aa00389b71);
@@ -41296,9 +40339,6 @@ impl Default for MFMPEG2DLNASINKSTATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFMPEG2DLNASINKSTATS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MFMPEG4Format_Base: windows_core::GUID = windows_core::GUID::from_u128(0x00000000_767a_494d_b478_f29d25dc9037);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -41311,9 +40351,6 @@ impl Default for MFMediaKeyStatus {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFMediaKeyStatus {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFMediaType_Audio: windows_core::GUID = windows_core::GUID::from_u128(0x73647561_0000_0010_8000_00aa00389b71);
 pub const MFMediaType_Binary: windows_core::GUID = windows_core::GUID::from_u128(0x72178c25_e45b_11d5_bc2a_00b0d0f3f4ab);
@@ -41468,9 +40505,6 @@ impl Default for MFNetCredentialManagerGetParam {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFNetCredentialManagerGetParam {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MFNetCredentialOptions(pub i32);
@@ -41499,9 +40533,6 @@ impl Default for MFOffset {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFOffset {
-    type TypeKind = windows_core::CopyType;
 }
 pub type MFPERIODICCALLBACK = Option<unsafe extern "system" fn(pcontext: Option<windows_core::IUnknown>)>;
 #[repr(transparent)]
@@ -41554,10 +40585,6 @@ impl Default for MFP_ACQUIRE_USER_CREDENTIAL_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_ACQUIRE_USER_CREDENTIAL_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MFP_CREATION_OPTIONS(pub i32);
@@ -41579,10 +40606,6 @@ impl Default for MFP_ERROR_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_ERROR_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 #[derive(Clone, Debug, PartialEq)]
@@ -41598,10 +40621,6 @@ impl Default for MFP_EVENT_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_EVENT_HEADER {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -41632,10 +40651,6 @@ impl Default for MFP_FRAME_STEP_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_FRAME_STEP_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 pub const MFP_MEDIAITEM_CAN_PAUSE: _MFP_MEDIAITEM_CHARACTERISTICS = _MFP_MEDIAITEM_CHARACTERISTICS(4i32);
 pub const MFP_MEDIAITEM_CAN_SEEK: _MFP_MEDIAITEM_CHARACTERISTICS = _MFP_MEDIAITEM_CHARACTERISTICS(2i32);
 #[repr(C)]
@@ -41651,10 +40666,6 @@ impl Default for MFP_MEDIAITEM_CLEARED_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_MEDIAITEM_CLEARED_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 #[derive(Clone, Debug, PartialEq)]
@@ -41668,10 +40679,6 @@ impl Default for MFP_MEDIAITEM_CREATED_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_MEDIAITEM_CREATED_EVENT {
-    type TypeKind = windows_core::CloneType;
 }
 pub const MFP_MEDIAITEM_HAS_SLOW_SEEK: _MFP_MEDIAITEM_CHARACTERISTICS = _MFP_MEDIAITEM_CHARACTERISTICS(8i32);
 pub const MFP_MEDIAITEM_IS_LIVE: _MFP_MEDIAITEM_CHARACTERISTICS = _MFP_MEDIAITEM_CHARACTERISTICS(1i32);
@@ -41687,10 +40694,6 @@ impl Default for MFP_MEDIAITEM_SET_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_MEDIAITEM_SET_EVENT {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -41715,10 +40718,6 @@ impl Default for MFP_MF_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_MF_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 pub const MFP_OPTION_FREE_THREADED_CALLBACK: MFP_CREATION_OPTIONS = MFP_CREATION_OPTIONS(1i32);
 pub const MFP_OPTION_NONE: MFP_CREATION_OPTIONS = MFP_CREATION_OPTIONS(0i32);
 pub const MFP_OPTION_NO_MMCSS: MFP_CREATION_OPTIONS = MFP_CREATION_OPTIONS(2i32);
@@ -41736,10 +40735,6 @@ impl Default for MFP_PAUSE_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_PAUSE_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 #[derive(Clone, Debug, PartialEq)]
@@ -41753,10 +40748,6 @@ impl Default for MFP_PLAYBACK_ENDED_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_PLAYBACK_ENDED_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 #[derive(Clone, Debug, PartialEq)]
@@ -41769,10 +40760,6 @@ impl Default for MFP_PLAY_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_PLAY_EVENT {
-    type TypeKind = windows_core::CloneType;
 }
 pub const MFP_POSITIONTYPE_100NS: windows_core::GUID = windows_core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000);
 #[repr(C)]
@@ -41788,10 +40775,6 @@ impl Default for MFP_POSITION_SET_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_POSITION_SET_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 #[derive(Clone, Debug, PartialEq)]
@@ -41806,10 +40789,6 @@ impl Default for MFP_RATE_SET_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_RATE_SET_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 #[derive(Clone, Debug, PartialEq)]
@@ -41823,10 +40802,6 @@ impl Default for MFP_STOP_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-impl windows_core::TypeKind for MFP_STOP_EVENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MFPaletteEntry {
@@ -41837,9 +40812,6 @@ impl Default for MFPaletteEntry {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFPaletteEntry {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -41854,9 +40826,6 @@ impl Default for MFPinholeCameraIntrinsic_IntrinsicModel {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFPinholeCameraIntrinsic_IntrinsicModel {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFPinholeCameraIntrinsics {
@@ -41867,9 +40836,6 @@ impl Default for MFPinholeCameraIntrinsics {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFPinholeCameraIntrinsics {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -41888,9 +40854,6 @@ impl Default for MFRR_COMPONENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFRR_COMPONENTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFRR_COMPONENT_HASH_INFO {
@@ -41904,9 +40867,6 @@ impl Default for MFRR_COMPONENT_HASH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFRR_COMPONENT_HASH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MFRR_INFO_VERSION: u32 = 0u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -41918,9 +40878,6 @@ impl Default for MFRatio {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFRatio {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFSEQUENCER_INVALID_ELEMENT_ID: u32 = 4294967295u32;
 pub const MFSESSIONCAP_DOES_NOT_USE_NETWORK: u32 = 64u32;
@@ -42125,9 +41082,6 @@ impl Default for MFTOPONODE_ATTRIBUTE_UPDATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFTOPONODE_ATTRIBUTE_UPDATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MFTOPONODE_ATTRIBUTE_UPDATE_0 {
@@ -42139,9 +41093,6 @@ impl Default for MFTOPONODE_ATTRIBUTE_UPDATE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFTOPONODE_ATTRIBUTE_UPDATE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFT_AUDIO_DECODER_AUDIO_ENDPOINT_ID: windows_core::GUID = windows_core::GUID::from_u128(0xc7ccdd6e_5398_4695_8be7_51b3e95111bd);
 pub const MFT_AUDIO_DECODER_DEGRADATION_INFO_ATTRIBUTE: windows_core::GUID = windows_core::GUID::from_u128(0x6c3386ad_ec20_430d_b2a5_505c7178d9c4);
@@ -42261,9 +41212,6 @@ impl Default for MFT_INPUT_STREAM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFT_INPUT_STREAM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MFT_INPUT_STREAM_OPTIONAL: _MFT_INPUT_STREAM_INFO_FLAGS = _MFT_INPUT_STREAM_INFO_FLAGS(1024i32);
 pub const MFT_INPUT_STREAM_PROCESSES_IN_PLACE: _MFT_INPUT_STREAM_INFO_FLAGS = _MFT_INPUT_STREAM_INFO_FLAGS(2048i32);
 pub const MFT_INPUT_STREAM_REMOVABLE: _MFT_INPUT_STREAM_INFO_FLAGS = _MFT_INPUT_STREAM_INFO_FLAGS(512i32);
@@ -42302,9 +41250,6 @@ impl Default for MFT_OUTPUT_DATA_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFT_OUTPUT_DATA_BUFFER {
-    type TypeKind = windows_core::CloneType;
-}
 pub const MFT_OUTPUT_DATA_BUFFER_FORMAT_CHANGE: _MFT_OUTPUT_DATA_BUFFER_FLAGS = _MFT_OUTPUT_DATA_BUFFER_FLAGS(256i32);
 pub const MFT_OUTPUT_DATA_BUFFER_INCOMPLETE: _MFT_OUTPUT_DATA_BUFFER_FLAGS = _MFT_OUTPUT_DATA_BUFFER_FLAGS(16777216i32);
 pub const MFT_OUTPUT_DATA_BUFFER_NO_SAMPLE: _MFT_OUTPUT_DATA_BUFFER_FLAGS = _MFT_OUTPUT_DATA_BUFFER_FLAGS(768i32);
@@ -42324,9 +41269,6 @@ impl Default for MFT_OUTPUT_STREAM_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFT_OUTPUT_STREAM_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFT_OUTPUT_STREAM_LAZY_READ: _MFT_OUTPUT_STREAM_INFO_FLAGS = _MFT_OUTPUT_STREAM_INFO_FLAGS(1024i32);
 pub const MFT_OUTPUT_STREAM_OPTIONAL: _MFT_OUTPUT_STREAM_INFO_FLAGS = _MFT_OUTPUT_STREAM_INFO_FLAGS(16i32);
@@ -42353,9 +41295,6 @@ impl Default for MFT_REGISTER_TYPE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFT_REGISTER_TYPE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFT_REGISTRATION_INFO {
@@ -42373,9 +41312,6 @@ impl Default for MFT_REGISTRATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFT_REGISTRATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MFT_REMUX_MARK_I_PICTURE_AS_CLEAN_POINT: windows_core::GUID = windows_core::GUID::from_u128(0x364e8f85_3f2e_436c_b2a2_4440a012a9e8);
 pub const MFT_SET_TYPE_TEST_ONLY: _MFT_SET_TYPE_FLAGS = _MFT_SET_TYPE_FLAGS(1i32);
 pub const MFT_STREAMS_UNLIMITED: u32 = 4294967295u32;
@@ -42389,9 +41325,6 @@ impl Default for MFT_STREAM_STATE_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFT_STREAM_STATE_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFT_SUPPORT_3DVIDEO: windows_core::GUID = windows_core::GUID::from_u128(0x093f81b1_4f2e_4631_8168_7934032a01d3);
 pub const MFT_SUPPORT_DYNAMIC_FORMAT_CHANGE: windows_core::GUID = windows_core::GUID::from_u128(0x53476a11_3f13_49fb_ac42_ee2733c96741);
@@ -42422,9 +41355,6 @@ impl Default for MFVIDEOFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFVIDEOFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFVP_MESSAGE_BEGINSTREAMING: MFVP_MESSAGE_TYPE = MFVP_MESSAGE_TYPE(3i32);
 pub const MFVP_MESSAGE_CANCELSTEP: MFVP_MESSAGE_TYPE = MFVP_MESSAGE_TYPE(7i32);
@@ -42471,10 +41401,6 @@ impl Default for MFVideoAlphaBitmap {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for MFVideoAlphaBitmap {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
 pub union MFVideoAlphaBitmap_0 {
@@ -42492,10 +41418,6 @@ impl Default for MFVideoAlphaBitmap_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
-impl windows_core::TypeKind for MFVideoAlphaBitmap_0 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -42515,9 +41437,6 @@ impl Default for MFVideoAlphaBitmapParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFVideoAlphaBitmapParams {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MFVideoAlphaBitmap_Alpha: MFVideoAlphaBitmapFlags = MFVideoAlphaBitmapFlags(32i32);
 pub const MFVideoAlphaBitmap_BitMask: MFVideoAlphaBitmapFlags = MFVideoAlphaBitmapFlags(63i32);
 pub const MFVideoAlphaBitmap_DestRect: MFVideoAlphaBitmapFlags = MFVideoAlphaBitmapFlags(8i32);
@@ -42536,9 +41455,6 @@ impl Default for MFVideoArea {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFVideoArea {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -42568,9 +41484,6 @@ impl Default for MFVideoCompressedInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFVideoCompressedInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFVideoDRMFlag_AnalogProtected: MFVideoDRMFlags = MFVideoDRMFlags(1i32);
 pub const MFVideoDRMFlag_DigitallyProtected: MFVideoDRMFlags = MFVideoDRMFlags(2i32);
@@ -42703,9 +41616,6 @@ impl Default for MFVideoInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFVideoInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MFVideoInterlaceMode(pub i32);
@@ -42749,9 +41659,6 @@ impl Default for MFVideoNormalizedRect {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFVideoNormalizedRect {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFVideoPadFlag_PAD_TO_16x9: MFVideoPadFlags = MFVideoPadFlags(2i32);
 pub const MFVideoPadFlag_PAD_TO_4x3: MFVideoPadFlags = MFVideoPadFlags(1i32);
@@ -42826,9 +41733,6 @@ impl Default for MFVideoSurfaceInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MFVideoSurfaceInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MFVideoTransFunc_10: MFVideoTransferFunction = MFVideoTransferFunction(1i32);
 pub const MFVideoTransFunc_10_rel: MFVideoTransferFunction = MFVideoTransferFunction(17i32);
@@ -42978,9 +41882,6 @@ impl Default for MF_BYTE_STREAM_CACHE_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MF_BYTE_STREAM_CACHE_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MF_CAMERA_CONTROL_CONFIGURATION_TYPE(pub i32);
@@ -42998,9 +41899,6 @@ impl Default for MF_CAMERA_CONTROL_RANGE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MF_CAMERA_CONTROL_RANGE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MF_CAPTURE_ENGINE_ALL_EFFECTS_REMOVED: windows_core::GUID = windows_core::GUID::from_u128(0xfded7521_8ed8_431a_a96b_f3e2565e981c);
 pub const MF_CAPTURE_ENGINE_AUDIO_PROCESSING: windows_core::GUID = windows_core::GUID::from_u128(0x10f1be5e_7e11_410b_973d_f4b6109000fe);
@@ -43584,9 +42482,6 @@ impl Default for MF_FLOAT2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MF_FLOAT2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MF_FLOAT3 {
@@ -43598,9 +42493,6 @@ impl Default for MF_FLOAT3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MF_FLOAT3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MF_FRAMESERVER_VCAMEVENT_EXTENDED_CUSTOM_EVENT: windows_core::GUID = windows_core::GUID::from_u128(0x6e59489c_47d3_4467_83ef_12d34e871665);
 pub const MF_FRAMESERVER_VCAMEVENT_EXTENDED_PIPELINE_SHUTDOWN: windows_core::GUID = windows_core::GUID::from_u128(0x45a81b31_43f8_4e5d_8ce2_22dce026996d);
@@ -43640,9 +42532,6 @@ impl Default for MF_LEAKY_BUCKET_PAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MF_LEAKY_BUCKET_PAIR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MF_LICENSE_URL_TAMPERED: MF_URL_TRUST_STATUS = MF_URL_TRUST_STATUS(2i32);
 pub const MF_LICENSE_URL_TRUSTED: MF_URL_TRUST_STATUS = MF_URL_TRUST_STATUS(1i32);
@@ -44198,9 +43087,6 @@ impl Default for MF_QUATERNION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MF_QUATERNION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MF_QUOTA_EXCEEDED_ERR: u32 = 2154823702u32;
 pub const MF_RATE_CONTROL_SERVICE: windows_core::GUID = windows_core::GUID::from_u128(0x866fa297_b802_4bf8_9dc9_5e3b6a9f53c9);
 pub const MF_READWRITE_D3D_OPTIONAL: windows_core::GUID = windows_core::GUID::from_u128(0x216479d9_3071_42ca_bb6c_4c22102e1d18);
@@ -44369,9 +43255,6 @@ impl Default for MF_SINK_WRITER_STATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MF_SINK_WRITER_STATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MF_SOURCE_PRESENTATION_PROVIDER_SERVICE: windows_core::GUID = windows_core::GUID::from_u128(0xe002aadc_f4af_4ee5_9847_053edf840426);
 pub const MF_SOURCE_READERF_ALLEFFECTSREMOVED: MF_SOURCE_READER_FLAG = MF_SOURCE_READER_FLAG(512i32);
@@ -44722,9 +43605,6 @@ impl Default for MF_TRANSCODE_SINK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MF_TRANSCODE_SINK_INFO {
-    type TypeKind = windows_core::CloneType;
-}
 pub const MF_TRANSCODE_SKIP_METADATA_TRANSFER: windows_core::GUID = windows_core::GUID::from_u128(0x4e4469ef_b571_4959_8f83_3dcfba33a393);
 pub const MF_TRANSCODE_TOPOLOGYMODE: windows_core::GUID = windows_core::GUID::from_u128(0x3e3df610_394a_40b2_9dea_3bab650bebf2);
 #[repr(transparent)]
@@ -44772,9 +43652,6 @@ impl Default for MF_VIDEO_SPHERICAL_VIEWDIRECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MF_VIDEO_SPHERICAL_VIEWDIRECTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MF_VIRTUALCAMERA_ASSOCIATED_CAMERA_SOURCES: windows_core::GUID = windows_core::GUID::from_u128(0x1bb79e7c_5d83_438c_94d8_e5f0df6d3279);
 pub const MF_VIRTUALCAMERA_CONFIGURATION_APP_PACKAGE_FAMILY_NAME: windows_core::GUID = windows_core::GUID::from_u128(0x658abe51_8044_462e_97ea_e676fd72055f);
 pub const MF_VIRTUALCAMERA_PROVIDE_ASSOCIATED_CAMERA_SOURCES: windows_core::GUID = windows_core::GUID::from_u128(0xf0273718_4a4d_4ac5_a15d_305eb5e90667);
@@ -44816,9 +43693,6 @@ impl Default for MOVEREGION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MOVEREGION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MOVE_RECT {
@@ -44829,9 +43703,6 @@ impl Default for MOVE_RECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MOVE_RECT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MP3ACMCodecWrapper: windows_core::GUID = windows_core::GUID::from_u128(0x11103421_354c_4cca_a7a3_1aff9a5b6701);
 #[repr(C)]
@@ -44848,10 +43719,6 @@ impl Default for MPEG1VIDEOINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for MPEG1VIDEOINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -44870,10 +43737,6 @@ impl Default for MPEG2VIDEOINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for MPEG2VIDEOINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -44936,9 +43799,6 @@ impl Default for MT_ARBITRARY_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MT_ARBITRARY_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MT_CUSTOM_VIDEO_PRIMARIES {
@@ -44955,9 +43815,6 @@ impl Default for MT_CUSTOM_VIDEO_PRIMARIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MT_CUSTOM_VIDEO_PRIMARIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MULawCodecWrapper: windows_core::GUID = windows_core::GUID::from_u128(0x92b66080_5e2d_449e_90c4_c41f268e5514);
 pub const OPENMODE_APPEND_IF_EXIST: FILE_OPENMODE = FILE_OPENMODE(3i32);
@@ -44988,9 +43845,6 @@ impl Default for OPM_ACP_AND_CGMSA_SIGNALING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPM_ACP_AND_CGMSA_SIGNALING {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OPM_ACP_LEVEL_ONE: OPM_ACP_PROTECTION_LEVEL = OPM_ACP_PROTECTION_LEVEL(1i32);
 pub const OPM_ACP_LEVEL_THREE: OPM_ACP_PROTECTION_LEVEL = OPM_ACP_PROTECTION_LEVEL(3i32);
 pub const OPM_ACP_LEVEL_TWO: OPM_ACP_PROTECTION_LEVEL = OPM_ACP_PROTECTION_LEVEL(2i32);
@@ -45016,10 +43870,6 @@ impl Default for OPM_ACTUAL_OUTPUT_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Direct3D9")]
-impl windows_core::TypeKind for OPM_ACTUAL_OUTPUT_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPM_ASPECT_RATIO_EN300294_BOX_14_BY_9_CENTER: OPM_IMAGE_ASPECT_RATIO_EN300294 = OPM_IMAGE_ASPECT_RATIO_EN300294(1i32);
 pub const OPM_ASPECT_RATIO_EN300294_BOX_14_BY_9_TOP: OPM_IMAGE_ASPECT_RATIO_EN300294 = OPM_IMAGE_ASPECT_RATIO_EN300294(2i32);
@@ -45068,9 +43918,6 @@ impl Default for OPM_CONFIGURE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPM_CONFIGURE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OPM_CONFIGURE_SETTING_DATA_SIZE: OPM_TYPE = OPM_TYPE(4056i32);
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -45087,9 +43934,6 @@ impl Default for OPM_CONNECTED_HDCP_DEVICE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPM_CONNECTED_HDCP_DEVICE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -45128,9 +43972,6 @@ impl Default for OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPM_COPP_COMPATIBLE_GET_INFO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OPM_DPCP_OFF: OPM_DPCP_PROTECTION_LEVEL = OPM_DPCP_PROTECTION_LEVEL(0i32);
 pub const OPM_DPCP_ON: OPM_DPCP_PROTECTION_LEVEL = OPM_DPCP_PROTECTION_LEVEL(1i32);
 #[repr(transparent)]
@@ -45151,9 +43992,6 @@ impl Default for OPM_ENCRYPTED_INITIALIZATION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPM_ENCRYPTED_INITIALIZATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OPM_ENCRYPTED_INITIALIZATION_PARAMETERS_SIZE: OPM_TYPE = OPM_TYPE(256i32);
 pub const OPM_GET_ACP_AND_CGMSA_SIGNALING: windows_core::GUID = windows_core::GUID::from_u128(0x6629a591_3b79_4cf3_924a_11e8e7811671);
 pub const OPM_GET_ACTUAL_OUTPUT_FORMAT: windows_core::GUID = windows_core::GUID::from_u128(0xd7bf1ba3_ad13_4f8e_af98_0dcb3ca204cc);
@@ -45171,9 +44009,6 @@ impl Default for OPM_GET_CODEC_INFO_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPM_GET_CODEC_INFO_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct OPM_GET_CODEC_INFO_PARAMETERS {
@@ -45184,9 +44019,6 @@ impl Default for OPM_GET_CODEC_INFO_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPM_GET_CODEC_INFO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPM_GET_CONNECTED_HDCP_DEVICE_INFORMATION: windows_core::GUID = windows_core::GUID::from_u128(0x0db59d74_a992_492e_a0bd_c23fda564e00);
 pub const OPM_GET_CONNECTOR_TYPE: windows_core::GUID = windows_core::GUID::from_u128(0x81d0bfd5_6afe_48c2_99c0_95a08f97c5da);
@@ -45207,9 +44039,6 @@ impl Default for OPM_GET_INFO_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPM_GET_INFO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPM_GET_OUTPUT_HARDWARE_PROTECTION_SUPPORT: windows_core::GUID = windows_core::GUID::from_u128(0x3b129589_2af8_4ef0_96a2_704a845a218e);
 pub const OPM_GET_OUTPUT_ID: windows_core::GUID = windows_core::GUID::from_u128(0x72cb6df3_244f_40ce_b09e_20506af6302f);
@@ -45263,9 +44092,6 @@ impl Default for OPM_HDCP_KEY_SELECTION_VECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPM_HDCP_KEY_SELECTION_VECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OPM_HDCP_KEY_SELECTION_VECTOR_SIZE: OPM_TYPE = OPM_TYPE(5i32);
 pub const OPM_HDCP_OFF: OPM_HDCP_PROTECTION_LEVEL = OPM_HDCP_PROTECTION_LEVEL(0i32);
 pub const OPM_HDCP_ON: OPM_HDCP_PROTECTION_LEVEL = OPM_HDCP_PROTECTION_LEVEL(1i32);
@@ -45295,9 +44121,6 @@ impl Default for OPM_OMAC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPM_OMAC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OPM_OMAC_SIZE: OPM_TYPE = OPM_TYPE(16i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -45315,9 +44138,6 @@ impl Default for OPM_OUTPUT_ID_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPM_OUTPUT_ID_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPM_PROTECTION_STANDARD_ARIBTRB15_1125I: OPM_PROTECTION_STANDARD_TYPE = OPM_PROTECTION_STANDARD_TYPE(16384u32);
 pub const OPM_PROTECTION_STANDARD_ARIBTRB15_525I: OPM_PROTECTION_STANDARD_TYPE = OPM_PROTECTION_STANDARD_TYPE(2048u32);
@@ -45361,9 +44181,6 @@ impl Default for OPM_RANDOM_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPM_RANDOM_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct OPM_REQUESTED_INFORMATION {
@@ -45375,9 +44192,6 @@ impl Default for OPM_REQUESTED_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPM_REQUESTED_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPM_REQUESTED_INFORMATION_SIZE: OPM_TYPE = OPM_TYPE(4076i32);
 pub const OPM_SET_ACP_AND_CGMSA_SIGNALING: windows_core::GUID = windows_core::GUID::from_u128(0x09a631a5_d684_4c60_8e4d_d3bb0f0be3ee);
@@ -45400,9 +44214,6 @@ impl Default for OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPM_SET_ACP_AND_CGMSA_SIGNALING_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OPM_SET_HDCP_SRM: windows_core::GUID = windows_core::GUID::from_u128(0x8b5ef5d1_c30d_44ff_84a5_ea71dce78f13);
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -45413,9 +44224,6 @@ impl Default for OPM_SET_HDCP_SRM_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPM_SET_HDCP_SRM_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPM_SET_PROTECTION_LEVEL: windows_core::GUID = windows_core::GUID::from_u128(0x9bb9327c_4eb5_4727_9f00_b42b0919c0da);
 pub const OPM_SET_PROTECTION_LEVEL_ACCORDING_TO_CSS_DVD: windows_core::GUID = windows_core::GUID::from_u128(0x39ce333e_4cc0_44ae_bfcc_da50b5f82e72);
@@ -45432,9 +44240,6 @@ impl Default for OPM_SET_PROTECTION_LEVEL_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPM_SET_PROTECTION_LEVEL_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct OPM_STANDARD_INFORMATION {
@@ -45448,9 +44253,6 @@ impl Default for OPM_STANDARD_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPM_STANDARD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -45578,9 +44380,6 @@ impl Default for ROI_AREA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ROI_AREA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ROTATION_NONE: MF_VIDEO_PROCESSOR_ROTATION = MF_VIDEO_PROCESSOR_ROTATION(0i32);
 pub const ROTATION_NORMAL: MF_VIDEO_PROCESSOR_ROTATION = MF_VIDEO_PROCESSOR_ROTATION(1i32);
 #[repr(transparent)]
@@ -45606,9 +44405,6 @@ impl Default for SENSORPROFILEID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SENSORPROFILEID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SHA_HASH_LEN: u32 = 20u32;
 pub const SINGLE_CHANNEL_AEC: AEC_SYSTEM_MODE = AEC_SYSTEM_MODE(0i32);
 pub const SINGLE_CHANNEL_NSAGC: AEC_SYSTEM_MODE = AEC_SYSTEM_MODE(5i32);
@@ -45622,9 +44418,6 @@ impl Default for STREAM_MEDIUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STREAM_MEDIUM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SYSFXUI_DONOTSHOW_BASSBOOST: u32 = 8u32;
 pub const SYSFXUI_DONOTSHOW_BASSMANAGEMENT: u32 = 4u32;
@@ -45654,9 +44447,6 @@ impl Default for TOC_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOC_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOC_ENTRY_DESCRIPTOR {
@@ -45670,9 +44460,6 @@ impl Default for TOC_ENTRY_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOC_ENTRY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TOC_ENTRY_MAX_TITLE_SIZE: u32 = 65535u32;
 pub const TOC_MAX_DESCRIPTION_SIZE: u32 = 65535u32;
@@ -45700,10 +44487,6 @@ impl Default for VIDEOINFOHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for VIDEOINFOHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -45727,10 +44510,6 @@ impl Default for VIDEOINFOHEADER2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for VIDEOINFOHEADER2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -45743,10 +44522,6 @@ impl Default for VIDEOINFOHEADER2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for VIDEOINFOHEADER2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIDEO_ZOOM_RECT: windows_core::GUID = windows_core::GUID::from_u128(0x7aaa1638_1b7f_4c93_bd89_5b9c9fb6fcf0);
 pub const VRHP_BIGROOM: MF_AUVRHP_ROOMMODEL = MF_AUVRHP_ROOMMODEL(2i32);

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/mod.rs
@@ -13900,9 +13900,6 @@ impl Default for TimedLevel {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TimedLevel {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WMPAccountType(pub i32);
@@ -13935,9 +13932,6 @@ impl Default for WMPContextMenuInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMPContextMenuInfo {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14028,9 +14022,6 @@ impl Default for WMP_WMDM_METADATA_ROUND_TRIP_DEVICE2PC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMP_WMDM_METADATA_ROUND_TRIP_DEVICE2PC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WMP_WMDM_METADATA_ROUND_TRIP_PC2DEVICE {
@@ -14041,9 +14032,6 @@ impl Default for WMP_WMDM_METADATA_ROUND_TRIP_PC2DEVICE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMP_WMDM_METADATA_ROUND_TRIP_PC2DEVICE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMProfile_V40_100Video: windows_core::GUID = windows_core::GUID::from_u128(0x8f99ddd8_6684_456b_a0a3_33e1316895f0);
 pub const WMProfile_V40_128Audio: windows_core::GUID = windows_core::GUID::from_u128(0x93ddbe12_13dc_4e32_a35e_40378e34279a);

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
@@ -1159,9 +1159,6 @@ impl Default for ADPCMCOEFSET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADPCMCOEFSET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -1174,10 +1171,6 @@ impl Default for ADPCMEWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for ADPCMEWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
@@ -1194,10 +1187,6 @@ impl Default for ADPCMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for ADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -1209,10 +1198,6 @@ impl Default for APTXWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for APTXWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
@@ -1226,10 +1211,6 @@ impl Default for AUDIOFILE_AF10WAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for AUDIOFILE_AF10WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -1241,10 +1222,6 @@ impl Default for AUDIOFILE_AF36WAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for AUDIOFILE_AF36WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AUXDM_GETDEVCAPS: u32 = 4u32;
 pub const AUXDM_GETNUMDEVS: u32 = 3u32;
@@ -1276,9 +1253,6 @@ impl Default for AVICOMPRESSOPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVICOMPRESSOPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AVIERR_OK: i32 = 0i32;
 pub const AVIFILECAPS_ALLKEYFRAMES: u32 = 16u32;
 pub const AVIFILECAPS_CANREAD: u32 = 1u32;
@@ -1308,9 +1282,6 @@ impl Default for AVIFILEINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVIFILEINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AVIFILEINFOW {
@@ -1331,9 +1302,6 @@ impl Default for AVIFILEINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVIFILEINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AVIFILEINFO_COPYRIGHTED: u32 = 131072u32;
 pub const AVIFILEINFO_HASINDEX: u32 = 16u32;
@@ -1371,9 +1339,6 @@ impl Default for AVISTREAMINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVISTREAMINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AVISTREAMINFOW {
@@ -1400,9 +1365,6 @@ impl Default for AVISTREAMINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVISTREAMINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AVISTREAMINFO_DISABLED: u32 = 1u32;
 pub const AVISTREAMINFO_FORMATCHANGES: u32 = 65536u32;
@@ -1431,9 +1393,6 @@ impl Default for CAPDRIVERCAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CAPDRIVERCAPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub type CAPERRORCALLBACKA = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, nid: i32, lpsz: windows_core::PCSTR) -> super::super::Foundation::LRESULT>;
 pub type CAPERRORCALLBACKW = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, nid: i32, lpsz: windows_core::PCWSTR) -> super::super::Foundation::LRESULT>;
 #[repr(C)]
@@ -1447,9 +1406,6 @@ impl Default for CAPINFOCHUNK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CAPINFOCHUNK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1479,10 +1435,6 @@ impl Default for CAPSTATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CAPSTATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub type CAPSTATUSCALLBACKA = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, nid: i32, lpsz: windows_core::PCSTR) -> super::super::Foundation::LRESULT>;
 pub type CAPSTATUSCALLBACKW = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, nid: i32, lpsz: windows_core::PCWSTR) -> super::super::Foundation::LRESULT>;
@@ -1519,9 +1471,6 @@ impl Default for CAPTUREPARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CAPTUREPARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub type CAPVIDEOCALLBACK = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, lpvhdr: *const VIDEOHDR) -> super::super::Foundation::LRESULT>;
 #[cfg(feature = "Win32_Media_Audio")]
 pub type CAPWAVECALLBACK = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, lpwhdr: *const super::Audio::WAVEHDR) -> super::super::Foundation::LRESULT>;
@@ -1543,9 +1492,6 @@ impl Default for CHANNEL_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANNEL_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLSID_AVIFile: windows_core::GUID = windows_core::GUID::from_u128(0x00020000_0000_0000_c000_000000000046);
 pub const CLSID_AVISimpleUnMarshal: windows_core::GUID = windows_core::GUID::from_u128(0x00020009_0000_0000_c000_000000000046);
@@ -1576,10 +1522,6 @@ impl Default for COMPVARS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for COMPVARS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -1593,10 +1535,6 @@ impl Default for CONTRESCR10WAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for CONTRESCR10WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -1609,10 +1547,6 @@ impl Default for CONTRESVQLPCWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for CONTRESVQLPCWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONTROLCALLBACK_CAPTURING: u32 = 2u32;
 pub const CONTROLCALLBACK_PREROLL: u32 = 1u32;
@@ -1629,10 +1563,6 @@ impl Default for CREATIVEADPCMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for CREATIVEADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -1645,10 +1575,6 @@ impl Default for CREATIVEFASTSPEECH10WAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for CREATIVEFASTSPEECH10WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
@@ -1663,10 +1589,6 @@ impl Default for CREATIVEFASTSPEECH8WAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for CREATIVEFASTSPEECH8WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYSTAL_NET_SFM_CODEC: u32 = 1u32;
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
@@ -1679,10 +1601,6 @@ impl Default for CSIMAADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for CSIMAADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DCB_EVENT: u32 = 5u32;
 pub const DCB_FUNCTION: u32 = 3u32;
@@ -1720,10 +1638,6 @@ impl Default for DIALOGICOKIADPCMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for DIALOGICOKIADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -1737,10 +1651,6 @@ impl Default for DIGIADPCMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for DIGIADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -1752,10 +1662,6 @@ impl Default for DIGIFIXWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for DIGIFIXWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
@@ -1770,10 +1676,6 @@ impl Default for DIGIREALWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for DIGIREALWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -1785,10 +1687,6 @@ impl Default for DIGISTDWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for DIGISTDWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DLG_ACMFILTERCHOOSE_ID: u32 = 71u32;
 pub const DLG_ACMFORMATCHOOSE_ID: u32 = 70u32;
@@ -1805,10 +1703,6 @@ impl Default for DOLBYAC2WAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for DOLBYAC2WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRAWDIBTIME {
@@ -1824,9 +1718,6 @@ impl Default for DRAWDIBTIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRAWDIBTIME {
-    type TypeKind = windows_core::CopyType;
 }
 pub type DRIVERMSGPROC = Option<unsafe extern "system" fn(param0: u32, param1: u32, param2: usize, param3: usize, param4: usize) -> u32>;
 pub type DRIVERPROC = Option<unsafe extern "system" fn(param0: usize, param1: HDRVR, param2: u32, param3: super::super::Foundation::LPARAM, param4: super::super::Foundation::LPARAM) -> super::super::Foundation::LRESULT>;
@@ -1846,10 +1737,6 @@ impl Default for DRMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for DRMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DRVCNF_CANCEL: u32 = 0u32;
 pub const DRVCNF_OK: u32 = 1u32;
 pub const DRVCNF_RESTART: u32 = 2u32;
@@ -1865,9 +1752,6 @@ impl Default for DRVCONFIGINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRVCONFIGINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DRVCONFIGINFOEX {
@@ -1880,9 +1764,6 @@ impl Default for DRVCONFIGINFOEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRVCONFIGINFOEX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRVM_ADD_THRU: u32 = 257u32;
 pub const DRVM_DISABLE: u32 = 102u32;
@@ -1903,9 +1784,6 @@ impl Default for DRVM_IOCTL_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRVM_IOCTL_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRVM_IOCTL_LAST: u32 = 261u32;
 pub const DRVM_MAPPER_CONSOLEVOICECOM_GET: u32 = 8215u32;
@@ -1956,10 +1834,6 @@ impl Default for DVIADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for DVIADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DVM_CONFIGURE_END: u32 = 8191u32;
 pub const DVM_CONFIGURE_START: u32 = 4096u32;
@@ -2017,10 +1891,6 @@ impl Default for ECHOSC1WAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for ECHOSC1WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -2033,10 +1903,6 @@ impl Default for EXBMINFOHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for EXBMINFOHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FACILITY_NS: u32 = 13u32;
 pub const FACILITY_NS_WIN32: u32 = 7u32;
@@ -2067,10 +1933,6 @@ impl Default for FMTOWNS_SND_WAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for FMTOWNS_SND_WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -2083,10 +1945,6 @@ impl Default for G721_ADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for G721_ADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
@@ -2102,10 +1960,6 @@ impl Default for G723_ADPCMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for G723_ADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -2118,10 +1972,6 @@ impl Default for GSM610WAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for GSM610WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2601,10 +2451,6 @@ impl Default for ICCOMPRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICCOMPRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2632,10 +2478,6 @@ impl Default for ICCOMPRESSFRAMES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICCOMPRESSFRAMES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ICCOMPRESSFRAMES_PADDING: u32 = 1u32;
 pub const ICCOMPRESS_KEYFRAME: i32 = 1i32;
 #[repr(C)]
@@ -2654,10 +2496,6 @@ impl Default for ICDECOMPRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICDECOMPRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2683,10 +2521,6 @@ impl Default for ICDECOMPRESSEX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICDECOMPRESSEX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ICDECOMPRESS_HURRYUP: i32 = -2147483648i32;
 pub const ICDECOMPRESS_NOTKEYFRAME: i32 = 134217728i32;
 pub const ICDECOMPRESS_NULLFRAME: i32 = 268435456i32;
@@ -2705,9 +2539,6 @@ impl Default for ICDRAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ICDRAW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -2735,10 +2566,6 @@ impl Default for ICDRAWBEGIN {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICDRAWBEGIN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2756,10 +2583,6 @@ impl Default for ICDRAWSUGGEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICDRAWSUGGEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ICDRAW_ANIMATE: i32 = 8i32;
 pub const ICDRAW_BUFFER: i32 = 256i32;
@@ -2811,9 +2634,6 @@ impl Default for ICINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ICINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ICINSTALL_DRIVER: u32 = 2u32;
 pub const ICINSTALL_DRIVERW: u32 = 32770u32;
@@ -2912,9 +2732,6 @@ impl Default for ICOPEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ICOPEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2930,10 +2747,6 @@ impl Default for ICPALETTE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICPALETTE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ICQUALITY_DEFAULT: i32 = -1i32;
 pub const ICQUALITY_HIGH: u32 = 10000u32;
 pub const ICQUALITY_LOW: u32 = 0u32;
@@ -2948,9 +2761,6 @@ impl Default for ICSETSTATUSPROC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ICSETSTATUSPROC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ICSTATUS_END: u32 = 2u32;
 pub const ICSTATUS_ERROR: u32 = 3u32;
@@ -3109,10 +2919,6 @@ impl Default for IMAADPCMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for IMAADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const JDD_CONFIGCHANGED: u32 = 2307u32;
 pub const JDD_GETDEVCAPS: u32 = 2050u32;
 pub const JDD_GETNUMDEVS: u32 = 2049u32;
@@ -3214,9 +3020,6 @@ impl Default for JOYCAPS2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOYCAPS2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct JOYCAPS2W {
@@ -3253,9 +3056,6 @@ impl Default for JOYCAPS2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOYCAPS2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct JOYCAPSA {
@@ -3288,9 +3088,6 @@ impl Default for JOYCAPSA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOYCAPSA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3325,9 +3122,6 @@ impl Default for JOYCAPSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOYCAPSW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const JOYCAPS_HASPOV: u32 = 16u32;
 pub const JOYCAPS_HASR: u32 = 2u32;
 pub const JOYCAPS_HASU: u32 = 4u32;
@@ -3352,9 +3146,6 @@ impl Default for JOYINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOYINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct JOYINFOEX {
@@ -3376,9 +3167,6 @@ impl Default for JOYINFOEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOYINFOEX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JOYSTICKID1: u32 = 0u32;
 pub const JOYSTICKID2: u32 = 1u32;
@@ -3461,9 +3249,6 @@ impl Default for JPEGINFOHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JPEGINFOHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JPEG_PROCESS_BASELINE: u32 = 0u32;
 pub const JPEG_RGB: u32 = 3u32;
@@ -3694,9 +3479,6 @@ impl Default for MCI_ANIM_OPEN_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_ANIM_OPEN_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_ANIM_OPEN_PARMSW {
@@ -3713,9 +3495,6 @@ impl Default for MCI_ANIM_OPEN_PARMSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_ANIM_OPEN_PARMSW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_ANIM_OPEN_WS: i32 = 65536i32;
 pub const MCI_ANIM_PLAY_FAST: i32 = 262144i32;
 #[repr(C, packed(1))]
@@ -3730,9 +3509,6 @@ impl Default for MCI_ANIM_PLAY_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_ANIM_PLAY_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_ANIM_PLAY_REVERSE: i32 = 131072i32;
 pub const MCI_ANIM_PLAY_SCAN: i32 = 1048576i32;
@@ -3754,9 +3530,6 @@ impl Default for MCI_ANIM_RECT_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_ANIM_RECT_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_ANIM_STATUS_FORWARD: i32 = 16386i32;
 pub const MCI_ANIM_STATUS_HPAL: i32 = 16388i32;
 pub const MCI_ANIM_STATUS_HWND: i32 = 16387i32;
@@ -3774,9 +3547,6 @@ impl Default for MCI_ANIM_STEP_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_ANIM_STEP_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_ANIM_STEP_REVERSE: i32 = 65536i32;
 pub const MCI_ANIM_UPDATE_HDC: i32 = 131072i32;
 #[repr(C, packed(1))]
@@ -3792,10 +3562,6 @@ impl Default for MCI_ANIM_UPDATE_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for MCI_ANIM_UPDATE_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_ANIM_WHERE_DESTINATION: i32 = 262144i32;
 pub const MCI_ANIM_WHERE_SOURCE: i32 = 131072i32;
@@ -3816,9 +3582,6 @@ impl Default for MCI_ANIM_WINDOW_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_ANIM_WINDOW_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_ANIM_WINDOW_PARMSW {
@@ -3831,9 +3594,6 @@ impl Default for MCI_ANIM_WINDOW_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_ANIM_WINDOW_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_ANIM_WINDOW_STATE: i32 = 262144i32;
 pub const MCI_ANIM_WINDOW_TEXT: i32 = 524288i32;
@@ -3858,9 +3618,6 @@ impl Default for MCI_BREAK_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_BREAK_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_CAPTURE: u32 = 2160u32;
 pub const MCI_CDA_STATUS_TYPE_TRACK: i32 = 16385i32;
@@ -3905,9 +3662,6 @@ impl Default for MCI_DGV_CAPTURE_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_CAPTURE_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_CAPTURE_PARMSW {
@@ -3919,9 +3673,6 @@ impl Default for MCI_DGV_CAPTURE_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_CAPTURE_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_COPY_AT: i32 = 65536i32;
 pub const MCI_DGV_COPY_AUDIO_STREAM: i32 = 131072i32;
@@ -3940,9 +3691,6 @@ impl Default for MCI_DGV_COPY_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_COPY_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_DGV_COPY_VIDEO_STREAM: i32 = 262144i32;
 pub const MCI_DGV_CUE_INPUT: i32 = 65536i32;
 pub const MCI_DGV_CUE_NOSHOW: i32 = 262144i32;
@@ -3957,9 +3705,6 @@ impl Default for MCI_DGV_CUE_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_CUE_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_CUT_AT: i32 = 65536i32;
 pub const MCI_DGV_CUT_AUDIO_STREAM: i32 = 131072i32;
@@ -3978,9 +3723,6 @@ impl Default for MCI_DGV_CUT_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_CUT_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_DGV_CUT_VIDEO_STREAM: i32 = 262144i32;
 pub const MCI_DGV_DELETE_AT: i32 = 65536i32;
 pub const MCI_DGV_DELETE_AUDIO_STREAM: i32 = 131072i32;
@@ -3998,9 +3740,6 @@ impl Default for MCI_DGV_DELETE_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_DELETE_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_DELETE_VIDEO_STREAM: i32 = 262144i32;
 pub const MCI_DGV_FF_AVI: i32 = 16385i32;
@@ -4049,9 +3788,6 @@ impl Default for MCI_DGV_INFO_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_INFO_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_INFO_PARMSW {
@@ -4064,9 +3800,6 @@ impl Default for MCI_DGV_INFO_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_INFO_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_INFO_STILL_ALG: i32 = 16389i32;
 pub const MCI_DGV_INFO_STILL_QUALITY: i32 = 16386i32;
@@ -4097,9 +3830,6 @@ impl Default for MCI_DGV_LIST_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_LIST_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_LIST_PARMSW {
@@ -4114,9 +3844,6 @@ impl Default for MCI_DGV_LIST_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_LIST_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_LIST_STILL_ALG: i32 = 16387i32;
 pub const MCI_DGV_LIST_STILL_QUALITY: i32 = 16388i32;
@@ -4142,9 +3869,6 @@ impl Default for MCI_DGV_MONITOR_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_MONITOR_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_DGV_MONITOR_SOURCE: i32 = 131072i32;
 pub const MCI_DGV_OPEN_16BIT: i32 = 524288i32;
 pub const MCI_DGV_OPEN_32BIT: i32 = 1048576i32;
@@ -4166,9 +3890,6 @@ impl Default for MCI_DGV_OPEN_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_OPEN_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_OPEN_PARMSW {
@@ -4184,9 +3905,6 @@ impl Default for MCI_DGV_OPEN_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_OPEN_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_OPEN_WS: i32 = 65536i32;
 pub const MCI_DGV_PASTE_AT: i32 = 65536i32;
@@ -4206,9 +3924,6 @@ impl Default for MCI_DGV_PASTE_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_PASTE_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_PASTE_VIDEO_STREAM: i32 = 262144i32;
 pub const MCI_DGV_PLAY_REPEAT: i32 = 65536i32;
@@ -4233,9 +3948,6 @@ impl Default for MCI_DGV_QUALITY_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_QUALITY_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_QUALITY_PARMSW {
@@ -4249,9 +3961,6 @@ impl Default for MCI_DGV_QUALITY_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_QUALITY_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_REALIZE_BKGD: i32 = 131072i32;
 pub const MCI_DGV_REALIZE_NORM: i32 = 65536i32;
@@ -4272,9 +3981,6 @@ impl Default for MCI_DGV_RECORD_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_RECORD_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_DGV_RECORD_VIDEO_STREAM: i32 = 524288i32;
 pub const MCI_DGV_RECT: i32 = 65536i32;
 #[repr(C, packed(1))]
@@ -4287,9 +3993,6 @@ impl Default for MCI_DGV_RECT_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_RECT_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_RESERVE_IN: i32 = 65536i32;
 #[repr(C, packed(1))]
@@ -4304,9 +4007,6 @@ impl Default for MCI_DGV_RESERVE_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_RESERVE_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_RESERVE_PARMSW {
@@ -4318,9 +4018,6 @@ impl Default for MCI_DGV_RESERVE_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_RESERVE_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_RESERVE_SIZE: i32 = 131072i32;
 pub const MCI_DGV_RESTORE_AT: i32 = 131072i32;
@@ -4337,9 +4034,6 @@ impl Default for MCI_DGV_RESTORE_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_RESTORE_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_RESTORE_PARMSW {
@@ -4351,9 +4045,6 @@ impl Default for MCI_DGV_RESTORE_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_RESTORE_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_SAVE_ABORT: i32 = 131072i32;
 pub const MCI_DGV_SAVE_KEEPRESERVE: i32 = 262144i32;
@@ -4369,9 +4060,6 @@ impl Default for MCI_DGV_SAVE_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_SAVE_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_SAVE_PARMSW {
@@ -4383,9 +4071,6 @@ impl Default for MCI_DGV_SAVE_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_SAVE_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_SETAUDIO_ALG: i32 = 262144i32;
 pub const MCI_DGV_SETAUDIO_AVGBYTESPERSEC: i32 = 16390i32;
@@ -4413,9 +4098,6 @@ impl Default for MCI_DGV_SETAUDIO_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_SETAUDIO_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_SETAUDIO_PARMSW {
@@ -4430,9 +4112,6 @@ impl Default for MCI_DGV_SETAUDIO_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_SETAUDIO_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_SETAUDIO_QUALITY: i32 = 524288i32;
 pub const MCI_DGV_SETAUDIO_RECORD: i32 = 1048576i32;
@@ -4482,9 +4161,6 @@ impl Default for MCI_DGV_SETVIDEO_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_SETVIDEO_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_SETVIDEO_PARMSW {
@@ -4500,9 +4176,6 @@ impl Default for MCI_DGV_SETVIDEO_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_SETVIDEO_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_SETVIDEO_QUALITY: i32 = 65536i32;
 pub const MCI_DGV_SETVIDEO_RECORD: i32 = 4194304i32;
@@ -4540,9 +4213,6 @@ impl Default for MCI_DGV_SET_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_SET_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_DGV_SET_SEEK_EXACTLY: i32 = 65536i32;
 pub const MCI_DGV_SET_SPEED: i32 = 131072i32;
 pub const MCI_DGV_SET_STILL: i32 = 262144i32;
@@ -4561,9 +4231,6 @@ impl Default for MCI_DGV_SIGNAL_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_SIGNAL_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_SIGNAL_POSITION: i32 = 1048576i32;
 pub const MCI_DGV_SIGNAL_USERVAL: i32 = 262144i32;
@@ -4612,9 +4279,6 @@ impl Default for MCI_DGV_STATUS_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_STATUS_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_STATUS_PARMSW {
@@ -4629,9 +4293,6 @@ impl Default for MCI_DGV_STATUS_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_STATUS_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_STATUS_PAUSE_MODE: i32 = 16422i32;
 pub const MCI_DGV_STATUS_RECORD: i32 = 16777216i32;
@@ -4668,9 +4329,6 @@ impl Default for MCI_DGV_STEP_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_STEP_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_DGV_STEP_REVERSE: i32 = 65536i32;
 pub const MCI_DGV_STOP_HOLD: i32 = 65536i32;
 pub const MCI_DGV_UPDATE_HDC: i32 = 131072i32;
@@ -4688,10 +4346,6 @@ impl Default for MCI_DGV_UPDATE_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for MCI_DGV_UPDATE_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_WHERE_DESTINATION: i32 = 262144i32;
 pub const MCI_DGV_WHERE_FRAME: i32 = 524288i32;
@@ -4714,9 +4368,6 @@ impl Default for MCI_DGV_WINDOW_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_DGV_WINDOW_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_DGV_WINDOW_PARMSW {
@@ -4729,9 +4380,6 @@ impl Default for MCI_DGV_WINDOW_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_DGV_WINDOW_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_DGV_WINDOW_STATE: i32 = 262144i32;
 pub const MCI_DGV_WINDOW_TEXT: i32 = 524288i32;
@@ -4776,9 +4424,6 @@ impl Default for MCI_GENERIC_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_GENERIC_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_GETDEVCAPS: u32 = 2059u32;
 pub const MCI_GETDEVCAPS_CAN_EJECT: i32 = 7i32;
 pub const MCI_GETDEVCAPS_CAN_PLAY: i32 = 8i32;
@@ -4800,9 +4445,6 @@ impl Default for MCI_GETDEVCAPS_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_GETDEVCAPS_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_GETDEVCAPS_USES_FILES: i32 = 5i32;
 pub const MCI_HDC: u32 = 12u32;
@@ -4826,9 +4468,6 @@ impl Default for MCI_INFO_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_INFO_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_INFO_PARMSW {
@@ -4840,9 +4479,6 @@ impl Default for MCI_INFO_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_INFO_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_INFO_PRODUCT: i32 = 256i32;
 pub const MCI_INFO_VERSION: i32 = 1024i32;
@@ -4864,9 +4500,6 @@ impl Default for MCI_LOAD_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_LOAD_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_LOAD_PARMSW {
@@ -4877,9 +4510,6 @@ impl Default for MCI_LOAD_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_LOAD_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_MAX_DEVICE_TYPE_LENGTH: u32 = 80u32;
 pub const MCI_MCIAVI_PLAY_FULLBY2: i32 = 67108864i32;
@@ -4918,9 +4548,6 @@ impl Default for MCI_OPEN_DRIVER_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_OPEN_DRIVER_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_OPEN_ELEMENT: i32 = 512i32;
 pub const MCI_OPEN_ELEMENT_ID: i32 = 2048i32;
 #[repr(C, packed(1))]
@@ -4937,9 +4564,6 @@ impl Default for MCI_OPEN_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_OPEN_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_OPEN_PARMSW {
@@ -4953,9 +4577,6 @@ impl Default for MCI_OPEN_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_OPEN_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_OPEN_SHAREABLE: i32 = 256i32;
 pub const MCI_OPEN_TYPE: i32 = 8192i32;
@@ -4976,9 +4597,6 @@ impl Default for MCI_OVLY_LOAD_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_OVLY_LOAD_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_OVLY_LOAD_PARMSW {
@@ -4990,9 +4608,6 @@ impl Default for MCI_OVLY_LOAD_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_OVLY_LOAD_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_OVLY_OPEN_PARENT: i32 = 131072i32;
 #[repr(C, packed(1))]
@@ -5011,9 +4626,6 @@ impl Default for MCI_OVLY_OPEN_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_OVLY_OPEN_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_OVLY_OPEN_PARMSW {
@@ -5029,9 +4641,6 @@ impl Default for MCI_OVLY_OPEN_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_OVLY_OPEN_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_OVLY_OPEN_WS: i32 = 65536i32;
 pub const MCI_OVLY_PUT_DESTINATION: i32 = 262144i32;
@@ -5050,9 +4659,6 @@ impl Default for MCI_OVLY_RECT_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_OVLY_RECT_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_OVLY_SAVE_PARMSA {
@@ -5065,9 +4671,6 @@ impl Default for MCI_OVLY_SAVE_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_OVLY_SAVE_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_OVLY_SAVE_PARMSW {
@@ -5079,9 +4682,6 @@ impl Default for MCI_OVLY_SAVE_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_OVLY_SAVE_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_OVLY_STATUS_HWND: i32 = 16385i32;
 pub const MCI_OVLY_STATUS_STRETCH: i32 = 16386i32;
@@ -5106,9 +4706,6 @@ impl Default for MCI_OVLY_WINDOW_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_OVLY_WINDOW_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_OVLY_WINDOW_PARMSW {
@@ -5121,9 +4718,6 @@ impl Default for MCI_OVLY_WINDOW_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_OVLY_WINDOW_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_OVLY_WINDOW_STATE: i32 = 262144i32;
 pub const MCI_OVLY_WINDOW_TEXT: i32 = 524288i32;
@@ -5141,9 +4735,6 @@ impl Default for MCI_PLAY_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_PLAY_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_PUT: u32 = 2114u32;
 pub const MCI_QUALITY: u32 = 2167u32;
@@ -5171,9 +4762,6 @@ impl Default for MCI_RECORD_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_RECORD_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_RECT: u32 = 7u32;
 pub const MCI_RESERVE: u32 = 2162u32;
 pub const MCI_RESOURCE_DRIVER: u32 = 1048576u32;
@@ -5194,9 +4782,6 @@ impl Default for MCI_SAVE_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_SAVE_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_SAVE_PARMSW {
@@ -5207,9 +4792,6 @@ impl Default for MCI_SAVE_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_SAVE_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_SECTION: windows_core::PCWSTR = windows_core::w!("MCI32");
 pub const MCI_SEEK: u32 = 2055u32;
@@ -5223,9 +4805,6 @@ impl Default for MCI_SEEK_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_SEEK_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_SEEK_TO_END: i32 = 512i32;
 pub const MCI_SEEK_TO_START: i32 = 256i32;
@@ -5257,9 +4836,6 @@ impl Default for MCI_SEQ_SET_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_SEQ_SET_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_SEQ_SET_PORT: i32 = 131072i32;
 pub const MCI_SEQ_SET_SLAVE: i32 = 262144i32;
@@ -5297,9 +4873,6 @@ impl Default for MCI_SET_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_SET_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_SET_TIME_FORMAT: i32 = 1024i32;
 pub const MCI_SET_VIDEO: i32 = 4096i32;
 pub const MCI_SIGNAL: u32 = 2165u32;
@@ -5323,9 +4896,6 @@ impl Default for MCI_STATUS_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_STATUS_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_STATUS_POSITION: i32 = 2i32;
 pub const MCI_STATUS_READY: i32 = 7i32;
@@ -5352,9 +4922,6 @@ impl Default for MCI_SYSINFO_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_SYSINFO_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_SYSINFO_PARMSW {
@@ -5368,9 +4935,6 @@ impl Default for MCI_SYSINFO_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_SYSINFO_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_SYSINFO_QUANTITY: i32 = 256i32;
 pub const MCI_TEST: i32 = 32i32;
@@ -5392,9 +4956,6 @@ impl Default for MCI_VD_ESCAPE_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_VD_ESCAPE_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_VD_ESCAPE_PARMSW {
@@ -5405,9 +4966,6 @@ impl Default for MCI_VD_ESCAPE_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_VD_ESCAPE_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_VD_ESCAPE_STRING: i32 = 256i32;
 pub const MCI_VD_FORMAT_TRACK: u32 = 16385u32;
@@ -5436,9 +4994,6 @@ impl Default for MCI_VD_PLAY_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_VD_PLAY_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_VD_PLAY_REVERSE: i32 = 65536i32;
 pub const MCI_VD_PLAY_SCAN: i32 = 524288i32;
 pub const MCI_VD_PLAY_SLOW: i32 = 1048576i32;
@@ -5463,9 +5018,6 @@ impl Default for MCI_VD_STEP_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_VD_STEP_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_VD_STEP_REVERSE: i32 = 131072i32;
 pub const MCI_WAIT: i32 = 2i32;
 #[repr(C, packed(1))]
@@ -5479,9 +5031,6 @@ impl Default for MCI_WAVE_DELETE_PARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_WAVE_DELETE_PARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_WAVE_GETDEVCAPS_INPUTS: i32 = 16385i32;
 pub const MCI_WAVE_GETDEVCAPS_OUTPUTS: i32 = 16386i32;
@@ -5503,9 +5052,6 @@ impl Default for MCI_WAVE_OPEN_PARMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_WAVE_OPEN_PARMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MCI_WAVE_OPEN_PARMSW {
@@ -5520,9 +5066,6 @@ impl Default for MCI_WAVE_OPEN_PARMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCI_WAVE_OPEN_PARMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MCI_WAVE_OUTPUT: i32 = 8388608i32;
 pub const MCI_WAVE_PCM: u32 = 1152u32;
@@ -5557,9 +5100,6 @@ impl Default for MCI_WAVE_SET_PARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCI_WAVE_SET_PARMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCI_WAVE_SET_SAMPLESPERSEC: i32 = 262144i32;
 pub const MCI_WAVE_STATUS_AVGBYTESPERSEC: i32 = 16388i32;
 pub const MCI_WAVE_STATUS_BITSPERSAMPLE: i32 = 16390i32;
@@ -5585,10 +5125,6 @@ impl Default for MEDIASPACEADPCMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for MEDIASPACEADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MIDIMAPPER_S: u32 = 1227u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5600,9 +5136,6 @@ impl Default for MIDIOPENSTRMID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIDIOPENSTRMID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIDI_IO_COOKED: i32 = 2i32;
 pub const MIDI_IO_PACKED: i32 = 0i32;
@@ -5639,10 +5172,6 @@ impl Default for MIXEROPENDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for MIXEROPENDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MMCKINFO {
@@ -5656,9 +5185,6 @@ impl Default for MMCKINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMCKINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MMIOERR_ACCESSDENIED: u32 = 268u32;
 pub const MMIOERR_BASE: u32 = 256u32;
@@ -5701,9 +5227,6 @@ impl Default for MMIOINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMIOINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MMIOM_CLOSE: u32 = 4u32;
 pub const MMIOM_OPEN: u32 = 3u32;
@@ -7296,10 +6819,6 @@ impl Default for MSAUDIO1WAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for MSAUDIO1WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MSAUDIO1_BITS_PER_SAMPLE: u32 = 16u32;
 pub const MSAUDIO1_MAX_CHANNELS: u32 = 2u32;
 pub const MXDM_BASE: u32 = 1u32;
@@ -7326,10 +6845,6 @@ impl Default for NMS_VBXADPCMWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for NMS_VBXADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NS_DRM_E_MIGRATION_IMAGE_ALREADY_EXISTS: windows_core::HRESULT = windows_core::HRESULT(0xC00D278E_u32 as _);
 pub const NS_DRM_E_MIGRATION_SOURCE_MACHINE_IN_USE: windows_core::HRESULT = windows_core::HRESULT(0xC00D278C_u32 as _);
@@ -8548,10 +8063,6 @@ impl Default for OLIADPCMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for OLIADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -8563,10 +8074,6 @@ impl Default for OLICELPWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for OLICELPWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
@@ -8580,10 +8087,6 @@ impl Default for OLIGSMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for OLIGSMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -8596,10 +8099,6 @@ impl Default for OLIOPRWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for OLIOPRWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -8611,10 +8110,6 @@ impl Default for OLISBCWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for OLISBCWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PD_CAN_DRAW_DIB: u32 = 1u32;
 pub const PD_CAN_STRETCHDIB: u32 = 2u32;
@@ -8654,10 +8149,6 @@ impl Default for SIERRAADPCMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for SIERRAADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -8670,10 +8161,6 @@ impl Default for SONARCWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for SONARCWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TARGET_DEVICE_FRIENDLY_NAME: windows_core::PCSTR = windows_core::s!("TargetDeviceFriendlyName");
 pub const TARGET_DEVICE_OPEN_EXCLUSIVELY: windows_core::PCSTR = windows_core::s!("TargetDeviceOpenExclusively");
@@ -8700,9 +8187,6 @@ impl Default for TIMEREVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TIMEREVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_Media_Audio")]
 #[derive(Clone, Copy)]
@@ -8717,10 +8201,6 @@ impl Default for TRUESPEECHWAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for TRUESPEECHWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VADMAD_Device_ID: u32 = 1092u32;
 pub const VCAPS_CAN_SCALE: u32 = 8u32;
@@ -8763,9 +8243,6 @@ impl Default for VIDEOHDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIDEOHDR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIDEO_CONFIGURE_CURRENT: u32 = 16u32;
 pub const VIDEO_CONFIGURE_GET: u32 = 8192u32;
@@ -8834,10 +8311,6 @@ impl Default for WAVEOPENDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for WAVEOPENDESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WAVE_FILTER_DEVELOPMENT: u32 = 65535u32;
 pub const WAVE_FILTER_ECHO: u32 = 2u32;
@@ -9141,10 +8614,6 @@ impl Default for WMAUDIO2WAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for WMAUDIO2WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WMAUDIO2_BITS_PER_SAMPLE: u32 = 16u32;
 pub const WMAUDIO2_MAX_CHANNELS: u32 = 2u32;
 #[repr(C, packed(1))]
@@ -9164,10 +8633,6 @@ impl Default for WMAUDIO3WAVEFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for WMAUDIO3WAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMAUDIO_BITS_PER_SAMPLE: u32 = 16u32;
 pub const WMAUDIO_MAX_CHANNELS: u32 = 2u32;
@@ -9287,10 +8752,6 @@ impl Default for YAMAHA_ADPCMWAVEFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media_Audio")]
-impl windows_core::TypeKind for YAMAHA_ADPCMWAVEFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub type YIELDPROC = Option<unsafe extern "system" fn(mciid: u32, dwyielddata: u32) -> u32>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9307,7 +8768,4 @@ impl Default for s_RIFFWAVE_inst {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for s_RIFFWAVE_inst {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/mod.rs
@@ -14743,9 +14743,6 @@ impl Default for SPAUDIOBUFFERINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPAUDIOBUFFERINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SPAUDIOOPTIONS(pub i32);
@@ -14768,9 +14765,6 @@ impl Default for SPAUDIOSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPAUDIOSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPBINARYGRAMMAR {
@@ -14780,9 +14774,6 @@ impl Default for SPBINARYGRAMMAR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPBINARYGRAMMAR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14850,9 +14841,6 @@ impl Default for SPDISPLAYPHRASE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPDISPLAYPHRASE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPDISPLAYTOKEN {
@@ -14864,9 +14852,6 @@ impl Default for SPDISPLAYTOKEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPDISPLAYTOKEN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPDKL_CurrentConfig: SPDATAKEYLOCATION = SPDATAKEYLOCATION(5i32);
 pub const SPDKL_CurrentUser: SPDATAKEYLOCATION = SPDATAKEYLOCATION(1i32);
@@ -14950,9 +14935,6 @@ impl Default for SPEVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPEVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SPEVENTENUM(pub i32);
@@ -14971,9 +14953,6 @@ impl Default for SPEVENTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPEVENTEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SPEVENTLPARAMTYPE(pub i32);
@@ -14988,9 +14967,6 @@ impl Default for SPEVENTSOURCEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPEVENTSOURCEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -15098,9 +15074,6 @@ impl Default for SPNORMALIZATIONLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPNORMALIZATIONLIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub type SPNOTIFYCALLBACK = Option<unsafe extern "system" fn(wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15121,9 +15094,6 @@ impl Default for SPPARSEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPPARSEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SPPARTOFSPEECH(pub i32);
@@ -15138,9 +15108,6 @@ impl Default for SPPATHENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPPATHENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15154,10 +15121,6 @@ impl Default for SPPHRASE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SPPHRASE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -15174,9 +15137,6 @@ impl Default for SPPHRASEALT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPPHRASEALT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct SPPHRASEALTREQUEST {
@@ -15192,9 +15152,6 @@ impl Default for SPPHRASEALTREQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPPHRASEALTREQUEST {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15218,9 +15175,6 @@ impl Default for SPPHRASEELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPPHRASEELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -15248,10 +15202,6 @@ impl Default for SPPHRASEPROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SPPHRASEPROPERTY {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy)]
@@ -15264,10 +15214,6 @@ impl Default for SPPHRASEPROPERTY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SPPHRASEPROPERTY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -15282,10 +15228,6 @@ impl Default for SPPHRASEPROPERTY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SPPHRASEPROPERTY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -15319,9 +15261,6 @@ impl Default for SPPHRASEREPLACEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPPHRASEREPLACEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SPPHRASERNG(pub i32);
@@ -15341,9 +15280,6 @@ impl Default for SPPHRASERULE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPPHRASERULE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -15389,10 +15325,6 @@ impl Default for SPPHRASE_50 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SPPHRASE_50 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SPPPUT_ARRAY_INDEX: SPPHRASEPROPERTYUNIONTYPE = SPPHRASEPROPERTYUNIONTYPE(1i32);
 pub const SPPPUT_UNUSED: SPPHRASEPROPERTYUNIONTYPE = SPPHRASEPROPERTYUNIONTYPE(0i32);
 #[repr(transparent)]
@@ -15417,10 +15349,6 @@ impl Default for SPPROPERTYINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SPPROPERTYINFO {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -15491,9 +15419,6 @@ impl Default for SPRECOCONTEXTSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPRECOCONTEXTSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SPRECOEVENTFLAGS(pub i32);
@@ -15514,9 +15439,6 @@ impl Default for SPRECOGNIZERSTATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPRECOGNIZERSTATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -15539,9 +15461,6 @@ impl Default for SPRECORESULTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPRECORESULTINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct SPRECORESULTINFOEX {
@@ -15553,9 +15472,6 @@ impl Default for SPRECORESULTINFOEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPRECORESULTINFOEX {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15569,9 +15485,6 @@ impl Default for SPRECORESULTTIMES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPRECORESULTTIMES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -15621,9 +15534,6 @@ impl Default for SPRULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPRULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPRULEENTRY {
@@ -15637,9 +15547,6 @@ impl Default for SPRULEENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPRULEENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -15680,9 +15587,6 @@ impl Default for SPSEMANTICERRORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPSEMANTICERRORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SPSEMANTICFORMAT(pub i32);
@@ -15700,9 +15604,6 @@ impl Default for SPSERIALIZEDEVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPSERIALIZEDEVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPSERIALIZEDEVENT64 {
@@ -15717,9 +15618,6 @@ impl Default for SPSERIALIZEDEVENT64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPSERIALIZEDEVENT64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPSERIALIZEDPHRASE {
@@ -15730,9 +15628,6 @@ impl Default for SPSERIALIZEDPHRASE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPSERIALIZEDPHRASE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPSERIALIZEDRESULT {
@@ -15742,9 +15637,6 @@ impl Default for SPSERIALIZEDRESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPSERIALIZEDRESULT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPSF_11kHz16BitMono: SPSTREAMFORMAT = SPSTREAMFORMAT(10i32);
 pub const SPSF_11kHz16BitStereo: SPSTREAMFORMAT = SPSTREAMFORMAT(11i32);
@@ -15832,9 +15724,6 @@ impl Default for SPSHORTCUTPAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPSHORTCUTPAIR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPSHORTCUTPAIRLIST {
@@ -15846,9 +15735,6 @@ impl Default for SPSHORTCUTPAIRLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPSHORTCUTPAIRLIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -15899,9 +15785,6 @@ impl Default for SPSTATEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPSTATEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SPSTREAMFORMAT(pub i32);
@@ -15923,9 +15806,6 @@ impl Default for SPTEXTSELECTIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPTEXTSELECTIONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPTMTHREADINFO {
@@ -15938,9 +15818,6 @@ impl Default for SPTMTHREADINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPTMTHREADINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPTOKENKEY_ATTRIBUTES: windows_core::PCWSTR = windows_core::w!("Attributes");
 pub const SPTOKENKEY_AUDIO_LATENCY_TRUNCATE: windows_core::PCWSTR = windows_core::w!("LatencyTruncateThreshold");
@@ -15969,9 +15846,6 @@ impl Default for SPTRANSITIONENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPTRANSITIONENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPTRANSITIONENTRY_0 {
@@ -15981,9 +15855,6 @@ impl Default for SPTRANSITIONENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPTRANSITIONENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -15997,9 +15868,6 @@ impl Default for SPTRANSITIONENTRY_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPTRANSITIONENTRY_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPTRANSITIONENTRY_1_0 {
@@ -16012,9 +15880,6 @@ impl Default for SPTRANSITIONENTRY_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPTRANSITIONENTRY_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPTRANSITIONENTRY_1_1 {
@@ -16026,9 +15891,6 @@ impl Default for SPTRANSITIONENTRY_1_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPTRANSITIONENTRY_1_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPTRANSITIONENTRY_1_2 {
@@ -16038,9 +15900,6 @@ impl Default for SPTRANSITIONENTRY_1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPTRANSITIONENTRY_1_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -16078,10 +15937,6 @@ impl Default for SPTRANSITIONPROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SPTRANSITIONPROPERTY {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SPTRANSITIONTYPE(pub i32);
@@ -16113,9 +15968,6 @@ impl Default for SPVCONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPVCONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -16159,9 +16011,6 @@ impl Default for SPVOICESTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPVOICESTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPVPITCH {
@@ -16172,9 +16021,6 @@ impl Default for SPVPITCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPVPITCH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -16205,9 +16051,6 @@ impl Default for SPVSTATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPVSTATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SPVST_SENTENCE: SPVSKIPTYPE = SPVSKIPTYPE(1i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16222,9 +16065,6 @@ impl Default for SPVTEXTFRAG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPVTEXTFRAG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPWF_INPUT: SPSTREAMFORMATTYPE = SPSTREAMFORMATTYPE(0i32);
 pub const SPWF_SRENGINE: SPSTREAMFORMATTYPE = SPSTREAMFORMATTYPE(1i32);
@@ -16246,9 +16086,6 @@ impl Default for SPWORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPWORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPWORDENTRY {
@@ -16263,9 +16100,6 @@ impl Default for SPWORDENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPWORDENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -16298,9 +16132,6 @@ impl Default for SPWORDLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPWORDLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SPWORDPRONOUNCEABLE(pub i32);
@@ -16319,9 +16150,6 @@ impl Default for SPWORDPRONUNCIATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPWORDPRONUNCIATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPWORDPRONUNCIATIONLIST {
@@ -16333,9 +16161,6 @@ impl Default for SPWORDPRONUNCIATIONLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPWORDPRONUNCIATIONLIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Media/Streaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Streaming/mod.rs
@@ -9,9 +9,6 @@ impl Default for CapturedMetadataExposureCompensation {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CapturedMetadataExposureCompensation {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CapturedMetadataISOGains {
@@ -22,9 +19,6 @@ impl Default for CapturedMetadataISOGains {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CapturedMetadataISOGains {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -37,9 +31,6 @@ impl Default for CapturedMetadataWhiteBalanceGains {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CapturedMetadataWhiteBalanceGains {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVPKEY_Device_DLNACAP: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x88ad39db_0d0c_4a38_8435_4043826b5c91), pid: 16 };
 pub const DEVPKEY_Device_DLNADOC: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x88ad39db_0d0c_4a38_8435_4043826b5c91), pid: 15 };
@@ -67,9 +58,6 @@ impl Default for FaceCharacterization {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FaceCharacterization {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FaceCharacterizationBlobHeader {
@@ -80,9 +68,6 @@ impl Default for FaceCharacterizationBlobHeader {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FaceCharacterizationBlobHeader {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -95,9 +80,6 @@ impl Default for FaceRectInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FaceRectInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FaceRectInfoBlobHeader {
@@ -108,9 +90,6 @@ impl Default for FaceRectInfoBlobHeader {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FaceRectInfoBlobHeader {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GUID_DEVINTERFACE_DMP: windows_core::GUID = windows_core::GUID::from_u128(0x25b4e268_2a05_496e_803b_266837fbda4b);
 pub const GUID_DEVINTERFACE_DMR: windows_core::GUID = windows_core::GUID::from_u128(0xd0875fb4_2196_4c7a_a63d_e416addd60a1);
@@ -126,9 +105,6 @@ impl Default for HistogramBlobHeader {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HistogramBlobHeader {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HistogramDataHeader {
@@ -141,9 +117,6 @@ impl Default for HistogramDataHeader {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HistogramDataHeader {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HistogramGrid {
@@ -155,9 +128,6 @@ impl Default for HistogramGrid {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HistogramGrid {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -172,9 +142,6 @@ impl Default for HistogramHeader {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HistogramHeader {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -198,7 +165,4 @@ impl Default for MetadataTimeStamps {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MetadataTimeStamps {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/mod.rs
@@ -92,9 +92,6 @@ impl Default for AM_WMT_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AM_WMT_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLSID_ClientNetManager: windows_core::GUID = windows_core::GUID::from_u128(0xcd12a3ce_9c42_11d2_beed_0060082f2054);
 pub const CLSID_WMBandwidthSharing_Exclusive: windows_core::GUID = windows_core::GUID::from_u128(0xaf6060aa_5197_11d2_b6af_00c04fd908e9);
 pub const CLSID_WMBandwidthSharing_Partial: windows_core::GUID = windows_core::GUID::from_u128(0xaf6060ab_5197_11d2_b6af_00c04fd908e9);
@@ -114,9 +111,6 @@ impl Default for DRM_COPY_OPL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRM_COPY_OPL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRM_MINIMUM_OUTPUT_PROTECTION_LEVELS {
@@ -131,9 +125,6 @@ impl Default for DRM_MINIMUM_OUTPUT_PROTECTION_LEVELS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRM_MINIMUM_OUTPUT_PROTECTION_LEVELS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRM_OPL_OUTPUT_IDS {
@@ -144,9 +135,6 @@ impl Default for DRM_OPL_OUTPUT_IDS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRM_OPL_OUTPUT_IDS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRM_OPL_TYPES: u32 = 1u32;
 #[repr(C)]
@@ -160,9 +148,6 @@ impl Default for DRM_OUTPUT_PROTECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRM_OUTPUT_PROTECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRM_PLAY_OPL {
@@ -175,9 +160,6 @@ impl Default for DRM_PLAY_OPL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRM_PLAY_OPL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRM_VAL16 {
@@ -187,9 +169,6 @@ impl Default for DRM_VAL16 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRM_VAL16 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -201,9 +180,6 @@ impl Default for DRM_VIDEO_OUTPUT_PROTECTION_IDS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRM_VIDEO_OUTPUT_PROTECTION_IDS {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(INSNetSourceCreator, INSNetSourceCreator_Vtbl, 0x0c0e4080_9081_11d2_beec_0060082f2054);
 windows_core::imp::interface_hierarchy!(INSNetSourceCreator, windows_core::IUnknown);
@@ -9473,9 +9449,6 @@ impl Default for WMDRM_IMPORT_INIT_STRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMDRM_IMPORT_INIT_STRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WMDRM_IMPORT_INIT_STRUCT_DEFINED: u32 = 1u32;
 pub const WMFORMAT_MPEG2Video: windows_core::GUID = windows_core::GUID::from_u128(0xe06d80e3_db46_11cf_b4d1_00805f6cbbea);
 pub const WMFORMAT_Script: windows_core::GUID = windows_core::GUID::from_u128(0x5c8510f2_debe_4ca7_bba5_f07a104f8dff);
@@ -9548,10 +9521,6 @@ impl Default for WMMPEG2VIDEOINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for WMMPEG2VIDEOINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WMSCRIPTFORMAT {
@@ -9561,9 +9530,6 @@ impl Default for WMSCRIPTFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMSCRIPTFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMSCRIPTTYPE_TwoStrings: windows_core::GUID = windows_core::GUID::from_u128(0x82f38a70_c29f_11d1_97ad_00a0c95ea850);
 pub const WMT_ACQUIRE_LICENSE: WMT_STATUS = WMT_STATUS(23i32);
@@ -9591,9 +9557,6 @@ impl Default for WMT_BUFFER_SEGMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMT_BUFFER_SEGMENT {
-    type TypeKind = windows_core::CloneType;
-}
 pub const WMT_CLEANPOINT_ONLY: WMT_STREAM_SELECTION = WMT_STREAM_SELECTION(1i32);
 pub const WMT_CLIENT_CONNECT: WMT_STATUS = WMT_STATUS(32i32);
 pub const WMT_CLIENT_CONNECT_EX: WMT_STATUS = WMT_STATUS(37i32);
@@ -9618,9 +9581,6 @@ impl Default for WMT_COLORSPACEINFO_EXTENSION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMT_COLORSPACEINFO_EXTENSION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMT_CONNECTING: WMT_STATUS = WMT_STATUS(8i32);
 pub const WMT_CONTENT_ENABLER: WMT_STATUS = WMT_STATUS(51i32);
@@ -9659,9 +9619,6 @@ impl Default for WMT_FILESINK_DATA_UNIT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMT_FILESINK_DATA_UNIT {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9734,9 +9691,6 @@ impl Default for WMT_PAYLOAD_FRAGMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMT_PAYLOAD_FRAGMENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WMT_PLAY_MODE(pub i32);
@@ -9804,9 +9758,6 @@ impl Default for WMT_TIMECODE_EXTENSION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMT_TIMECODE_EXTENSION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WMT_TIMECODE_FRAMERATE(pub i32);
@@ -9871,9 +9822,6 @@ impl Default for WMT_VIDEOIMAGE_SAMPLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMT_VIDEOIMAGE_SAMPLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WMT_VIDEOIMAGE_SAMPLE2 {
@@ -9909,9 +9857,6 @@ impl Default for WMT_VIDEOIMAGE_SAMPLE2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMT_VIDEOIMAGE_SAMPLE2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMT_VIDEOIMAGE_SAMPLE_ADV_BLENDING: u32 = 8u32;
 pub const WMT_VIDEOIMAGE_SAMPLE_BLENDING: u32 = 4u32;
@@ -9951,9 +9896,6 @@ impl Default for WMT_WATERMARK_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMT_WATERMARK_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WMT_WATERMARK_ENTRY_TYPE(pub i32);
@@ -9970,9 +9912,6 @@ impl Default for WMT_WEBSTREAM_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMT_WEBSTREAM_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WMT_WEBSTREAM_SAMPLE_HEADER {
@@ -9986,9 +9925,6 @@ impl Default for WMT_WEBSTREAM_SAMPLE_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMT_WEBSTREAM_SAMPLE_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMT_WMETYPE_AUDIO: WMT_WATERMARK_ENTRY_TYPE = WMT_WATERMARK_ENTRY_TYPE(1i32);
 pub const WMT_WMETYPE_VIDEO: WMT_WATERMARK_ENTRY_TYPE = WMT_WATERMARK_ENTRY_TYPE(2i32);
@@ -10008,10 +9944,6 @@ impl Default for WMVIDEOINFOHEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for WMVIDEOINFOHEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -10036,10 +9968,6 @@ impl Default for WMVIDEOINFOHEADER2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for WMVIDEOINFOHEADER2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WM_ADDRESS_ACCESSENTRY {
@@ -10050,9 +9978,6 @@ impl Default for WM_ADDRESS_ACCESSENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WM_ADDRESS_ACCESSENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10070,9 +9995,6 @@ impl Default for WM_CLIENT_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WM_CLIENT_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WM_CLIENT_PROPERTIES_EX {
@@ -10085,9 +10007,6 @@ impl Default for WM_CLIENT_PROPERTIES_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WM_CLIENT_PROPERTIES_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WM_CL_INTERLACED420: u32 = 0u32;
 pub const WM_CL_PROGRESSIVE420: u32 = 1u32;
@@ -10129,9 +10048,6 @@ impl Default for WM_LEAKY_BUCKET_PAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WM_LEAKY_BUCKET_PAIR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WM_MAX_STREAMS: u32 = 63u32;
 pub const WM_MAX_VIDEO_STREAMS: u32 = 63u32;
 #[repr(C)]
@@ -10152,9 +10068,6 @@ impl Default for WM_MEDIA_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WM_MEDIA_TYPE {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WM_PICTURE {
@@ -10168,9 +10081,6 @@ impl Default for WM_PICTURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WM_PICTURE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WM_PLAYBACK_DRC_HIGH: WM_PLAYBACK_DRC_LEVEL = WM_PLAYBACK_DRC_LEVEL(0i32);
 #[repr(transparent)]
@@ -10188,9 +10098,6 @@ impl Default for WM_PORT_NUMBER_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WM_PORT_NUMBER_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10210,9 +10117,6 @@ impl Default for WM_READER_CLIENTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WM_READER_CLIENTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WM_READER_STATISTICS {
@@ -10227,9 +10131,6 @@ impl Default for WM_READER_STATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WM_READER_STATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WM_SFEX_DATALOSS: WM_SFEX_TYPE = WM_SFEX_TYPE(4i32);
 pub const WM_SFEX_NOTASYNCPOINT: WM_SFEX_TYPE = WM_SFEX_TYPE(2i32);
@@ -10253,9 +10154,6 @@ impl Default for WM_STREAM_PRIORITY_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WM_STREAM_PRIORITY_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WM_STREAM_TYPE_INFO {
@@ -10266,9 +10164,6 @@ impl Default for WM_STREAM_TYPE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WM_STREAM_TYPE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -10283,9 +10178,6 @@ impl Default for WM_SYNCHRONISED_LYRICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WM_SYNCHRONISED_LYRICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WM_SampleExtensionGUID_ChromaLocation: windows_core::GUID = windows_core::GUID::from_u128(0x4c5acca0_9276_4b2c_9e4c_a0edefdd217e);
 pub const WM_SampleExtensionGUID_ColorSpaceInfo: windows_core::GUID = windows_core::GUID::from_u128(0xf79ada56_30eb_4f2b_9f7a_f24b139a1157);
@@ -10314,9 +10206,6 @@ impl Default for WM_USER_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WM_USER_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WM_USER_WEB_URL {
@@ -10327,9 +10216,6 @@ impl Default for WM_USER_WEB_URL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WM_USER_WEB_URL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10350,9 +10236,6 @@ impl Default for WM_WRITER_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WM_WRITER_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WM_WRITER_STATISTICS_EX {
@@ -10368,9 +10251,6 @@ impl Default for WM_WRITER_STATISTICS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WM_WRITER_STATISTICS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/mod.rs
@@ -279,9 +279,6 @@ impl Default for MMTIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MMTIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union MMTIME_0 {
@@ -297,9 +294,6 @@ impl Default for MMTIME_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MMTIME_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct MMTIME_0_1 {
@@ -309,9 +303,6 @@ impl Default for MMTIME_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMTIME_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -328,9 +319,6 @@ impl Default for MMTIME_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMTIME_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MM_ADLIB: u32 = 9u32;
 pub const MM_DRVM_CLOSE: u32 = 977u32;
@@ -392,9 +380,6 @@ impl Default for TIMECAPS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TIMECAPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TIMECODE {
@@ -405,9 +390,6 @@ impl Default for TIMECODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TIMECODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -421,9 +403,6 @@ impl Default for TIMECODE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TIMECODE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct TIMECODE_SAMPLE {
@@ -436,9 +415,6 @@ impl Default for TIMECODE_SAMPLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TIMECODE_SAMPLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dhcp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dhcp/mod.rs
@@ -1705,9 +1705,6 @@ impl Default for DATE_TIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DATE_TIME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEFAULTQUARSETTING: QuarantineStatus = QuarantineStatus(5i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1723,9 +1720,6 @@ impl Default for DHCPAPI_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPAPI_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCPCAPI_CLASSID {
@@ -1738,9 +1732,6 @@ impl Default for DHCPCAPI_CLASSID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPCAPI_CLASSID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DHCPCAPI_DEREGISTER_HANDLE_EVENT: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1752,9 +1743,6 @@ impl Default for DHCPCAPI_PARAMS_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCPCAPI_PARAMS_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DHCPCAPI_REGISTER_HANDLE_EVENT: u32 = 1u32;
 pub const DHCPCAPI_REQUEST_ASYNCHRONOUS: u32 = 4u32;
@@ -1778,9 +1766,6 @@ impl Default for DHCPDS_SERVER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPDS_SERVER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCPDS_SERVERS {
@@ -1792,9 +1777,6 @@ impl Default for DHCPDS_SERVERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCPDS_SERVERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1826,9 +1808,6 @@ impl Default for DHCPV4_FAILOVER_CLIENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPV4_FAILOVER_CLIENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCPV4_FAILOVER_CLIENT_INFO_ARRAY {
@@ -1839,9 +1818,6 @@ impl Default for DHCPV4_FAILOVER_CLIENT_INFO_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCPV4_FAILOVER_CLIENT_INFO_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1874,9 +1850,6 @@ impl Default for DHCPV4_FAILOVER_CLIENT_INFO_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPV4_FAILOVER_CLIENT_INFO_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCPV6CAPI_CLASSID {
@@ -1888,9 +1861,6 @@ impl Default for DHCPV6CAPI_CLASSID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCPV6CAPI_CLASSID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1906,9 +1876,6 @@ impl Default for DHCPV6CAPI_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPV6CAPI_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCPV6CAPI_PARAMS_ARRAY {
@@ -1919,9 +1886,6 @@ impl Default for DHCPV6CAPI_PARAMS_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCPV6CAPI_PARAMS_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1936,9 +1900,6 @@ impl Default for DHCPV6Prefix {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCPV6Prefix {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1959,9 +1920,6 @@ impl Default for DHCPV6PrefixLeaseInformation {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPV6PrefixLeaseInformation {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCPV6_BIND_ELEMENT {
@@ -1979,9 +1937,6 @@ impl Default for DHCPV6_BIND_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPV6_BIND_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCPV6_BIND_ELEMENT_ARRAY {
@@ -1993,9 +1948,6 @@ impl Default for DHCPV6_BIND_ELEMENT_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPV6_BIND_ELEMENT_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCPV6_IP_ARRAY {
@@ -2006,9 +1958,6 @@ impl Default for DHCPV6_IP_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCPV6_IP_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DHCPV6_OPTION_CLIENTID: u32 = 1u32;
 pub const DHCPV6_OPTION_DNS_SERVERS: u32 = 23u32;
@@ -2042,9 +1991,6 @@ impl Default for DHCPV6_STATELESS_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPV6_STATELESS_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DHCPV6_STATELESS_PARAM_TYPE(pub i32);
@@ -2060,9 +2006,6 @@ impl Default for DHCPV6_STATELESS_SCOPE_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCPV6_STATELESS_SCOPE_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCPV6_STATELESS_STATS {
@@ -2073,9 +2016,6 @@ impl Default for DHCPV6_STATELESS_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCPV6_STATELESS_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2091,9 +2031,6 @@ impl Default for DHCP_ADDR_PATTERN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_ADDR_PATTERN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_ALL_OPTIONS {
@@ -2107,9 +2044,6 @@ impl Default for DHCP_ALL_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_ALL_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_ALL_OPTIONS_0 {
@@ -2122,9 +2056,6 @@ impl Default for DHCP_ALL_OPTIONS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_ALL_OPTIONS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_ALL_OPTION_VALUES {
@@ -2136,9 +2067,6 @@ impl Default for DHCP_ALL_OPTION_VALUES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_ALL_OPTION_VALUES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2153,9 +2081,6 @@ impl Default for DHCP_ALL_OPTION_VALUES_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_ALL_OPTION_VALUES_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_ALL_OPTION_VALUES_PB {
@@ -2167,9 +2092,6 @@ impl Default for DHCP_ALL_OPTION_VALUES_PB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_ALL_OPTION_VALUES_PB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2184,9 +2106,6 @@ impl Default for DHCP_ALL_OPTION_VALUES_PB_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_ALL_OPTION_VALUES_PB_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DHCP_ATTRIB {
@@ -2199,9 +2118,6 @@ impl Default for DHCP_ATTRIB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_ATTRIB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DHCP_ATTRIB_0 {
@@ -2213,9 +2129,6 @@ impl Default for DHCP_ATTRIB_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_ATTRIB_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_ATTRIB_ARRAY {
@@ -2226,9 +2139,6 @@ impl Default for DHCP_ATTRIB_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_ATTRIB_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DHCP_ATTRIB_BOOL_IS_ADMIN: u32 = 5u32;
 pub const DHCP_ATTRIB_BOOL_IS_BINDING_AWARE: u32 = 4u32;
@@ -2249,9 +2159,6 @@ impl Default for DHCP_BINARY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_BINARY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_BIND_ELEMENT {
@@ -2268,9 +2175,6 @@ impl Default for DHCP_BIND_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_BIND_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_BIND_ELEMENT_ARRAY {
@@ -2281,9 +2185,6 @@ impl Default for DHCP_BIND_ELEMENT_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_BIND_ELEMENT_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2297,9 +2198,6 @@ impl Default for DHCP_BOOTP_IP_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_BOOTP_IP_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DHCP_CALLOUT_ENTRY_POINT: windows_core::PCSTR = windows_core::s!("DhcpServerCalloutEntry");
 pub const DHCP_CALLOUT_LIST_KEY: windows_core::PCWSTR = windows_core::w!("System\\CurrentControlSet\\Services\\DHCPServer\\Parameters");
@@ -2323,9 +2221,6 @@ impl Default for DHCP_CALLOUT_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_CALLOUT_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_CLASS_INFO {
@@ -2341,9 +2236,6 @@ impl Default for DHCP_CLASS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_CLASS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_CLASS_INFO_ARRAY {
@@ -2355,9 +2247,6 @@ impl Default for DHCP_CLASS_INFO_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_CLASS_INFO_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_CLASS_INFO_ARRAY_V6 {
@@ -2368,9 +2257,6 @@ impl Default for DHCP_CLASS_INFO_ARRAY_V6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLASS_INFO_ARRAY_V6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2387,9 +2273,6 @@ impl Default for DHCP_CLASS_INFO_V6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLASS_INFO_V6 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DHCP_CLIENT_BOOTP: u32 = 805306371u32;
 pub const DHCP_CLIENT_DHCP: u32 = 805306372u32;
@@ -2415,9 +2298,6 @@ impl Default for DHCP_CLIENT_FILTER_STATUS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_CLIENT_FILTER_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_CLIENT_FILTER_STATUS_INFO_ARRAY {
@@ -2428,9 +2308,6 @@ impl Default for DHCP_CLIENT_FILTER_STATUS_INFO_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLIENT_FILTER_STATUS_INFO_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2448,9 +2325,6 @@ impl Default for DHCP_CLIENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_CLIENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_CLIENT_INFO_ARRAY {
@@ -2461,9 +2335,6 @@ impl Default for DHCP_CLIENT_INFO_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2476,9 +2347,6 @@ impl Default for DHCP_CLIENT_INFO_ARRAY_V4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_ARRAY_V4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_CLIENT_INFO_ARRAY_V5 {
@@ -2489,9 +2357,6 @@ impl Default for DHCP_CLIENT_INFO_ARRAY_V5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_ARRAY_V5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2504,9 +2369,6 @@ impl Default for DHCP_CLIENT_INFO_ARRAY_V6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_ARRAY_V6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_CLIENT_INFO_ARRAY_VQ {
@@ -2517,9 +2379,6 @@ impl Default for DHCP_CLIENT_INFO_ARRAY_VQ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_ARRAY_VQ {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2545,9 +2404,6 @@ impl Default for DHCP_CLIENT_INFO_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_CLIENT_INFO_EX_ARRAY {
@@ -2558,9 +2414,6 @@ impl Default for DHCP_CLIENT_INFO_EX_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_EX_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2585,9 +2438,6 @@ impl Default for DHCP_CLIENT_INFO_PB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_PB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_CLIENT_INFO_PB_ARRAY {
@@ -2598,9 +2448,6 @@ impl Default for DHCP_CLIENT_INFO_PB_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_PB_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2618,9 +2465,6 @@ impl Default for DHCP_CLIENT_INFO_V4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_V4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2640,9 +2484,6 @@ impl Default for DHCP_CLIENT_INFO_V5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_V5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_CLIENT_INFO_V6 {
@@ -2660,9 +2501,6 @@ impl Default for DHCP_CLIENT_INFO_V6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_V6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2684,9 +2522,6 @@ impl Default for DHCP_CLIENT_INFO_VQ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_CLIENT_INFO_VQ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DHCP_CONTROL_CONTINUE: u32 = 4u32;
 pub const DHCP_CONTROL_PAUSE: u32 = 3u32;
@@ -2734,9 +2569,6 @@ impl Default for DHCP_FAILOVER_RELATIONSHIP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_FAILOVER_RELATIONSHIP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_FAILOVER_RELATIONSHIP_ARRAY {
@@ -2747,9 +2579,6 @@ impl Default for DHCP_FAILOVER_RELATIONSHIP_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_FAILOVER_RELATIONSHIP_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2770,9 +2599,6 @@ impl Default for DHCP_FAILOVER_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_FAILOVER_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_FILTER_ADD_INFO {
@@ -2785,9 +2611,6 @@ impl Default for DHCP_FILTER_ADD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_FILTER_ADD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_FILTER_ENUM_INFO {
@@ -2799,9 +2622,6 @@ impl Default for DHCP_FILTER_ENUM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_FILTER_ENUM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_FILTER_GLOBAL_INFO {
@@ -2812,9 +2632,6 @@ impl Default for DHCP_FILTER_GLOBAL_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_FILTER_GLOBAL_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2829,9 +2646,6 @@ impl Default for DHCP_FILTER_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_FILTER_RECORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DHCP_FLAGS_DONT_ACCESS_DS: u32 = 1u32;
 pub const DHCP_FLAGS_DONT_DO_RPC: u32 = 2u32;
@@ -2853,9 +2667,6 @@ impl Default for DHCP_HOST_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_HOST_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_HOST_INFO_V6 {
@@ -2868,9 +2679,6 @@ impl Default for DHCP_HOST_INFO_V6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_HOST_INFO_V6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_IPV6_ADDRESS {
@@ -2881,9 +2689,6 @@ impl Default for DHCP_IPV6_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_IPV6_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2896,9 +2701,6 @@ impl Default for DHCP_IP_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_IP_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_IP_CLUSTER {
@@ -2909,9 +2711,6 @@ impl Default for DHCP_IP_CLUSTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_IP_CLUSTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2924,9 +2723,6 @@ impl Default for DHCP_IP_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_IP_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_IP_RANGE_ARRAY {
@@ -2937,9 +2733,6 @@ impl Default for DHCP_IP_RANGE_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_IP_RANGE_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2952,9 +2745,6 @@ impl Default for DHCP_IP_RANGE_V6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_IP_RANGE_V6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_IP_RESERVATION {
@@ -2965,9 +2755,6 @@ impl Default for DHCP_IP_RESERVATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_IP_RESERVATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2984,9 +2771,6 @@ impl Default for DHCP_IP_RESERVATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_IP_RESERVATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_IP_RESERVATION_V4 {
@@ -2999,9 +2783,6 @@ impl Default for DHCP_IP_RESERVATION_V4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_IP_RESERVATION_V4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_IP_RESERVATION_V6 {
@@ -3013,9 +2794,6 @@ impl Default for DHCP_IP_RESERVATION_V6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_IP_RESERVATION_V6 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DHCP_MAX_DELAY: u32 = 1000u32;
 #[repr(C)]
@@ -3036,9 +2814,6 @@ impl Default for DHCP_MIB_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_MIB_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3068,9 +2843,6 @@ impl Default for DHCP_MIB_INFO_V5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_MIB_INFO_V5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_MIB_INFO_V6 {
@@ -3092,9 +2864,6 @@ impl Default for DHCP_MIB_INFO_V6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_MIB_INFO_V6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3122,9 +2891,6 @@ impl Default for DHCP_MIB_INFO_VQ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_MIB_INFO_VQ {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DHCP_MIN_DELAY: u32 = 0u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3140,9 +2906,6 @@ impl Default for DHCP_OPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_OPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_OPTION_ARRAY {
@@ -3153,9 +2916,6 @@ impl Default for DHCP_OPTION_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_OPTION_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3168,9 +2928,6 @@ impl Default for DHCP_OPTION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_OPTION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DHCP_OPTION_DATA_ELEMENT {
@@ -3181,9 +2938,6 @@ impl Default for DHCP_OPTION_DATA_ELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_OPTION_DATA_ELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3203,9 +2957,6 @@ impl Default for DHCP_OPTION_DATA_ELEMENT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_OPTION_DATA_ELEMENT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DHCP_OPTION_DATA_TYPE(pub i32);
@@ -3220,9 +2971,6 @@ impl Default for DHCP_OPTION_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_OPTION_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DHCP_OPTION_SCOPE_INFO {
@@ -3233,9 +2981,6 @@ impl Default for DHCP_OPTION_SCOPE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_OPTION_SCOPE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3251,9 +2996,6 @@ impl Default for DHCP_OPTION_SCOPE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_OPTION_SCOPE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DHCP_OPTION_SCOPE_INFO6 {
@@ -3264,9 +3006,6 @@ impl Default for DHCP_OPTION_SCOPE_INFO6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_OPTION_SCOPE_INFO6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3279,9 +3018,6 @@ impl Default for DHCP_OPTION_SCOPE_INFO6_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_OPTION_SCOPE_INFO6_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3303,9 +3039,6 @@ impl Default for DHCP_OPTION_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_OPTION_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_OPTION_VALUE_ARRAY {
@@ -3316,9 +3049,6 @@ impl Default for DHCP_OPTION_VALUE_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_OPTION_VALUE_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DHCP_OPT_ENUM_IGNORE_VENDOR: u32 = 1u32;
 pub const DHCP_OPT_ENUM_USE_CLASSNAME: u32 = 2u32;
@@ -3350,9 +3080,6 @@ impl Default for DHCP_PERF_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_PERF_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_POLICY {
@@ -3371,9 +3098,6 @@ impl Default for DHCP_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_POLICY_ARRAY {
@@ -3384,9 +3108,6 @@ impl Default for DHCP_POLICY_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_POLICY_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3407,9 +3128,6 @@ impl Default for DHCP_POLICY_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_POLICY_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_POLICY_EX_ARRAY {
@@ -3420,9 +3138,6 @@ impl Default for DHCP_POLICY_EX_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_POLICY_EX_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3450,9 +3165,6 @@ impl Default for DHCP_POL_COND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_POL_COND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_POL_COND_ARRAY {
@@ -3463,9 +3175,6 @@ impl Default for DHCP_POL_COND_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_POL_COND_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3478,9 +3187,6 @@ impl Default for DHCP_POL_EXPR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_POL_EXPR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_POL_EXPR_ARRAY {
@@ -3491,9 +3197,6 @@ impl Default for DHCP_POL_EXPR_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_POL_EXPR_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3514,9 +3217,6 @@ impl Default for DHCP_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DHCP_PROPERTY_0 {
@@ -3531,9 +3231,6 @@ impl Default for DHCP_PROPERTY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_PROPERTY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_PROPERTY_ARRAY {
@@ -3544,9 +3241,6 @@ impl Default for DHCP_PROPERTY_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_PROPERTY_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3565,9 +3259,6 @@ impl Default for DHCP_RESERVATION_INFO_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_RESERVATION_INFO_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_RESERVED_SCOPE {
@@ -3579,9 +3270,6 @@ impl Default for DHCP_RESERVED_SCOPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_RESERVED_SCOPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_RESERVED_SCOPE6 {
@@ -3592,9 +3280,6 @@ impl Default for DHCP_RESERVED_SCOPE6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_RESERVED_SCOPE6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3610,9 +3295,6 @@ impl Default for DHCP_SCAN_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SCAN_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_SCAN_LIST {
@@ -3623,9 +3305,6 @@ impl Default for DHCP_SCAN_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SCAN_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3638,9 +3317,6 @@ impl Default for DHCP_SEARCH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SEARCH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DHCP_SEARCH_INFO_0 {
@@ -3652,9 +3328,6 @@ impl Default for DHCP_SEARCH_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SEARCH_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3673,9 +3346,6 @@ impl Default for DHCP_SEARCH_INFO_V6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SEARCH_INFO_V6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DHCP_SEARCH_INFO_V6_0 {
@@ -3687,9 +3357,6 @@ impl Default for DHCP_SEARCH_INFO_V6_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SEARCH_INFO_V6_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DHCP_SEND_PACKET: u32 = 268435456u32;
 #[repr(C)]
@@ -3709,9 +3376,6 @@ impl Default for DHCP_SERVER_CONFIG_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SERVER_CONFIG_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3735,9 +3399,6 @@ impl Default for DHCP_SERVER_CONFIG_INFO_V4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SERVER_CONFIG_INFO_V4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_SERVER_CONFIG_INFO_V6 {
@@ -3755,9 +3416,6 @@ impl Default for DHCP_SERVER_CONFIG_INFO_V6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SERVER_CONFIG_INFO_V6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3783,9 +3441,6 @@ impl Default for DHCP_SERVER_CONFIG_INFO_VQ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SERVER_CONFIG_INFO_VQ {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3821,9 +3476,6 @@ impl Default for DHCP_SERVER_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SERVER_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_SERVER_SPECIFIC_STRINGS {
@@ -3835,9 +3487,6 @@ impl Default for DHCP_SERVER_SPECIFIC_STRINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SERVER_SPECIFIC_STRINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DHCP_SUBNET_ELEMENT_DATA {
@@ -3848,9 +3497,6 @@ impl Default for DHCP_SUBNET_ELEMENT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3866,9 +3512,6 @@ impl Default for DHCP_SUBNET_ELEMENT_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DHCP_SUBNET_ELEMENT_DATA_V4 {
@@ -3879,9 +3522,6 @@ impl Default for DHCP_SUBNET_ELEMENT_DATA_V4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_DATA_V4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3897,9 +3537,6 @@ impl Default for DHCP_SUBNET_ELEMENT_DATA_V4_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_DATA_V4_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DHCP_SUBNET_ELEMENT_DATA_V5 {
@@ -3910,9 +3547,6 @@ impl Default for DHCP_SUBNET_ELEMENT_DATA_V5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_DATA_V5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3928,9 +3562,6 @@ impl Default for DHCP_SUBNET_ELEMENT_DATA_V5_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_DATA_V5_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DHCP_SUBNET_ELEMENT_DATA_V6 {
@@ -3941,9 +3572,6 @@ impl Default for DHCP_SUBNET_ELEMENT_DATA_V6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_DATA_V6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3957,9 +3585,6 @@ impl Default for DHCP_SUBNET_ELEMENT_DATA_V6_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_DATA_V6_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_SUBNET_ELEMENT_INFO_ARRAY {
@@ -3970,9 +3595,6 @@ impl Default for DHCP_SUBNET_ELEMENT_INFO_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_INFO_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3985,9 +3607,6 @@ impl Default for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_SUBNET_ELEMENT_INFO_ARRAY_V5 {
@@ -3999,9 +3618,6 @@ impl Default for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_SUBNET_ELEMENT_INFO_ARRAY_V6 {
@@ -4012,9 +3628,6 @@ impl Default for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4037,9 +3650,6 @@ impl Default for DHCP_SUBNET_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SUBNET_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_SUBNET_INFO_V6 {
@@ -4055,9 +3665,6 @@ impl Default for DHCP_SUBNET_INFO_V6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SUBNET_INFO_V6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4079,9 +3686,6 @@ impl Default for DHCP_SUBNET_INFO_VQ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SUBNET_INFO_VQ {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DHCP_SUBNET_INFO_VQ_FLAG_QUARANTINE: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4097,9 +3701,6 @@ impl Default for DHCP_SUPER_SCOPE_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DHCP_SUPER_SCOPE_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DHCP_SUPER_SCOPE_TABLE_ENTRY {
@@ -4112,9 +3713,6 @@ impl Default for DHCP_SUPER_SCOPE_TABLE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DHCP_SUPER_SCOPE_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_FLAG_CLEANUP_EXPIRED: u32 = 4u32;
 pub const DNS_FLAG_DISABLE_PTR_UPDATE: u32 = 64u32;
@@ -4134,9 +3732,6 @@ impl Default for DWORD_DWORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWORD_DWORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const Deny: DHCP_FILTER_LIST_TYPE = DHCP_FILTER_LIST_TYPE(0i32);
 pub const DhcpArrayTypeOption: DHCP_OPTION_TYPE = DHCP_OPTION_TYPE(1i32);
@@ -4460,9 +4055,6 @@ impl Default for SCOPE_MIB_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCOPE_MIB_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCOPE_MIB_INFO_V5 {
@@ -4476,9 +4068,6 @@ impl Default for SCOPE_MIB_INFO_V5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCOPE_MIB_INFO_V5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCOPE_MIB_INFO_V6 {
@@ -4491,9 +4080,6 @@ impl Default for SCOPE_MIB_INFO_V6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCOPE_MIB_INFO_V6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4513,9 +4099,6 @@ impl Default for SCOPE_MIB_INFO_VQ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCOPE_MIB_INFO_VQ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHAREDSECRET: u32 = 64u32;
 pub const SHUTDOWN: FSM_STATE = FSM_STATE(13i32);

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
@@ -452,9 +452,6 @@ impl Default for DNS_AAAA_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_AAAA_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DNS_ADDR {
@@ -466,9 +463,6 @@ impl Default for DNS_ADDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_ADDR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union DNS_ADDR_0 {
@@ -478,9 +472,6 @@ impl Default for DNS_ADDR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_ADDR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_ADDRESS_STRING_LENGTH: u32 = 65u32;
 #[repr(C, packed(1))]
@@ -502,9 +493,6 @@ impl Default for DNS_ADDR_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_ADDR_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DNS_ADDR_MAX_SOCKADDR_LENGTH: u32 = 32u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -516,9 +504,6 @@ impl Default for DNS_APPLICATION_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_APPLICATION_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_APP_SETTINGS_EXCLUSIVE_SERVERS: u32 = 1u32;
 pub const DNS_APP_SETTINGS_VERSION1: u32 = 1u32;
@@ -534,9 +519,6 @@ impl Default for DNS_ATMA_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_ATMA_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DNS_ATMA_FORMAT_AESA: u32 = 2u32;
 pub const DNS_ATMA_FORMAT_E164: u32 = 1u32;
 pub const DNS_ATMA_MAX_ADDR_LENGTH: u32 = 20u32;
@@ -550,9 +532,6 @@ impl Default for DNS_A_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_A_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -581,9 +560,6 @@ impl Default for DNS_CONNECTION_IFINDEX_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_CONNECTION_IFINDEX_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_CONNECTION_IFINDEX_LIST {
@@ -595,9 +571,6 @@ impl Default for DNS_CONNECTION_IFINDEX_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_CONNECTION_IFINDEX_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_CONNECTION_NAME {
@@ -607,9 +580,6 @@ impl Default for DNS_CONNECTION_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_CONNECTION_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -621,9 +591,6 @@ impl Default for DNS_CONNECTION_NAME_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_CONNECTION_NAME_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_CONNECTION_NAME_MAX_LENGTH: u32 = 64u32;
 #[repr(C)]
@@ -642,9 +609,6 @@ impl Default for DNS_CONNECTION_POLICY_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_CONNECTION_POLICY_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_CONNECTION_POLICY_ENTRY_LIST {
@@ -655,9 +619,6 @@ impl Default for DNS_CONNECTION_POLICY_ENTRY_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_CONNECTION_POLICY_ENTRY_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_CONNECTION_POLICY_ENTRY_ONDEMAND: u32 = 1u32;
 #[repr(transparent)]
@@ -674,9 +635,6 @@ impl Default for DNS_CONNECTION_PROXY_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_CONNECTION_PROXY_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DNS_CONNECTION_PROXY_INFO {
@@ -691,9 +649,6 @@ impl Default for DNS_CONNECTION_PROXY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_CONNECTION_PROXY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DNS_CONNECTION_PROXY_INFO_0 {
@@ -704,9 +659,6 @@ impl Default for DNS_CONNECTION_PROXY_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_CONNECTION_PROXY_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -723,9 +675,6 @@ impl Default for DNS_CONNECTION_PROXY_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_CONNECTION_PROXY_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_CONNECTION_PROXY_INFO_0_1 {
@@ -737,9 +686,6 @@ impl Default for DNS_CONNECTION_PROXY_INFO_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_CONNECTION_PROXY_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_CONNECTION_PROXY_INFO_CURRENT_VERSION: u32 = 1u32;
 #[repr(C)]
@@ -755,9 +701,6 @@ impl Default for DNS_CONNECTION_PROXY_INFO_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_CONNECTION_PROXY_INFO_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_CONNECTION_PROXY_INFO_EXCEPTION_MAX_LENGTH: u32 = 1024u32;
 pub const DNS_CONNECTION_PROXY_INFO_EXTRA_INFO_MAX_LENGTH: u32 = 1024u32;
@@ -784,9 +727,6 @@ impl Default for DNS_CONNECTION_PROXY_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_CONNECTION_PROXY_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DNS_CONNECTION_PROXY_TYPE(pub i32);
@@ -808,9 +748,6 @@ impl Default for DNS_CUSTOM_SERVER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_CUSTOM_SERVER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DNS_CUSTOM_SERVER_0 {
@@ -821,9 +758,6 @@ impl Default for DNS_CUSTOM_SERVER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_CUSTOM_SERVER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DNS_CUSTOM_SERVER_1 {
@@ -833,9 +767,6 @@ impl Default for DNS_CUSTOM_SERVER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_CUSTOM_SERVER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_CUSTOM_SERVER_TYPE_DOH: u32 = 2u32;
 pub const DNS_CUSTOM_SERVER_TYPE_UDP: u32 = 1u32;
@@ -851,9 +782,6 @@ impl Default for DNS_DHCID_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_DHCID_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_DS_DATA {
@@ -868,9 +796,6 @@ impl Default for DNS_DS_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_DS_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -891,9 +816,6 @@ impl Default for DNS_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DNS_HEADER_EXT {
@@ -905,9 +827,6 @@ impl Default for DNS_HEADER_EXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_HEADER_EXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -924,9 +843,6 @@ impl Default for DNS_KEY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_KEY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_LOC_DATA {
@@ -942,9 +858,6 @@ impl Default for DNS_LOC_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_LOC_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_MAX_IP4_REVERSE_NAME_BUFFER_LENGTH: u32 = 31u32;
 pub const DNS_MAX_IP4_REVERSE_NAME_LENGTH: u32 = 31u32;
@@ -968,9 +881,6 @@ impl Default for DNS_MESSAGE_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_MESSAGE_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_MINFO_DATAA {
@@ -982,9 +892,6 @@ impl Default for DNS_MINFO_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_MINFO_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_MINFO_DATAW {
@@ -995,9 +902,6 @@ impl Default for DNS_MINFO_DATAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_MINFO_DATAW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1011,9 +915,6 @@ impl Default for DNS_MX_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_MX_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_MX_DATAW {
@@ -1025,9 +926,6 @@ impl Default for DNS_MX_DATAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_MX_DATAW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1047,9 +945,6 @@ impl Default for DNS_NAPTR_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_NAPTR_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_NAPTR_DATAW {
@@ -1065,9 +960,6 @@ impl Default for DNS_NAPTR_DATAW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_NAPTR_DATAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_NSEC3PARAM_DATA {
@@ -1082,9 +974,6 @@ impl Default for DNS_NSEC3PARAM_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_NSEC3PARAM_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1102,9 +991,6 @@ impl Default for DNS_NSEC3_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_NSEC3_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_NSEC_DATAA {
@@ -1117,9 +1003,6 @@ impl Default for DNS_NSEC_DATAA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_NSEC_DATAA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1134,9 +1017,6 @@ impl Default for DNS_NSEC_DATAW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_NSEC_DATAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_NULL_DATA {
@@ -1147,9 +1027,6 @@ impl Default for DNS_NULL_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_NULL_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1163,9 +1040,6 @@ impl Default for DNS_NXT_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_NXT_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_NXT_DATAW {
@@ -1177,9 +1051,6 @@ impl Default for DNS_NXT_DATAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_NXT_DATAW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_OPCODE_IQUERY: u32 = 1u32;
 pub const DNS_OPCODE_NOTIFY: u32 = 4u32;
@@ -1198,9 +1069,6 @@ impl Default for DNS_OPT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_OPT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_PORT_HOST_ORDER: u32 = 53u32;
 pub const DNS_PORT_NET_ORDER: u32 = 13568u32;
@@ -1222,9 +1090,6 @@ impl Default for DNS_PROXY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_PROXY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DNS_PROXY_INFORMATION_DEFAULT_SETTINGS: DNS_PROXY_INFORMATION_TYPE = DNS_PROXY_INFORMATION_TYPE(1i32);
 pub const DNS_PROXY_INFORMATION_DIRECT: DNS_PROXY_INFORMATION_TYPE = DNS_PROXY_INFORMATION_TYPE(0i32);
 pub const DNS_PROXY_INFORMATION_DOES_NOT_EXIST: DNS_PROXY_INFORMATION_TYPE = DNS_PROXY_INFORMATION_TYPE(3i32);
@@ -1242,9 +1107,6 @@ impl Default for DNS_PTR_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_PTR_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_PTR_DATAW {
@@ -1254,9 +1116,6 @@ impl Default for DNS_PTR_DATAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_PTR_DATAW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_QUERY_ACCEPT_TRUNCATED_RESPONSE: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(1u32);
 pub const DNS_QUERY_ADDRCONFIG: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(8192u32);
@@ -1272,9 +1131,6 @@ impl Default for DNS_QUERY_CANCEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_QUERY_CANCEL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_QUERY_DISABLE_IDN_ENCODING: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(2097152u32);
 pub const DNS_QUERY_DNSSEC_CHECKING_DISABLED: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(33554432u32);
@@ -1334,9 +1190,6 @@ impl Default for DNS_QUERY_RAW_CANCEL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_QUERY_RAW_CANCEL {
-    type TypeKind = windows_core::CopyType;
-}
 pub type DNS_QUERY_RAW_COMPLETION_ROUTINE = Option<unsafe extern "system" fn(querycontext: *const core::ffi::c_void, queryresults: *const DNS_QUERY_RAW_RESULT)>;
 pub const DNS_QUERY_RAW_OPTION_BEST_EFFORT_PARSE: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(1u32);
 #[repr(C)]
@@ -1363,9 +1216,6 @@ impl Default for DNS_QUERY_RAW_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_QUERY_RAW_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DNS_QUERY_RAW_REQUEST_0 {
@@ -1375,9 +1225,6 @@ impl Default for DNS_QUERY_RAW_REQUEST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_QUERY_RAW_REQUEST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_QUERY_RAW_REQUEST_VERSION1: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(1u32);
 #[repr(C)]
@@ -1399,9 +1246,6 @@ impl Default for DNS_QUERY_RAW_RESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_QUERY_RAW_RESULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DNS_QUERY_RAW_RESULT_0 {
@@ -1411,9 +1255,6 @@ impl Default for DNS_QUERY_RAW_RESULT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_QUERY_RAW_RESULT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_QUERY_RAW_RESULTS_VERSION1: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(1u32);
 #[repr(C)]
@@ -1432,9 +1273,6 @@ impl Default for DNS_QUERY_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_QUERY_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1457,9 +1295,6 @@ impl Default for DNS_QUERY_REQUEST3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_QUERY_REQUEST3 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DNS_QUERY_REQUEST_VERSION1: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(1u32);
 pub const DNS_QUERY_REQUEST_VERSION2: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(2u32);
 pub const DNS_QUERY_REQUEST_VERSION3: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(3u32);
@@ -1477,9 +1312,6 @@ impl Default for DNS_QUERY_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_QUERY_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_QUERY_RESULTS_VERSION1: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(1u32);
 pub const DNS_QUERY_RETURN_MESSAGE: DNS_QUERY_OPTIONS = DNS_QUERY_OPTIONS(512u32);
@@ -1533,9 +1365,6 @@ impl Default for DNS_RECORDA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_RECORDA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1632,9 +1461,6 @@ impl Default for DNS_RECORDA_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_RECORDA_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DNS_RECORDA_0 {
@@ -1645,9 +1471,6 @@ impl Default for DNS_RECORDA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_RECORDA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1665,9 +1488,6 @@ impl Default for DNS_RECORDW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_RECORDW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1764,9 +1584,6 @@ impl Default for DNS_RECORDW_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_RECORDW_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DNS_RECORDW_0 {
@@ -1778,9 +1595,6 @@ impl Default for DNS_RECORDW_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_RECORDW_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_RECORD_FLAGS {
@@ -1790,9 +1604,6 @@ impl Default for DNS_RECORD_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_RECORD_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1812,9 +1623,6 @@ impl Default for DNS_RECORD_OPTW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_RECORD_OPTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DNS_RECORD_OPTW_1 {
@@ -1825,9 +1633,6 @@ impl Default for DNS_RECORD_OPTW_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_RECORD_OPTW_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1840,9 +1645,6 @@ impl Default for DNS_RECORD_OPTW_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_RECORD_OPTW_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DNS_RFC_MAX_UDP_PACKET_LENGTH: u32 = 512u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1854,9 +1656,6 @@ impl Default for DNS_RRSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_RRSET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_RTYPE_A: u32 = 256u32;
 pub const DNS_RTYPE_A6: u32 = 9728u32;
@@ -1938,9 +1737,6 @@ impl Default for DNS_SERVICE_BROWSE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SERVICE_BROWSE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DNS_SERVICE_BROWSE_REQUEST_0 {
@@ -1952,9 +1748,6 @@ impl Default for DNS_SERVICE_BROWSE_REQUEST_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SERVICE_BROWSE_REQUEST_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SERVICE_CANCEL {
@@ -1964,9 +1757,6 @@ impl Default for DNS_SERVICE_CANCEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SERVICE_CANCEL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1988,9 +1778,6 @@ impl Default for DNS_SERVICE_INSTANCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SERVICE_INSTANCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SERVICE_REGISTER_REQUEST {
@@ -2007,9 +1794,6 @@ impl Default for DNS_SERVICE_REGISTER_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SERVICE_REGISTER_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SERVICE_RESOLVE_REQUEST {
@@ -2023,9 +1807,6 @@ impl Default for DNS_SERVICE_RESOLVE_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SERVICE_RESOLVE_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2046,9 +1827,6 @@ impl Default for DNS_SIG_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SIG_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SIG_DATAW {
@@ -2068,9 +1846,6 @@ impl Default for DNS_SIG_DATAW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SIG_DATAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SOA_DATAA {
@@ -2086,9 +1861,6 @@ impl Default for DNS_SOA_DATAA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SOA_DATAA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2106,9 +1878,6 @@ impl Default for DNS_SOA_DATAW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SOA_DATAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SRV_DATAA {
@@ -2122,9 +1891,6 @@ impl Default for DNS_SRV_DATAA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SRV_DATAA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2140,9 +1906,6 @@ impl Default for DNS_SRV_DATAW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SRV_DATAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SVCB_DATA {
@@ -2156,9 +1919,6 @@ impl Default for DNS_SVCB_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SVCB_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DNS_SVCB_PARAM {
@@ -2169,9 +1929,6 @@ impl Default for DNS_SVCB_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SVCB_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2190,9 +1947,6 @@ impl Default for DNS_SVCB_PARAM_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SVCB_PARAM_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SVCB_PARAM_ALPN {
@@ -2203,9 +1957,6 @@ impl Default for DNS_SVCB_PARAM_ALPN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SVCB_PARAM_ALPN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2218,9 +1969,6 @@ impl Default for DNS_SVCB_PARAM_ALPN_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SVCB_PARAM_ALPN_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SVCB_PARAM_IPV4 {
@@ -2231,9 +1979,6 @@ impl Default for DNS_SVCB_PARAM_IPV4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SVCB_PARAM_IPV4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2246,9 +1991,6 @@ impl Default for DNS_SVCB_PARAM_IPV6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SVCB_PARAM_IPV6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SVCB_PARAM_MANDATORY {
@@ -2259,9 +2001,6 @@ impl Default for DNS_SVCB_PARAM_MANDATORY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SVCB_PARAM_MANDATORY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2276,9 +2015,6 @@ impl Default for DNS_SVCB_PARAM_UNKNOWN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SVCB_PARAM_UNKNOWN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2301,9 +2037,6 @@ impl Default for DNS_TKEY_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_TKEY_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_TKEY_DATAW {
@@ -2325,9 +2058,6 @@ impl Default for DNS_TKEY_DATAW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_TKEY_DATAW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DNS_TKEY_MODE_DIFFIE_HELLMAN: u32 = 2u32;
 pub const DNS_TKEY_MODE_GSS: u32 = 3u32;
 pub const DNS_TKEY_MODE_RESOLVER_ASSIGN: u32 = 4u32;
@@ -2346,9 +2076,6 @@ impl Default for DNS_TLSA_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_TLSA_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2371,9 +2098,6 @@ impl Default for DNS_TSIG_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_TSIG_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_TSIG_DATAW {
@@ -2395,9 +2119,6 @@ impl Default for DNS_TSIG_DATAW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_TSIG_DATAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_TXT_DATAA {
@@ -2409,9 +2130,6 @@ impl Default for DNS_TXT_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_TXT_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_TXT_DATAW {
@@ -2422,9 +2140,6 @@ impl Default for DNS_TXT_DATAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_TXT_DATAW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2508,9 +2223,6 @@ impl Default for DNS_UNKNOWN_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_UNKNOWN_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DNS_UPDATE_CACHE_SECURITY_CONTEXT: u32 = 512u32;
 pub const DNS_UPDATE_FORCE_SECURITY_NEGO: u32 = 2048u32;
 pub const DNS_UPDATE_REMOTE_SERVER: u32 = 16384u32;
@@ -2543,9 +2255,6 @@ impl Default for DNS_WINSR_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_WINSR_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_WINSR_DATAW {
@@ -2558,9 +2267,6 @@ impl Default for DNS_WINSR_DATAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_WINSR_DATAW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2576,9 +2282,6 @@ impl Default for DNS_WINS_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_WINS_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DNS_WINS_FLAG_LOCAL: u32 = 65536u32;
 pub const DNS_WINS_FLAG_SCOPE: u32 = 2147483648u32;
 #[repr(C, packed(1))]
@@ -2591,9 +2294,6 @@ impl Default for DNS_WIRE_QUESTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_WIRE_QUESTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2608,9 +2308,6 @@ impl Default for DNS_WIRE_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_WIRE_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_WKS_DATA {
@@ -2622,9 +2319,6 @@ impl Default for DNS_WKS_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_WKS_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DnsCharSetAnsi: DNS_CHARSET = DNS_CHARSET(3i32);
 pub const DnsCharSetUnicode: DNS_CHARSET = DNS_CHARSET(1i32);
@@ -2686,9 +2380,6 @@ impl Default for IP4_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IP4_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -2702,10 +2393,6 @@ impl Default for IP6_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IP6_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -2722,10 +2409,6 @@ impl Default for IP6_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for IP6_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IP6_ADDRESS_STRING_BUFFER_LENGTH: u32 = 65u32;
 pub const IP6_ADDRESS_STRING_LENGTH: u32 = 65u32;
 #[repr(C)]
@@ -2741,9 +2424,6 @@ impl Default for MDNS_QUERY_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MDNS_QUERY_HANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2763,9 +2443,6 @@ impl Default for MDNS_QUERY_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MDNS_QUERY_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PDNS_QUERY_COMPLETION_ROUTINE = Option<unsafe extern "system" fn(pquerycontext: *const core::ffi::c_void, pqueryresults: *mut DNS_QUERY_RESULT)>;
 pub type PDNS_SERVICE_BROWSE_CALLBACK = Option<unsafe extern "system" fn(status: u32, pquerycontext: *const core::ffi::c_void, pdnsrecord: *const DNS_RECORDW)>;
@@ -2794,9 +2471,6 @@ impl Default for _DnsRecordOptA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _DnsRecordOptA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union _DnsRecordOptA_1 {
@@ -2808,9 +2482,6 @@ impl Default for _DnsRecordOptA_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _DnsRecordOptA_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union _DnsRecordOptA_0 {
@@ -2821,7 +2492,4 @@ impl Default for _DnsRecordOptA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _DnsRecordOptA_0 {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/IpHelper/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/IpHelper/mod.rs
@@ -1255,9 +1255,6 @@ impl Default for ARP_SEND_REPLY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ARP_SEND_REPLY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BEST_IF: u32 = 20u32;
 pub const BEST_ROUTE: u32 = 21u32;
 pub const BROADCAST_NODETYPE: u32 = 1u32;
@@ -1282,9 +1279,6 @@ impl Default for DNS_DOH_SERVER_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_DOH_SERVER_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_DOH_SERVER_SETTINGS_ENABLE: u32 = 2u32;
 pub const DNS_DOH_SERVER_SETTINGS_ENABLE_AUTO: u32 = 1u32;
@@ -1311,9 +1305,6 @@ impl Default for DNS_INTERFACE_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_INTERFACE_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_INTERFACE_SETTINGS3 {
@@ -1338,9 +1329,6 @@ impl Default for DNS_INTERFACE_SETTINGS3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_INTERFACE_SETTINGS3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1368,9 +1356,6 @@ impl Default for DNS_INTERFACE_SETTINGS4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_INTERFACE_SETTINGS4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_INTERFACE_SETTINGS_EX {
@@ -1382,9 +1367,6 @@ impl Default for DNS_INTERFACE_SETTINGS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_INTERFACE_SETTINGS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_INTERFACE_SETTINGS_VERSION1: u32 = 1u32;
 pub const DNS_INTERFACE_SETTINGS_VERSION2: u32 = 2u32;
@@ -1403,9 +1385,6 @@ impl Default for DNS_SERVER_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SERVER_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DNS_SERVER_PROPERTY_TYPE(pub i32);
@@ -1418,9 +1397,6 @@ impl Default for DNS_SERVER_PROPERTY_TYPES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SERVER_PROPERTY_TYPES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_SERVER_PROPERTY_VERSION1: u32 = 1u32;
 #[repr(C)]
@@ -1437,9 +1413,6 @@ impl Default for DNS_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DNS_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DNS_SETTINGS2 {
@@ -1454,9 +1427,6 @@ impl Default for DNS_SETTINGS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DNS_SETTINGS2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DNS_SETTINGS_ENABLE_LLMNR: u32 = 128u32;
 pub const DNS_SETTINGS_QUERY_ADAPTER_NAME: u32 = 256u32;
@@ -1501,9 +1471,6 @@ impl Default for FIXED_INFO_W2KSP1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FIXED_INFO_W2KSP1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GAA_FLAG_INCLUDE_ALL_COMPARTMENTS: GET_ADAPTERS_ADDRESSES_FLAGS = GET_ADAPTERS_ADDRESSES_FLAGS(512u32);
 pub const GAA_FLAG_INCLUDE_ALL_INTERFACES: GET_ADAPTERS_ADDRESSES_FLAGS = GET_ADAPTERS_ADDRESSES_FLAGS(256u32);
@@ -1627,9 +1594,6 @@ impl Default for ICMPV6_ECHO_REPLY_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ICMPV6_ECHO_REPLY_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ICMP_ECHO_REPLY {
@@ -1645,9 +1609,6 @@ impl Default for ICMP_ECHO_REPLY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ICMP_ECHO_REPLY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1666,10 +1627,6 @@ impl Default for ICMP_ECHO_REPLY32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ICMP_ECHO_REPLY32 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ICMP_STATS: u32 = 11u32;
 pub const IF_ACCESS_BROADCAST: IF_ACCESS_TYPE = IF_ACCESS_TYPE(2i32);
@@ -1913,9 +1870,6 @@ impl Default for INTERFACE_HARDWARE_CROSSTIMESTAMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERFACE_HARDWARE_CROSSTIMESTAMP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INTERFACE_HARDWARE_CROSSTIMESTAMP_VERSION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1937,9 +1891,6 @@ impl Default for INTERFACE_HARDWARE_TIMESTAMP_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERFACE_HARDWARE_TIMESTAMP_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERFACE_SOFTWARE_TIMESTAMP_CAPABILITIES {
@@ -1951,9 +1902,6 @@ impl Default for INTERFACE_SOFTWARE_TIMESTAMP_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERFACE_SOFTWARE_TIMESTAMP_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1967,9 +1915,6 @@ impl Default for INTERFACE_TIMESTAMP_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERFACE_TIMESTAMP_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERFACE_TIMESTAMP_CAPABILITIES_VERSION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -1995,9 +1940,6 @@ impl Default for IPV6_ADDRESS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV6_ADDRESS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPV6_GLOBAL_INFO: u32 = 4294901775u32;
 pub const IPV6_ROUTE_INFO: u32 = 4294901776u32;
@@ -2048,10 +1990,6 @@ impl Default for IP_ADAPTER_ADDRESSES_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for IP_ADAPTER_ADDRESSES_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -2064,10 +2002,6 @@ impl Default for IP_ADAPTER_ADDRESSES_LH_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for IP_ADAPTER_ADDRESSES_LH_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -2082,10 +2016,6 @@ impl Default for IP_ADAPTER_ADDRESSES_LH_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for IP_ADAPTER_ADDRESSES_LH_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -2099,10 +2029,6 @@ impl Default for IP_ADAPTER_ADDRESSES_LH_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for IP_ADAPTER_ADDRESSES_LH_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2114,10 +2040,6 @@ impl Default for IP_ADAPTER_ADDRESSES_LH_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for IP_ADAPTER_ADDRESSES_LH_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -2149,10 +2071,6 @@ impl Default for IP_ADAPTER_ADDRESSES_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for IP_ADAPTER_ADDRESSES_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -2166,10 +2084,6 @@ impl Default for IP_ADAPTER_ADDRESSES_XP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for IP_ADAPTER_ADDRESSES_XP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2182,10 +2096,6 @@ impl Default for IP_ADAPTER_ADDRESSES_XP_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for IP_ADAPTER_ADDRESSES_XP_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_ADAPTER_ADDRESS_DNS_ELIGIBLE: u32 = 1u32;
 pub const IP_ADAPTER_ADDRESS_TRANSIENT: u32 = 2u32;
@@ -2203,10 +2113,6 @@ impl Default for IP_ADAPTER_ANYCAST_ADDRESS_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_ANYCAST_ADDRESS_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -2220,10 +2126,6 @@ impl Default for IP_ADAPTER_ANYCAST_ADDRESS_XP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_ANYCAST_ADDRESS_XP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2236,10 +2138,6 @@ impl Default for IP_ADAPTER_ANYCAST_ADDRESS_XP_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_ANYCAST_ADDRESS_XP_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_ADAPTER_DDNS_ENABLED: u32 = 1u32;
 pub const IP_ADAPTER_DHCP_ENABLED: u32 = 4u32;
@@ -2257,10 +2155,6 @@ impl Default for IP_ADAPTER_DNS_SERVER_ADDRESS_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_DNS_SERVER_ADDRESS_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -2273,10 +2167,6 @@ impl Default for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2291,10 +2181,6 @@ impl Default for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_DNS_SERVER_ADDRESS_XP_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IP_ADAPTER_DNS_SUFFIX {
@@ -2305,9 +2191,6 @@ impl Default for IP_ADAPTER_DNS_SUFFIX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_ADAPTER_DNS_SUFFIX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2323,10 +2206,6 @@ impl Default for IP_ADAPTER_GATEWAY_ADDRESS_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_GATEWAY_ADDRESS_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -2339,10 +2218,6 @@ impl Default for IP_ADAPTER_GATEWAY_ADDRESS_LH_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_GATEWAY_ADDRESS_LH_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2357,10 +2232,6 @@ impl Default for IP_ADAPTER_GATEWAY_ADDRESS_LH_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_GATEWAY_ADDRESS_LH_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IP_ADAPTER_INDEX_MAP {
@@ -2371,9 +2242,6 @@ impl Default for IP_ADAPTER_INDEX_MAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_ADAPTER_INDEX_MAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2402,9 +2270,6 @@ impl Default for IP_ADAPTER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IP_ADAPTER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IP_ADAPTER_IPV4_ENABLED: u32 = 128u32;
 pub const IP_ADAPTER_IPV6_ENABLED: u32 = 256u32;
 pub const IP_ADAPTER_IPV6_MANAGE_ADDRESS_CONFIG: u32 = 512u32;
@@ -2423,10 +2288,6 @@ impl Default for IP_ADAPTER_MULTICAST_ADDRESS_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_MULTICAST_ADDRESS_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -2439,10 +2300,6 @@ impl Default for IP_ADAPTER_MULTICAST_ADDRESS_XP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_MULTICAST_ADDRESS_XP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2457,10 +2314,6 @@ impl Default for IP_ADAPTER_MULTICAST_ADDRESS_XP_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_MULTICAST_ADDRESS_XP_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IP_ADAPTER_NETBIOS_OVER_TCPIP_ENABLED: u32 = 64u32;
 pub const IP_ADAPTER_NO_MULTICAST: u32 = 16u32;
 #[repr(C)]
@@ -2473,9 +2326,6 @@ impl Default for IP_ADAPTER_ORDER_MAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_ADAPTER_ORDER_MAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2492,10 +2342,6 @@ impl Default for IP_ADAPTER_PREFIX_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_PREFIX_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -2509,10 +2355,6 @@ impl Default for IP_ADAPTER_PREFIX_XP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_PREFIX_XP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2525,10 +2367,6 @@ impl Default for IP_ADAPTER_PREFIX_XP_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_PREFIX_XP_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_ADAPTER_RECEIVE_ONLY: u32 = 8u32;
 pub const IP_ADAPTER_REGISTER_ADAPTER_SUFFIX: u32 = 2u32;
@@ -2553,10 +2391,6 @@ impl Default for IP_ADAPTER_UNICAST_ADDRESS_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_UNICAST_ADDRESS_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -2570,10 +2404,6 @@ impl Default for IP_ADAPTER_UNICAST_ADDRESS_LH_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_UNICAST_ADDRESS_LH_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2586,10 +2416,6 @@ impl Default for IP_ADAPTER_UNICAST_ADDRESS_LH_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_UNICAST_ADDRESS_LH_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2611,10 +2437,6 @@ impl Default for IP_ADAPTER_UNICAST_ADDRESS_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_UNICAST_ADDRESS_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -2628,10 +2450,6 @@ impl Default for IP_ADAPTER_UNICAST_ADDRESS_XP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_UNICAST_ADDRESS_XP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2644,10 +2462,6 @@ impl Default for IP_ADAPTER_UNICAST_ADDRESS_XP_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_UNICAST_ADDRESS_XP_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2663,10 +2477,6 @@ impl Default for IP_ADAPTER_WINS_SERVER_ADDRESS_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_WINS_SERVER_ADDRESS_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -2679,10 +2489,6 @@ impl Default for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2697,10 +2503,6 @@ impl Default for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADAPTER_WINS_SERVER_ADDRESS_LH_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -2714,10 +2516,6 @@ impl Default for IP_ADDRESS_PREFIX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for IP_ADDRESS_PREFIX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IP_ADDRESS_STRING {
@@ -2727,9 +2525,6 @@ impl Default for IP_ADDRESS_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_ADDRESS_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_ADDRROW: u32 = 5u32;
 pub const IP_ADDRTABLE: u32 = 4u32;
@@ -2747,9 +2542,6 @@ impl Default for IP_ADDR_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_ADDR_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_BAD_DESTINATION: u32 = 11018u32;
 pub const IP_BAD_HEADER: u32 = 11042u32;
@@ -2799,9 +2591,6 @@ impl Default for IP_INTERFACE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IP_INTERFACE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IP_INTERFACE_METRIC_CHANGE: u32 = 11030u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2817,9 +2606,6 @@ impl Default for IP_INTERFACE_NAME_INFO_W2KSP1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_INTERFACE_NAME_INFO_W2KSP1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_INTERFACE_STATUS_INFO: u32 = 4294901764u32;
 pub const IP_INTERFACE_WOL_CAPABILITY_CHANGE: u32 = 11033u32;
@@ -2839,9 +2625,6 @@ impl Default for IP_MCAST_COUNTER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_MCAST_COUNTER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_MCAST_HEARBEAT_INFO: u32 = 4294901770u32;
 pub const IP_MCAST_LIMIT_INFO: u32 = 4294901774u32;
@@ -2866,9 +2649,6 @@ impl Default for IP_OPTION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IP_OPTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2884,10 +2664,6 @@ impl Default for IP_OPTION_INFORMATION32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for IP_OPTION_INFORMATION32 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_OPTION_TOO_BIG: u32 = 11017u32;
 pub const IP_OUT_FILTER_INFO: u32 = 4294901762u32;
@@ -2908,9 +2684,6 @@ impl Default for IP_PER_ADAPTER_INFO_W2KSP1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_PER_ADAPTER_INFO_W2KSP1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_PROT_PRIORITY_INFO: u32 = 4294901766u32;
 pub const IP_PROT_PRIORITY_INFO_EX: u32 = 4294901783u32;
@@ -2939,9 +2712,6 @@ impl Default for IP_UNIDIRECTIONAL_ADAPTER_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_UNIDIRECTIONAL_ADAPTER_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_UNLOAD: u32 = 11022u32;
 pub const IP_UNRECOGNIZED_NEXT_HEADER: u32 = 11043u32;
@@ -2986,9 +2756,6 @@ impl Default for MIBICMPINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIBICMPINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIBICMPSTATS {
@@ -3011,9 +2778,6 @@ impl Default for MIBICMPSTATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIBICMPSTATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIBICMPSTATS_EX_XPSP1 {
@@ -3025,9 +2789,6 @@ impl Default for MIBICMPSTATS_EX_XPSP1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIBICMPSTATS_EX_XPSP1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -3044,10 +2805,6 @@ impl Default for MIB_ANYCASTIPADDRESS_ROW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_ANYCASTIPADDRESS_ROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -3061,10 +2818,6 @@ impl Default for MIB_ANYCASTIPADDRESS_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_ANYCASTIPADDRESS_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_BEST_IF {
@@ -3075,9 +2828,6 @@ impl Default for MIB_BEST_IF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_BEST_IF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3090,9 +2840,6 @@ impl Default for MIB_BOUNDARYROW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_BOUNDARYROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_ICMP {
@@ -3102,9 +2849,6 @@ impl Default for MIB_ICMP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_ICMP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3117,9 +2861,6 @@ impl Default for MIB_ICMP_EX_XPSP1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_ICMP_EX_XPSP1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IFNUMBER {
@@ -3129,9 +2870,6 @@ impl Default for MIB_IFNUMBER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IFNUMBER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3166,9 +2904,6 @@ impl Default for MIB_IFROW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IFROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IFSTACK_ROW {
@@ -3180,9 +2915,6 @@ impl Default for MIB_IFSTACK_ROW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IFSTACK_ROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IFSTACK_TABLE {
@@ -3193,9 +2925,6 @@ impl Default for MIB_IFSTACK_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IFSTACK_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3211,9 +2940,6 @@ impl Default for MIB_IFSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IFSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IFTABLE {
@@ -3224,9 +2950,6 @@ impl Default for MIB_IFTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IFTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIB_IF_ADMIN_STATUS_DOWN: u32 = 2u32;
 pub const MIB_IF_ADMIN_STATUS_TESTING: u32 = 3u32;
@@ -3286,10 +3009,6 @@ impl Default for MIB_IF_ROW2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for MIB_IF_ROW2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3301,10 +3020,6 @@ impl Default for MIB_IF_ROW2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for MIB_IF_ROW2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3318,10 +3033,6 @@ impl Default for MIB_IF_TABLE2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for MIB_IF_TABLE2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3345,9 +3056,6 @@ impl Default for MIB_INVERTEDIFSTACK_ROW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_INVERTEDIFSTACK_ROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_INVERTEDIFSTACK_TABLE {
@@ -3358,9 +3066,6 @@ impl Default for MIB_INVERTEDIFSTACK_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_INVERTEDIFSTACK_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3378,9 +3083,6 @@ impl Default for MIB_IPADDRROW_W2K {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPADDRROW_W2K {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IPADDRROW_XP {
@@ -3397,9 +3099,6 @@ impl Default for MIB_IPADDRROW_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPADDRROW_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IPADDRTABLE {
@@ -3410,9 +3109,6 @@ impl Default for MIB_IPADDRTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPADDRTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIB_IPADDR_DELETED: u32 = 64u32;
 pub const MIB_IPADDR_DISCONNECTED: u32 = 8u32;
@@ -3434,10 +3130,6 @@ impl Default for MIB_IPDESTROW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_IPDESTROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -3451,10 +3143,6 @@ impl Default for MIB_IPDESTTABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_IPDESTTABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IPFORWARDNUMBER {
@@ -3464,9 +3152,6 @@ impl Default for MIB_IPFORWARDNUMBER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPFORWARDNUMBER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -3493,10 +3178,6 @@ impl Default for MIB_IPFORWARDROW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_IPFORWARDROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -3509,10 +3190,6 @@ impl Default for MIB_IPFORWARDROW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_IPFORWARDROW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -3527,10 +3204,6 @@ impl Default for MIB_IPFORWARDROW_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_IPFORWARDROW_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -3543,10 +3216,6 @@ impl Default for MIB_IPFORWARDTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_IPFORWARDTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -3574,10 +3243,6 @@ impl Default for MIB_IPFORWARD_ROW2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPFORWARD_ROW2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -3590,10 +3255,6 @@ impl Default for MIB_IPFORWARD_TABLE2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPFORWARD_TABLE2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3644,10 +3305,6 @@ impl Default for MIB_IPINTERFACE_ROW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPINTERFACE_ROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -3660,10 +3317,6 @@ impl Default for MIB_IPINTERFACE_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPINTERFACE_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3678,9 +3331,6 @@ impl Default for MIB_IPMCAST_BOUNDARY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPMCAST_BOUNDARY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IPMCAST_BOUNDARY_TABLE {
@@ -3692,9 +3342,6 @@ impl Default for MIB_IPMCAST_BOUNDARY_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPMCAST_BOUNDARY_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IPMCAST_GLOBAL {
@@ -3704,9 +3351,6 @@ impl Default for MIB_IPMCAST_GLOBAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPMCAST_GLOBAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3723,9 +3367,6 @@ impl Default for MIB_IPMCAST_IF_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPMCAST_IF_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IPMCAST_IF_TABLE {
@@ -3736,9 +3377,6 @@ impl Default for MIB_IPMCAST_IF_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPMCAST_IF_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3765,9 +3403,6 @@ impl Default for MIB_IPMCAST_MFE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPMCAST_MFE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IPMCAST_MFE_STATS {
@@ -3793,9 +3428,6 @@ impl Default for MIB_IPMCAST_MFE_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPMCAST_MFE_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3828,9 +3460,6 @@ impl Default for MIB_IPMCAST_MFE_STATS_EX_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPMCAST_MFE_STATS_EX_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IPMCAST_OIF_STATS_LH {
@@ -3846,9 +3475,6 @@ impl Default for MIB_IPMCAST_OIF_STATS_LH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPMCAST_OIF_STATS_LH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3866,9 +3492,6 @@ impl Default for MIB_IPMCAST_OIF_STATS_W2K {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPMCAST_OIF_STATS_W2K {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IPMCAST_OIF_W2K {
@@ -3881,9 +3504,6 @@ impl Default for MIB_IPMCAST_OIF_W2K {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPMCAST_OIF_W2K {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3898,9 +3518,6 @@ impl Default for MIB_IPMCAST_OIF_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPMCAST_OIF_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_IPMCAST_SCOPE {
@@ -3913,9 +3530,6 @@ impl Default for MIB_IPMCAST_SCOPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPMCAST_SCOPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3931,9 +3545,6 @@ impl Default for MIB_IPNETROW_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPNETROW_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIB_IPNETROW_LH_0 {
@@ -3944,9 +3555,6 @@ impl Default for MIB_IPNETROW_LH_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPNETROW_LH_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3962,9 +3570,6 @@ impl Default for MIB_IPNETROW_W2K {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPNETROW_W2K {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MIB_IPNETTABLE {
@@ -3975,9 +3580,6 @@ impl Default for MIB_IPNETTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPNETTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -3998,10 +3600,6 @@ impl Default for MIB_IPNET_ROW2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPNET_ROW2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -4015,10 +3613,6 @@ impl Default for MIB_IPNET_ROW2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPNET_ROW2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4030,10 +3624,6 @@ impl Default for MIB_IPNET_ROW2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPNET_ROW2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -4048,10 +3638,6 @@ impl Default for MIB_IPNET_ROW2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPNET_ROW2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -4064,10 +3650,6 @@ impl Default for MIB_IPNET_TABLE2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPNET_TABLE2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4099,10 +3681,6 @@ impl Default for MIB_IPPATH_ROW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPPATH_ROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -4116,10 +3694,6 @@ impl Default for MIB_IPPATH_ROW_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPPATH_ROW_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -4132,10 +3706,6 @@ impl Default for MIB_IPPATH_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_IPPATH_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIB_IPROUTE_METRIC_UNUSED: u32 = 4294967295u32;
 pub const MIB_IPROUTE_TYPE_DIRECT: MIB_IPFORWARD_TYPE = MIB_IPFORWARD_TYPE(3i32);
@@ -4177,9 +3747,6 @@ impl Default for MIB_IPSTATS_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPSTATS_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIB_IPSTATS_LH_0 {
@@ -4190,9 +3757,6 @@ impl Default for MIB_IPSTATS_LH_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_IPSTATS_LH_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4226,9 +3790,6 @@ impl Default for MIB_IPSTATS_W2K {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_IPSTATS_W2K {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MIB_IP_FORWARDING: MIB_IPSTATS_FORWARDING = MIB_IPSTATS_FORWARDING(1i32);
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -4243,10 +3804,6 @@ impl Default for MIB_IP_NETWORK_CONNECTION_BANDWIDTH_ESTIMATES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_IP_NETWORK_CONNECTION_BANDWIDTH_ESTIMATES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MIB_IP_NOT_FORWARDING: MIB_IPSTATS_FORWARDING = MIB_IPSTATS_FORWARDING(2i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4259,9 +3816,6 @@ impl Default for MIB_MCAST_LIMIT_ROW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_MCAST_LIMIT_ROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_MFE_STATS_TABLE {
@@ -4272,9 +3826,6 @@ impl Default for MIB_MFE_STATS_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_MFE_STATS_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4287,9 +3838,6 @@ impl Default for MIB_MFE_STATS_TABLE_EX_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_MFE_STATS_TABLE_EX_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_MFE_TABLE {
@@ -4300,9 +3848,6 @@ impl Default for MIB_MFE_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_MFE_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -4319,10 +3864,6 @@ impl Default for MIB_MULTICASTIPADDRESS_ROW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_MULTICASTIPADDRESS_ROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -4335,10 +3876,6 @@ impl Default for MIB_MULTICASTIPADDRESS_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_MULTICASTIPADDRESS_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4354,9 +3891,6 @@ impl Default for MIB_OPAQUE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_OPAQUE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIB_OPAQUE_INFO_0 {
@@ -4368,9 +3902,6 @@ impl Default for MIB_OPAQUE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_OPAQUE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_OPAQUE_QUERY {
@@ -4381,9 +3912,6 @@ impl Default for MIB_OPAQUE_QUERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_OPAQUE_QUERY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4397,9 +3925,6 @@ impl Default for MIB_PROXYARP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_PROXYARP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_ROUTESTATE {
@@ -4409,9 +3934,6 @@ impl Default for MIB_ROUTESTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_ROUTESTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -4430,10 +3952,6 @@ impl Default for MIB_TCP6ROW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_TCP6ROW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -4455,10 +3973,6 @@ impl Default for MIB_TCP6ROW2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_TCP6ROW2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_TCP6ROW_OWNER_MODULE {
@@ -4478,9 +3992,6 @@ impl Default for MIB_TCP6ROW_OWNER_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCP6ROW_OWNER_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_TCP6ROW_OWNER_PID {
@@ -4498,9 +4009,6 @@ impl Default for MIB_TCP6ROW_OWNER_PID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCP6ROW_OWNER_PID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -4513,10 +4021,6 @@ impl Default for MIB_TCP6TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_TCP6TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -4531,10 +4035,6 @@ impl Default for MIB_TCP6TABLE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_TCP6TABLE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_TCP6TABLE_OWNER_MODULE {
@@ -4546,9 +4046,6 @@ impl Default for MIB_TCP6TABLE_OWNER_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCP6TABLE_OWNER_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_TCP6TABLE_OWNER_PID {
@@ -4559,9 +4056,6 @@ impl Default for MIB_TCP6TABLE_OWNER_PID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_TCP6TABLE_OWNER_PID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4579,9 +4073,6 @@ impl Default for MIB_TCPROW2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCPROW2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MIB_TCPROW_LH {
@@ -4596,9 +4087,6 @@ impl Default for MIB_TCPROW_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCPROW_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIB_TCPROW_LH_0 {
@@ -4609,9 +4097,6 @@ impl Default for MIB_TCPROW_LH_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_TCPROW_LH_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4630,9 +4115,6 @@ impl Default for MIB_TCPROW_OWNER_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCPROW_OWNER_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_TCPROW_OWNER_PID {
@@ -4648,9 +4130,6 @@ impl Default for MIB_TCPROW_OWNER_PID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCPROW_OWNER_PID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_TCPROW_W2K {
@@ -4664,9 +4143,6 @@ impl Default for MIB_TCPROW_W2K {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_TCPROW_W2K {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4692,9 +4168,6 @@ impl Default for MIB_TCPSTATS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCPSTATS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MIB_TCPSTATS_LH {
@@ -4719,9 +4192,6 @@ impl Default for MIB_TCPSTATS_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCPSTATS_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIB_TCPSTATS_LH_0 {
@@ -4732,9 +4202,6 @@ impl Default for MIB_TCPSTATS_LH_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_TCPSTATS_LH_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4760,9 +4227,6 @@ impl Default for MIB_TCPSTATS_W2K {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCPSTATS_W2K {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MIB_TCPTABLE {
@@ -4773,9 +4237,6 @@ impl Default for MIB_TCPTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_TCPTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4788,9 +4249,6 @@ impl Default for MIB_TCPTABLE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCPTABLE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_TCPTABLE_OWNER_MODULE {
@@ -4802,9 +4260,6 @@ impl Default for MIB_TCPTABLE_OWNER_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_TCPTABLE_OWNER_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_TCPTABLE_OWNER_PID {
@@ -4815,9 +4270,6 @@ impl Default for MIB_TCPTABLE_OWNER_PID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_TCPTABLE_OWNER_PID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIB_TCP_RTO_CONSTANT: TCP_RTO_ALGORITHM = TCP_RTO_ALGORITHM(2i32);
 pub const MIB_TCP_RTO_OTHER: TCP_RTO_ALGORITHM = TCP_RTO_ALGORITHM(1i32);
@@ -4853,10 +4305,6 @@ impl Default for MIB_UDP6ROW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_UDP6ROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MIB_UDP6ROW2 {
@@ -4876,9 +4324,6 @@ impl Default for MIB_UDP6ROW2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDP6ROW2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIB_UDP6ROW2_0 {
@@ -4890,9 +4335,6 @@ impl Default for MIB_UDP6ROW2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDP6ROW2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_UDP6ROW2_0_0 {
@@ -4902,9 +4344,6 @@ impl Default for MIB_UDP6ROW2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_UDP6ROW2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4922,9 +4361,6 @@ impl Default for MIB_UDP6ROW_OWNER_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDP6ROW_OWNER_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIB_UDP6ROW_OWNER_MODULE_0 {
@@ -4936,9 +4372,6 @@ impl Default for MIB_UDP6ROW_OWNER_MODULE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDP6ROW_OWNER_MODULE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_UDP6ROW_OWNER_MODULE_0_0 {
@@ -4948,9 +4381,6 @@ impl Default for MIB_UDP6ROW_OWNER_MODULE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_UDP6ROW_OWNER_MODULE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4965,9 +4395,6 @@ impl Default for MIB_UDP6ROW_OWNER_PID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDP6ROW_OWNER_PID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -4981,10 +4408,6 @@ impl Default for MIB_UDP6TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MIB_UDP6TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MIB_UDP6TABLE2 {
@@ -4995,9 +4418,6 @@ impl Default for MIB_UDP6TABLE2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_UDP6TABLE2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5010,9 +4430,6 @@ impl Default for MIB_UDP6TABLE_OWNER_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDP6TABLE_OWNER_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_UDP6TABLE_OWNER_PID {
@@ -5024,9 +4441,6 @@ impl Default for MIB_UDP6TABLE_OWNER_PID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDP6TABLE_OWNER_PID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_UDPROW {
@@ -5037,9 +4451,6 @@ impl Default for MIB_UDPROW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_UDPROW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5058,9 +4469,6 @@ impl Default for MIB_UDPROW2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDPROW2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIB_UDPROW2_0 {
@@ -5072,9 +4480,6 @@ impl Default for MIB_UDPROW2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDPROW2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_UDPROW2_0_0 {
@@ -5084,9 +4489,6 @@ impl Default for MIB_UDPROW2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_UDPROW2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5103,9 +4505,6 @@ impl Default for MIB_UDPROW_OWNER_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDPROW_OWNER_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIB_UDPROW_OWNER_MODULE_0 {
@@ -5117,9 +4516,6 @@ impl Default for MIB_UDPROW_OWNER_MODULE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDPROW_OWNER_MODULE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_UDPROW_OWNER_MODULE_0_0 {
@@ -5129,9 +4525,6 @@ impl Default for MIB_UDPROW_OWNER_MODULE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_UDPROW_OWNER_MODULE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5144,9 +4537,6 @@ impl Default for MIB_UDPROW_OWNER_PID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_UDPROW_OWNER_PID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5162,9 +4552,6 @@ impl Default for MIB_UDPSTATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDPSTATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_UDPSTATS2 {
@@ -5179,9 +4566,6 @@ impl Default for MIB_UDPSTATS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDPSTATS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_UDPTABLE {
@@ -5192,9 +4576,6 @@ impl Default for MIB_UDPTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_UDPTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5207,9 +4588,6 @@ impl Default for MIB_UDPTABLE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDPTABLE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MIB_UDPTABLE_OWNER_MODULE {
@@ -5221,9 +4599,6 @@ impl Default for MIB_UDPTABLE_OWNER_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIB_UDPTABLE_OWNER_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIB_UDPTABLE_OWNER_PID {
@@ -5234,9 +4609,6 @@ impl Default for MIB_UDPTABLE_OWNER_PID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIB_UDPTABLE_OWNER_PID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -5261,10 +4633,6 @@ impl Default for MIB_UNICASTIPADDRESS_ROW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_UNICASTIPADDRESS_ROW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
 #[derive(Clone, Copy)]
@@ -5277,10 +4645,6 @@ impl Default for MIB_UNICASTIPADDRESS_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for MIB_UNICASTIPADDRESS_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIB_USE_CURRENT_FORWARDING: u32 = 4294967295u32;
 pub const MIB_USE_CURRENT_TTL: u32 = 4294967295u32;
@@ -5318,10 +4682,6 @@ impl Default for NET_ADDRESS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for NET_ADDRESS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -5337,10 +4697,6 @@ impl Default for NET_ADDRESS_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for NET_ADDRESS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5353,10 +4709,6 @@ impl Default for NET_ADDRESS_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for NET_ADDRESS_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NET_ADDRESS_IPV4: NET_ADDRESS_FORMAT = NET_ADDRESS_FORMAT(2i32);
 pub const NET_ADDRESS_IPV6: NET_ADDRESS_FORMAT = NET_ADDRESS_FORMAT(3i32);
@@ -5405,9 +4757,6 @@ impl Default for PFLOGFRAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PFLOGFRAME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PF_ACTION_DROP: PFFORWARD_ACTION = PFFORWARD_ACTION(1i32);
 pub const PF_ACTION_FORWARD: PFFORWARD_ACTION = PFFORWARD_ACTION(0i32);
 #[repr(C)]
@@ -5432,9 +4781,6 @@ impl Default for PF_FILTER_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PF_FILTER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PF_FILTER_STATS {
@@ -5445,9 +4791,6 @@ impl Default for PF_FILTER_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PF_FILTER_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5474,9 +4817,6 @@ impl Default for PF_INTERFACE_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PF_INTERFACE_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PF_IPV4: PFADDRESSTYPE = PFADDRESSTYPE(0i32);
 pub const PF_IPV6: PFADDRESSTYPE = PFADDRESSTYPE(1i32);
 #[repr(C)]
@@ -5490,9 +4830,6 @@ impl Default for PF_LATEBIND_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PF_LATEBIND_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PINTERFACE_TIMESTAMP_CONFIG_CHANGE_CALLBACK = Option<unsafe extern "system" fn(callercontext: *const core::ffi::c_void)>;
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Networking_WinSock"))]
@@ -5523,9 +4860,6 @@ impl Default for TCPIP_OWNER_MODULE_BASIC_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCPIP_OWNER_MODULE_BASIC_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TCPIP_OWNER_MODULE_INFO_BASIC: TCPIP_OWNER_MODULE_INFO_CLASS = TCPIP_OWNER_MODULE_INFO_CLASS(0i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5552,9 +4886,6 @@ impl Default for TCP_ESTATS_BANDWIDTH_ROD_v0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_ESTATS_BANDWIDTH_ROD_v0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_ESTATS_BANDWIDTH_RW_v0 {
@@ -5565,9 +4896,6 @@ impl Default for TCP_ESTATS_BANDWIDTH_RW_v0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_ESTATS_BANDWIDTH_RW_v0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5592,9 +4920,6 @@ impl Default for TCP_ESTATS_DATA_ROD_v0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_ESTATS_DATA_ROD_v0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_ESTATS_DATA_RW_v0 {
@@ -5604,9 +4929,6 @@ impl Default for TCP_ESTATS_DATA_RW_v0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_ESTATS_DATA_RW_v0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5621,9 +4943,6 @@ impl Default for TCP_ESTATS_FINE_RTT_ROD_v0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_ESTATS_FINE_RTT_ROD_v0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_ESTATS_FINE_RTT_RW_v0 {
@@ -5633,9 +4952,6 @@ impl Default for TCP_ESTATS_FINE_RTT_RW_v0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_ESTATS_FINE_RTT_RW_v0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5650,9 +4966,6 @@ impl Default for TCP_ESTATS_OBS_REC_ROD_v0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_ESTATS_OBS_REC_ROD_v0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_ESTATS_OBS_REC_RW_v0 {
@@ -5662,9 +4975,6 @@ impl Default for TCP_ESTATS_OBS_REC_RW_v0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_ESTATS_OBS_REC_RW_v0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5715,9 +5025,6 @@ impl Default for TCP_ESTATS_PATH_ROD_v0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_ESTATS_PATH_ROD_v0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_ESTATS_PATH_RW_v0 {
@@ -5727,9 +5034,6 @@ impl Default for TCP_ESTATS_PATH_RW_v0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_ESTATS_PATH_RW_v0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5754,9 +5058,6 @@ impl Default for TCP_ESTATS_REC_ROD_v0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_ESTATS_REC_ROD_v0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_ESTATS_REC_RW_v0 {
@@ -5766,9 +5067,6 @@ impl Default for TCP_ESTATS_REC_RW_v0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_ESTATS_REC_RW_v0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5783,9 +5081,6 @@ impl Default for TCP_ESTATS_SEND_BUFF_ROD_v0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_ESTATS_SEND_BUFF_ROD_v0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_ESTATS_SEND_BUFF_RW_v0 {
@@ -5795,9 +5090,6 @@ impl Default for TCP_ESTATS_SEND_BUFF_RW_v0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_ESTATS_SEND_BUFF_RW_v0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5826,9 +5118,6 @@ impl Default for TCP_ESTATS_SND_CONG_ROD_v0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_ESTATS_SND_CONG_ROD_v0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_ESTATS_SND_CONG_ROS_v0 {
@@ -5839,9 +5128,6 @@ impl Default for TCP_ESTATS_SND_CONG_ROS_v0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_ESTATS_SND_CONG_ROS_v0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_ESTATS_SND_CONG_RW_v0 {
@@ -5851,9 +5137,6 @@ impl Default for TCP_ESTATS_SND_CONG_RW_v0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_ESTATS_SND_CONG_RW_v0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5866,9 +5149,6 @@ impl Default for TCP_ESTATS_SYN_OPTS_ROS_v0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_ESTATS_SYN_OPTS_ROS_v0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5883,9 +5163,6 @@ impl Default for TCP_RESERVE_PORT_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_RESERVE_PORT_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TCP_ROW: u32 = 14u32;
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/mod.rs
@@ -3856,9 +3856,6 @@ impl Default for MBN_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MBN_CONTEXT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MBN_CONTEXT_CONSTANTS(pub i32);
@@ -3918,9 +3915,6 @@ impl Default for MBN_DEVICE_SERVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MBN_DEVICE_SERVICE {
-    type TypeKind = windows_core::CloneType;
-}
 pub const MBN_DEVICE_SERVICES_CAPABLE_INTERFACE_ARRIVAL: MBN_DEVICE_SERVICES_INTERFACE_STATE = MBN_DEVICE_SERVICES_INTERFACE_STATE(0i32);
 pub const MBN_DEVICE_SERVICES_CAPABLE_INTERFACE_REMOVAL: MBN_DEVICE_SERVICES_INTERFACE_STATE = MBN_DEVICE_SERVICES_INTERFACE_STATE(1i32);
 #[repr(transparent)]
@@ -3953,9 +3947,6 @@ impl Default for MBN_INTERFACE_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MBN_INTERFACE_CAPS {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3991,9 +3982,6 @@ impl Default for MBN_PIN_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MBN_PIN_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MBN_PIN_LENGTH_UNKNOWN: MBN_PIN_CONSTANTS = MBN_PIN_CONSTANTS(-1i32);
 #[repr(transparent)]
@@ -4034,9 +4022,6 @@ impl Default for MBN_PROVIDER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MBN_PROVIDER {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct MBN_PROVIDER2 {
@@ -4049,9 +4034,6 @@ impl Default for MBN_PROVIDER2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MBN_PROVIDER2 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const MBN_PROVIDERID_LEN: MBN_PROVIDER_CONSTANTS = MBN_PROVIDER_CONSTANTS(6i32);
 pub const MBN_PROVIDERNAME_LEN: MBN_PROVIDER_CONSTANTS = MBN_PROVIDER_CONSTANTS(20i32);
@@ -4154,9 +4136,6 @@ impl Default for MBN_SMS_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MBN_SMS_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MBN_SMS_FLAG(pub i32);
@@ -4189,9 +4168,6 @@ impl Default for MBN_SMS_STATUS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MBN_SMS_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MBN_USERNAME_LEN: MBN_CONTEXT_CONSTANTS = MBN_CONTEXT_CONSTANTS(255i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4223,9 +4199,6 @@ impl Default for __DummyPinType__ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for __DummyPinType__ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct __mbnapi_ReferenceRemainingTypes__ {
@@ -4248,7 +4221,4 @@ impl Default for __mbnapi_ReferenceRemainingTypes__ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for __mbnapi_ReferenceRemainingTypes__ {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Multicast/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Multicast/mod.rs
@@ -47,9 +47,6 @@ impl Default for IPNG_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPNG_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MCAST_API_CURRENT_VERSION: i32 = 1i32;
 pub const MCAST_API_VERSION_0: i32 = 0i32;
 pub const MCAST_API_VERSION_1: i32 = 1i32;
@@ -64,9 +61,6 @@ impl Default for MCAST_CLIENT_UID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCAST_CLIENT_UID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -85,9 +79,6 @@ impl Default for MCAST_LEASE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCAST_LEASE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MCAST_LEASE_RESPONSE {
@@ -102,9 +93,6 @@ impl Default for MCAST_LEASE_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCAST_LEASE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MCAST_SCOPE_CTX {
@@ -116,9 +104,6 @@ impl Default for MCAST_SCOPE_CTX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCAST_SCOPE_CTX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -132,7 +117,4 @@ impl Default for MCAST_SCOPE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCAST_SCOPE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Ndis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Ndis/mod.rs
@@ -10,9 +10,6 @@ impl Default for BSSID_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BSSID_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLOCK_NETWORK_DERIVED: u32 = 2u32;
 pub const CLOCK_PRECISION: u32 = 4u32;
 pub const DD_NDIS_DEVICE_NAME: windows_core::PCWSTR = windows_core::w!("\\Device\\NDIS");
@@ -32,9 +29,6 @@ impl Default for GEN_GET_NETCARD_TIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GEN_GET_NETCARD_TIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GEN_GET_TIME_CAPS {
@@ -45,9 +39,6 @@ impl Default for GEN_GET_TIME_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GEN_GET_TIME_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GUID_DEVINTERFACE_NET: windows_core::GUID = windows_core::GUID::from_u128(0xcac88484_7515_4c03_82e6_71a87abac361);
 pub const GUID_DEVINTERFACE_NETUIO: windows_core::GUID = windows_core::GUID::from_u128(0x08336f60_0679_4c6c_85d2_ae7ced65fff7);
@@ -256,9 +247,6 @@ impl Default for IF_COUNTED_STRING_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IF_COUNTED_STRING_LH {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IF_MAX_PHYS_ADDRESS_LENGTH: u32 = 32u32;
 pub const IF_MAX_STRING_SIZE: u32 = 256u32;
 #[repr(transparent)]
@@ -274,9 +262,6 @@ impl Default for IF_PHYSICAL_ADDRESS_LH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IF_PHYSICAL_ADDRESS_LH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IOCTL_NDIS_RESERVED5: u32 = 1507380u32;
 pub const IOCTL_NDIS_RESERVED6: u32 = 1540152u32;
@@ -323,9 +308,6 @@ impl Default for NDIS_802_11_AI_REQFI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_AI_REQFI {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_802_11_AI_REQFI_CAPABILITIES: u32 = 1u32;
 pub const NDIS_802_11_AI_REQFI_CURRENTAPADDRESS: u32 = 4u32;
 pub const NDIS_802_11_AI_REQFI_LISTENINTERVAL: u32 = 2u32;
@@ -340,9 +322,6 @@ impl Default for NDIS_802_11_AI_RESFI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_AI_RESFI {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_802_11_AI_RESFI_ASSOCIATIONID: u32 = 4u32;
 pub const NDIS_802_11_AI_RESFI_CAPABILITIES: u32 = 1u32;
@@ -365,9 +344,6 @@ impl Default for NDIS_802_11_ASSOCIATION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_ASSOCIATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_AUTHENTICATION_ENCRYPTION {
@@ -379,9 +355,6 @@ impl Default for NDIS_802_11_AUTHENTICATION_ENCRYPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_AUTHENTICATION_ENCRYPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_AUTHENTICATION_EVENT {
@@ -392,9 +365,6 @@ impl Default for NDIS_802_11_AUTHENTICATION_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_AUTHENTICATION_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -410,9 +380,6 @@ impl Default for NDIS_802_11_AUTHENTICATION_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_AUTHENTICATION_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_802_11_AUTH_REQUEST_AUTH_FIELDS: u32 = 15u32;
 pub const NDIS_802_11_AUTH_REQUEST_GROUP_ERROR: u32 = 14u32;
@@ -430,9 +397,6 @@ impl Default for NDIS_802_11_BSSID_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_BSSID_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_BSSID_LIST_EX {
@@ -443,9 +407,6 @@ impl Default for NDIS_802_11_BSSID_LIST_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_BSSID_LIST_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -461,9 +422,6 @@ impl Default for NDIS_802_11_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_CONFIGURATION {
@@ -478,9 +436,6 @@ impl Default for NDIS_802_11_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_CONFIGURATION_FH {
@@ -494,9 +449,6 @@ impl Default for NDIS_802_11_CONFIGURATION_FH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_CONFIGURATION_FH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_FIXED_IEs {
@@ -508,9 +460,6 @@ impl Default for NDIS_802_11_FIXED_IEs {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_FIXED_IEs {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -526,9 +475,6 @@ impl Default for NDIS_802_11_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_802_11_LENGTH_RATES: u32 = 8u32;
 pub const NDIS_802_11_LENGTH_RATES_EX: u32 = 16u32;
@@ -553,9 +499,6 @@ impl Default for NDIS_802_11_NETWORK_TYPE_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_NETWORK_TYPE_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_NON_BCAST_SSID_LIST {
@@ -566,9 +509,6 @@ impl Default for NDIS_802_11_NON_BCAST_SSID_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_NON_BCAST_SSID_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -582,9 +522,6 @@ impl Default for NDIS_802_11_PMKID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_PMKID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_PMKID_CANDIDATE_LIST {
@@ -596,9 +533,6 @@ impl Default for NDIS_802_11_PMKID_CANDIDATE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_PMKID_CANDIDATE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_802_11_PMKID_CANDIDATE_PREAUTH_ENABLED: u32 = 1u32;
 #[repr(transparent)]
@@ -625,9 +559,6 @@ impl Default for NDIS_802_11_REMOVE_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_REMOVE_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_SSID {
@@ -638,9 +569,6 @@ impl Default for NDIS_802_11_SSID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_SSID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -676,9 +604,6 @@ impl Default for NDIS_802_11_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_STATUS_INDICATION {
@@ -688,9 +613,6 @@ impl Default for NDIS_802_11_STATUS_INDICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_STATUS_INDICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -707,9 +629,6 @@ impl Default for NDIS_802_11_TEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_TEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NDIS_802_11_TEST_0 {
@@ -720,9 +639,6 @@ impl Default for NDIS_802_11_TEST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_TEST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -736,9 +652,6 @@ impl Default for NDIS_802_11_VARIABLE_IEs {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_802_11_VARIABLE_IEs {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_802_11_WEP {
@@ -751,9 +664,6 @@ impl Default for NDIS_802_11_WEP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_802_11_WEP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -799,9 +709,6 @@ impl Default for NDIS_CO_DEVICE_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_CO_DEVICE_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_CO_LINK_SPEED {
@@ -812,9 +719,6 @@ impl Default for NDIS_CO_LINK_SPEED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_CO_LINK_SPEED {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_CO_MAC_OPTION_DYNAMIC_LINK_SPEED: u32 = 1u32;
 pub const NDIS_DEFAULT_RECEIVE_FILTER_ID: u32 = 0u32;
@@ -1044,9 +948,6 @@ impl Default for NDIS_GUID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_GUID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NDIS_GUID_0 {
@@ -1057,9 +958,6 @@ impl Default for NDIS_GUID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_GUID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1074,9 +972,6 @@ impl Default for NDIS_HARDWARE_CROSSTIMESTAMP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_HARDWARE_CROSSTIMESTAMP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_HARDWARE_CROSSTIMESTAMP_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -1144,9 +1039,6 @@ impl Default for NDIS_INTERFACE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_INTERFACE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NDIS_INTERRUPT_MODERATION(pub i32);
@@ -1164,9 +1056,6 @@ impl Default for NDIS_INTERRUPT_MODERATION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_INTERRUPT_MODERATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_INTERRUPT_MODERATION_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1180,9 +1069,6 @@ impl Default for NDIS_IPSEC_OFFLOAD_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_IPSEC_OFFLOAD_V1_1 {
@@ -1193,9 +1079,6 @@ impl Default for NDIS_IPSEC_OFFLOAD_V1_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_IPSEC_OFFLOAD_V1_2 {
@@ -1205,9 +1088,6 @@ impl Default for NDIS_IPSEC_OFFLOAD_V1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1223,9 +1103,6 @@ impl Default for NDIS_IPSEC_OFFLOAD_V1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_IPSEC_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_IP_OPER_STATE {
@@ -1237,9 +1114,6 @@ impl Default for NDIS_IP_OPER_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_IP_OPER_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_IP_OPER_STATE_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -1254,9 +1128,6 @@ impl Default for NDIS_IP_OPER_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_IP_OPER_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_IP_OPER_STATUS_INFO {
@@ -1270,9 +1141,6 @@ impl Default for NDIS_IP_OPER_STATUS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_IP_OPER_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_IP_OPER_STATUS_INFO_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1284,9 +1152,6 @@ impl Default for NDIS_IRDA_PACKET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_IRDA_PACKET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_ISOLATION_NAME_MAX_STRING_SIZE: u32 = 127u32;
 pub const NDIS_ISOLATION_PARAMETERS_REVISION_1: u32 = 1u32;
@@ -1305,9 +1170,6 @@ impl Default for NDIS_LINK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_LINK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_LINK_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1319,9 +1181,6 @@ impl Default for NDIS_LINK_SPEED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_LINK_SPEED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1338,9 +1197,6 @@ impl Default for NDIS_LINK_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_LINK_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_LINK_STATE_DUPLEX_AUTO_NEGOTIATED: u32 = 4u32;
 pub const NDIS_LINK_STATE_PAUSE_FUNCTIONS_AUTO_NEGOTIATED: u32 = 8u32;
@@ -1437,9 +1293,6 @@ impl Default for NDIS_OBJECT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_OBJECT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_OBJECT_REVISION_1: u32 = 1u32;
 pub const NDIS_OBJECT_TYPE_BIND_PARAMETERS: u32 = 134u32;
 pub const NDIS_OBJECT_TYPE_CLIENT_CHIMNEY_OFFLOAD_CHARACTERISTICS: u32 = 147u32;
@@ -1521,9 +1374,6 @@ impl Default for NDIS_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_OFFLOAD_FLAGS_GROUP_CHECKSUM_CAPABILITIES: u32 = 1u32;
 pub const NDIS_OFFLOAD_NOT_SUPPORTED: u32 = 0u32;
 #[repr(C)]
@@ -1547,9 +1397,6 @@ impl Default for NDIS_OFFLOAD_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_OFFLOAD_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_OFFLOAD_PARAMETERS_CONNECTION_OFFLOAD_DISABLED: u32 = 1u32;
 pub const NDIS_OFFLOAD_PARAMETERS_CONNECTION_OFFLOAD_ENABLED: u32 = 2u32;
@@ -1603,9 +1450,6 @@ impl Default for NDIS_OPER_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_OPER_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_OPER_STATE_REVISION_1: u32 = 1u32;
 pub const NDIS_PACKET_TYPE_ALL_FUNCTIONAL: u32 = 8192u32;
 pub const NDIS_PACKET_TYPE_ALL_LOCAL: u32 = 128u32;
@@ -1642,9 +1486,6 @@ impl Default for NDIS_PCI_DEVICE_CUSTOM_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_PCI_DEVICE_CUSTOM_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_PD_CAPABILITIES_REVISION_1: u32 = 1u32;
 pub const NDIS_PD_CAPS_DRAIN_NOTIFICATIONS_SUPPORTED: u32 = 2u32;
 pub const NDIS_PD_CAPS_NOTIFICATION_MODERATION_COUNT_SUPPORTED: u32 = 8u32;
@@ -1672,9 +1513,6 @@ impl Default for NDIS_PM_PACKET_PATTERN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_PM_PACKET_PATTERN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_PM_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const NDIS_PM_PARAMETERS_REVISION_2: u32 = 2u32;
@@ -1711,9 +1549,6 @@ impl Default for NDIS_PM_WAKE_UP_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_PM_WAKE_UP_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_PM_WOL_BITMAP_PATTERN_ENABLED: u32 = 1u32;
 pub const NDIS_PM_WOL_BITMAP_PATTERN_SUPPORTED: u32 = 1u32;
 pub const NDIS_PM_WOL_EAPOL_REQUEST_ID_MESSAGE_ENABLED: u32 = 65536u32;
@@ -1744,9 +1579,6 @@ impl Default for NDIS_PNP_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_PNP_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_PNP_WAKE_UP_LINK_CHANGE: u32 = 4u32;
 pub const NDIS_PNP_WAKE_UP_MAGIC_PACKET: u32 = 1u32;
 pub const NDIS_PNP_WAKE_UP_PATTERN_MATCH: u32 = 2u32;
@@ -1764,9 +1596,6 @@ impl Default for NDIS_PORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_PORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_PORT_ARRAY {
@@ -1780,9 +1609,6 @@ impl Default for NDIS_PORT_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_PORT_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_PORT_ARRAY_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -1798,9 +1624,6 @@ impl Default for NDIS_PORT_AUTHENTICATION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_PORT_AUTHENTICATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_PORT_AUTHENTICATION_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -1827,9 +1650,6 @@ impl Default for NDIS_PORT_CHARACTERISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_PORT_CHARACTERISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_PORT_CHARACTERISTICS_REVISION_1: u32 = 1u32;
 pub const NDIS_PORT_CHAR_USE_DEFAULT_AUTH_SETTINGS: u32 = 1u32;
 #[repr(transparent)]
@@ -1853,9 +1673,6 @@ impl Default for NDIS_PORT_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_PORT_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_PORT_STATE_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -1988,9 +1805,6 @@ impl Default for NDIS_RECEIVE_HASH_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_RECEIVE_HASH_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_RECEIVE_HASH_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const NDIS_RECEIVE_QUEUE_ALLOCATION_COMPLETE_ARRAY_REVISION_1: u32 = 1u32;
 pub const NDIS_RECEIVE_QUEUE_ALLOCATION_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
@@ -2023,9 +1837,6 @@ impl Default for NDIS_RECEIVE_SCALE_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_RECEIVE_SCALE_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_RECEIVE_SCALE_CAPABILITIES_REVISION_1: u32 = 1u32;
 pub const NDIS_RECEIVE_SCALE_CAPABILITIES_REVISION_2: u32 = 2u32;
 pub const NDIS_RECEIVE_SCALE_CAPABILITIES_REVISION_3: u32 = 3u32;
@@ -2045,9 +1856,6 @@ impl Default for NDIS_RECEIVE_SCALE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_RECEIVE_SCALE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_RECEIVE_SCALE_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const NDIS_RECEIVE_SCALE_PARAMETERS_REVISION_2: u32 = 2u32;
@@ -2170,9 +1978,6 @@ impl Default for NDIS_STATISTICS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_STATISTICS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_STATISTICS_INFO_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2186,9 +1991,6 @@ impl Default for NDIS_STATISTICS_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_STATISTICS_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_STATISTICS_VALUE_EX {
@@ -2201,9 +2003,6 @@ impl Default for NDIS_STATISTICS_VALUE_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_STATISTICS_VALUE_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2276,9 +2075,6 @@ impl Default for NDIS_TCP_CONNECTION_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_CONNECTION_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_TCP_CONNECTION_OFFLOAD_REVISION_1: u32 = 1u32;
 pub const NDIS_TCP_CONNECTION_OFFLOAD_REVISION_2: u32 = 2u32;
 #[repr(C)]
@@ -2294,9 +2090,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
@@ -2307,9 +2100,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2322,9 +2112,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
@@ -2335,9 +2122,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2350,9 +2134,6 @@ impl Default for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_IP_CHECKSUM_OFFLOAD_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_TCP_LARGE_SEND_OFFLOAD_V1 {
@@ -2362,9 +2143,6 @@ impl Default for NDIS_TCP_LARGE_SEND_OFFLOAD_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_LARGE_SEND_OFFLOAD_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2379,9 +2157,6 @@ impl Default for NDIS_TCP_LARGE_SEND_OFFLOAD_V1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_LARGE_SEND_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_TCP_LARGE_SEND_OFFLOAD_V2 {
@@ -2392,9 +2167,6 @@ impl Default for NDIS_TCP_LARGE_SEND_OFFLOAD_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_LARGE_SEND_OFFLOAD_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2407,9 +2179,6 @@ impl Default for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2424,9 +2193,6 @@ impl Default for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TCP_LARGE_SEND_OFFLOAD_V2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_TCP_RECV_SEG_COALESC_OFFLOAD_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2440,9 +2206,6 @@ impl Default for NDIS_TIMEOUT_DPC_REQUEST_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TIMEOUT_DPC_REQUEST_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_TIMEOUT_DPC_REQUEST_CAPABILITIES_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -2459,9 +2222,6 @@ impl Default for NDIS_TIMESTAMP_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_TIMESTAMP_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_TIMESTAMP_CAPABILITIES_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -2487,9 +2247,6 @@ impl Default for NDIS_TIMESTAMP_CAPABILITY_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_TIMESTAMP_CAPABILITY_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_VAR_DATA_DESC {
@@ -2501,9 +2258,6 @@ impl Default for NDIS_VAR_DATA_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_VAR_DATA_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2521,9 +2275,6 @@ impl Default for NDIS_WAN_PROTOCOL_CAPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WAN_PROTOCOL_CAPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2547,9 +2298,6 @@ impl Default for NDIS_WLAN_BSSID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WLAN_BSSID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WLAN_BSSID_EX {
@@ -2570,9 +2318,6 @@ impl Default for NDIS_WLAN_BSSID_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WLAN_BSSID_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_WLAN_WAKE_ON_4WAY_HANDSHAKE_REQUEST_ENABLED: u32 = 8u32;
 pub const NDIS_WLAN_WAKE_ON_4WAY_HANDSHAKE_REQUEST_SUPPORTED: u32 = 8u32;
@@ -2597,9 +2342,6 @@ impl Default for NDIS_WMI_ENUM_ADAPTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_ENUM_ADAPTER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_WMI_ENUM_ADAPTER_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2618,9 +2360,6 @@ impl Default for NDIS_WMI_EVENT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_EVENT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_WMI_EVENT_HEADER_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2633,9 +2372,6 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2651,9 +2387,6 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2672,9 +2405,6 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
@@ -2688,9 +2418,6 @@ impl Default for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_IPSEC_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2706,9 +2433,6 @@ impl Default for NDIS_WMI_METHOD_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_METHOD_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_WMI_METHOD_HEADER_REVISION_1: u32 = 1u32;
 pub const NDIS_WMI_OBJECT_TYPE_ENUM_ADAPTER: u32 = 4u32;
@@ -2731,9 +2455,6 @@ impl Default for NDIS_WMI_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_OUTPUT_INFO {
@@ -2746,9 +2467,6 @@ impl Default for NDIS_WMI_OUTPUT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_OUTPUT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_WMI_PM_ACTIVE_CAPABILITIES_REVISION_1: u32 = 1u32;
 pub const NDIS_WMI_PM_ADMIN_CONFIG_REVISION_1: u32 = 1u32;
@@ -2769,9 +2487,6 @@ impl Default for NDIS_WMI_SET_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_SET_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDIS_WMI_SET_HEADER_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2790,9 +2505,6 @@ impl Default for NDIS_WMI_TCP_CONNECTION_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_CONNECTION_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
@@ -2805,9 +2517,6 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2824,9 +2533,6 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
@@ -2842,9 +2548,6 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
@@ -2858,9 +2561,6 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2876,9 +2576,6 @@ impl Default for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_IP_CHECKSUM_OFFLOAD_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1 {
@@ -2888,9 +2585,6 @@ impl Default for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2906,9 +2600,6 @@ impl Default for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2 {
@@ -2919,9 +2610,6 @@ impl Default for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2934,9 +2622,6 @@ impl Default for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2951,9 +2636,6 @@ impl Default for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDIS_WMI_TCP_LARGE_SEND_OFFLOAD_V2_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDIS_WWAN_WAKE_ON_PACKET_STATE_ENABLED: u32 = 8u32;
 pub const NDIS_WWAN_WAKE_ON_PACKET_STATE_SUPPORTED: u32 = 8u32;
@@ -3003,9 +2685,6 @@ impl Default for NDK_ADAPTER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDK_ADAPTER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NDK_RDMA_TECHNOLOGY(pub i32);
@@ -3020,9 +2699,6 @@ impl Default for NDK_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDK_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_ADDRESS {
@@ -3035,9 +2711,6 @@ impl Default for NETWORK_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_ADDRESS_IP {
@@ -3049,9 +2722,6 @@ impl Default for NETWORK_ADDRESS_IP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETWORK_ADDRESS_IP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3066,9 +2736,6 @@ impl Default for NETWORK_ADDRESS_IP6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_ADDRESS_IP6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_ADDRESS_IPX {
@@ -3081,9 +2748,6 @@ impl Default for NETWORK_ADDRESS_IPX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_ADDRESS_IPX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETWORK_ADDRESS_LIST {
@@ -3095,9 +2759,6 @@ impl Default for NETWORK_ADDRESS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETWORK_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NET_IFLUID_UNSPECIFIED: u32 = 0u32;
 pub const NET_IF_ACCESS_BROADCAST: NET_IF_ACCESS_TYPE = NET_IF_ACCESS_TYPE(2i32);
@@ -3124,9 +2785,6 @@ impl Default for NET_IF_ALIAS_LH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NET_IF_ALIAS_LH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -3186,9 +2844,6 @@ impl Default for NET_IF_RCV_ADDRESS_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NET_IF_RCV_ADDRESS_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NET_IF_RCV_ADDRESS_TYPE(pub i32);
@@ -3206,9 +2861,6 @@ impl Default for NET_LUID_LH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NET_LUID_LH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NET_LUID_LH_0 {
@@ -3218,9 +2870,6 @@ impl Default for NET_LUID_LH_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NET_LUID_LH_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3233,9 +2882,6 @@ impl Default for NET_PHYSICAL_LOCATION_LH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NET_PHYSICAL_LOCATION_LH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NET_SITEID_MAXSYSTEM: u32 = 268435455u32;
 pub const NET_SITEID_MAXUSER: u32 = 134217727u32;
@@ -3480,9 +3126,6 @@ impl Default for OFFLOAD_ALGO_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OFFLOAD_ALGO_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct OFFLOAD_CONF_ALGO(pub i32);
@@ -3514,9 +3157,6 @@ impl Default for OFFLOAD_IPSEC_ADD_SA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OFFLOAD_IPSEC_ADD_SA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OFFLOAD_IPSEC_ADD_UDPESP_SA {
@@ -3543,9 +3183,6 @@ impl Default for OFFLOAD_IPSEC_ADD_UDPESP_SA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OFFLOAD_IPSEC_ADD_UDPESP_SA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OFFLOAD_IPSEC_CONF_3_DES: OFFLOAD_CONF_ALGO = OFFLOAD_CONF_ALGO(3i32);
 pub const OFFLOAD_IPSEC_CONF_DES: OFFLOAD_CONF_ALGO = OFFLOAD_CONF_ALGO(1i32);
 pub const OFFLOAD_IPSEC_CONF_MAX: OFFLOAD_CONF_ALGO = OFFLOAD_CONF_ALGO(4i32);
@@ -3561,9 +3198,6 @@ impl Default for OFFLOAD_IPSEC_DELETE_SA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OFFLOAD_IPSEC_DELETE_SA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OFFLOAD_IPSEC_DELETE_UDPESP_SA {
@@ -3574,9 +3208,6 @@ impl Default for OFFLOAD_IPSEC_DELETE_UDPESP_SA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OFFLOAD_IPSEC_DELETE_UDPESP_SA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OFFLOAD_IPSEC_INTEGRITY_MAX: OFFLOAD_INTEGRITY_ALGO = OFFLOAD_INTEGRITY_ALGO(3i32);
 pub const OFFLOAD_IPSEC_INTEGRITY_MD5: OFFLOAD_INTEGRITY_ALGO = OFFLOAD_INTEGRITY_ALGO(1i32);
@@ -3592,9 +3223,6 @@ impl Default for OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_IKE: UDP_ENCAP_TYPE = UDP_ENCAP_TYPE(0i32);
 pub const OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_OTHER: UDP_ENCAP_TYPE = UDP_ENCAP_TYPE(1i32);
@@ -3616,9 +3244,6 @@ impl Default for OFFLOAD_SECURITY_ASSOCIATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OFFLOAD_SECURITY_ASSOCIATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OID_1394_LOCAL_NODE_INFO: u32 = 201392385u32;
 pub const OID_1394_VC_INFO: u32 = 201392386u32;
@@ -4402,9 +4027,6 @@ impl Default for PMKID_CANDIDATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PMKID_CANDIDATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const READABLE_LOCAL_CLOCK: u32 = 1u32;
 pub const RECEIVE_TIME_INDICATION_CAPABLE: u32 = 8u32;
 pub const TIMED_SEND_CAPABLE: u32 = 16u32;
@@ -4419,9 +4041,6 @@ impl Default for TRANSPORT_HEADER_OFFSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSPORT_HEADER_OFFSET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetBios/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetBios/mod.rs
@@ -15,9 +15,6 @@ impl Default for ACTION_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADAPTER_STATUS {
@@ -54,9 +51,6 @@ impl Default for ADAPTER_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADAPTER_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ALL_TRANSPORTS: windows_core::PCSTR = windows_core::s!("M\u{0}\u{0}\u{0}");
 pub const ASYNCH: u32 = 128u32;
 pub const CALL_PENDING: u32 = 2u32;
@@ -78,9 +72,6 @@ impl Default for FIND_NAME_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FIND_NAME_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FIND_NAME_HEADER {
@@ -92,9 +83,6 @@ impl Default for FIND_NAME_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FIND_NAME_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GROUP_NAME: u32 = 128u32;
 pub const HANGUP_COMPLETE: u32 = 5u32;
@@ -110,9 +98,6 @@ impl Default for LANA_ENUM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LANA_ENUM {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LISTEN_OUTSTANDING: u32 = 1u32;
 pub const MAX_LANA: u32 = 254u32;
 pub const MS_NBF: windows_core::PCSTR = windows_core::s!("MNBF");
@@ -127,9 +112,6 @@ impl Default for NAME_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NAME_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NAME_FLAGS_MASK: u32 = 135u32;
 #[repr(C)]
@@ -158,10 +140,6 @@ impl Default for NCB {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for NCB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -187,10 +165,6 @@ impl Default for NCB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for NCB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCBACTION: u32 = 119u32;
 pub const NCBADDGRNAME: u32 = 54u32;
@@ -276,9 +250,6 @@ impl Default for SESSION_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SESSION_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SESSION_ESTABLISHED: u32 = 3u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -292,8 +263,5 @@ impl Default for SESSION_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SESSION_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UNIQUE_NAME: u32 = 0u32;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
@@ -1455,9 +1455,6 @@ impl Default for ACCESS_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACCESS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACCESS_INFO_1 {
@@ -1470,9 +1467,6 @@ impl Default for ACCESS_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACCESS_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACCESS_INFO_1002 {
@@ -1482,9 +1476,6 @@ impl Default for ACCESS_INFO_1002 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACCESS_INFO_1002 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACCESS_LETTERS: windows_core::PCSTR = windows_core::s!("RWCXDAP         ");
 #[repr(C)]
@@ -1497,9 +1488,6 @@ impl Default for ACCESS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACCESS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACCESS_NONE: u32 = 0u32;
 pub const ACCESS_RESOURCE_NAME_PARMNUM: u32 = 1u32;
@@ -1521,9 +1509,6 @@ impl Default for ADMIN_OTHER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADMIN_OTHER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AE_ACCLIM {
@@ -1536,9 +1521,6 @@ impl Default for AE_ACCLIM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AE_ACCLIM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AE_ACCLIMITEXCD: u32 = 17u32;
 pub const AE_ACCRESTRICT: u32 = 4u32;
@@ -1555,9 +1537,6 @@ impl Default for AE_ACLMOD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AE_ACLMOD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AE_ACLMOD: u32 = 12u32;
 pub const AE_ACLMODFAIL: u32 = 19u32;
@@ -1583,9 +1562,6 @@ impl Default for AE_CLOSEFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AE_CLOSEFILE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AE_CLOSEFILE: u32 = 9u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1599,9 +1575,6 @@ impl Default for AE_CONNREJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AE_CONNREJ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AE_CONNREJ: u32 = 6u32;
 #[repr(C)]
@@ -1617,9 +1590,6 @@ impl Default for AE_CONNSTART {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AE_CONNSTART {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AE_CONNSTART: u32 = 4u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1634,9 +1604,6 @@ impl Default for AE_CONNSTOP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AE_CONNSTOP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AE_CONNSTOP: u32 = 5u32;
 pub const AE_DELETE: u32 = 1u32;
@@ -1663,9 +1630,6 @@ impl Default for AE_GENERIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AE_GENERIC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AE_GENERIC_TYPE: u32 = 21u32;
 pub const AE_GUEST: u32 = 0u32;
 pub const AE_LIM_DELETED: u32 = 5u32;
@@ -1687,9 +1651,6 @@ impl Default for AE_LOCKOUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AE_LOCKOUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AE_LOCKOUT: u32 = 20u32;
 pub const AE_MOD: u32 = 0u32;
 pub const AE_NETLOGDENIED: u32 = 16u32;
@@ -1706,9 +1667,6 @@ impl Default for AE_NETLOGOFF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AE_NETLOGOFF {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AE_NETLOGOFF: u32 = 15u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1722,9 +1680,6 @@ impl Default for AE_NETLOGON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AE_NETLOGON {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AE_NETLOGON: u32 = 14u32;
 pub const AE_NOACCESSPERM: u32 = 3u32;
@@ -1746,9 +1701,6 @@ impl Default for AE_RESACCESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AE_RESACCESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AE_RESACCESS: u32 = 7u32;
 pub const AE_RESACCESS2: u32 = 18u32;
 #[repr(C)]
@@ -1763,9 +1715,6 @@ impl Default for AE_RESACCESSREJ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AE_RESACCESSREJ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AE_RESACCESSREJ: u32 = 8u32;
 #[repr(C)]
@@ -1784,9 +1733,6 @@ impl Default for AE_SERVICESTAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AE_SERVICESTAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AE_SERVICESTAT: u32 = 11u32;
 pub const AE_SESSDIS: u32 = 1u32;
 #[repr(C)]
@@ -1801,9 +1747,6 @@ impl Default for AE_SESSLOGOFF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AE_SESSLOGOFF {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AE_SESSLOGOFF: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1817,9 +1760,6 @@ impl Default for AE_SESSLOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AE_SESSLOGON {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AE_SESSLOGON: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1831,9 +1771,6 @@ impl Default for AE_SESSPWERR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AE_SESSPWERR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AE_SESSPWERR: u32 = 3u32;
 pub const AE_SES_CLOSE: u32 = 1u32;
@@ -1849,9 +1786,6 @@ impl Default for AE_SRVSTATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AE_SRVSTATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AE_SRVSTATUS: u32 = 0u32;
 pub const AE_SRVSTOP: u32 = 3u32;
@@ -1869,9 +1803,6 @@ impl Default for AE_UASMOD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AE_UASMOD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AE_UASMOD: u32 = 13u32;
 pub const AE_UAS_GROUP: u32 = 1u32;
@@ -1945,9 +1876,6 @@ impl Default for AT_ENUM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AT_ENUM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AT_INFO {
@@ -1961,9 +1889,6 @@ impl Default for AT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1979,9 +1904,6 @@ impl Default for AUDIT_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIT_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BACKUP_MSG_FILENAME: windows_core::PCWSTR = windows_core::w!("BAK.MSG");
 #[repr(transparent)]
@@ -2002,9 +1924,6 @@ impl Default for CONFIG_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONFIG_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COULD_NOT_VERIFY_VOLUMES: i32 = -1073727512i32;
 pub const CREATE_BYPASS_CSC: u32 = 2u32;
@@ -2105,10 +2024,6 @@ impl Default for DSREG_JOIN_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for DSREG_JOIN_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DSREG_JOIN_TYPE(pub i32);
@@ -2124,9 +2039,6 @@ impl Default for DSREG_USER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSREG_USER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSREG_WORKPLACE_JOIN: DSREG_JOIN_TYPE = DSREG_JOIN_TYPE(2i32);
 pub const EBP_ABOVE: ENUM_BINDING_PATHS_FLAGS = ENUM_BINDING_PATHS_FLAGS(1i32);
@@ -2148,9 +2060,6 @@ impl Default for ERRLOG_OTHER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ERRLOG_OTHER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ERROR_LOG {
@@ -2168,9 +2077,6 @@ impl Default for ERROR_LOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ERROR_LOG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_BAD_ACCOUNT_NAME: i32 = -1073734816i32;
 pub const EVENT_BAD_SERVICE_STATE: i32 = -1073734808i32;
@@ -2682,9 +2588,6 @@ impl Default for FLAT_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLAT_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FORCE_LEVEL_FLAGS(pub u32);
@@ -2703,9 +2606,6 @@ impl Default for GROUP_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GROUP_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GROUP_INFO_1 {
@@ -2717,9 +2617,6 @@ impl Default for GROUP_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GROUP_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GROUP_INFO_1002 {
@@ -2730,9 +2627,6 @@ impl Default for GROUP_INFO_1002 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GROUP_INFO_1002 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GROUP_INFO_1005 {
@@ -2742,9 +2636,6 @@ impl Default for GROUP_INFO_1005 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GROUP_INFO_1005 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2758,9 +2649,6 @@ impl Default for GROUP_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GROUP_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2777,10 +2665,6 @@ impl Default for GROUP_INFO_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for GROUP_INFO_3 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GROUP_NAME_PARMNUM: u32 = 1u32;
 pub const GROUP_SPECIALGRP_ADMINS: windows_core::PCWSTR = windows_core::w!("ADMINS");
 pub const GROUP_SPECIALGRP_GUESTS: windows_core::PCWSTR = windows_core::w!("GUESTS");
@@ -2796,9 +2680,6 @@ impl Default for GROUP_USERS_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GROUP_USERS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GROUP_USERS_INFO_1 {
@@ -2810,9 +2691,6 @@ impl Default for GROUP_USERS_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GROUP_USERS_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HARDWARE_ADDRESS {
@@ -2822,9 +2700,6 @@ impl Default for HARDWARE_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HARDWARE_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HARDWARE_ADDRESS_LENGTH: u32 = 6u32;
 pub const HELP_MSG_FILENAME: windows_core::PCWSTR = windows_core::w!("NETH");
@@ -2840,9 +2715,6 @@ impl Default for HLOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HLOG {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IEnumNetCfgBindingInterface, IEnumNetCfgBindingInterface_Vtbl, 0xc0e8ae90_306e_11d1_aacf_00805fc1270e);
 windows_core::imp::interface_hierarchy!(IEnumNetCfgBindingInterface, windows_core::IUnknown);
@@ -4540,9 +4412,6 @@ impl Default for LOCALGROUP_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOCALGROUP_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LOCALGROUP_INFO_1 {
@@ -4554,9 +4423,6 @@ impl Default for LOCALGROUP_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOCALGROUP_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LOCALGROUP_INFO_1002 {
@@ -4566,9 +4432,6 @@ impl Default for LOCALGROUP_INFO_1002 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LOCALGROUP_INFO_1002 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -4581,10 +4444,6 @@ impl Default for LOCALGROUP_MEMBERS_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for LOCALGROUP_MEMBERS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -4600,10 +4459,6 @@ impl Default for LOCALGROUP_MEMBERS_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for LOCALGROUP_MEMBERS_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4618,10 +4473,6 @@ impl Default for LOCALGROUP_MEMBERS_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for LOCALGROUP_MEMBERS_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LOCALGROUP_MEMBERS_INFO_3 {
@@ -4631,9 +4482,6 @@ impl Default for LOCALGROUP_MEMBERS_INFO_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LOCALGROUP_MEMBERS_INFO_3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LOCALGROUP_NAME_PARMNUM: u32 = 1u32;
 #[repr(C)]
@@ -4645,9 +4493,6 @@ impl Default for LOCALGROUP_USERS_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LOCALGROUP_USERS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LOGFLAGS_BACKWARD: u32 = 1u32;
 pub const LOGFLAGS_FORWARD: u32 = 0u32;
@@ -4710,9 +4555,6 @@ impl Default for MPR_PROTOCOL_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPR_PROTOCOL_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MRINFO_DISABLED_FLAG: u32 = 32u32;
 pub const MRINFO_DOWN_FLAG: u32 = 16u32;
 pub const MRINFO_LEAF_FLAG: u32 = 128u32;
@@ -4728,9 +4570,6 @@ impl Default for MSA_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSA_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4751,9 +4590,6 @@ impl Default for MSG_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSG_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MSG_INFO_1 {
@@ -4765,9 +4601,6 @@ impl Default for MSG_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSG_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MS_ROUTER_VERSION: u32 = 1536u32;
 pub const MsaInfoCanInstall: MSA_INFO_STATE = MSA_INFO_STATE(4i32);
@@ -5450,9 +5283,6 @@ impl Default for NETLOGON_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETLOGON_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETLOGON_INFO_2 {
@@ -5465,9 +5295,6 @@ impl Default for NETLOGON_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETLOGON_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5485,9 +5312,6 @@ impl Default for NETLOGON_INFO_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETLOGON_INFO_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETLOGON_INFO_4 {
@@ -5498,9 +5322,6 @@ impl Default for NETLOGON_INFO_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETLOGON_INFO_4 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NETLOGON_REDO_NEEDED: u32 = 8u32;
 pub const NETLOGON_REPLICATION_IN_PROGRESS: u32 = 2u32;
@@ -5610,9 +5431,6 @@ impl Default for NETSETUP_PROVISIONING_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETSETUP_PROVISIONING_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NETSETUP_PROVISIONING_PARAMS_CURRENT_VERSION: u32 = 2u32;
 pub const NETSETUP_PROVISIONING_PARAMS_WIN8_VERSION: u32 = 1u32;
 pub const NETSETUP_PROVISION_CHECK_PWD_ONLY: u32 = 2147483648u32;
@@ -5638,9 +5456,6 @@ impl Default for NETWORK_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NETWORK_UPGRADE_TYPE(pub i32);
@@ -5663,9 +5478,6 @@ impl Default for NET_DISPLAY_GROUP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NET_DISPLAY_GROUP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NET_DISPLAY_MACHINE {
@@ -5679,9 +5491,6 @@ impl Default for NET_DISPLAY_MACHINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NET_DISPLAY_MACHINE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5697,9 +5506,6 @@ impl Default for NET_DISPLAY_USER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NET_DISPLAY_USER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NET_IGNORE_UNSUPPORTED_FLAGS: u32 = 1u32;
 #[repr(transparent)]
@@ -5860,9 +5666,6 @@ impl Default for NET_VALIDATE_AUTHENTICATION_INPUT_ARG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NET_VALIDATE_AUTHENTICATION_INPUT_ARG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NET_VALIDATE_BAD_PASSWORD_COUNT: u32 = 8u32;
 pub const NET_VALIDATE_BAD_PASSWORD_TIME: u32 = 2u32;
 pub const NET_VALIDATE_LOCKOUT_TIME: u32 = 4u32;
@@ -5876,9 +5679,6 @@ impl Default for NET_VALIDATE_OUTPUT_ARG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NET_VALIDATE_OUTPUT_ARG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5894,9 +5694,6 @@ impl Default for NET_VALIDATE_PASSWORD_CHANGE_INPUT_ARG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NET_VALIDATE_PASSWORD_CHANGE_INPUT_ARG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NET_VALIDATE_PASSWORD_HASH {
@@ -5907,9 +5704,6 @@ impl Default for NET_VALIDATE_PASSWORD_HASH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NET_VALIDATE_PASSWORD_HASH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NET_VALIDATE_PASSWORD_HISTORY: u32 = 32u32;
 pub const NET_VALIDATE_PASSWORD_HISTORY_LENGTH: u32 = 16u32;
@@ -5929,9 +5723,6 @@ impl Default for NET_VALIDATE_PASSWORD_RESET_INPUT_ARG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NET_VALIDATE_PASSWORD_RESET_INPUT_ARG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NET_VALIDATE_PASSWORD_TYPE(pub i32);
@@ -5950,9 +5741,6 @@ impl Default for NET_VALIDATE_PERSISTED_FIELDS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NET_VALIDATE_PERSISTED_FIELDS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NON_VALIDATED_LOGON: u32 = 3u32;
 pub const NOT_A_DFS_PATH: i32 = 1073756224i32;
@@ -6048,9 +5836,6 @@ impl Default for OBO_TOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OBO_TOKEN {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct OBO_TOKEN_TYPE(pub i32);
@@ -6082,9 +5867,6 @@ impl Default for PRINT_OTHER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRINT_OTHER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRJOB_COMPLETE: u32 = 4u32;
 pub const PRJOB_DELETED: u32 = 32768u32;
@@ -6148,9 +5930,6 @@ impl Default for RASCON_IPUI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASCON_IPUI {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct RASCON_UIINFO_FLAGS(pub i32);
@@ -6181,9 +5960,6 @@ impl Default for REPL_EDIR_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPL_EDIR_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPL_EDIR_INFO_1 {
@@ -6196,9 +5972,6 @@ impl Default for REPL_EDIR_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPL_EDIR_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPL_EDIR_INFO_1000 {
@@ -6209,9 +5982,6 @@ impl Default for REPL_EDIR_INFO_1000 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPL_EDIR_INFO_1000 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPL_EDIR_INFO_1001 {
@@ -6221,9 +5991,6 @@ impl Default for REPL_EDIR_INFO_1001 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REPL_EDIR_INFO_1001 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6238,9 +6005,6 @@ impl Default for REPL_EDIR_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REPL_EDIR_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REPL_EXPORT_EXTENT_INFOLEVEL: u32 = 1001u32;
 pub const REPL_EXPORT_INTEGRITY_INFOLEVEL: u32 = 1000u32;
@@ -6257,9 +6021,6 @@ impl Default for REPL_IDIR_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPL_IDIR_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPL_IDIR_INFO_1 {
@@ -6274,9 +6035,6 @@ impl Default for REPL_IDIR_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REPL_IDIR_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6297,9 +6055,6 @@ impl Default for REPL_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPL_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPL_INFO_1000 {
@@ -6309,9 +6064,6 @@ impl Default for REPL_INFO_1000 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REPL_INFO_1000 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6323,9 +6075,6 @@ impl Default for REPL_INFO_1001 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPL_INFO_1001 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPL_INFO_1002 {
@@ -6336,9 +6085,6 @@ impl Default for REPL_INFO_1002 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPL_INFO_1002 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPL_INFO_1003 {
@@ -6348,9 +6094,6 @@ impl Default for REPL_INFO_1003 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REPL_INFO_1003 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REPL_INTEGRITY_FILE: u32 = 1u32;
 pub const REPL_INTEGRITY_TREE: u32 = 2u32;
@@ -6391,9 +6134,6 @@ impl Default for RTR_INFO_BLOCK_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTR_INFO_BLOCK_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RTR_INFO_BLOCK_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6407,9 +6147,6 @@ impl Default for RTR_TOC_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTR_TOC_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RTUTILS_MAX_PROTOCOL_DLL_LEN: u32 = 48u32;
 pub const RTUTILS_MAX_PROTOCOL_NAME_LEN: u32 = 40u32;
@@ -6426,9 +6163,6 @@ impl Default for SERVER_INFO_100 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_100 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1005 {
@@ -6438,9 +6172,6 @@ impl Default for SERVER_INFO_1005 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1005 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6457,9 +6188,6 @@ impl Default for SERVER_INFO_101 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_101 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1010 {
@@ -6469,9 +6197,6 @@ impl Default for SERVER_INFO_1010 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1010 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6483,9 +6208,6 @@ impl Default for SERVER_INFO_1016 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1016 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1017 {
@@ -6496,9 +6218,6 @@ impl Default for SERVER_INFO_1017 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1017 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1018 {
@@ -6508,9 +6227,6 @@ impl Default for SERVER_INFO_1018 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1018 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6533,9 +6249,6 @@ impl Default for SERVER_INFO_102 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_102 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6560,9 +6273,6 @@ impl Default for SERVER_INFO_103 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_103 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1107 {
@@ -6572,9 +6282,6 @@ impl Default for SERVER_INFO_1107 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1107 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6586,9 +6293,6 @@ impl Default for SERVER_INFO_1501 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1501 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1502 {
@@ -6598,9 +6302,6 @@ impl Default for SERVER_INFO_1502 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1502 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6612,9 +6313,6 @@ impl Default for SERVER_INFO_1503 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1503 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1506 {
@@ -6624,9 +6322,6 @@ impl Default for SERVER_INFO_1506 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1506 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6638,9 +6333,6 @@ impl Default for SERVER_INFO_1509 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1509 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1510 {
@@ -6650,9 +6342,6 @@ impl Default for SERVER_INFO_1510 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1510 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6664,9 +6353,6 @@ impl Default for SERVER_INFO_1511 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1511 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1512 {
@@ -6676,9 +6362,6 @@ impl Default for SERVER_INFO_1512 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1512 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6690,9 +6373,6 @@ impl Default for SERVER_INFO_1513 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1513 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1514 {
@@ -6702,9 +6382,6 @@ impl Default for SERVER_INFO_1514 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1514 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6716,9 +6393,6 @@ impl Default for SERVER_INFO_1515 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1515 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1516 {
@@ -6728,9 +6402,6 @@ impl Default for SERVER_INFO_1516 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1516 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6742,9 +6413,6 @@ impl Default for SERVER_INFO_1518 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1518 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1520 {
@@ -6754,9 +6422,6 @@ impl Default for SERVER_INFO_1520 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1520 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6768,9 +6433,6 @@ impl Default for SERVER_INFO_1521 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1521 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1522 {
@@ -6780,9 +6442,6 @@ impl Default for SERVER_INFO_1522 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1522 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6794,9 +6453,6 @@ impl Default for SERVER_INFO_1523 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1523 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1524 {
@@ -6806,9 +6462,6 @@ impl Default for SERVER_INFO_1524 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1524 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6820,9 +6473,6 @@ impl Default for SERVER_INFO_1525 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1525 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1528 {
@@ -6832,9 +6482,6 @@ impl Default for SERVER_INFO_1528 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1528 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6846,9 +6493,6 @@ impl Default for SERVER_INFO_1529 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1529 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1530 {
@@ -6858,9 +6502,6 @@ impl Default for SERVER_INFO_1530 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1530 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6872,9 +6513,6 @@ impl Default for SERVER_INFO_1533 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1533 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1534 {
@@ -6884,9 +6522,6 @@ impl Default for SERVER_INFO_1534 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1534 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6898,9 +6533,6 @@ impl Default for SERVER_INFO_1535 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1535 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1536 {
@@ -6910,9 +6542,6 @@ impl Default for SERVER_INFO_1536 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1536 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6924,9 +6553,6 @@ impl Default for SERVER_INFO_1537 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1537 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1538 {
@@ -6936,9 +6562,6 @@ impl Default for SERVER_INFO_1538 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1538 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6950,9 +6573,6 @@ impl Default for SERVER_INFO_1539 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1539 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1540 {
@@ -6962,9 +6582,6 @@ impl Default for SERVER_INFO_1540 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1540 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6976,9 +6593,6 @@ impl Default for SERVER_INFO_1541 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1541 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1542 {
@@ -6988,9 +6602,6 @@ impl Default for SERVER_INFO_1542 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1542 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7002,9 +6613,6 @@ impl Default for SERVER_INFO_1543 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1543 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1544 {
@@ -7014,9 +6622,6 @@ impl Default for SERVER_INFO_1544 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1544 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7028,9 +6633,6 @@ impl Default for SERVER_INFO_1545 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1545 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1546 {
@@ -7040,9 +6642,6 @@ impl Default for SERVER_INFO_1546 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1546 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7054,9 +6653,6 @@ impl Default for SERVER_INFO_1547 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1547 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1548 {
@@ -7066,9 +6662,6 @@ impl Default for SERVER_INFO_1548 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1548 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7080,9 +6673,6 @@ impl Default for SERVER_INFO_1549 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1549 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1550 {
@@ -7092,9 +6682,6 @@ impl Default for SERVER_INFO_1550 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1550 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7106,9 +6693,6 @@ impl Default for SERVER_INFO_1552 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1552 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1553 {
@@ -7118,9 +6702,6 @@ impl Default for SERVER_INFO_1553 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1553 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7132,9 +6713,6 @@ impl Default for SERVER_INFO_1554 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1554 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1555 {
@@ -7144,9 +6722,6 @@ impl Default for SERVER_INFO_1555 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1555 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7158,9 +6733,6 @@ impl Default for SERVER_INFO_1556 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1556 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1557 {
@@ -7170,9 +6742,6 @@ impl Default for SERVER_INFO_1557 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1557 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7184,9 +6753,6 @@ impl Default for SERVER_INFO_1560 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1560 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1561 {
@@ -7196,9 +6762,6 @@ impl Default for SERVER_INFO_1561 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1561 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7210,9 +6773,6 @@ impl Default for SERVER_INFO_1562 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1562 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1563 {
@@ -7222,9 +6782,6 @@ impl Default for SERVER_INFO_1563 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1563 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7236,9 +6793,6 @@ impl Default for SERVER_INFO_1564 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1564 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1565 {
@@ -7248,9 +6802,6 @@ impl Default for SERVER_INFO_1565 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1565 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7262,9 +6813,6 @@ impl Default for SERVER_INFO_1566 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1566 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1567 {
@@ -7274,9 +6822,6 @@ impl Default for SERVER_INFO_1567 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1567 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7288,9 +6833,6 @@ impl Default for SERVER_INFO_1568 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1568 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1569 {
@@ -7300,9 +6842,6 @@ impl Default for SERVER_INFO_1569 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1569 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7314,9 +6853,6 @@ impl Default for SERVER_INFO_1570 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1570 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1571 {
@@ -7326,9 +6862,6 @@ impl Default for SERVER_INFO_1571 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1571 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7340,9 +6873,6 @@ impl Default for SERVER_INFO_1572 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1572 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1573 {
@@ -7352,9 +6882,6 @@ impl Default for SERVER_INFO_1573 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1573 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7366,9 +6893,6 @@ impl Default for SERVER_INFO_1574 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1574 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1575 {
@@ -7378,9 +6902,6 @@ impl Default for SERVER_INFO_1575 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1575 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7392,9 +6913,6 @@ impl Default for SERVER_INFO_1576 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1576 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1577 {
@@ -7404,9 +6922,6 @@ impl Default for SERVER_INFO_1577 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1577 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7418,9 +6933,6 @@ impl Default for SERVER_INFO_1578 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1578 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1579 {
@@ -7430,9 +6942,6 @@ impl Default for SERVER_INFO_1579 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1579 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7444,9 +6953,6 @@ impl Default for SERVER_INFO_1580 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1580 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1581 {
@@ -7456,9 +6962,6 @@ impl Default for SERVER_INFO_1581 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1581 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7470,9 +6973,6 @@ impl Default for SERVER_INFO_1582 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1582 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1583 {
@@ -7482,9 +6982,6 @@ impl Default for SERVER_INFO_1583 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1583 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7496,9 +6993,6 @@ impl Default for SERVER_INFO_1584 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1584 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1585 {
@@ -7508,9 +7002,6 @@ impl Default for SERVER_INFO_1585 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1585 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7522,9 +7013,6 @@ impl Default for SERVER_INFO_1586 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1586 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1587 {
@@ -7534,9 +7022,6 @@ impl Default for SERVER_INFO_1587 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1587 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7548,9 +7033,6 @@ impl Default for SERVER_INFO_1588 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1588 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1590 {
@@ -7560,9 +7042,6 @@ impl Default for SERVER_INFO_1590 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1590 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7574,9 +7053,6 @@ impl Default for SERVER_INFO_1591 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1591 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1592 {
@@ -7586,9 +7062,6 @@ impl Default for SERVER_INFO_1592 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1592 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7600,9 +7073,6 @@ impl Default for SERVER_INFO_1593 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1593 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1594 {
@@ -7612,9 +7082,6 @@ impl Default for SERVER_INFO_1594 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1594 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7626,9 +7093,6 @@ impl Default for SERVER_INFO_1595 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1595 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1596 {
@@ -7638,9 +7102,6 @@ impl Default for SERVER_INFO_1596 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1596 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7652,9 +7113,6 @@ impl Default for SERVER_INFO_1597 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1597 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1598 {
@@ -7664,9 +7122,6 @@ impl Default for SERVER_INFO_1598 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1598 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7678,9 +7133,6 @@ impl Default for SERVER_INFO_1599 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1599 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1600 {
@@ -7690,9 +7142,6 @@ impl Default for SERVER_INFO_1600 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1600 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7704,9 +7153,6 @@ impl Default for SERVER_INFO_1601 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_1601 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_1602 {
@@ -7716,9 +7162,6 @@ impl Default for SERVER_INFO_1602 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_1602 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7759,9 +7202,6 @@ impl Default for SERVER_INFO_402 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_402 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7806,9 +7246,6 @@ impl Default for SERVER_INFO_403 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_403 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_502 {
@@ -7835,9 +7272,6 @@ impl Default for SERVER_INFO_502 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_502 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7890,9 +7324,6 @@ impl Default for SERVER_INFO_503 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_503 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_INFO_598 {
@@ -7944,9 +7375,6 @@ impl Default for SERVER_INFO_598 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_INFO_598 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8013,9 +7441,6 @@ impl Default for SERVER_INFO_599 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_INFO_599 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SERVER_INFO_HIDDEN(pub i32);
@@ -8036,9 +7461,6 @@ impl Default for SERVER_TRANSPORT_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_TRANSPORT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_TRANSPORT_INFO_1 {
@@ -8053,9 +7475,6 @@ impl Default for SERVER_TRANSPORT_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_TRANSPORT_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8072,9 +7491,6 @@ impl Default for SERVER_TRANSPORT_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_TRANSPORT_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8093,9 +7509,6 @@ impl Default for SERVER_TRANSPORT_INFO_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVER_TRANSPORT_INFO_3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE2_BASE: u32 = 5600u32;
 pub const SERVICE_ACCOUNT_FLAG_ADD_AGAINST_RODC: i32 = 2i32;
@@ -8134,9 +7547,6 @@ impl Default for SERVICE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_INFO_1 {
@@ -8149,9 +7559,6 @@ impl Default for SERVICE_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8168,9 +7575,6 @@ impl Default for SERVICE_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_INSTALLED: u32 = 3u32;
 pub const SERVICE_INSTALL_PENDING: u32 = 1u32;
@@ -8319,9 +7723,6 @@ impl Default for SMB_COMPRESSION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SMB_COMPRESSION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SMB_TREE_CONNECT_PARAMETERS {
@@ -8335,9 +7736,6 @@ impl Default for SMB_TREE_CONNECT_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SMB_TREE_CONNECT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SMB_USE_OPTION_COMPRESSION_PARAMETERS {
@@ -8349,9 +7747,6 @@ impl Default for SMB_USE_OPTION_COMPRESSION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SMB_USE_OPTION_COMPRESSION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SNLEN: u32 = 80u32;
 pub const SRV_HASH_GENERATION_ACTIVE: u32 = 2u32;
@@ -8367,9 +7762,6 @@ impl Default for STD_ALERT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STD_ALERT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STXTLEN: u32 = 256u32;
 pub const SUPPORTS_ANY: i32 = -1i32;
@@ -8607,9 +7999,6 @@ impl Default for TIME_OF_DAY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TIME_OF_DAY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TITLE_SC_MESSAGE_BOX: i32 = -1073734795i32;
 pub const TRACE_NO_STDINFO: u32 = 1u32;
 pub const TRACE_NO_SYNCH: u32 = 4u32;
@@ -8628,9 +8017,6 @@ impl Default for TRANSPORT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSPORT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRANSPORT_NAME_PARMNUM: u32 = 202u32;
 pub const TRANSPORT_QUALITYOFSERVICE_PARMNUM: u32 = 201u32;
@@ -8725,9 +8111,6 @@ impl Default for USER_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1 {
@@ -8745,9 +8128,6 @@ impl Default for USER_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_10 {
@@ -8761,9 +8141,6 @@ impl Default for USER_INFO_10 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_10 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1003 {
@@ -8773,9 +8150,6 @@ impl Default for USER_INFO_1003 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_1003 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8787,9 +8161,6 @@ impl Default for USER_INFO_1005 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1005 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1006 {
@@ -8799,9 +8170,6 @@ impl Default for USER_INFO_1006 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_1006 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8813,9 +8181,6 @@ impl Default for USER_INFO_1007 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1007 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1008 {
@@ -8825,9 +8190,6 @@ impl Default for USER_INFO_1008 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_1008 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8839,9 +8201,6 @@ impl Default for USER_INFO_1009 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1009 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1010 {
@@ -8851,9 +8210,6 @@ impl Default for USER_INFO_1010 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_1010 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8865,9 +8221,6 @@ impl Default for USER_INFO_1011 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1011 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1012 {
@@ -8877,9 +8230,6 @@ impl Default for USER_INFO_1012 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_1012 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8891,9 +8241,6 @@ impl Default for USER_INFO_1013 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1013 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1014 {
@@ -8903,9 +8250,6 @@ impl Default for USER_INFO_1014 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_1014 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8917,9 +8261,6 @@ impl Default for USER_INFO_1017 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1017 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1018 {
@@ -8929,9 +8270,6 @@ impl Default for USER_INFO_1018 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_1018 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8944,9 +8282,6 @@ impl Default for USER_INFO_1020 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1020 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1023 {
@@ -8956,9 +8291,6 @@ impl Default for USER_INFO_1023 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_1023 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8970,9 +8302,6 @@ impl Default for USER_INFO_1024 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1024 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1025 {
@@ -8982,9 +8311,6 @@ impl Default for USER_INFO_1025 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_1025 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8996,9 +8322,6 @@ impl Default for USER_INFO_1051 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1051 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1052 {
@@ -9009,9 +8332,6 @@ impl Default for USER_INFO_1052 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_1052 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_1053 {
@@ -9021,9 +8341,6 @@ impl Default for USER_INFO_1053 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_1053 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9053,9 +8370,6 @@ impl Default for USER_INFO_11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_11 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9090,9 +8404,6 @@ impl Default for USER_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_20 {
@@ -9107,9 +8418,6 @@ impl Default for USER_INFO_20 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_20 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_INFO_21 {
@@ -9119,9 +8427,6 @@ impl Default for USER_INFO_21 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_21 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9156,9 +8461,6 @@ impl Default for USER_INFO_22 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_INFO_22 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9175,10 +8477,6 @@ impl Default for USER_INFO_23 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for USER_INFO_23 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9194,10 +8492,6 @@ impl Default for USER_INFO_24 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for USER_INFO_24 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9236,9 +8530,6 @@ impl Default for USER_INFO_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_INFO_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -9280,10 +8571,6 @@ impl Default for USER_INFO_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for USER_INFO_4 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USER_LAST_LOGOFF_PARMNUM: u32 = 16u32;
 pub const USER_LAST_LOGON_PARMNUM: u32 = 15u32;
 pub const USER_LOGON_HOURS_PARMNUM: u32 = 20u32;
@@ -9303,9 +8590,6 @@ impl Default for USER_MODALS_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_MODALS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_MODALS_INFO_1 {
@@ -9317,9 +8601,6 @@ impl Default for USER_MODALS_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_MODALS_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_MODALS_INFO_1001 {
@@ -9329,9 +8610,6 @@ impl Default for USER_MODALS_INFO_1001 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_MODALS_INFO_1001 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9343,9 +8621,6 @@ impl Default for USER_MODALS_INFO_1002 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_MODALS_INFO_1002 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_MODALS_INFO_1003 {
@@ -9355,9 +8630,6 @@ impl Default for USER_MODALS_INFO_1003 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_MODALS_INFO_1003 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9369,9 +8641,6 @@ impl Default for USER_MODALS_INFO_1004 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_MODALS_INFO_1004 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_MODALS_INFO_1005 {
@@ -9381,9 +8650,6 @@ impl Default for USER_MODALS_INFO_1005 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_MODALS_INFO_1005 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9395,9 +8661,6 @@ impl Default for USER_MODALS_INFO_1006 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_MODALS_INFO_1006 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_MODALS_INFO_1007 {
@@ -9407,9 +8670,6 @@ impl Default for USER_MODALS_INFO_1007 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_MODALS_INFO_1007 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -9424,10 +8684,6 @@ impl Default for USER_MODALS_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for USER_MODALS_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USER_MODALS_INFO_3 {
@@ -9439,9 +8695,6 @@ impl Default for USER_MODALS_INFO_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_MODALS_INFO_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9458,9 +8711,6 @@ impl Default for USER_OTHER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USER_OTHER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USER_PAD_PW_COUNT_PARMNUM: u32 = 21u32;
 pub const USER_PARMS_PARMNUM: u32 = 13u32;
@@ -9503,9 +8753,6 @@ impl Default for USE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USE_INFO_1 {
@@ -9521,9 +8768,6 @@ impl Default for USE_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USE_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9543,9 +8787,6 @@ impl Default for USE_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USE_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USE_INFO_3 {
@@ -9556,9 +8797,6 @@ impl Default for USE_INFO_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USE_INFO_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9571,9 +8809,6 @@ impl Default for USE_INFO_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USE_INFO_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9590,9 +8825,6 @@ impl Default for USE_INFO_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USE_INFO_5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9616,9 +8848,6 @@ impl Default for USE_OPTION_DEFERRED_CONNECTION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USE_OPTION_DEFERRED_CONNECTION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USE_OPTION_GENERIC {
@@ -9630,9 +8859,6 @@ impl Default for USE_OPTION_GENERIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USE_OPTION_GENERIC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9646,9 +8872,6 @@ impl Default for USE_OPTION_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USE_OPTION_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USE_OPTION_TRANSPORT_PARAMETERS {
@@ -9660,9 +8883,6 @@ impl Default for USE_OPTION_TRANSPORT_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USE_OPTION_TRANSPORT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USE_PASSWORD_PARMNUM: u32 = 3u32;
 pub const USE_PAUSED: u32 = 1u32;
@@ -9704,9 +8924,6 @@ impl Default for WKSTA_INFO_100 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_100 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_101 {
@@ -9722,9 +8939,6 @@ impl Default for WKSTA_INFO_101 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_101 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1010 {
@@ -9734,9 +8948,6 @@ impl Default for WKSTA_INFO_1010 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1010 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9748,9 +8959,6 @@ impl Default for WKSTA_INFO_1011 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1011 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1012 {
@@ -9760,9 +8968,6 @@ impl Default for WKSTA_INFO_1012 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1012 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9774,9 +8979,6 @@ impl Default for WKSTA_INFO_1013 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1013 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1018 {
@@ -9786,9 +8988,6 @@ impl Default for WKSTA_INFO_1018 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1018 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9806,9 +9005,6 @@ impl Default for WKSTA_INFO_102 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_102 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1023 {
@@ -9818,9 +9014,6 @@ impl Default for WKSTA_INFO_1023 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1023 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9832,9 +9025,6 @@ impl Default for WKSTA_INFO_1027 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1027 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1028 {
@@ -9844,9 +9034,6 @@ impl Default for WKSTA_INFO_1028 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1028 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9858,9 +9045,6 @@ impl Default for WKSTA_INFO_1032 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1032 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1033 {
@@ -9870,9 +9054,6 @@ impl Default for WKSTA_INFO_1033 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1033 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9884,9 +9065,6 @@ impl Default for WKSTA_INFO_1041 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1041 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1042 {
@@ -9896,9 +9074,6 @@ impl Default for WKSTA_INFO_1042 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1042 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9910,9 +9085,6 @@ impl Default for WKSTA_INFO_1043 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1043 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1044 {
@@ -9922,9 +9094,6 @@ impl Default for WKSTA_INFO_1044 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1044 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9936,9 +9105,6 @@ impl Default for WKSTA_INFO_1045 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1045 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1046 {
@@ -9948,9 +9114,6 @@ impl Default for WKSTA_INFO_1046 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1046 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9962,9 +9125,6 @@ impl Default for WKSTA_INFO_1047 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1047 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1048 {
@@ -9974,9 +9134,6 @@ impl Default for WKSTA_INFO_1048 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1048 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9988,9 +9145,6 @@ impl Default for WKSTA_INFO_1049 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1049 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1050 {
@@ -10000,9 +9154,6 @@ impl Default for WKSTA_INFO_1050 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1050 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10014,9 +9165,6 @@ impl Default for WKSTA_INFO_1051 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1051 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1052 {
@@ -10026,9 +9174,6 @@ impl Default for WKSTA_INFO_1052 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1052 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10040,9 +9185,6 @@ impl Default for WKSTA_INFO_1053 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1053 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1054 {
@@ -10052,9 +9194,6 @@ impl Default for WKSTA_INFO_1054 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1054 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10066,9 +9205,6 @@ impl Default for WKSTA_INFO_1055 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1055 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1056 {
@@ -10078,9 +9214,6 @@ impl Default for WKSTA_INFO_1056 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1056 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10092,9 +9225,6 @@ impl Default for WKSTA_INFO_1057 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1057 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1058 {
@@ -10104,9 +9234,6 @@ impl Default for WKSTA_INFO_1058 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1058 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10118,9 +9245,6 @@ impl Default for WKSTA_INFO_1059 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1059 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1060 {
@@ -10130,9 +9254,6 @@ impl Default for WKSTA_INFO_1060 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1060 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10144,9 +9265,6 @@ impl Default for WKSTA_INFO_1061 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_1061 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_1062 {
@@ -10156,9 +9274,6 @@ impl Default for WKSTA_INFO_1062 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_1062 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10189,9 +9304,6 @@ impl Default for WKSTA_INFO_302 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_302 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_INFO_402 {
@@ -10221,9 +9333,6 @@ impl Default for WKSTA_INFO_402 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_INFO_402 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10269,9 +9378,6 @@ impl Default for WKSTA_INFO_502 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_INFO_502 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WKSTA_KEEPCONN_PARMNUM: u32 = 13u32;
 pub const WKSTA_KEEPSEARCH_PARMNUM: u32 = 14u32;
 pub const WKSTA_LANGROUP_PARMNUM: u32 = 2u32;
@@ -10315,9 +9421,6 @@ impl Default for WKSTA_TRANSPORT_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_TRANSPORT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WKSTA_USE512BYTESMAXTRANSFER_PARMNUM: u32 = 61u32;
 pub const WKSTA_USECLOSEBEHIND_PARMNUM: u32 = 50u32;
 pub const WKSTA_USEENCRYPTION_PARMNUM: u32 = 57u32;
@@ -10335,9 +9438,6 @@ impl Default for WKSTA_USER_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_USER_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_USER_INFO_1 {
@@ -10351,9 +9451,6 @@ impl Default for WKSTA_USER_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WKSTA_USER_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WKSTA_USER_INFO_1101 {
@@ -10363,9 +9460,6 @@ impl Default for WKSTA_USER_INFO_1101 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WKSTA_USER_INFO_1101 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WKSTA_USEUNLOCKBEHIND_PARMNUM: u32 = 49u32;
 pub const WKSTA_USEWRITERAWWITHDATA_PARMNUM: u32 = 56u32;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetShell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetShell/mod.rs
@@ -64,9 +64,6 @@ impl Default for CMD_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMD_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CMD_FLAG_HIDDEN: NS_CMD_FLAGS = NS_CMD_FLAGS(32i32);
 pub const CMD_FLAG_INTERACTIVE: NS_CMD_FLAGS = NS_CMD_FLAGS(2i32);
 pub const CMD_FLAG_LIMIT_MASK: NS_CMD_FLAGS = NS_CMD_FLAGS(65535i32);
@@ -88,9 +85,6 @@ impl Default for CMD_GROUP_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMD_GROUP_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEFAULT_CONTEXT_PRIORITY: u32 = 100u32;
 pub const ERROR_CMD_NOT_FOUND: u32 = 15004u32;
@@ -154,9 +148,6 @@ impl Default for NS_CONTEXT_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NS_CONTEXT_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NS_CONTEXT_ATTRIBUTES_0 {
@@ -168,9 +159,6 @@ impl Default for NS_CONTEXT_ATTRIBUTES_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NS_CONTEXT_ATTRIBUTES_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NS_CONTEXT_ATTRIBUTES_0_0 {
@@ -181,9 +169,6 @@ impl Default for NS_CONTEXT_ATTRIBUTES_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NS_CONTEXT_ATTRIBUTES_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -207,9 +192,6 @@ impl Default for NS_HELPER_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NS_HELPER_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NS_HELPER_ATTRIBUTES_0 {
@@ -221,9 +203,6 @@ impl Default for NS_HELPER_ATTRIBUTES_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NS_HELPER_ATTRIBUTES_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NS_HELPER_ATTRIBUTES_0_0 {
@@ -234,9 +213,6 @@ impl Default for NS_HELPER_ATTRIBUTES_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NS_HELPER_ATTRIBUTES_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -271,9 +247,6 @@ impl Default for TAG_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TAG_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOKEN_VALUE {
@@ -284,7 +257,4 @@ impl Default for TOKEN_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKEN_VALUE {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/mod.rs
@@ -149,9 +149,6 @@ impl Default for DIAG_SOCKADDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIAG_SOCKADDR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DS_CONFIRMED: DIAGNOSIS_STATUS = DIAGNOSIS_STATUS(1i32);
 pub const DS_DEFERRED: DIAGNOSIS_STATUS = DIAGNOSIS_STATUS(4i32);
 pub const DS_INDETERMINATE: DIAGNOSIS_STATUS = DIAGNOSIS_STATUS(3i32);
@@ -169,9 +166,6 @@ impl Default for DiagnosticsInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DiagnosticsInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HELPER_ATTRIBUTE {
@@ -183,9 +177,6 @@ impl Default for HELPER_ATTRIBUTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HELPER_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -210,9 +201,6 @@ impl Default for HELPER_ATTRIBUTE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HELPER_ATTRIBUTE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HYPOTHESIS {
@@ -226,9 +214,6 @@ impl Default for HYPOTHESIS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HYPOTHESIS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HelperAttributeInfo {
@@ -240,9 +225,6 @@ impl Default for HelperAttributeInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HelperAttributeInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HypothesisResult {
@@ -253,9 +235,6 @@ impl Default for HypothesisResult {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HypothesisResult {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(INetDiagExtensibleHelper, INetDiagExtensibleHelper_Vtbl, 0xc0b35748_ebf5_11d8_bbe9_505054503030);
 windows_core::imp::interface_hierarchy!(INetDiagExtensibleHelper, windows_core::IUnknown);
@@ -638,9 +617,6 @@ impl Default for LIFE_TIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LIFE_TIME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDF_ADD_CAPTURE_TRACE: u32 = 1u32;
 pub const NDF_APPLY_INCLUSION_LIST_FILTER: u32 = 2u32;
 pub const NDF_ERROR_START: u32 = 63744u32;
@@ -664,9 +640,6 @@ impl Default for OCTET_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OCTET_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -733,9 +706,6 @@ impl Default for RepairInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RepairInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RepairInfoEx {
@@ -746,9 +716,6 @@ impl Default for RepairInfoEx {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RepairInfoEx {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -765,9 +732,6 @@ impl Default for RootCauseInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RootCauseInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ShellCommandInfo {
@@ -781,9 +745,6 @@ impl Default for ShellCommandInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ShellCommandInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UIT_DUI: UI_INFO_TYPE = UI_INFO_TYPE(4i32);
 pub const UIT_HELP_PANE: UI_INFO_TYPE = UI_INFO_TYPE(3i32);
@@ -804,9 +765,6 @@ impl Default for UiInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UiInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union UiInfo_0 {
@@ -819,7 +777,4 @@ impl Default for UiInfo_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UiInfo_0 {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/mod.rs
@@ -1310,9 +1310,6 @@ impl Default for RADIUS_ATTRIBUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RADIUS_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RADIUS_ATTRIBUTE_0 {
@@ -1323,9 +1320,6 @@ impl Default for RADIUS_ATTRIBUTE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RADIUS_ATTRIBUTE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RADIUS_ATTRIBUTE_ACCT_AUTHENTIC: ATTRIBUTEID = ATTRIBUTEID(45u32);
 pub const RADIUS_ATTRIBUTE_ACCT_DELAY_TIME: ATTRIBUTEID = ATTRIBUTEID(41u32);
@@ -1362,9 +1356,6 @@ impl Default for RADIUS_ATTRIBUTE_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RADIUS_ATTRIBUTE_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RADIUS_ATTRIBUTE_CALLBACK_ID: ATTRIBUTEID = ATTRIBUTEID(20u32);
 pub const RADIUS_ATTRIBUTE_CALLBACK_NUMBER: ATTRIBUTEID = ATTRIBUTEID(19u32);
@@ -1458,9 +1449,6 @@ impl Default for RADIUS_EXTENSION_CONTROL_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RADIUS_EXTENSION_CONTROL_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RADIUS_EXTENSION_FREE_ATTRIBUTES: windows_core::PCSTR = windows_core::s!("RadiusExtensionFreeAttributes");
 pub const RADIUS_EXTENSION_INIT: windows_core::PCSTR = windows_core::s!("RadiusExtensionInit");
 #[repr(transparent)]
@@ -1486,9 +1474,6 @@ impl Default for RADIUS_VSA_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RADIUS_VSA_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RAS_ATTRIBUTE_BAP_LINE_DOWN_LIMIT: ATTRIBUTEID = ATTRIBUTEID(4294967210u32);
 pub const RAS_ATTRIBUTE_BAP_LINE_DOWN_TIME: ATTRIBUTEID = ATTRIBUTEID(4294967209u32);

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/P2P/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/P2P/mod.rs
@@ -1293,10 +1293,6 @@ impl Default for DRT_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for DRT_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DRT_ADDRESS_FLAGS(pub i32);
@@ -1321,10 +1317,6 @@ impl Default for DRT_ADDRESS_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for DRT_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DRT_ALONE: DRT_STATUS = DRT_STATUS(1i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1343,9 +1335,6 @@ impl Default for DRT_BOOTSTRAP_PROVIDER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRT_BOOTSTRAP_PROVIDER {
-    type TypeKind = windows_core::CopyType;
-}
 #[cfg(feature = "Win32_Networking_WinSock")]
 pub type DRT_BOOTSTRAP_RESOLVE_CALLBACK = Option<unsafe extern "system" fn(hr: windows_core::HRESULT, pvcontext: *mut core::ffi::c_void, paddresses: *mut super::super::Networking::WinSock::SOCKET_ADDRESS_LIST, ffatalerror: super::super::Foundation::BOOL)>;
 #[repr(C)]
@@ -1358,9 +1347,6 @@ impl Default for DRT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1377,10 +1363,6 @@ impl Default for DRT_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for DRT_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -1394,10 +1376,6 @@ impl Default for DRT_EVENT_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for DRT_EVENT_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1413,10 +1391,6 @@ impl Default for DRT_EVENT_DATA_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for DRT_EVENT_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1429,10 +1403,6 @@ impl Default for DRT_EVENT_DATA_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for DRT_EVENT_DATA_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1447,10 +1417,6 @@ impl Default for DRT_EVENT_DATA_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for DRT_EVENT_DATA_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1463,10 +1429,6 @@ impl Default for DRT_EVENT_DATA_0_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for DRT_EVENT_DATA_0_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRT_EVENT_LEAFSET_KEY_CHANGED: DRT_EVENT_TYPE = DRT_EVENT_TYPE(1i32);
 pub const DRT_EVENT_REGISTRATION_STATE_CHANGED: DRT_EVENT_TYPE = DRT_EVENT_TYPE(2i32);
@@ -1547,9 +1509,6 @@ impl Default for DRT_REGISTRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRT_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DRT_REGISTRATION_STATE(pub i32);
@@ -1573,9 +1532,6 @@ impl Default for DRT_SEARCH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRT_SEARCH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRT_SEARCH_RESULT {
@@ -1588,9 +1544,6 @@ impl Default for DRT_SEARCH_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRT_SEARCH_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRT_SECURE_CONFIDENTIALPAYLOAD: DRT_SECURITY_MODE = DRT_SECURITY_MODE(2i32);
 pub const DRT_SECURE_MEMBERSHIP: DRT_SECURITY_MODE = DRT_SECURITY_MODE(1i32);
@@ -1621,9 +1574,6 @@ impl Default for DRT_SECURITY_PROVIDER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRT_SECURITY_PROVIDER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRT_SETTINGS {
@@ -1642,9 +1592,6 @@ impl Default for DRT_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRT_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRT_SITE_LOCAL_SCOPE: DRT_SCOPE = DRT_SCOPE(2i32);
 #[repr(transparent)]
@@ -1667,9 +1614,6 @@ impl Default for PEERDIST_CLIENT_BASIC_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEERDIST_CLIENT_BASIC_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PEERDIST_CLIENT_INFO_BY_HANDLE_CLASS(pub i32);
@@ -1683,9 +1627,6 @@ impl Default for PEERDIST_CONTENT_TAG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEERDIST_CONTENT_TAG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PEERDIST_PUBLICATION_OPTIONS {
@@ -1696,9 +1637,6 @@ impl Default for PEERDIST_PUBLICATION_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEERDIST_PUBLICATION_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEERDIST_PUBLICATION_OPTIONS_VERSION: i32 = 2i32;
 pub const PEERDIST_PUBLICATION_OPTIONS_VERSION_1: i32 = 1i32;
@@ -1717,9 +1655,6 @@ impl Default for PEERDIST_RETRIEVAL_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEERDIST_RETRIEVAL_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEERDIST_RETRIEVAL_OPTIONS_CONTENTINFO_VERSION: PEERDIST_RETRIEVAL_OPTIONS_CONTENTINFO_VERSION_VALUE = PEERDIST_RETRIEVAL_OPTIONS_CONTENTINFO_VERSION_VALUE(2u32);
 pub const PEERDIST_RETRIEVAL_OPTIONS_CONTENTINFO_VERSION_1: PEERDIST_RETRIEVAL_OPTIONS_CONTENTINFO_VERSION_VALUE = PEERDIST_RETRIEVAL_OPTIONS_CONTENTINFO_VERSION_VALUE(1u32);
@@ -1745,9 +1680,6 @@ impl Default for PEERDIST_STATUS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEERDIST_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PEERDIST_STATUS_UNAVAILABLE: PEERDIST_STATUS = PEERDIST_STATUS(1i32);
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1762,10 +1694,6 @@ impl Default for PEER_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PEER_APPLICATION {
@@ -1777,9 +1705,6 @@ impl Default for PEER_APPLICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_APPLICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_APPLICATION_ALL_USERS: PEER_APPLICATION_REGISTRATION_TYPE = PEER_APPLICATION_REGISTRATION_TYPE(1i32);
 pub const PEER_APPLICATION_CURRENT_USER: PEER_APPLICATION_REGISTRATION_TYPE = PEER_APPLICATION_REGISTRATION_TYPE(0i32);
@@ -1795,9 +1720,6 @@ impl Default for PEER_APPLICATION_REGISTRATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_APPLICATION_REGISTRATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1815,10 +1737,6 @@ impl Default for PEER_APP_LAUNCH_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_APP_LAUNCH_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_CHANGE_ADDED: PEER_CHANGE_TYPE = PEER_CHANGE_TYPE(0i32);
 pub const PEER_CHANGE_DELETED: PEER_CHANGE_TYPE = PEER_CHANGE_TYPE(1i32);
@@ -1839,10 +1757,6 @@ impl Default for PEER_COLLAB_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_COLLAB_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -1861,10 +1775,6 @@ impl Default for PEER_COLLAB_EVENT_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_COLLAB_EVENT_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PEER_COLLAB_EVENT_REGISTRATION {
@@ -1875,9 +1785,6 @@ impl Default for PEER_COLLAB_EVENT_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_COLLAB_EVENT_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1906,10 +1813,6 @@ impl Default for PEER_CONNECTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_CONNECTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PEER_CONNECTION_NEIGHBOR: PEER_CONNECTION_FLAGS = PEER_CONNECTION_FLAGS(1i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1929,9 +1832,6 @@ impl Default for PEER_CONTACT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_CONTACT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -1954,10 +1854,6 @@ impl Default for PEER_CREDENTIAL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for PEER_CREDENTIAL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PEER_DATA {
@@ -1968,9 +1864,6 @@ impl Default for PEER_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_DEFER_EXPIRATION: PEER_GROUP_PROPERTY_FLAGS = PEER_GROUP_PROPERTY_FLAGS(4i32);
 pub const PEER_DISABLE_PRESENCE: PEER_GROUP_PROPERTY_FLAGS = PEER_GROUP_PROPERTY_FLAGS(2i32);
@@ -1988,10 +1881,6 @@ impl Default for PEER_ENDPOINT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_ENDPOINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2006,10 +1895,6 @@ impl Default for PEER_EVENT_APPLICATION_CHANGED_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_EVENT_APPLICATION_CHANGED_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2026,9 +1911,6 @@ impl Default for PEER_EVENT_CONNECTION_CHANGE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEER_EVENT_CONNECTION_CHANGE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PEER_EVENT_ENDPOINT_APPLICATION_CHANGED: PEER_COLLAB_EVENT_TYPE = PEER_COLLAB_EVENT_TYPE(4i32);
 pub const PEER_EVENT_ENDPOINT_CHANGED: PEER_COLLAB_EVENT_TYPE = PEER_COLLAB_EVENT_TYPE(2i32);
 #[repr(C)]
@@ -2043,10 +1925,6 @@ impl Default for PEER_EVENT_ENDPOINT_CHANGED_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_EVENT_ENDPOINT_CHANGED_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_EVENT_ENDPOINT_OBJECT_CHANGED: PEER_COLLAB_EVENT_TYPE = PEER_COLLAB_EVENT_TYPE(5i32);
 pub const PEER_EVENT_ENDPOINT_PRESENCE_CHANGED: PEER_COLLAB_EVENT_TYPE = PEER_COLLAB_EVENT_TYPE(3i32);
@@ -2063,9 +1941,6 @@ impl Default for PEER_EVENT_INCOMING_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEER_EVENT_INCOMING_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PEER_EVENT_MEMBER_CHANGE_DATA {
@@ -2077,9 +1952,6 @@ impl Default for PEER_EVENT_MEMBER_CHANGE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_EVENT_MEMBER_CHANGE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_EVENT_MY_APPLICATION_CHANGED: PEER_COLLAB_EVENT_TYPE = PEER_COLLAB_EVENT_TYPE(8i32);
 pub const PEER_EVENT_MY_ENDPOINT_CHANGED: PEER_COLLAB_EVENT_TYPE = PEER_COLLAB_EVENT_TYPE(6i32);
@@ -2098,9 +1970,6 @@ impl Default for PEER_EVENT_NODE_CHANGE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEER_EVENT_NODE_CHANGE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2116,10 +1985,6 @@ impl Default for PEER_EVENT_OBJECT_CHANGED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_EVENT_OBJECT_CHANGED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PEER_EVENT_PEOPLE_NEAR_ME_CHANGED: PEER_COLLAB_EVENT_TYPE = PEER_COLLAB_EVENT_TYPE(10i32);
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2133,10 +1998,6 @@ impl Default for PEER_EVENT_PEOPLE_NEAR_ME_CHANGED_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_EVENT_PEOPLE_NEAR_ME_CHANGED_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2153,10 +2014,6 @@ impl Default for PEER_EVENT_PRESENCE_CHANGED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_EVENT_PRESENCE_CHANGED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PEER_EVENT_RECORD_CHANGE_DATA {
@@ -2169,9 +2026,6 @@ impl Default for PEER_EVENT_RECORD_CHANGE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_EVENT_RECORD_CHANGE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_EVENT_REQUEST_STATUS_CHANGED: PEER_COLLAB_EVENT_TYPE = PEER_COLLAB_EVENT_TYPE(11i32);
 #[repr(C)]
@@ -2187,10 +2041,6 @@ impl Default for PEER_EVENT_REQUEST_STATUS_CHANGED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_EVENT_REQUEST_STATUS_CHANGED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PEER_EVENT_SYNCHRONIZED_DATA {
@@ -2201,9 +2051,6 @@ impl Default for PEER_EVENT_SYNCHRONIZED_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_EVENT_SYNCHRONIZED_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_EVENT_WATCHLIST_CHANGED: PEER_COLLAB_EVENT_TYPE = PEER_COLLAB_EVENT_TYPE(1i32);
 #[repr(C)]
@@ -2216,9 +2063,6 @@ impl Default for PEER_EVENT_WATCHLIST_CHANGED_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_EVENT_WATCHLIST_CHANGED_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_E_ALREADY_EXISTS: windows_core::HRESULT = windows_core::HRESULT(0x800700B7_u32 as _);
 pub const PEER_E_CLIENT_INVALID_COMPARTMENT_ID: windows_core::HRESULT = windows_core::HRESULT(0x80072CF2_u32 as _);
@@ -2243,9 +2087,6 @@ impl Default for PEER_GRAPH_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEER_GRAPH_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PEER_GRAPH_EVENT_DATA_0 {
@@ -2260,9 +2101,6 @@ impl Default for PEER_GRAPH_EVENT_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_GRAPH_EVENT_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_GRAPH_EVENT_DIRECT_CONNECTION: PEER_GRAPH_EVENT_TYPE = PEER_GRAPH_EVENT_TYPE(4i32);
 pub const PEER_GRAPH_EVENT_INCOMING_DATA: PEER_GRAPH_EVENT_TYPE = PEER_GRAPH_EVENT_TYPE(6i32);
@@ -2280,9 +2118,6 @@ impl Default for PEER_GRAPH_EVENT_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_GRAPH_EVENT_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_GRAPH_EVENT_STATUS_CHANGED: PEER_GRAPH_EVENT_TYPE = PEER_GRAPH_EVENT_TYPE(1i32);
 pub const PEER_GRAPH_EVENT_SYNCHRONIZED: PEER_GRAPH_EVENT_TYPE = PEER_GRAPH_EVENT_TYPE(9i32);
@@ -2307,9 +2142,6 @@ impl Default for PEER_GRAPH_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_GRAPH_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_GRAPH_PROPERTY_DEFER_EXPIRATION: PEER_GRAPH_PROPERTY_FLAGS = PEER_GRAPH_PROPERTY_FLAGS(2i32);
 #[repr(transparent)]
@@ -2346,9 +2178,6 @@ impl Default for PEER_GROUP_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEER_GROUP_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PEER_GROUP_EVENT_DATA_0 {
@@ -2363,9 +2192,6 @@ impl Default for PEER_GROUP_EVENT_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_GROUP_EVENT_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_GROUP_EVENT_DIRECT_CONNECTION: PEER_GROUP_EVENT_TYPE = PEER_GROUP_EVENT_TYPE(4i32);
 pub const PEER_GROUP_EVENT_INCOMING_DATA: PEER_GROUP_EVENT_TYPE = PEER_GROUP_EVENT_TYPE(6i32);
@@ -2383,9 +2209,6 @@ impl Default for PEER_GROUP_EVENT_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_GROUP_EVENT_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_GROUP_EVENT_STATUS_CHANGED: PEER_GROUP_EVENT_TYPE = PEER_GROUP_EVENT_TYPE(1i32);
 #[repr(transparent)]
@@ -2418,9 +2241,6 @@ impl Default for PEER_GROUP_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEER_GROUP_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PEER_GROUP_PROPERTY_FLAGS(pub i32);
@@ -2444,9 +2264,6 @@ impl Default for PEER_INVITATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_INVITATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2478,10 +2295,6 @@ impl Default for PEER_INVITATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for PEER_INVITATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PEER_INVITATION_RESPONSE {
@@ -2493,9 +2306,6 @@ impl Default for PEER_INVITATION_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_INVITATION_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_INVITATION_RESPONSE_ACCEPTED: PEER_INVITATION_RESPONSE_TYPE = PEER_INVITATION_RESPONSE_TYPE(1i32);
 pub const PEER_INVITATION_RESPONSE_DECLINED: PEER_INVITATION_RESPONSE_TYPE = PEER_INVITATION_RESPONSE_TYPE(0i32);
@@ -2523,10 +2333,6 @@ impl Default for PEER_MEMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
-impl windows_core::TypeKind for PEER_MEMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PEER_MEMBER_CHANGE_TYPE(pub i32);
@@ -2552,9 +2358,6 @@ impl Default for PEER_NAME_PAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEER_NAME_PAIR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PEER_NODE_CHANGE_CONNECTED: PEER_NODE_CHANGE_TYPE = PEER_NODE_CHANGE_TYPE(1i32);
 pub const PEER_NODE_CHANGE_DISCONNECTED: PEER_NODE_CHANGE_TYPE = PEER_NODE_CHANGE_TYPE(2i32);
 #[repr(transparent)]
@@ -2578,10 +2381,6 @@ impl Default for PEER_NODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_NODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PEER_OBJECT {
@@ -2593,9 +2392,6 @@ impl Default for PEER_OBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_OBJECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2611,10 +2407,6 @@ impl Default for PEER_PEOPLE_NEAR_ME {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_PEOPLE_NEAR_ME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PEER_PNRP_ALL_LINK_CLOUDS: windows_core::PCWSTR = windows_core::w!("PEER_PNRP_ALL_LINKS");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2627,9 +2419,6 @@ impl Default for PEER_PNRP_CLOUD_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_PNRP_CLOUD_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2646,10 +2435,6 @@ impl Default for PEER_PNRP_ENDPOINT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_PNRP_ENDPOINT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2669,10 +2454,6 @@ impl Default for PEER_PNRP_REGISTRATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PEER_PNRP_REGISTRATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PEER_PRESENCE_AWAY: PEER_PRESENCE_STATUS = PEER_PRESENCE_STATUS(2i32);
 pub const PEER_PRESENCE_BE_RIGHT_BACK: PEER_PRESENCE_STATUS = PEER_PRESENCE_STATUS(3i32);
 pub const PEER_PRESENCE_BUSY: PEER_PRESENCE_STATUS = PEER_PRESENCE_STATUS(5i32);
@@ -2687,9 +2468,6 @@ impl Default for PEER_PRESENCE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_PRESENCE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_PRESENCE_OFFLINE: PEER_PRESENCE_STATUS = PEER_PRESENCE_STATUS(0i32);
 pub const PEER_PRESENCE_ONLINE: PEER_PRESENCE_STATUS = PEER_PRESENCE_STATUS(7i32);
@@ -2727,9 +2505,6 @@ impl Default for PEER_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEER_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PEER_RECORD_ADDED: PEER_RECORD_CHANGE_TYPE = PEER_RECORD_CHANGE_TYPE(1i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2761,9 +2536,6 @@ impl Default for PEER_SECURITY_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PEER_SECURITY_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PEER_SIGNIN_ALL: PEER_SIGNIN_FLAGS = PEER_SIGNIN_FLAGS(3i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2781,9 +2553,6 @@ impl Default for PEER_VERSION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PEER_VERSION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PEER_WATCH_ALLOWED: PEER_WATCH_PERMISSION = PEER_WATCH_PERMISSION(1i32);
 pub const PEER_WATCH_BLOCKED: PEER_WATCH_PERMISSION = PEER_WATCH_PERMISSION(0i32);
@@ -2807,9 +2576,6 @@ impl Default for PNRPCLOUDINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PNRPCLOUDINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PNRPINFO_HINT: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2830,10 +2596,6 @@ impl Default for PNRPINFO_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for PNRPINFO_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_System_Com"))]
@@ -2857,10 +2619,6 @@ impl Default for PNRPINFO_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_System_Com"))]
-impl windows_core::TypeKind for PNRPINFO_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_System_Com"))]
 #[derive(Clone, Copy)]
@@ -2873,10 +2631,6 @@ impl Default for PNRPINFO_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_System_Com"))]
-impl windows_core::TypeKind for PNRPINFO_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2893,9 +2647,6 @@ impl Default for PNRP_CLOUD_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PNRP_CLOUD_ID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PNRP_CLOUD_NAME_LOCAL: PNRP_CLOUD_FLAGS = PNRP_CLOUD_FLAGS(1i32);
 pub const PNRP_CLOUD_NO_FLAGS: PNRP_CLOUD_FLAGS = PNRP_CLOUD_FLAGS(0i32);

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/QoS/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/QoS/mod.rs
@@ -200,10 +200,6 @@ impl Default for ADDRESS_LIST_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for ADDRESS_LIST_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ADM_CTRL_FAILED: u32 = 3u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -215,9 +211,6 @@ impl Default for ADSPEC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADSPEC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AD_FLAG_BREAK_BIT: u32 = 1u32;
 #[repr(C)]
@@ -234,9 +227,6 @@ impl Default for AD_GENERAL_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AD_GENERAL_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AD_GUARANTEED {
@@ -249,9 +239,6 @@ impl Default for AD_GUARANTEED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AD_GUARANTEED {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ALLOWED_TO_SEND_DATA: u32 = 50001u32;
 pub const ANY_DEST_ADDR: u32 = 4294967295u32;
@@ -272,9 +259,6 @@ impl Default for CONTROL_SERVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONTROL_SERVICE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CONTROL_SERVICE_0 {
@@ -285,9 +269,6 @@ impl Default for CONTROL_SERVICE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONTROL_SERVICE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CREDENTIAL_SUB_TYPE_ASCII_ID: u32 = 1u32;
 pub const CREDENTIAL_SUB_TYPE_KERBEROS_TKT: u32 = 3u32;
@@ -306,9 +287,6 @@ impl Default for CtrlLoadFlowspec {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CtrlLoadFlowspec {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DD_TCP_DEVICE_NAME: windows_core::PCWSTR = windows_core::w!("\\Device\\Tcp");
 pub const DUP_RESULTS: u32 = 4u32;
@@ -330,10 +308,6 @@ impl Default for ENUMERATION_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for ENUMERATION_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ERROR_ADDRESS_TYPE_NOT_SUPPORTED: u32 = 7511u32;
 pub const ERROR_DS_MAPPING_EXISTS: u32 = 7518u32;
@@ -366,10 +340,6 @@ impl Default for ERROR_SPEC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for ERROR_SPEC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -381,10 +351,6 @@ impl Default for ERROR_SPEC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for ERROR_SPEC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ERROR_SPECF_InPlace: u32 = 1u32;
 pub const ERROR_SPECF_NotGuilty: u32 = 2u32;
@@ -413,10 +379,6 @@ impl Default for Error_Spec_IPv4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for Error_Spec_IPv4 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILTERSPECV4: FilterType = FilterType(1i32);
 pub const FILTERSPECV4_GPI: FilterType = FilterType(4i32);
 pub const FILTERSPECV6: FilterType = FilterType(2i32);
@@ -436,10 +398,6 @@ impl Default for FILTER_SPEC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for FILTER_SPEC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -452,10 +410,6 @@ impl Default for FILTER_SPEC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for FILTER_SPEC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -471,10 +425,6 @@ impl Default for FLOWDESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for FLOWDESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -487,10 +437,6 @@ impl Default for FLOW_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for FLOW_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -505,10 +451,6 @@ impl Default for FLOW_DESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for FLOW_DESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -521,10 +463,6 @@ impl Default for FLOW_DESC_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for FLOW_DESC_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLOW_DURATION: u32 = 5u32;
 pub const FORCE_IMMEDIATE_REFRESH: u32 = 1u32;
@@ -556,10 +494,6 @@ impl Default for Filter_Spec_IPv4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for Filter_Spec_IPv4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -572,10 +506,6 @@ impl Default for Filter_Spec_IPv4GPI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for Filter_Spec_IPv4GPI {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GENERAL_INFO: u32 = 1u32;
 pub const GQOS_API: u32 = 56400u32;
@@ -630,9 +560,6 @@ impl Default for Gads_parms_t {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Gads_parms_t {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GenAdspecParams {
@@ -651,9 +578,6 @@ impl Default for GenAdspecParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GenAdspecParams {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GenTspec {
@@ -665,9 +589,6 @@ impl Default for GenTspec {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GenTspec {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -683,9 +604,6 @@ impl Default for GenTspecParms {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GenTspecParms {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GuarFlowSpec {
@@ -700,9 +618,6 @@ impl Default for GuarFlowSpec {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GuarFlowSpec {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GuarRspec {
@@ -713,9 +628,6 @@ impl Default for GuarRspec {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GuarRspec {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HIGHLY_DELAY_SENSITIVE: u32 = 4294967294u32;
 #[repr(C, packed(1))]
@@ -731,9 +643,6 @@ impl Default for HSP_UPGRADE_IMAGEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSP_UPGRADE_IMAGEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IDENTITY_CHANGED: u32 = 5u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -747,9 +656,6 @@ impl Default for IDPE_ATTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IDPE_ATTR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -765,9 +671,6 @@ impl Default for ID_ERROR_OBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ID_ERROR_OBJECT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IF_MIB_STATS_ID: u32 = 1u32;
 pub const INFO_NOT_AVAILABLE: u32 = 4294967295u32;
@@ -788,9 +691,6 @@ impl Default for IN_ADDR_IPV4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IN_ADDR_IPV4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IN_ADDR_IPV6 {
@@ -800,9 +700,6 @@ impl Default for IN_ADDR_IPV6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IN_ADDR_IPV6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -815,9 +712,6 @@ impl Default for IPX_PATTERN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPX_PATTERN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPX_PATTERN_0 {
@@ -829,9 +723,6 @@ impl Default for IPX_PATTERN_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPX_PATTERN_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_INTFC_INFO_ID: u32 = 259u32;
 pub const IP_MIB_ADDRTABLE_ENTRY_ID: u32 = 258u32;
@@ -852,9 +743,6 @@ impl Default for IP_PATTERN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IP_PATTERN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IP_PATTERN_0 {
@@ -866,9 +754,6 @@ impl Default for IP_PATTERN_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_PATTERN_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -882,9 +767,6 @@ impl Default for IP_PATTERN_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IP_PATTERN_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IP_PATTERN_0_0 {
@@ -895,9 +777,6 @@ impl Default for IP_PATTERN_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_PATTERN_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ISPH_FLG_INV: u32 = 128u32;
 pub const ISSH_BREAK_BIT: u32 = 128u32;
@@ -912,9 +791,6 @@ impl Default for IS_ADSPEC_BODY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IS_ADSPEC_BODY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IS_FLOWSPEC {
@@ -925,9 +801,6 @@ impl Default for IS_FLOWSPEC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IS_FLOWSPEC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IS_GUAR_RSPEC: i32 = 130i32;
 pub const IS_WKP_COMPOSED_MTU: int_serv_wkp = int_serv_wkp(10i32);
@@ -947,9 +820,6 @@ impl Default for IntServFlowSpec {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IntServFlowSpec {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IntServFlowSpec_0 {
@@ -961,9 +831,6 @@ impl Default for IntServFlowSpec_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IntServFlowSpec_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -977,9 +844,6 @@ impl Default for IntServMainHdr {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IntServMainHdr {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IntServParmHdr {
@@ -991,9 +855,6 @@ impl Default for IntServParmHdr {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IntServParmHdr {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1007,9 +868,6 @@ impl Default for IntServServiceHdr {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IntServServiceHdr {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IntServTspecBody {
@@ -1021,9 +879,6 @@ impl Default for IntServTspecBody {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IntServTspecBody {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IntServTspecBody_0 {
@@ -1034,9 +889,6 @@ impl Default for IntServTspecBody_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IntServTspecBody_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LINE_RATE: u32 = 50003u32;
 pub const LOCAL_QOSABILITY: u32 = 50005u32;
@@ -1055,10 +907,6 @@ impl Default for LPMIPTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for LPMIPTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LPM_API_VERSION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -1092,9 +940,6 @@ impl Default for LPM_INIT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LPM_INIT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LPM_OK: u32 = 0u32;
 pub const LPM_PE_ALL_TYPES: u32 = 0u32;
@@ -1145,9 +990,6 @@ impl Default for PARAM_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PARAM_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PCM_VERSION_1: u32 = 1u32;
 pub const PE_ATTRIB_TYPE_CREDENTIAL: u32 = 2u32;
 pub const PE_ATTRIB_TYPE_POLICY_LOCATOR: u32 = 1u32;
@@ -1165,9 +1007,6 @@ impl Default for POLICY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLICY_DECISION {
@@ -1180,9 +1019,6 @@ impl Default for POLICY_DECISION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICY_DECISION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLICY_ELEMENT {
@@ -1194,9 +1030,6 @@ impl Default for POLICY_ELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_ELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POLICY_ERRV_CRAZY_FLOWSPEC: u32 = 57u32;
 pub const POLICY_ERRV_EXPIRED_CREDENTIALS: u32 = 4u32;
@@ -1306,10 +1139,6 @@ impl Default for QOS_DESTADDR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for QOS_DESTADDR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QOS_DIFFSERV {
@@ -1321,9 +1150,6 @@ impl Default for QOS_DIFFSERV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QOS_DIFFSERV {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1339,9 +1165,6 @@ impl Default for QOS_DIFFSERV_RULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QOS_DIFFSERV_RULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QOS_DS_CLASS {
@@ -1352,9 +1175,6 @@ impl Default for QOS_DS_CLASS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QOS_DS_CLASS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1367,9 +1187,6 @@ impl Default for QOS_FLOWRATE_OUTGOING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QOS_FLOWRATE_OUTGOING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1389,9 +1206,6 @@ impl Default for QOS_FLOW_FUNDAMENTALS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QOS_FLOW_FUNDAMENTALS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QOS_FRIENDLY_NAME {
@@ -1402,9 +1216,6 @@ impl Default for QOS_FRIENDLY_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QOS_FRIENDLY_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const QOS_GENERAL_ID_BASE: u32 = 2000u32;
 pub const QOS_MAX_OBJECT_STRING_LENGTH: u32 = 256u32;
@@ -1424,9 +1235,6 @@ impl Default for QOS_OBJECT_HDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QOS_OBJECT_HDR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const QOS_OUTGOING_DEFAULT_MINIMUM_BANDWIDTH: u32 = 4294967295u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1440,9 +1248,6 @@ impl Default for QOS_PACKET_PRIORITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QOS_PACKET_PRIORITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const QOS_QUERYFLOW_FRESH: u32 = 1u32;
 #[repr(transparent)]
@@ -1458,9 +1263,6 @@ impl Default for QOS_SD_MODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QOS_SD_MODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1479,9 +1281,6 @@ impl Default for QOS_SHAPING_RATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QOS_SHAPING_RATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QOS_TCP_TRAFFIC {
@@ -1491,9 +1290,6 @@ impl Default for QOS_TCP_TRAFFIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QOS_TCP_TRAFFIC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1505,9 +1301,6 @@ impl Default for QOS_TRAFFIC_CLASS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QOS_TRAFFIC_CLASS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const QOS_TRAFFIC_GENERAL_ID_BASE: u32 = 4000u32;
 #[repr(transparent)]
@@ -1524,9 +1317,6 @@ impl Default for QOS_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QOS_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const QUALITATIVE_SERV: u32 = 6u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1540,9 +1330,6 @@ impl Default for QualAppFlowSpec {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QualAppFlowSpec {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QualTspec {
@@ -1555,9 +1342,6 @@ impl Default for QualTspec {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QualTspec {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QualTspecParms {
@@ -1567,9 +1351,6 @@ impl Default for QualTspecParms {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QualTspecParms {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RCVD_PATH_TEAR: u32 = 1u32;
 pub const RCVD_RESV_TEAR: u32 = 2u32;
@@ -1585,9 +1366,6 @@ impl Default for RESV_STYLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESV_STYLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1617,9 +1395,6 @@ impl Default for RSVP_ADSPEC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RSVP_ADSPEC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RSVP_DEFAULT_STYLE: u32 = 0u32;
 pub const RSVP_Err_ADMISSION: u32 = 1u32;
@@ -1665,9 +1440,6 @@ impl Default for RSVP_FILTERSPEC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RSVP_FILTERSPEC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RSVP_FILTERSPEC_0 {
@@ -1682,9 +1454,6 @@ impl Default for RSVP_FILTERSPEC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RSVP_FILTERSPEC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RSVP_FILTERSPEC_V4 {
@@ -1697,9 +1466,6 @@ impl Default for RSVP_FILTERSPEC_V4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RSVP_FILTERSPEC_V4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RSVP_FILTERSPEC_V4_GPI {
@@ -1710,9 +1476,6 @@ impl Default for RSVP_FILTERSPEC_V4_GPI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RSVP_FILTERSPEC_V4_GPI {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1726,9 +1489,6 @@ impl Default for RSVP_FILTERSPEC_V6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RSVP_FILTERSPEC_V6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RSVP_FILTERSPEC_V6_FLOW {
@@ -1741,9 +1501,6 @@ impl Default for RSVP_FILTERSPEC_V6_FLOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RSVP_FILTERSPEC_V6_FLOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RSVP_FILTERSPEC_V6_GPI {
@@ -1754,9 +1511,6 @@ impl Default for RSVP_FILTERSPEC_V6_GPI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RSVP_FILTERSPEC_V6_GPI {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RSVP_FIXED_FILTER_STYLE: u32 = 2u32;
 #[repr(C)]
@@ -1772,10 +1526,6 @@ impl Default for RSVP_HOP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RSVP_HOP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -1787,10 +1537,6 @@ impl Default for RSVP_HOP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RSVP_HOP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1815,10 +1561,6 @@ impl Default for RSVP_MSG_OBJS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RSVP_MSG_OBJS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RSVP_OBJECT_ID_BASE: u32 = 1000u32;
 pub const RSVP_PATH: u32 = 1u32;
 pub const RSVP_PATH_ERR: u32 = 3u32;
@@ -1835,9 +1577,6 @@ impl Default for RSVP_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RSVP_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RSVP_POLICY_INFO {
@@ -1849,9 +1588,6 @@ impl Default for RSVP_POLICY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RSVP_POLICY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1870,10 +1606,6 @@ impl Default for RSVP_RESERVE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RSVP_RESERVE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RSVP_RESV: u32 = 2u32;
 pub const RSVP_RESV_ERR: u32 = 4u32;
 pub const RSVP_RESV_TEAR: u32 = 6u32;
@@ -1890,10 +1622,6 @@ impl Default for RSVP_SCOPE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RSVP_SCOPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -1905,10 +1633,6 @@ impl Default for RSVP_SCOPE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RSVP_SCOPE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1923,10 +1647,6 @@ impl Default for RSVP_SESSION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RSVP_SESSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -1938,10 +1658,6 @@ impl Default for RSVP_SESSION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RSVP_SESSION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RSVP_SHARED_EXPLICIT_STYLE: u32 = 3u32;
 #[repr(C)]
@@ -1957,9 +1673,6 @@ impl Default for RSVP_STATUS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RSVP_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RSVP_WILDCARD_STYLE: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1972,9 +1685,6 @@ impl Default for RsvpObjHdr {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RsvpObjHdr {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1989,10 +1699,6 @@ impl Default for Rsvp_Hop_IPv4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for Rsvp_Hop_IPv4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct SENDER_TSPEC {
@@ -2003,9 +1709,6 @@ impl Default for SENDER_TSPEC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SENDER_TSPEC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICETYPE_BESTEFFORT: u32 = 1u32;
 pub const SERVICETYPE_CONTROLLEDLOAD: u32 = 2u32;
@@ -2096,9 +1799,6 @@ impl Default for SIPAEVENT_KSR_SIGNATURE_PAYLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIPAEVENT_KSR_SIGNATURE_PAYLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SIPAEVENT_LSAISO_CONFIG: u32 = 327720u32;
 pub const SIPAEVENT_MODULE_HSP: u32 = 458764u32;
 pub const SIPAEVENT_MODULE_SVN: u32 = 458763u32;
@@ -2123,9 +1823,6 @@ impl Default for SIPAEVENT_REVOCATION_LIST_PAYLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIPAEVENT_REVOCATION_LIST_PAYLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SIPAEVENT_SAFEMODE: u32 = 327685u32;
 pub const SIPAEVENT_SBCP_INFO: u32 = 327721u32;
 #[repr(C, packed(1))]
@@ -2144,9 +1841,6 @@ impl Default for SIPAEVENT_SBCP_INFO_PAYLOAD_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIPAEVENT_SBCP_INFO_PAYLOAD_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SIPAEVENT_SI_POLICY: u32 = 327695u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2161,9 +1855,6 @@ impl Default for SIPAEVENT_SI_POLICY_PAYLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIPAEVENT_SI_POLICY_PAYLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SIPAEVENT_SMT_STATUS: u32 = 327700u32;
 pub const SIPAEVENT_SVN_CHAIN_STATUS: u32 = 131082u32;
@@ -2193,9 +1884,6 @@ impl Default for SIPAEVENT_VSM_IDK_INFO_PAYLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIPAEVENT_VSM_IDK_INFO_PAYLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SIPAEVENT_VSM_IDK_INFO_PAYLOAD_0 {
@@ -2205,9 +1893,6 @@ impl Default for SIPAEVENT_VSM_IDK_INFO_PAYLOAD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIPAEVENT_VSM_IDK_INFO_PAYLOAD_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2221,9 +1906,6 @@ impl Default for SIPAEVENT_VSM_IDK_RSA_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIPAEVENT_VSM_IDK_RSA_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SIPAEVENT_VSM_LAUNCH_TYPE: u32 = 327698u32;
 pub const SIPAEVENT_WINPE: u32 = 327686u32;
@@ -2311,10 +1993,6 @@ impl Default for Scope_list_ipv4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for Scope_list_ipv4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -2329,10 +2007,6 @@ impl Default for Session_IPv4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for Session_IPv4 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TCBASE: u32 = 7500u32;
 #[repr(C, packed(1))]
@@ -2349,9 +2023,6 @@ impl Default for TCG_PCClientPCREventStruct {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCG_PCClientPCREventStruct {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct TCG_PCClientTaggedEventStruct {
@@ -2363,9 +2034,6 @@ impl Default for TCG_PCClientTaggedEventStruct {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCG_PCClientTaggedEventStruct {
-    type TypeKind = windows_core::CopyType;
 }
 pub type TCI_ADD_FLOW_COMPLETE_HANDLER = Option<unsafe extern "system" fn(clflowctx: super::super::Foundation::HANDLE, status: u32)>;
 #[repr(C)]
@@ -2380,9 +2048,6 @@ impl Default for TCI_CLIENT_FUNC_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCI_CLIENT_FUNC_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub type TCI_DEL_FLOW_COMPLETE_HANDLER = Option<unsafe extern "system" fn(clflowctx: super::super::Foundation::HANDLE, status: u32)>;
 pub type TCI_MOD_FLOW_COMPLETE_HANDLER = Option<unsafe extern "system" fn(clflowctx: super::super::Foundation::HANDLE, status: u32)>;
@@ -2400,9 +2065,6 @@ impl Default for TC_GEN_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TC_GEN_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2418,10 +2080,6 @@ impl Default for TC_GEN_FLOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for TC_GEN_FLOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2436,10 +2094,6 @@ impl Default for TC_IFC_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for TC_IFC_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TC_NONCONF_BORROW: u32 = 0u32;
 pub const TC_NONCONF_BORROW_PLUS: u32 = 3u32;
@@ -2464,10 +2118,6 @@ impl Default for TC_SUPPORTED_INFO_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for TC_SUPPORTED_INFO_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UNSUPPORTED_CREDENTIAL_TYPE: u32 = 2u32;
 pub const WBCL_DIGEST_ALG_BITMAP_SHA3_256: u32 = 32u32;
@@ -2506,9 +2156,6 @@ impl Default for WBCL_Iterator {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WBCL_Iterator {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WBCL_LogHdr {
@@ -2521,9 +2168,6 @@ impl Default for WBCL_LogHdr {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WBCL_LogHdr {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WBCL_MAX_HSP_UPGRADE_HASH_LEN: u32 = 64u32;
 pub const class_ADSPEC: u32 = 13u32;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
@@ -1741,9 +1741,6 @@ impl Default for AUTH_VALIDATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTH_VALIDATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DO_NOT_ALLOW_NO_AUTH: u32 = 0u32;
 pub const ERROR_ACCESSING_TCPCFGDLL: u32 = 727u32;
 pub const ERROR_ACCT_DISABLED: u32 = 647u32;
@@ -2036,9 +2033,6 @@ impl Default for GRE_CONFIG_PARAMS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GRE_CONFIG_PARAMS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HRASCONN(pub *mut core::ffi::c_void);
@@ -2069,10 +2063,6 @@ impl Default for IKEV2_CONFIG_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for IKEV2_CONFIG_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2114,9 +2104,6 @@ impl Default for IKEV2_PROJECTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEV2_PROJECTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEV2_PROJECTION_INFO2 {
@@ -2142,9 +2129,6 @@ impl Default for IKEV2_PROJECTION_INFO2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEV2_PROJECTION_INFO2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2165,10 +2149,6 @@ impl Default for IKEV2_TUNNEL_CONFIG_PARAMS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for IKEV2_TUNNEL_CONFIG_PARAMS2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2193,10 +2173,6 @@ impl Default for IKEV2_TUNNEL_CONFIG_PARAMS3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for IKEV2_TUNNEL_CONFIG_PARAMS3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2223,10 +2199,6 @@ impl Default for IKEV2_TUNNEL_CONFIG_PARAMS4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for IKEV2_TUNNEL_CONFIG_PARAMS4 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IPADDRESSLEN: u32 = 15u32;
 pub const IPV6_ADDRESS_LEN_IN_BYTES: u32 = 16u32;
 pub const IPXADDRESSLEN: u32 = 22u32;
@@ -2241,9 +2213,6 @@ impl Default for L2TP_CONFIG_PARAMS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for L2TP_CONFIG_PARAMS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct L2TP_CONFIG_PARAMS1 {
@@ -2256,9 +2225,6 @@ impl Default for L2TP_CONFIG_PARAMS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for L2TP_CONFIG_PARAMS1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2274,9 +2240,6 @@ impl Default for L2TP_TUNNEL_CONFIG_PARAMS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for L2TP_TUNNEL_CONFIG_PARAMS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct L2TP_TUNNEL_CONFIG_PARAMS2 {
@@ -2291,9 +2254,6 @@ impl Default for L2TP_TUNNEL_CONFIG_PARAMS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for L2TP_TUNNEL_CONFIG_PARAMS2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MAXIPADRESSLEN: u32 = 64u32;
 pub const MAX_SSTP_HASH_SIZE: u32 = 32u32;
@@ -2323,9 +2283,6 @@ impl Default for MGM_IF_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MGM_IF_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MGM_JOIN_STATE_FLAG: u32 = 1u32;
 pub const MGM_MFE_STATS_0: u32 = 1u32;
 pub const MGM_MFE_STATS_1: u32 = 2u32;
@@ -2352,10 +2309,6 @@ impl Default for MPRAPI_ADMIN_DLL_CALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MPRAPI_ADMIN_DLL_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MPRAPI_ADMIN_DLL_VERSION_1: u32 = 1u32;
 pub const MPRAPI_ADMIN_DLL_VERSION_2: u32 = 2u32;
@@ -2390,9 +2343,6 @@ impl Default for MPRAPI_OBJECT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPRAPI_OBJECT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MPRAPI_OBJECT_TYPE(pub i32);
@@ -2425,10 +2375,6 @@ impl Default for MPRAPI_TUNNEL_CONFIG_PARAMS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for MPRAPI_TUNNEL_CONFIG_PARAMS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2444,10 +2390,6 @@ impl Default for MPRAPI_TUNNEL_CONFIG_PARAMS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for MPRAPI_TUNNEL_CONFIG_PARAMS1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MPRDM_DialAll: MPR_INTERFACE_DIAL_MODE = MPR_INTERFACE_DIAL_MODE(1u32);
 pub const MPRDM_DialAsNeeded: MPR_INTERFACE_DIAL_MODE = MPR_INTERFACE_DIAL_MODE(2u32);
@@ -2508,9 +2450,6 @@ impl Default for MPR_CERT_EKU {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPR_CERT_EKU {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MPR_CREDENTIALSEX_0 {
@@ -2521,9 +2460,6 @@ impl Default for MPR_CREDENTIALSEX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPR_CREDENTIALSEX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2536,9 +2472,6 @@ impl Default for MPR_CREDENTIALSEX_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPR_CREDENTIALSEX_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MPR_DEVICE_0 {
@@ -2549,9 +2482,6 @@ impl Default for MPR_DEVICE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPR_DEVICE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2565,9 +2495,6 @@ impl Default for MPR_DEVICE_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPR_DEVICE_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MPR_ENABLE_RAS_ON_DEVICE: u32 = 1u32;
 pub const MPR_ENABLE_ROUTING_ON_DEVICE: u32 = 2u32;
@@ -2588,9 +2515,6 @@ impl Default for MPR_FILTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPR_FILTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MPR_IFTRANSPORT_0 {
@@ -2602,9 +2526,6 @@ impl Default for MPR_IFTRANSPORT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPR_IFTRANSPORT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2620,10 +2541,6 @@ impl Default for MPR_IF_CUSTOMINFOEX0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for MPR_IF_CUSTOMINFOEX0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2638,10 +2555,6 @@ impl Default for MPR_IF_CUSTOMINFOEX1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for MPR_IF_CUSTOMINFOEX1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2655,10 +2568,6 @@ impl Default for MPR_IF_CUSTOMINFOEX2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
-impl windows_core::TypeKind for MPR_IF_CUSTOMINFOEX2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2676,9 +2585,6 @@ impl Default for MPR_INTERFACE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPR_INTERFACE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MPR_INTERFACE_1 {
@@ -2695,9 +2601,6 @@ impl Default for MPR_INTERFACE_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPR_INTERFACE_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2744,9 +2647,6 @@ impl Default for MPR_INTERFACE_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPR_INTERFACE_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2800,10 +2700,6 @@ impl Default for MPR_INTERFACE_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MPR_INTERFACE_3 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MPR_INTERFACE_ADMIN_DISABLED: u32 = 2u32;
 pub const MPR_INTERFACE_CONNECTION_FAILURE: u32 = 4u32;
 pub const MPR_INTERFACE_DIALOUT_HOURS_RESTRICTION: u32 = 16u32;
@@ -2824,9 +2720,6 @@ impl Default for MPR_IPINIP_INTERFACE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPR_IPINIP_INTERFACE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MPR_MaxAreaCode: u32 = 10u32;
 pub const MPR_MaxCallbackNumber: u32 = 128u32;
@@ -2853,9 +2746,6 @@ impl Default for MPR_SERVER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPR_SERVER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MPR_SERVER_1 {
@@ -2868,9 +2758,6 @@ impl Default for MPR_SERVER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPR_SERVER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2886,9 +2773,6 @@ impl Default for MPR_SERVER_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPR_SERVER_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2908,10 +2792,6 @@ impl Default for MPR_SERVER_EX0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for MPR_SERVER_EX0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2930,10 +2810,6 @@ impl Default for MPR_SERVER_EX1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for MPR_SERVER_EX1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2947,10 +2823,6 @@ impl Default for MPR_SERVER_SET_CONFIG_EX0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for MPR_SERVER_SET_CONFIG_EX0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2966,10 +2838,6 @@ impl Default for MPR_SERVER_SET_CONFIG_EX1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for MPR_SERVER_SET_CONFIG_EX1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MPR_TRANSPORT_0 {
@@ -2981,9 +2849,6 @@ impl Default for MPR_TRANSPORT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPR_TRANSPORT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -3003,10 +2868,6 @@ impl Default for MPR_VPN_TRAFFIC_SELECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MPR_VPN_TRAFFIC_SELECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3021,10 +2882,6 @@ impl Default for MPR_VPN_TRAFFIC_SELECTORS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for MPR_VPN_TRAFFIC_SELECTORS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MPR_VPN_TS_IPv4_ADDR_RANGE: MPR_VPN_TS_TYPE = MPR_VPN_TS_TYPE(7i32);
 pub const MPR_VPN_TS_IPv6_ADDR_RANGE: MPR_VPN_TS_TYPE = MPR_VPN_TS_TYPE(8i32);
@@ -3095,9 +2952,6 @@ impl Default for PPP_ATCP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPP_ATCP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PPP_CCP_COMPRESSION: u32 = 1u32;
 pub const PPP_CCP_ENCRYPTION128BIT: u32 = 64u32;
 pub const PPP_CCP_ENCRYPTION40BIT: u32 = 32u32;
@@ -3118,9 +2972,6 @@ impl Default for PPP_CCP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPP_CCP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPP_INFO {
@@ -3133,9 +2984,6 @@ impl Default for PPP_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPP_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3152,9 +3000,6 @@ impl Default for PPP_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPP_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPP_INFO_3 {
@@ -3169,9 +3014,6 @@ impl Default for PPP_INFO_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPP_INFO_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPP_IPCP_INFO {
@@ -3183,9 +3025,6 @@ impl Default for PPP_IPCP_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPP_IPCP_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3200,9 +3039,6 @@ impl Default for PPP_IPCP_INFO2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPP_IPCP_INFO2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PPP_IPCP_VJ: u32 = 1u32;
 #[repr(C)]
@@ -3223,9 +3059,6 @@ impl Default for PPP_IPV6_CP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPP_IPV6_CP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPP_IPXCP_INFO {
@@ -3236,9 +3069,6 @@ impl Default for PPP_IPXCP_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPP_IPXCP_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3277,9 +3107,6 @@ impl Default for PPP_LCP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPP_LCP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PPP_LCP_INFO_AUTH_DATA(pub u32);
@@ -3298,9 +3125,6 @@ impl Default for PPP_NBFCP_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPP_NBFCP_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3338,9 +3162,6 @@ impl Default for PPP_PROJECTION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPP_PROJECTION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3380,9 +3201,6 @@ impl Default for PPP_PROJECTION_INFO2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPP_PROJECTION_INFO2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPTP_CONFIG_PARAMS {
@@ -3393,9 +3211,6 @@ impl Default for PPTP_CONFIG_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPTP_CONFIG_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3408,9 +3223,6 @@ impl Default for PROJECTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROJECTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROJECTION_INFO_0 {
@@ -3421,9 +3233,6 @@ impl Default for PROJECTION_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROJECTION_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3436,9 +3245,6 @@ impl Default for PROJECTION_INFO2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROJECTION_INFO2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROJECTION_INFO2_0 {
@@ -3449,9 +3255,6 @@ impl Default for PROJECTION_INFO2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROJECTION_INFO2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROJECTION_INFO_TYPE_IKEv2: RASPROJECTION_INFO_TYPE = RASPROJECTION_INFO_TYPE(2i32);
 pub const PROJECTION_INFO_TYPE_PPP: RASPROJECTION_INFO_TYPE = RASPROJECTION_INFO_TYPE(1i32);
@@ -3472,9 +3275,6 @@ impl Default for RASADPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASADPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RASADP_ConnectionQueryTimeout: u32 = 4u32;
 pub const RASADP_DisableConnectionQuery: u32 = 0u32;
 pub const RASADP_FailedConnectionTimeout: u32 = 3u32;
@@ -3493,9 +3293,6 @@ impl Default for RASAMBA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASAMBA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASAMBW {
@@ -3508,9 +3305,6 @@ impl Default for RASAMBW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASAMBW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3532,9 +3326,6 @@ impl Default for RASAUTODIALENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASAUTODIALENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASAUTODIALENTRYW {
@@ -3547,9 +3338,6 @@ impl Default for RASAUTODIALENTRYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASAUTODIALENTRYW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RASBASE: u32 = 600u32;
 pub const RASBASEEND: u32 = 877u32;
@@ -3592,9 +3380,6 @@ impl Default for RASCOMMSETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASCOMMSETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3617,10 +3402,6 @@ impl Default for RASCONNA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for RASCONNA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -3642,10 +3423,6 @@ impl Default for RASCONNA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for RASCONNA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3670,10 +3447,6 @@ impl Default for RASCONNSTATUSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RASCONNSTATUSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -3693,10 +3466,6 @@ impl Default for RASCONNSTATUSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RASCONNSTATUSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3723,10 +3492,6 @@ impl Default for RASCONNW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for RASCONNW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -3749,10 +3514,6 @@ impl Default for RASCONNW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for RASCONNW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASCREDENTIALSA {
@@ -3767,9 +3528,6 @@ impl Default for RASCREDENTIALSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASCREDENTIALSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASCREDENTIALSW {
@@ -3783,9 +3541,6 @@ impl Default for RASCREDENTIALSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASCREDENTIALSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RASCSS_DONE: u32 = 8192u32;
 pub const RASCSS_Dormant: RASCONNSUBSTATE = RASCONNSUBSTATE(1i32);
@@ -3840,9 +3595,6 @@ impl Default for RASCTRYINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASCTRYINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct RASCUSTOMSCRIPTEXTENSIONS {
@@ -3853,9 +3605,6 @@ impl Default for RASCUSTOMSCRIPTEXTENSIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASCUSTOMSCRIPTEXTENSIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RASDDFLAG_AoacRedial: u32 = 4u32;
 pub const RASDDFLAG_LinkFailure: u32 = 2147483648u32;
@@ -3873,9 +3622,6 @@ impl Default for RASDEVINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASDEVINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASDEVINFOW {
@@ -3887,9 +3633,6 @@ impl Default for RASDEVINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASDEVINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -3903,10 +3646,6 @@ impl Default for RASDEVSPECIFICINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for RASDEVSPECIFICINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -3920,10 +3659,6 @@ impl Default for RASDEVSPECIFICINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for RASDEVSPECIFICINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -3943,9 +3678,6 @@ impl Default for RASDIALDLG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASDIALDLG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RASDIALEVENT: windows_core::PCSTR = windows_core::s!("RasDialEvent");
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -3963,9 +3695,6 @@ impl Default for RASDIALEXTENSIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASDIALEXTENSIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub type RASDIALFUNC = Option<unsafe extern "system" fn(param0: u32, param1: RASCONNSTATE, param2: u32)>;
 pub type RASDIALFUNC1 = Option<unsafe extern "system" fn(param0: HRASCONN, param1: u32, param2: RASCONNSTATE, param3: u32, param4: u32)>;
@@ -3992,10 +3721,6 @@ impl Default for RASDIALPARAMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for RASDIALPARAMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -4017,10 +3742,6 @@ impl Default for RASDIALPARAMSA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for RASDIALPARAMSA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -4044,10 +3765,6 @@ impl Default for RASDIALPARAMSW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for RASDIALPARAMSW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -4069,10 +3786,6 @@ impl Default for RASDIALPARAMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for RASDIALPARAMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RASDT_Atm: windows_core::PCWSTR = windows_core::w!("ATM");
 pub const RASDT_FrameRelay: windows_core::PCWSTR = windows_core::w!("FRAMERELAY");
@@ -4102,9 +3815,6 @@ impl Default for RASEAPINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASEAPINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASEAPUSERIDENTITYA {
@@ -4117,9 +3827,6 @@ impl Default for RASEAPUSERIDENTITYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASEAPUSERIDENTITYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASEAPUSERIDENTITYW {
@@ -4131,9 +3838,6 @@ impl Default for RASEAPUSERIDENTITYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASEAPUSERIDENTITYW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RASEDFLAG_CloneEntry: u32 = 4u32;
 pub const RASEDFLAG_IncomingConnection: u32 = 1024u32;
@@ -4221,10 +3925,6 @@ impl Default for RASENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RASENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4244,10 +3944,6 @@ impl Default for RASENTRYDLGA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for RASENTRYDLGA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -4269,10 +3965,6 @@ impl Default for RASENTRYDLGA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for RASENTRYDLGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4293,10 +3985,6 @@ impl Default for RASENTRYDLGW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for RASENTRYDLGW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -4316,10 +4004,6 @@ impl Default for RASENTRYDLGW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for RASENTRYDLGW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4334,9 +4018,6 @@ impl Default for RASENTRYNAMEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASENTRYNAMEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASENTRYNAMEW {
@@ -4349,9 +4030,6 @@ impl Default for RASENTRYNAMEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASENTRYNAMEW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -4424,10 +4102,6 @@ impl Default for RASENTRYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RASENTRYW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4533,11 +4207,6 @@ impl Default for RASIKEV2_PROJECTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RASIKEV2_PROJECTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -4565,11 +4234,6 @@ impl Default for RASIKEV2_PROJECTION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RASIKEV2_PROJECTION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4626,9 +4290,6 @@ impl Default for RASIPADDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASIPADDR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RASIPO_VJ: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4641,9 +4302,6 @@ impl Default for RASIPXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASIPXW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RASLCPAD_CHAP_MD5: RASPPP_PROJECTION_INFO_SERVER_AUTH_DATA = RASPPP_PROJECTION_INFO_SERVER_AUTH_DATA(5u32);
 pub const RASLCPAD_CHAP_MS: RASPPP_PROJECTION_INFO_SERVER_AUTH_DATA = RASPPP_PROJECTION_INFO_SERVER_AUTH_DATA(128u32);
@@ -4679,9 +4337,6 @@ impl Default for RASNOUSERA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASNOUSERA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASNOUSERW {
@@ -4696,9 +4351,6 @@ impl Default for RASNOUSERW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASNOUSERW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RASNOUSER_SmartCard: u32 = 1u32;
 pub const RASNP_Ip: u32 = 4u32;
@@ -4737,10 +4389,6 @@ impl Default for RASPBDLGA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for RASPBDLGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -4761,10 +4409,6 @@ impl Default for RASPBDLGA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for RASPBDLGA {
-    type TypeKind = windows_core::CopyType;
 }
 pub type RASPBDLGFUNCA = Option<unsafe extern "system" fn(param0: usize, param1: u32, param2: windows_core::PCSTR, param3: *mut core::ffi::c_void)>;
 pub type RASPBDLGFUNCW = Option<unsafe extern "system" fn(param0: usize, param1: u32, param2: windows_core::PCWSTR, param3: *mut core::ffi::c_void)>;
@@ -4789,10 +4433,6 @@ impl Default for RASPBDLGW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for RASPBDLGW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -4814,10 +4454,6 @@ impl Default for RASPBDLGW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for RASPBDLGW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASPPPCCP {
@@ -4832,9 +4468,6 @@ impl Default for RASPPPCCP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASPPPCCP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4851,9 +4484,6 @@ impl Default for RASPPPIPA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASPPPIPA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASPPPIPV6 {
@@ -4868,9 +4498,6 @@ impl Default for RASPPPIPV6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASPPPIPV6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4887,9 +4514,6 @@ impl Default for RASPPPIPW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASPPPIPW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASPPPIPXA {
@@ -4901,9 +4525,6 @@ impl Default for RASPPPIPXA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASPPPIPXA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4929,9 +4550,6 @@ impl Default for RASPPPLCPA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASPPPLCPA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASPPPLCPW {
@@ -4956,9 +4574,6 @@ impl Default for RASPPPLCPW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASPPPLCPW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASPPPNBFA {
@@ -4974,9 +4589,6 @@ impl Default for RASPPPNBFA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASPPPNBFA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASPPPNBFW {
@@ -4991,9 +4603,6 @@ impl Default for RASPPPNBFW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RASPPPNBFW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -5028,10 +4637,6 @@ impl Default for RASPPP_PROJECTION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RASPPP_PROJECTION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5073,9 +4678,6 @@ impl Default for RASSUBENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASSUBENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RASSUBENTRYW {
@@ -5091,9 +4693,6 @@ impl Default for RASSUBENTRYW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RASSUBENTRYW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -5107,10 +4706,6 @@ impl Default for RASTUNNELENDPOINT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RASTUNNELENDPOINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -5123,10 +4718,6 @@ impl Default for RASTUNNELENDPOINT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RASTUNNELENDPOINT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RASTUNNELENDPOINT_IPv4: u32 = 1u32;
 pub const RASTUNNELENDPOINT_IPv6: u32 = 2u32;
@@ -5148,10 +4739,6 @@ impl Default for RASUPDATECONN {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RASUPDATECONN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RAS_CONNECTION_0 {
@@ -5169,9 +4756,6 @@ impl Default for RAS_CONNECTION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAS_CONNECTION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5197,9 +4781,6 @@ impl Default for RAS_CONNECTION_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAS_CONNECTION_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RAS_CONNECTION_2 {
@@ -5213,9 +4794,6 @@ impl Default for RAS_CONNECTION_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAS_CONNECTION_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5234,9 +4812,6 @@ impl Default for RAS_CONNECTION_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAS_CONNECTION_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5277,9 +4852,6 @@ impl Default for RAS_CONNECTION_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAS_CONNECTION_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RAS_CONNECTION_EX {
@@ -5317,9 +4889,6 @@ impl Default for RAS_CONNECTION_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAS_CONNECTION_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5369,9 +4938,6 @@ impl Default for RAS_PORT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAS_PORT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RAS_PORT_1 {
@@ -5396,9 +4962,6 @@ impl Default for RAS_PORT_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAS_PORT_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5436,9 +4999,6 @@ impl Default for RAS_PORT_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAS_PORT_2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RAS_PORT_AUTHENTICATED: RAS_PORT_CONDITION = RAS_PORT_CONDITION(5i32);
 pub const RAS_PORT_AUTHENTICATING: RAS_PORT_CONDITION = RAS_PORT_CONDITION(4i32);
 pub const RAS_PORT_CALLING_BACK: RAS_PORT_CONDITION = RAS_PORT_CONDITION(2i32);
@@ -5463,10 +5023,6 @@ impl Default for RAS_PROJECTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RAS_PROJECTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -5479,10 +5035,6 @@ impl Default for RAS_PROJECTION_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for RAS_PROJECTION_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5502,9 +5054,6 @@ impl Default for RAS_SECURITY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAS_SECURITY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5530,9 +5079,6 @@ impl Default for RAS_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAS_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RAS_UPDATE_CONNECTION {
@@ -5546,9 +5092,6 @@ impl Default for RAS_UPDATE_CONNECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAS_UPDATE_CONNECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RAS_USER_0 {
@@ -5559,9 +5102,6 @@ impl Default for RAS_USER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAS_USER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5574,9 +5114,6 @@ impl Default for RAS_USER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAS_USER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RCD_AllUsers: u32 = 1u32;
 pub const RCD_Eap: u32 = 2u32;
@@ -5618,9 +5155,6 @@ impl Default for ROUTER_CUSTOM_IKEv2_POLICY0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ROUTER_CUSTOM_IKEv2_POLICY0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ROUTER_IF_STATE_CONNECTED: ROUTER_CONNECTION_STATE = ROUTER_CONNECTION_STATE(3i32);
 pub const ROUTER_IF_STATE_CONNECTING: ROUTER_CONNECTION_STATE = ROUTER_CONNECTION_STATE(2i32);
 pub const ROUTER_IF_STATE_DISCONNECTED: ROUTER_CONNECTION_STATE = ROUTER_CONNECTION_STATE(1i32);
@@ -5649,10 +5183,6 @@ impl Default for ROUTER_IKEv2_IF_CUSTOM_CONFIG0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for ROUTER_IKEv2_IF_CUSTOM_CONFIG0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5668,10 +5198,6 @@ impl Default for ROUTER_IKEv2_IF_CUSTOM_CONFIG1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for ROUTER_IKEv2_IF_CUSTOM_CONFIG1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
@@ -5690,10 +5216,6 @@ impl Default for ROUTER_IKEv2_IF_CUSTOM_CONFIG2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Networking_WinSock", feature = "Win32_Security_Cryptography"))]
-impl windows_core::TypeKind for ROUTER_IKEv2_IF_CUSTOM_CONFIG2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5716,9 +5238,6 @@ impl Default for ROUTING_PROTOCOL_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ROUTING_PROTOCOL_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RRAS_SERVICE_NAME: windows_core::PCWSTR = windows_core::w!("RemoteAccess");
 pub const RTM_BLOCK_METHODS: u32 = 1u32;
@@ -5744,9 +5263,6 @@ impl Default for RTM_DEST_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTM_DEST_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RTM_DEST_INFO_0 {
@@ -5762,9 +5278,6 @@ impl Default for RTM_DEST_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTM_DEST_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RTM_ENTITY_DEREGISTERED: RTM_EVENT_TYPE = RTM_EVENT_TYPE(1i32);
 pub type RTM_ENTITY_EXPORT_METHOD = Option<unsafe extern "system" fn(callerhandle: isize, calleehandle: isize, input: *mut RTM_ENTITY_METHOD_INPUT, output: *mut RTM_ENTITY_METHOD_OUTPUT)>;
 #[repr(C)]
@@ -5778,9 +5291,6 @@ impl Default for RTM_ENTITY_EXPORT_METHODS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTM_ENTITY_EXPORT_METHODS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RTM_ENTITY_ID {
@@ -5790,9 +5300,6 @@ impl Default for RTM_ENTITY_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTM_ENTITY_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5805,9 +5312,6 @@ impl Default for RTM_ENTITY_ID_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTM_ENTITY_ID_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RTM_ENTITY_ID_0_0 {
@@ -5818,9 +5322,6 @@ impl Default for RTM_ENTITY_ID_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTM_ENTITY_ID_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5834,9 +5335,6 @@ impl Default for RTM_ENTITY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTM_ENTITY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RTM_ENTITY_METHOD_INPUT {
@@ -5848,9 +5346,6 @@ impl Default for RTM_ENTITY_METHOD_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTM_ENTITY_METHOD_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5864,9 +5359,6 @@ impl Default for RTM_ENTITY_METHOD_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTM_ENTITY_METHOD_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RTM_ENTITY_REGISTERED: RTM_EVENT_TYPE = RTM_EVENT_TYPE(0i32);
 pub const RTM_ENUM_ALL_DESTS: u32 = 0u32;
@@ -5901,9 +5393,6 @@ impl Default for RTM_NET_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTM_NET_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RTM_NEXTHOP_CHANGE_NEW: u32 = 1u32;
 pub const RTM_NEXTHOP_FLAGS_DOWN: u32 = 2u32;
 pub const RTM_NEXTHOP_FLAGS_REMOTE: u32 = 1u32;
@@ -5923,9 +5412,6 @@ impl Default for RTM_NEXTHOP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTM_NEXTHOP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RTM_NEXTHOP_LIST {
@@ -5936,9 +5422,6 @@ impl Default for RTM_NEXTHOP_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTM_NEXTHOP_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RTM_NEXTHOP_STATE_CREATED: u32 = 0u32;
 pub const RTM_NEXTHOP_STATE_DELETED: u32 = 1u32;
@@ -5955,9 +5438,6 @@ impl Default for RTM_PREF_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTM_PREF_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RTM_REGN_PROFILE {
@@ -5970,9 +5450,6 @@ impl Default for RTM_REGN_PROFILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTM_REGN_PROFILE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RTM_RESUME_METHODS: u32 = 0u32;
 pub const RTM_ROUTE_CHANGE_BEST: u32 = 65536u32;
@@ -6013,9 +5490,6 @@ impl Default for RTM_ROUTE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTM_ROUTE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RTM_ROUTE_STATE_CREATED: u32 = 0u32;
 pub const RTM_ROUTE_STATE_DELETED: u32 = 2u32;
 pub const RTM_ROUTE_STATE_DELETING: u32 = 1u32;
@@ -6050,9 +5524,6 @@ impl Default for SECURITY_MESSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURITY_MESSAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SECURITY_MESSAGE_MSG_ID(pub u32);
@@ -6069,9 +5540,6 @@ impl Default for SOURCE_GROUP_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOURCE_GROUP_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6084,10 +5552,6 @@ impl Default for SSTP_CERT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SSTP_CERT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -6105,10 +5569,6 @@ impl Default for SSTP_CONFIG_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SSTP_CONFIG_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -6122,10 +5582,6 @@ impl Default for VPN_TS_IP_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for VPN_TS_IP_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -6138,10 +5594,6 @@ impl Default for VPN_TS_IP_ADDRESS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for VPN_TS_IP_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VS_Default: u32 = 0u32;
 pub const VS_GREOnly: u32 = 9u32;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Snmp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Snmp/mod.rs
@@ -453,9 +453,6 @@ impl Default for AsnAny {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AsnAny {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub union AsnAny_0 {
@@ -477,9 +474,6 @@ impl Default for AsnAny_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AsnAny_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -493,10 +487,6 @@ impl Default for AsnObjectIdentifier {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for AsnObjectIdentifier {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -509,10 +499,6 @@ impl Default for AsnObjectIdentifier {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for AsnObjectIdentifier {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -528,10 +514,6 @@ impl Default for AsnOctetString {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for AsnOctetString {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -545,10 +527,6 @@ impl Default for AsnOctetString {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for AsnOctetString {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEFAULT_SNMPTRAP_PORT_IPX: u32 = 36880u32;
 pub const DEFAULT_SNMPTRAP_PORT_UDP: u32 = 162u32;
@@ -753,9 +731,6 @@ impl Default for SnmpVarBind {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SnmpVarBind {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -768,10 +743,6 @@ impl Default for SnmpVarBindList {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SnmpVarBindList {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -786,10 +757,6 @@ impl Default for SnmpVarBindList {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SnmpVarBindList {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct smiCNTR64 {
@@ -800,9 +767,6 @@ impl Default for smiCNTR64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for smiCNTR64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -815,9 +779,6 @@ impl Default for smiOCTETS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for smiOCTETS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct smiOID {
@@ -829,9 +790,6 @@ impl Default for smiOID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for smiOID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct smiVALUE {
@@ -842,9 +800,6 @@ impl Default for smiVALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for smiVALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -861,9 +816,6 @@ impl Default for smiVALUE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for smiVALUE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct smiVENDORINFO {
@@ -877,7 +829,4 @@ impl Default for smiVENDORINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for smiVENDORINFO {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WNet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WNet/mod.rs
@@ -484,9 +484,6 @@ impl Default for CONNECTDLGSTRUCTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONNECTDLGSTRUCTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONNECTDLGSTRUCTW {
@@ -500,9 +497,6 @@ impl Default for CONNECTDLGSTRUCTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONNECTDLGSTRUCTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -573,9 +567,6 @@ impl Default for DISCDLGSTRUCTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISCDLGSTRUCTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISCDLGSTRUCTW {
@@ -589,9 +580,6 @@ impl Default for DISCDLGSTRUCTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISCDLGSTRUCTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -645,9 +633,6 @@ impl Default for NETCONNECTINFOSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETCONNECTINFOSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETINFOSTRUCT {
@@ -664,9 +649,6 @@ impl Default for NETINFOSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETINFOSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -725,9 +707,6 @@ impl Default for NETRESOURCEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETRESOURCEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETRESOURCEW {
@@ -744,9 +723,6 @@ impl Default for NETRESOURCEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETRESOURCEW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -838,9 +814,6 @@ impl Default for NOTIFYADD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NOTIFYADD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NOTIFYCANCEL {
@@ -854,9 +827,6 @@ impl Default for NOTIFYCANCEL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NOTIFYCANCEL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NOTIFYINFO {
@@ -868,9 +838,6 @@ impl Default for NOTIFYINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NOTIFYINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NOTIFY_POST: u32 = 2u32;
 pub const NOTIFY_PRE: u32 = 1u32;
@@ -923,9 +890,6 @@ impl Default for REMOTE_NAME_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REMOTE_NAME_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REMOTE_NAME_INFOW {
@@ -937,9 +901,6 @@ impl Default for REMOTE_NAME_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REMOTE_NAME_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REMOTE_NAME_INFO_LEVEL: UNC_INFO_LEVEL = UNC_INFO_LEVEL(2u32);
 pub const RESOURCEDISPLAYTYPE_DIRECTORY: u32 = 9u32;
@@ -978,9 +939,6 @@ impl Default for UNIVERSAL_NAME_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UNIVERSAL_NAME_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UNIVERSAL_NAME_INFOW {
@@ -990,9 +948,6 @@ impl Default for UNIVERSAL_NAME_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UNIVERSAL_NAME_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UNIVERSAL_NAME_INFO_LEVEL: UNC_INFO_LEVEL = UNC_INFO_LEVEL(1u32);
 pub const WNCON_DYNAMIC: u32 = 8u32;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WebDav/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WebDav/mod.rs
@@ -97,9 +97,6 @@ impl Default for DAV_CALLBACK_AUTH_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DAV_CALLBACK_AUTH_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DAV_CALLBACK_AUTH_UNP {
@@ -113,9 +110,6 @@ impl Default for DAV_CALLBACK_AUTH_UNP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DAV_CALLBACK_AUTH_UNP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DAV_CALLBACK_CRED {
@@ -128,9 +122,6 @@ impl Default for DAV_CALLBACK_CRED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DAV_CALLBACK_CRED {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DefaultBehavior: AUTHNEXTSTEP = AUTHNEXTSTEP(0i32);
 pub type PFNDAVAUTHCALLBACK = Option<unsafe extern "system" fn(lpwzservername: windows_core::PCWSTR, lpwzremotename: windows_core::PCWSTR, dwauthscheme: u32, dwflags: u32, pcallbackcred: *mut DAV_CALLBACK_CRED, nextstep: *mut AUTHNEXTSTEP, pfreecred: *mut PFNDAVAUTHCALLBACK_FREECRED) -> u32>;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
@@ -580,10 +580,6 @@ impl Default for DOT11EXT_APIS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol"))]
-impl windows_core::TypeKind for DOT11EXT_APIS {
-    type TypeKind = windows_core::CopyType;
-}
 pub type DOT11EXT_FREE_BUFFER = Option<unsafe extern "system" fn(pvmemory: *const core::ffi::c_void)>;
 pub type DOT11EXT_GET_PROFILE_CUSTOM_USER_DATA = Option<unsafe extern "system" fn(hdot11svchandle: super::super::Foundation::HANDLE, hconnectsession: super::super::Foundation::HANDLE, dwsessionid: u32, pdwdatasize: *mut u32, ppvdata: *mut *mut core::ffi::c_void) -> u32>;
 #[repr(transparent)]
@@ -599,9 +595,6 @@ impl Default for DOT11EXT_IHV_CONNECTIVITY_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11EXT_IHV_CONNECTIVITY_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11EXT_IHV_DISCOVERY_PROFILE {
@@ -613,9 +606,6 @@ impl Default for DOT11EXT_IHV_DISCOVERY_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11EXT_IHV_DISCOVERY_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11EXT_IHV_DISCOVERY_PROFILE_LIST {
@@ -626,9 +616,6 @@ impl Default for DOT11EXT_IHV_DISCOVERY_PROFILE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11EXT_IHV_DISCOVERY_PROFILE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol", feature = "Win32_System_RemoteDesktop"))]
@@ -660,10 +647,6 @@ impl Default for DOT11EXT_IHV_HANDLERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_Ndis", feature = "Win32_Security_ExtensibleAuthenticationProtocol", feature = "Win32_System_RemoteDesktop"))]
-impl windows_core::TypeKind for DOT11EXT_IHV_HANDLERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DOT11EXT_IHV_INDICATION_TYPE(pub i32);
@@ -682,10 +665,6 @@ impl Default for DOT11EXT_IHV_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
-impl windows_core::TypeKind for DOT11EXT_IHV_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -700,10 +679,6 @@ impl Default for DOT11EXT_IHV_PROFILE_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
-impl windows_core::TypeKind for DOT11EXT_IHV_PROFILE_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11EXT_IHV_SECURITY_PROFILE {
@@ -715,9 +690,6 @@ impl Default for DOT11EXT_IHV_SECURITY_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11EXT_IHV_SECURITY_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11EXT_IHV_SSID_LIST {
@@ -728,9 +700,6 @@ impl Default for DOT11EXT_IHV_SSID_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11EXT_IHV_SSID_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -745,9 +714,6 @@ impl Default for DOT11EXT_IHV_UI_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11EXT_IHV_UI_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub type DOT11EXT_NIC_SPECIFIC_EXTENSION = Option<unsafe extern "system" fn(hdot11svchandle: super::super::Foundation::HANDLE, dwinbuffersize: u32, pvinbuffer: *const core::ffi::c_void, pdwoutbuffersize: *mut u32, pvoutbuffer: *mut core::ffi::c_void) -> u32>;
 #[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
@@ -788,9 +754,6 @@ impl Default for DOT11EXT_VIRTUAL_STATION_APIS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11EXT_VIRTUAL_STATION_APIS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11EXT_VIRTUAL_STATION_AP_PROPERTY {
@@ -806,9 +769,6 @@ impl Default for DOT11EXT_VIRTUAL_STATION_AP_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11EXT_VIRTUAL_STATION_AP_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_ACCESSNETWORKOPTIONS {
@@ -822,9 +782,6 @@ impl Default for DOT11_ACCESSNETWORKOPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_ACCESSNETWORKOPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -841,9 +798,6 @@ impl Default for DOT11_ADAPTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_ADAPTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -859,10 +813,6 @@ impl Default for DOT11_ADDITIONAL_IE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_ADDITIONAL_IE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_ADDITIONAL_IE_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -907,10 +857,6 @@ impl Default for DOT11_ANQP_QUERY_COMPLETE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_ANQP_QUERY_COMPLETE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_ANQP_QUERY_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -927,9 +873,6 @@ impl Default for DOT11_AP_JOIN_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_AP_JOIN_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -968,10 +911,6 @@ impl Default for DOT11_ASSOCIATION_COMPLETION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_ASSOCIATION_COMPLETION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_ASSOCIATION_COMPLETION_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const DOT11_ASSOCIATION_COMPLETION_PARAMETERS_REVISION_2: u32 = 2u32;
 #[repr(C)]
@@ -996,9 +935,6 @@ impl Default for DOT11_ASSOCIATION_INFO_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_ASSOCIATION_INFO_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1013,10 +949,6 @@ impl Default for DOT11_ASSOCIATION_INFO_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_ASSOCIATION_INFO_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_ASSOCIATION_INFO_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -1034,10 +966,6 @@ impl Default for DOT11_ASSOCIATION_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_ASSOCIATION_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_ASSOCIATION_PARAMS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -1054,10 +982,6 @@ impl Default for DOT11_ASSOCIATION_START_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_ASSOCIATION_START_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_ASSOCIATION_START_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -1084,10 +1008,6 @@ impl Default for DOT11_AUTH_ALGORITHM_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_AUTH_ALGORITHM_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_AUTH_ALGORITHM_LIST_REVISION_1: u32 = 1u32;
 pub const DOT11_AUTH_ALGO_80211_OPEN: DOT11_AUTH_ALGORITHM = DOT11_AUTH_ALGORITHM(1i32);
@@ -1116,9 +1036,6 @@ impl Default for DOT11_AUTH_CIPHER_PAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_AUTH_CIPHER_PAIR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1133,10 +1050,6 @@ impl Default for DOT11_AUTH_CIPHER_PAIR_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_AUTH_CIPHER_PAIR_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_AUTH_CIPHER_PAIR_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -1154,10 +1067,6 @@ impl Default for DOT11_AVAILABLE_CHANNEL_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_AVAILABLE_CHANNEL_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_AVAILABLE_CHANNEL_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -1174,10 +1083,6 @@ impl Default for DOT11_AVAILABLE_FREQUENCY_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_AVAILABLE_FREQUENCY_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_AVAILABLE_FREQUENCY_LIST_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1193,9 +1098,6 @@ impl Default for DOT11_BSSID_CANDIDATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_BSSID_CANDIDATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1210,10 +1112,6 @@ impl Default for DOT11_BSSID_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_BSSID_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_BSSID_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -1232,9 +1130,6 @@ impl Default for DOT11_BSS_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_BSS_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1258,9 +1153,6 @@ impl Default for DOT11_BSS_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_BSS_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_BSS_ENTRY_BYTE_ARRAY_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1272,9 +1164,6 @@ impl Default for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1288,9 +1177,6 @@ impl Default for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_BSS_ENTRY_PHY_SPECIFIC_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_BSS_LIST {
@@ -1301,9 +1187,6 @@ impl Default for DOT11_BSS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_BSS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1323,10 +1206,6 @@ impl Default for DOT11_BYTE_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_BYTE_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1339,10 +1218,6 @@ impl Default for DOT11_CAN_SUSTAIN_AP_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_CAN_SUSTAIN_AP_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_CAN_SUSTAIN_AP_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const DOT11_CAN_SUSTAIN_AP_REASON_IHV_END: u32 = 4294967295u32;
@@ -1373,9 +1248,6 @@ impl Default for DOT11_CHANNEL_HINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_CHANNEL_HINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DOT11_CIPHER_ALGORITHM(pub i32);
@@ -1393,10 +1265,6 @@ impl Default for DOT11_CIPHER_ALGORITHM_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_CIPHER_ALGORITHM_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_CIPHER_ALGORITHM_LIST_REVISION_1: u32 = 1u32;
 pub const DOT11_CIPHER_ALGO_BIP: DOT11_CIPHER_ALGORITHM = DOT11_CIPHER_ALGORITHM(6i32);
@@ -1435,10 +1303,6 @@ impl Default for DOT11_CIPHER_DEFAULT_KEY_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_CIPHER_DEFAULT_KEY_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_CIPHER_DEFAULT_KEY_VALUE_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1456,9 +1320,6 @@ impl Default for DOT11_CIPHER_KEY_MAPPING_KEY_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_CIPHER_KEY_MAPPING_KEY_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_CIPHER_KEY_MAPPING_KEY_VALUE_BYTE_ARRAY_REVISION_1: u32 = 1u32;
 pub const DOT11_CONF_ALGO_TKIP: u32 = 2u32;
 pub const DOT11_CONF_ALGO_WEP_RC4: u32 = 1u32;
@@ -1475,10 +1336,6 @@ impl Default for DOT11_CONNECTION_COMPLETION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_CONNECTION_COMPLETION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_CONNECTION_COMPLETION_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -1494,10 +1351,6 @@ impl Default for DOT11_CONNECTION_START_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_CONNECTION_START_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_CONNECTION_START_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const DOT11_CONNECTION_STATUS_SUCCESS: u32 = 0u32;
@@ -1523,9 +1376,6 @@ impl Default for DOT11_COUNTERS_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_COUNTERS_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1541,10 +1391,6 @@ impl Default for DOT11_COUNTRY_OR_REGION_STRING_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_COUNTRY_OR_REGION_STRING_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_COUNTRY_OR_REGION_STRING_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1557,9 +1403,6 @@ impl Default for DOT11_CURRENT_OFFLOAD_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_CURRENT_OFFLOAD_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_CURRENT_OPERATION_MODE {
@@ -1570,9 +1413,6 @@ impl Default for DOT11_CURRENT_OPERATION_MODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_CURRENT_OPERATION_MODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1588,9 +1428,6 @@ impl Default for DOT11_CURRENT_OPTIONAL_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_CURRENT_OPTIONAL_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_DATA_RATE_MAPPING_ENTRY {
@@ -1602,9 +1439,6 @@ impl Default for DOT11_DATA_RATE_MAPPING_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_DATA_RATE_MAPPING_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -1619,10 +1453,6 @@ impl Default for DOT11_DATA_RATE_MAPPING_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_DATA_RATE_MAPPING_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_DATA_RATE_MAPPING_TABLE_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -1648,9 +1478,6 @@ impl Default for DOT11_DEFAULT_WEP_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_DEFAULT_WEP_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_DEFAULT_WEP_UPLOAD {
@@ -1665,9 +1492,6 @@ impl Default for DOT11_DEFAULT_WEP_UPLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_DEFAULT_WEP_UPLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_DEVICE_ENTRY_BYTE_ARRAY_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -1690,10 +1514,6 @@ impl Default for DOT11_DISASSOCIATE_PEER_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_DISASSOCIATE_PEER_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_DISASSOCIATE_PEER_REQUEST_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -1711,10 +1531,6 @@ impl Default for DOT11_DISASSOCIATION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_DISASSOCIATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_DISASSOCIATION_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1727,9 +1543,6 @@ impl Default for DOT11_DIVERSITY_SELECTION_RX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_DIVERSITY_SELECTION_RX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_DIVERSITY_SELECTION_RX_LIST {
@@ -1741,9 +1554,6 @@ impl Default for DOT11_DIVERSITY_SELECTION_RX_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_DIVERSITY_SELECTION_RX_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1767,10 +1577,6 @@ impl Default for DOT11_EAP_RESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
-impl windows_core::TypeKind for DOT11_EAP_RESULT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_ENCAP_802_1H: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1782,9 +1588,6 @@ impl Default for DOT11_ENCAP_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_ENCAP_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_ENCAP_RFC_1042: u32 = 1u32;
 #[repr(C)]
@@ -1799,9 +1602,6 @@ impl Default for DOT11_ERP_PHY_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_ERP_PHY_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_EXEMPT_ALWAYS: u32 = 1u32;
 pub const DOT11_EXEMPT_BOTH: u32 = 3u32;
@@ -1833,10 +1633,6 @@ impl Default for DOT11_EXTAP_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_EXTAP_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_EXTAP_ATTRIBUTES_REVISION_1: u32 = 1u32;
 pub const DOT11_EXTAP_RECV_CONTEXT_REVISION_1: u32 = 1u32;
@@ -1886,10 +1682,6 @@ impl Default for DOT11_EXTSTA_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_EXTSTA_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_EXTSTA_ATTRIBUTES_REVISION_1: u32 = 1u32;
 pub const DOT11_EXTSTA_ATTRIBUTES_REVISION_2: u32 = 2u32;
 pub const DOT11_EXTSTA_ATTRIBUTES_REVISION_3: u32 = 3u32;
@@ -1919,10 +1711,6 @@ impl Default for DOT11_EXTSTA_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_EXTSTA_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_EXTSTA_CAPABILITY_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -1945,10 +1733,6 @@ impl Default for DOT11_EXTSTA_RECV_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_EXTSTA_RECV_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_EXTSTA_RECV_CONTEXT_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -1966,10 +1750,6 @@ impl Default for DOT11_EXTSTA_SEND_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_EXTSTA_SEND_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_EXTSTA_SEND_CONTEXT_REVISION_1: u32 = 1u32;
 pub const DOT11_FLAGS_80211B_CHANNEL_AGILITY: u32 = 4u32;
@@ -1991,9 +1771,6 @@ impl Default for DOT11_FRAGMENT_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_FRAGMENT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_FREQUENCY_BANDS_LOWER: u32 = 1u32;
 pub const DOT11_FREQUENCY_BANDS_MIDDLE: u32 = 2u32;
 pub const DOT11_FREQUENCY_BANDS_UPPER: u32 = 4u32;
@@ -2014,10 +1791,6 @@ impl Default for DOT11_GO_NEGOTIATION_CONFIRMATION_SEND_COMPLETE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_GO_NEGOTIATION_CONFIRMATION_SEND_COMPLETE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_GO_NEGOTIATION_CONFIRMATION_SEND_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2035,10 +1808,6 @@ impl Default for DOT11_GO_NEGOTIATION_REQUEST_SEND_COMPLETE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_GO_NEGOTIATION_REQUEST_SEND_COMPLETE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_GO_NEGOTIATION_REQUEST_SEND_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -2058,10 +1827,6 @@ impl Default for DOT11_GO_NEGOTIATION_RESPONSE_SEND_COMPLETE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_GO_NEGOTIATION_RESPONSE_SEND_COMPLETE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_GO_NEGOTIATION_RESPONSE_SEND_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const DOT11_HESSID_LENGTH: u32 = 6u32;
 #[repr(C)]
@@ -2075,9 +1840,6 @@ impl Default for DOT11_HOPPING_PATTERN_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_HOPPING_PATTERN_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_HOPPING_PATTERN_ENTRY_LIST {
@@ -2089,9 +1851,6 @@ impl Default for DOT11_HOPPING_PATTERN_ENTRY_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_HOPPING_PATTERN_ENTRY_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2108,9 +1867,6 @@ impl Default for DOT11_HRDSSS_PHY_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_HRDSSS_PHY_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_HR_CCA_MODE_CS_AND_ED: u32 = 4u32;
 pub const DOT11_HR_CCA_MODE_CS_ONLY: u32 = 2u32;
@@ -2138,10 +1894,6 @@ impl Default for DOT11_IBSS_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_IBSS_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_IBSS_PARAMS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2153,9 +1905,6 @@ impl Default for DOT11_IHV_VERSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_IHV_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2185,10 +1934,6 @@ impl Default for DOT11_INCOMING_ASSOC_COMPLETION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_INCOMING_ASSOC_COMPLETION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_INCOMING_ASSOC_COMPLETION_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2206,10 +1951,6 @@ impl Default for DOT11_INCOMING_ASSOC_DECISION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_INCOMING_ASSOC_DECISION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_INCOMING_ASSOC_DECISION_REVISION_1: u32 = 1u32;
 pub const DOT11_INCOMING_ASSOC_DECISION_REVISION_2: u32 = 2u32;
@@ -2231,10 +1972,6 @@ impl Default for DOT11_INCOMING_ASSOC_DECISION_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_INCOMING_ASSOC_DECISION_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2251,10 +1988,6 @@ impl Default for DOT11_INCOMING_ASSOC_REQUEST_RECEIVED_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_INCOMING_ASSOC_REQUEST_RECEIVED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_INCOMING_ASSOC_REQUEST_RECEIVED_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2268,10 +2001,6 @@ impl Default for DOT11_INCOMING_ASSOC_STARTED_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_INCOMING_ASSOC_STARTED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_INCOMING_ASSOC_STARTED_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const DOT11_INVALID_CHANNEL_NUMBER: u32 = 0u32;
@@ -2293,10 +2022,6 @@ impl Default for DOT11_INVITATION_REQUEST_SEND_COMPLETE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_INVITATION_REQUEST_SEND_COMPLETE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_INVITATION_REQUEST_SEND_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2315,10 +2040,6 @@ impl Default for DOT11_INVITATION_RESPONSE_SEND_COMPLETE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_INVITATION_RESPONSE_SEND_COMPLETE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_INVITATION_RESPONSE_SEND_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2330,9 +2051,6 @@ impl Default for DOT11_IV48_COUNTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_IV48_COUNTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2347,9 +2065,6 @@ impl Default for DOT11_JOIN_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_JOIN_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_KEY_ALGO_BIP {
@@ -2361,9 +2076,6 @@ impl Default for DOT11_KEY_ALGO_BIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_KEY_ALGO_BIP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2377,9 +2089,6 @@ impl Default for DOT11_KEY_ALGO_BIP_GMAC_256 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_KEY_ALGO_BIP_GMAC_256 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_KEY_ALGO_CCMP {
@@ -2391,9 +2100,6 @@ impl Default for DOT11_KEY_ALGO_CCMP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_KEY_ALGO_CCMP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2407,9 +2113,6 @@ impl Default for DOT11_KEY_ALGO_GCMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_KEY_ALGO_GCMP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_KEY_ALGO_GCMP_256 {
@@ -2421,9 +2124,6 @@ impl Default for DOT11_KEY_ALGO_GCMP_256 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_KEY_ALGO_GCMP_256 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2437,9 +2137,6 @@ impl Default for DOT11_KEY_ALGO_TKIP_MIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_KEY_ALGO_TKIP_MIC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2455,9 +2152,6 @@ impl Default for DOT11_LINK_QUALITY_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_LINK_QUALITY_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2471,10 +2165,6 @@ impl Default for DOT11_LINK_QUALITY_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_LINK_QUALITY_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_LINK_QUALITY_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -2491,10 +2181,6 @@ impl Default for DOT11_MAC_ADDRESS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_MAC_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_MAC_ADDRESS_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -2520,9 +2206,6 @@ impl Default for DOT11_MAC_FRAME_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_MAC_FRAME_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_MAC_INFO {
@@ -2534,9 +2217,6 @@ impl Default for DOT11_MAC_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_MAC_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2550,10 +2230,6 @@ impl Default for DOT11_MAC_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_MAC_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_MAC_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -2571,10 +2247,6 @@ impl Default for DOT11_MANUFACTURING_CALLBACK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_MANUFACTURING_CALLBACK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_MANUFACTURING_CALLBACK_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2591,9 +2263,6 @@ impl Default for DOT11_MANUFACTURING_FUNCTIONAL_TEST_QUERY_ADC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_MANUFACTURING_FUNCTIONAL_TEST_QUERY_ADC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_MANUFACTURING_FUNCTIONAL_TEST_RX {
@@ -2606,9 +2275,6 @@ impl Default for DOT11_MANUFACTURING_FUNCTIONAL_TEST_RX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_MANUFACTURING_FUNCTIONAL_TEST_RX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2624,9 +2290,6 @@ impl Default for DOT11_MANUFACTURING_FUNCTIONAL_TEST_TX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_MANUFACTURING_FUNCTIONAL_TEST_TX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2644,9 +2307,6 @@ impl Default for DOT11_MANUFACTURING_SELF_TEST_QUERY_RESULTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_MANUFACTURING_SELF_TEST_QUERY_RESULTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_MANUFACTURING_SELF_TEST_SET_PARAMS {
@@ -2661,9 +2321,6 @@ impl Default for DOT11_MANUFACTURING_SELF_TEST_SET_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_MANUFACTURING_SELF_TEST_SET_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2683,9 +2340,6 @@ impl Default for DOT11_MANUFACTURING_TEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_MANUFACTURING_TEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_MANUFACTURING_TEST_QUERY_DATA {
@@ -2699,9 +2353,6 @@ impl Default for DOT11_MANUFACTURING_TEST_QUERY_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_MANUFACTURING_TEST_QUERY_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_MANUFACTURING_TEST_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -2717,9 +2368,6 @@ impl Default for DOT11_MANUFACTURING_TEST_SET_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_MANUFACTURING_TEST_SET_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_MANUFACTURING_TEST_SLEEP {
@@ -2730,9 +2378,6 @@ impl Default for DOT11_MANUFACTURING_TEST_SLEEP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_MANUFACTURING_TEST_SLEEP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2755,9 +2400,6 @@ impl Default for DOT11_MD_CAPABILITY_ENTRY_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_MD_CAPABILITY_ENTRY_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_MIN_PDU_SIZE: u32 = 256u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2772,10 +2414,6 @@ impl Default for DOT11_MPDU_MAX_LENGTH_INDICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_MPDU_MAX_LENGTH_INDICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_MPDU_MAX_LENGTH_INDICATION_REVISION_1: u32 = 1u32;
 pub const DOT11_MSONEX_FAILURE: DOT11_MSONEX_RESULT = DOT11_MSONEX_RESULT(1i32);
@@ -2801,10 +2439,6 @@ impl Default for DOT11_MSONEX_RESULT_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
-impl windows_core::TypeKind for DOT11_MSONEX_RESULT_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_MSONEX_SUCCESS: DOT11_MSONEX_RESULT = DOT11_MSONEX_RESULT(0i32);
 #[repr(C)]
 #[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
@@ -2823,10 +2457,6 @@ impl Default for DOT11_MSSECURITY_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
-impl windows_core::TypeKind for DOT11_MSSECURITY_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_MULTI_DOMAIN_CAPABILITY_ENTRY {
@@ -2840,9 +2470,6 @@ impl Default for DOT11_MULTI_DOMAIN_CAPABILITY_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_MULTI_DOMAIN_CAPABILITY_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_NETWORK {
@@ -2853,9 +2480,6 @@ impl Default for DOT11_NETWORK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_NETWORK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2869,9 +2493,6 @@ impl Default for DOT11_NETWORK_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_NETWORK_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_NIC_SPECIFIC_EXTENSION {
@@ -2883,9 +2504,6 @@ impl Default for DOT11_NIC_SPECIFIC_EXTENSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_NIC_SPECIFIC_EXTENSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_NLO_FLAG_SCAN_AT_SYSTEM_RESUME: u32 = 4u32;
 pub const DOT11_NLO_FLAG_SCAN_ON_AOAC_PLATFORM: u32 = 2u32;
@@ -2899,9 +2517,6 @@ impl Default for DOT11_OFDM_PHY_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_OFDM_PHY_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2919,9 +2534,6 @@ impl Default for DOT11_OFFLOAD_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_OFFLOAD_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_OFFLOAD_NETWORK {
@@ -2934,9 +2546,6 @@ impl Default for DOT11_OFFLOAD_NETWORK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_OFFLOAD_NETWORK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2956,10 +2565,6 @@ impl Default for DOT11_OFFLOAD_NETWORK_LIST_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_OFFLOAD_NETWORK_LIST_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_OFFLOAD_NETWORK_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -2973,10 +2578,6 @@ impl Default for DOT11_OFFLOAD_NETWORK_STATUS_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_OFFLOAD_NETWORK_STATUS_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_OFFLOAD_NETWORK_STATUS_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -2992,9 +2593,6 @@ impl Default for DOT11_OI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_OI {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_OI_MAX_LENGTH: u32 = 5u32;
 pub const DOT11_OI_MIN_LENGTH: u32 = 3u32;
@@ -3013,9 +2611,6 @@ impl Default for DOT11_OPERATION_MODE_CAPABILITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_OPERATION_MODE_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_OPERATION_MODE_EXTENSIBLE_AP: u32 = 8u32;
 pub const DOT11_OPERATION_MODE_EXTENSIBLE_STATION: u32 = 4u32;
@@ -3038,9 +2633,6 @@ impl Default for DOT11_OPTIONAL_CAPABILITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_OPTIONAL_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_PACKET_TYPE_ALL_MULTICAST_CTRL: u32 = 4096u32;
 pub const DOT11_PACKET_TYPE_ALL_MULTICAST_DATA: u32 = 16384u32;
@@ -3079,9 +2671,6 @@ impl Default for DOT11_PEER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_PEER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3096,10 +2685,6 @@ impl Default for DOT11_PEER_INFO_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PEER_INFO_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_PEER_INFO_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -3117,9 +2702,6 @@ impl Default for DOT11_PEER_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_PEER_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_PER_MSDU_COUNTERS {
@@ -3133,9 +2715,6 @@ impl Default for DOT11_PER_MSDU_COUNTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_PER_MSDU_COUNTERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3162,10 +2741,6 @@ impl Default for DOT11_PHY_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PHY_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy)]
@@ -3179,10 +2754,6 @@ impl Default for DOT11_PHY_ATTRIBUTES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PHY_ATTRIBUTES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_PHY_ATTRIBUTES_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -3212,9 +2783,6 @@ impl Default for DOT11_PHY_FRAME_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_PHY_FRAME_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy)]
@@ -3229,10 +2797,6 @@ impl Default for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy)]
@@ -3245,10 +2809,6 @@ impl Default for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_PHY_FREQUENCY_ADOPTED_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -3266,10 +2826,6 @@ impl Default for DOT11_PHY_ID_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PHY_ID_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_PHY_ID_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3285,10 +2841,6 @@ impl Default for DOT11_PHY_STATE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PHY_STATE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_PHY_STATE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -3311,9 +2863,6 @@ impl Default for DOT11_PHY_TYPE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_PHY_TYPE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3328,10 +2877,6 @@ impl Default for DOT11_PHY_TYPE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PHY_TYPE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_PHY_TYPE_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -3348,10 +2893,6 @@ impl Default for DOT11_PMKID_CANDIDATE_LIST_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PMKID_CANDIDATE_LIST_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_PMKID_CANDIDATE_LIST_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3364,9 +2905,6 @@ impl Default for DOT11_PMKID_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_PMKID_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3383,10 +2921,6 @@ impl Default for DOT11_PMKID_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PMKID_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_PMKID_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3400,9 +2934,6 @@ impl Default for DOT11_PORT_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_PORT_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3418,10 +2949,6 @@ impl Default for DOT11_PORT_STATE_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PORT_STATE_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_PORT_STATE_NOTIFICATION_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3435,10 +2962,6 @@ impl Default for DOT11_POWER_MGMT_AUTO_MODE_ENABLED_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_POWER_MGMT_AUTO_MODE_ENABLED_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_POWER_MGMT_AUTO_MODE_ENABLED_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -3455,9 +2978,6 @@ impl Default for DOT11_POWER_MGMT_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_POWER_MGMT_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3472,10 +2992,6 @@ impl Default for DOT11_POWER_MGMT_MODE_STATUS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_POWER_MGMT_MODE_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_POWER_MGMT_MODE_STATUS_INFO_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -3504,9 +3020,6 @@ impl Default for DOT11_PRIVACY_EXEMPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_PRIVACY_EXEMPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3521,10 +3034,6 @@ impl Default for DOT11_PRIVACY_EXEMPTION_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PRIVACY_EXEMPTION_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_PRIVACY_EXEMPTION_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -3545,10 +3054,6 @@ impl Default for DOT11_PROVISION_DISCOVERY_REQUEST_SEND_COMPLETE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PROVISION_DISCOVERY_REQUEST_SEND_COMPLETE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_PROVISION_DISCOVERY_REQUEST_SEND_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3567,10 +3072,6 @@ impl Default for DOT11_PROVISION_DISCOVERY_RESPONSE_SEND_COMPLETE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_PROVISION_DISCOVERY_RESPONSE_SEND_COMPLETE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_PROVISION_DISCOVERY_RESPONSE_SEND_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const DOT11_PSD_IE_MAX_DATA_SIZE: u32 = 240u32;
 pub const DOT11_PSD_IE_MAX_ENTRY_NUMBER: u32 = 5u32;
@@ -3587,10 +3088,6 @@ impl Default for DOT11_QOS_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_QOS_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_QOS_PARAMS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3604,9 +3101,6 @@ impl Default for DOT11_QOS_TX_DURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_QOS_TX_DURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_QOS_TX_MEDIUM_TIME {
@@ -3618,9 +3112,6 @@ impl Default for DOT11_QOS_TX_MEDIUM_TIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_QOS_TX_MEDIUM_TIME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3635,9 +3126,6 @@ impl Default for DOT11_RATE_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_RATE_SET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_RATE_SET_MAX_LENGTH: u32 = 126u32;
 #[repr(C)]
@@ -3655,10 +3143,6 @@ impl Default for DOT11_RECEIVED_GO_NEGOTIATION_CONFIRMATION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_RECEIVED_GO_NEGOTIATION_CONFIRMATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_RECEIVED_GO_NEGOTIATION_CONFIRMATION_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -3678,10 +3162,6 @@ impl Default for DOT11_RECEIVED_GO_NEGOTIATION_REQUEST_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_RECEIVED_GO_NEGOTIATION_REQUEST_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_RECEIVED_GO_NEGOTIATION_REQUEST_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3699,10 +3179,6 @@ impl Default for DOT11_RECEIVED_GO_NEGOTIATION_RESPONSE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_RECEIVED_GO_NEGOTIATION_RESPONSE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_RECEIVED_GO_NEGOTIATION_RESPONSE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -3723,10 +3199,6 @@ impl Default for DOT11_RECEIVED_INVITATION_REQUEST_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_RECEIVED_INVITATION_REQUEST_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_RECEIVED_INVITATION_REQUEST_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3744,10 +3216,6 @@ impl Default for DOT11_RECEIVED_INVITATION_RESPONSE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_RECEIVED_INVITATION_RESPONSE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_RECEIVED_INVITATION_RESPONSE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -3768,10 +3236,6 @@ impl Default for DOT11_RECEIVED_PROVISION_DISCOVERY_REQUEST_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_RECEIVED_PROVISION_DISCOVERY_REQUEST_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_RECEIVED_PROVISION_DISCOVERY_REQUEST_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3789,10 +3253,6 @@ impl Default for DOT11_RECEIVED_PROVISION_DISCOVERY_RESPONSE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_RECEIVED_PROVISION_DISCOVERY_RESPONSE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_RECEIVED_PROVISION_DISCOVERY_RESPONSE_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const DOT11_RECV_CONTEXT_REVISION_1: u32 = 1u32;
@@ -3828,9 +3288,6 @@ impl Default for DOT11_RECV_EXTENSION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_RECV_EXTENSION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_RECV_EXTENSION_INFO_V2 {
@@ -3861,9 +3318,6 @@ impl Default for DOT11_RECV_EXTENSION_INFO_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_RECV_EXTENSION_INFO_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_RECV_SENSITIVITY {
@@ -3875,9 +3329,6 @@ impl Default for DOT11_RECV_SENSITIVITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_RECV_SENSITIVITY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3892,9 +3343,6 @@ impl Default for DOT11_RECV_SENSITIVITY_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_RECV_SENSITIVITY_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DOT11_RECV_SENSITIVITY_LIST_0 {
@@ -3905,9 +3353,6 @@ impl Default for DOT11_RECV_SENSITIVITY_LIST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_RECV_SENSITIVITY_LIST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3920,9 +3365,6 @@ impl Default for DOT11_REG_DOMAINS_SUPPORT_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_REG_DOMAINS_SUPPORT_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_REG_DOMAIN_DOC: u32 = 32u32;
 pub const DOT11_REG_DOMAIN_ETSI: u32 = 48u32;
@@ -3942,9 +3384,6 @@ impl Default for DOT11_REG_DOMAIN_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_REG_DOMAIN_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_RESET_REQUEST {
@@ -3956,9 +3395,6 @@ impl Default for DOT11_RESET_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_RESET_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3976,10 +3412,6 @@ impl Default for DOT11_ROAMING_COMPLETION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_ROAMING_COMPLETION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_ROAMING_COMPLETION_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -3996,10 +3428,6 @@ impl Default for DOT11_ROAMING_START_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_ROAMING_START_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_ROAMING_START_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4012,9 +3440,6 @@ impl Default for DOT11_RSSI_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_RSSI_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4037,9 +3462,6 @@ impl Default for DOT11_SCAN_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_SCAN_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4064,9 +3486,6 @@ impl Default for DOT11_SCAN_REQUEST_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_SCAN_REQUEST_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DOT11_SCAN_TYPE(pub i32);
@@ -4081,9 +3500,6 @@ impl Default for DOT11_SECURITY_PACKET_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_SECURITY_PACKET_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_SEND_CONTEXT_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -4108,10 +3524,6 @@ impl Default for DOT11_SEND_GO_NEGOTIATION_CONFIRMATION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_SEND_GO_NEGOTIATION_CONFIRMATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_SEND_GO_NEGOTIATION_CONFIRMATION_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4133,10 +3545,6 @@ impl Default for DOT11_SEND_GO_NEGOTIATION_REQUEST_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_SEND_GO_NEGOTIATION_REQUEST_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_SEND_GO_NEGOTIATION_REQUEST_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -4164,10 +3572,6 @@ impl Default for DOT11_SEND_GO_NEGOTIATION_RESPONSE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_SEND_GO_NEGOTIATION_RESPONSE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_SEND_GO_NEGOTIATION_RESPONSE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4194,10 +3598,6 @@ impl Default for DOT11_SEND_INVITATION_REQUEST_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_SEND_INVITATION_REQUEST_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_SEND_INVITATION_REQUEST_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4223,10 +3623,6 @@ impl Default for DOT11_SEND_INVITATION_RESPONSE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_SEND_INVITATION_RESPONSE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_SEND_INVITATION_RESPONSE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4248,10 +3644,6 @@ impl Default for DOT11_SEND_PROVISION_DISCOVERY_REQUEST_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_SEND_PROVISION_DISCOVERY_REQUEST_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_SEND_PROVISION_DISCOVERY_REQUEST_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4271,10 +3663,6 @@ impl Default for DOT11_SEND_PROVISION_DISCOVERY_RESPONSE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_SEND_PROVISION_DISCOVERY_RESPONSE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_SEND_PROVISION_DISCOVERY_RESPONSE_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const DOT11_SERVICE_CLASS_REORDERABLE_MULTICAST: u32 = 0u32;
 pub const DOT11_SERVICE_CLASS_STRICTLY_ORDERED: u32 = 1u32;
@@ -4288,9 +3676,6 @@ impl Default for DOT11_SSID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_SSID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4307,10 +3692,6 @@ impl Default for DOT11_SSID_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_SSID_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_SSID_LIST_REVISION_1: u32 = 1u32;
 pub const DOT11_SSID_MAX_LENGTH: u32 = 32u32;
 #[repr(C)]
@@ -4325,9 +3706,6 @@ impl Default for DOT11_START_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_START_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4346,10 +3724,6 @@ impl Default for DOT11_STATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_STATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_STATISTICS_REVISION_1: u32 = 1u32;
 pub const DOT11_STATUS_AP_JOIN_CONFIRM: u32 = 5u32;
@@ -4370,9 +3744,6 @@ impl Default for DOT11_STATUS_INDICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_STATUS_INDICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_STATUS_JOIN_CONFIRM: u32 = 2u32;
 pub const DOT11_STATUS_MPDU_MAX_LENGTH_CHANGED: u32 = 6u32;
@@ -4404,10 +3775,6 @@ impl Default for DOT11_STOP_AP_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_STOP_AP_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_STOP_AP_PARAMETERS_REVISION_1: u32 = 1u32;
 pub const DOT11_STOP_AP_REASON_AP_ACTIVE: u32 = 3u32;
 pub const DOT11_STOP_AP_REASON_CHANNEL_NOT_AVAILABLE: u32 = 2u32;
@@ -4425,9 +3792,6 @@ impl Default for DOT11_SUPPORTED_ANTENNA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_SUPPORTED_ANTENNA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_SUPPORTED_ANTENNA_LIST {
@@ -4440,9 +3804,6 @@ impl Default for DOT11_SUPPORTED_ANTENNA_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_SUPPORTED_ANTENNA_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_SUPPORTED_DATA_RATES_VALUE {
@@ -4453,9 +3814,6 @@ impl Default for DOT11_SUPPORTED_DATA_RATES_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_SUPPORTED_DATA_RATES_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4468,9 +3826,6 @@ impl Default for DOT11_SUPPORTED_DATA_RATES_VALUE_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_SUPPORTED_DATA_RATES_VALUE_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_SUPPORTED_DSSS_CHANNEL {
@@ -4480,9 +3835,6 @@ impl Default for DOT11_SUPPORTED_DSSS_CHANNEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_SUPPORTED_DSSS_CHANNEL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4496,9 +3848,6 @@ impl Default for DOT11_SUPPORTED_DSSS_CHANNEL_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_SUPPORTED_DSSS_CHANNEL_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_SUPPORTED_OFDM_FREQUENCY {
@@ -4508,9 +3857,6 @@ impl Default for DOT11_SUPPORTED_OFDM_FREQUENCY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_SUPPORTED_OFDM_FREQUENCY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4524,9 +3870,6 @@ impl Default for DOT11_SUPPORTED_OFDM_FREQUENCY_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_SUPPORTED_OFDM_FREQUENCY_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_SUPPORTED_PHY_TYPES {
@@ -4539,9 +3882,6 @@ impl Default for DOT11_SUPPORTED_PHY_TYPES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_SUPPORTED_PHY_TYPES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_SUPPORTED_POWER_LEVELS {
@@ -4552,9 +3892,6 @@ impl Default for DOT11_SUPPORTED_POWER_LEVELS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_SUPPORTED_POWER_LEVELS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4574,10 +3911,6 @@ impl Default for DOT11_TKIPMIC_FAILURE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_TKIPMIC_FAILURE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_TKIPMIC_FAILURE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4590,9 +3923,6 @@ impl Default for DOT11_UPDATE_IE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_UPDATE_IE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4608,9 +3938,6 @@ impl Default for DOT11_VENUEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_VENUEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4624,10 +3951,6 @@ impl Default for DOT11_VWIFI_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_VWIFI_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_VWIFI_ATTRIBUTES_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -4644,10 +3967,6 @@ impl Default for DOT11_VWIFI_COMBINATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_VWIFI_COMBINATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_VWIFI_COMBINATION_REVISION_1: u32 = 1u32;
 pub const DOT11_VWIFI_COMBINATION_REVISION_2: u32 = 2u32;
@@ -4668,10 +3987,6 @@ impl Default for DOT11_VWIFI_COMBINATION_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_VWIFI_COMBINATION_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4688,10 +4003,6 @@ impl Default for DOT11_VWIFI_COMBINATION_V3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_VWIFI_COMBINATION_V3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4717,9 +4028,6 @@ impl Default for DOT11_WEP_OFFLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_WEP_OFFLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_WEP_UPLOAD {
@@ -4734,9 +4042,6 @@ impl Default for DOT11_WEP_UPLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WEP_UPLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4756,10 +4061,6 @@ impl Default for DOT11_WFD_ADDITIONAL_IE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_ADDITIONAL_IE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_WFD_ADDITIONAL_IE_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4774,9 +4075,6 @@ impl Default for DOT11_WFD_ADVERTISED_SERVICE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_WFD_ADVERTISED_SERVICE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_WFD_ADVERTISED_SERVICE_LIST {
@@ -4788,9 +4086,6 @@ impl Default for DOT11_WFD_ADVERTISED_SERVICE_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_WFD_ADVERTISED_SERVICE_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_WFD_ADVERTISEMENT_ID {
@@ -4801,9 +4096,6 @@ impl Default for DOT11_WFD_ADVERTISEMENT_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WFD_ADVERTISEMENT_ID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WFD_APS2_SERVICE_TYPE_MAX_LENGTH: u32 = 21u32;
 pub const DOT11_WFD_ASP2_INSTANCE_NAME_MAX_LENGTH: u32 = 63u32;
@@ -4833,10 +4125,6 @@ impl Default for DOT11_WFD_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_WFD_ATTRIBUTES_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4850,9 +4138,6 @@ impl Default for DOT11_WFD_CHANNEL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_WFD_CHANNEL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_WFD_CONFIGURATION_TIMEOUT {
@@ -4863,9 +4148,6 @@ impl Default for DOT11_WFD_CONFIGURATION_TIMEOUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WFD_CONFIGURATION_TIMEOUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WFD_DEVICE_AUTO_AVAILABILITY: u32 = 16u32;
 pub const DOT11_WFD_DEVICE_CAPABILITY_CONCURRENT_OPERATION: u32 = 4u32;
@@ -4887,10 +4169,6 @@ impl Default for DOT11_WFD_DEVICE_CAPABILITY_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_DEVICE_CAPABILITY_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WFD_DEVICE_CAPABILITY_CONFIG_REVISION_1: u32 = 1u32;
 pub const DOT11_WFD_DEVICE_CAPABILITY_P2P_CLIENT_DISCOVERABILITY: u32 = 2u32;
@@ -4925,9 +4203,6 @@ impl Default for DOT11_WFD_DEVICE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_WFD_DEVICE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_WFD_DEVICE_HIGH_AVAILABILITY: u32 = 24u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4945,10 +4220,6 @@ impl Default for DOT11_WFD_DEVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_WFD_DEVICE_INFO_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -4963,10 +4234,6 @@ impl Default for DOT11_WFD_DEVICE_LISTEN_CHANNEL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_DEVICE_LISTEN_CHANNEL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_WFD_DEVICE_LISTEN_CHANNEL_REVISION_1: u32 = 1u32;
 pub const DOT11_WFD_DEVICE_NOT_DISCOVERABLE: u32 = 0u32;
 #[repr(C)]
@@ -4980,9 +4247,6 @@ impl Default for DOT11_WFD_DEVICE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WFD_DEVICE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WFD_DISCOVER_COMPLETE_MAX_LIST_SIZE: u32 = 128u32;
 #[repr(C)]
@@ -5002,10 +4266,6 @@ impl Default for DOT11_WFD_DISCOVER_COMPLETE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_DISCOVER_COMPLETE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_WFD_DISCOVER_COMPLETE_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5018,9 +4278,6 @@ impl Default for DOT11_WFD_DISCOVER_DEVICE_FILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WFD_DISCOVER_DEVICE_FILTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
@@ -5042,10 +4299,6 @@ impl Default for DOT11_WFD_DISCOVER_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_DISCOVER_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_WFD_DISCOVER_REQUEST_REVISION_1: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5059,9 +4312,6 @@ impl Default for DOT11_WFD_GO_INTENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WFD_GO_INTENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WFD_GROUP_CAPABILITY_CROSS_CONNECTION_SUPPORTED: u32 = 16u32;
 pub const DOT11_WFD_GROUP_CAPABILITY_EAPOL_KEY_IP_ADDRESS_ALLOCATION_SUPPORTED: u32 = 128u32;
@@ -5084,9 +4334,6 @@ impl Default for DOT11_WFD_GROUP_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_WFD_GROUP_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5102,10 +4349,6 @@ impl Default for DOT11_WFD_GROUP_JOIN_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_GROUP_JOIN_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WFD_GROUP_JOIN_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
@@ -5125,10 +4368,6 @@ impl Default for DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG_REVISION_1: u32 = 1u32;
 pub const DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG_REVISION_2: u32 = 2u32;
@@ -5151,10 +4390,6 @@ impl Default for DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_GROUP_OWNER_CAPABILITY_CONFIG_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5168,10 +4403,6 @@ impl Default for DOT11_WFD_GROUP_START_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_GROUP_START_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_WFD_GROUP_START_PARAMETERS_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5182,9 +4413,6 @@ impl Default for DOT11_WFD_INVITATION_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WFD_INVITATION_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WFD_MINOR_REASON_DISASSOCIATED_FROM_WLAN_CROSS_CONNECTION_POLICY: u32 = 1u32;
 pub const DOT11_WFD_MINOR_REASON_DISASSOCIATED_INFRASTRUCTURE_MANAGED_POLICY: u32 = 4u32;
@@ -5209,10 +4437,6 @@ impl Default for DOT11_WFD_SECONDARY_DEVICE_TYPE_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for DOT11_WFD_SECONDARY_DEVICE_TYPE_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DOT11_WFD_SECONDARY_DEVICE_TYPE_LIST_REVISION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5224,9 +4448,6 @@ impl Default for DOT11_WFD_SERVICE_HASH_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WFD_SERVICE_HASH_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WFD_SERVICE_INFORMATION_MAX_LENGTH: u32 = 65535u32;
 pub const DOT11_WFD_SERVICE_NAME_MAX_LENGTH: u32 = 255u32;
@@ -5241,9 +4462,6 @@ impl Default for DOT11_WFD_SESSION_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_WFD_SESSION_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_WFD_SESSION_INFO {
@@ -5254,9 +4472,6 @@ impl Default for DOT11_WFD_SESSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WFD_SESSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WFD_SESSION_INFO_MAX_LENGTH: u32 = 144u32;
 pub const DOT11_WFD_STATUS_FAILED_INCOMPATIBLE_PARAMETERS: u32 = 2u32;
@@ -5286,9 +4501,6 @@ impl Default for DOT11_WME_AC_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_WME_AC_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_WME_AC_PARAMETERS_LIST {
@@ -5300,9 +4512,6 @@ impl Default for DOT11_WME_AC_PARAMETERS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WME_AC_PARAMETERS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WME_PACKET: u32 = 256u32;
 #[repr(C)]
@@ -5320,9 +4529,6 @@ impl Default for DOT11_WME_UPDATE_IE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOT11_WME_UPDATE_IE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOT11_WPA_TSC {
@@ -5335,9 +4541,6 @@ impl Default for DOT11_WPA_TSC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WPA_TSC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5359,9 +4562,6 @@ impl Default for DOT11_WPS_DEVICE_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOT11_WPS_DEVICE_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOT11_WPS_DEVICE_NAME_MAX_LENGTH: u32 = 32u32;
 #[repr(transparent)]
@@ -6303,9 +5503,6 @@ impl Default for L2_NOTIFICATION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for L2_NOTIFICATION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const L2_NOTIFICATION_SOURCE_ALL: u32 = 65535u32;
 pub const L2_NOTIFICATION_SOURCE_DOT3_AUTO_CONFIG: u32 = 1u32;
 pub const L2_NOTIFICATION_SOURCE_NONE: u32 = 0u32;
@@ -6487,9 +5684,6 @@ impl Default for ONEX_AUTH_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ONEX_AUTH_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ONEX_AUTH_RESTART_REASON(pub i32);
@@ -6515,10 +5709,6 @@ impl Default for ONEX_EAP_ERROR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_ExtensibleAuthenticationProtocol")]
-impl windows_core::TypeKind for ONEX_EAP_ERROR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ONEX_EAP_FAILURE_RECEIVED: ONEX_REASON_CODE = ONEX_REASON_CODE(327685i32);
 #[repr(transparent)]
@@ -6560,9 +5750,6 @@ impl Default for ONEX_RESULT_UPDATE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ONEX_RESULT_UPDATE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ONEX_STATUS {
@@ -6574,9 +5761,6 @@ impl Default for ONEX_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ONEX_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ONEX_UI_CANCELLED: ONEX_REASON_CODE = ONEX_REASON_CODE(327697i32);
 pub const ONEX_UI_DISABLED: ONEX_REASON_CODE = ONEX_REASON_CODE(327683i32);
@@ -6596,9 +5780,6 @@ impl Default for ONEX_USER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ONEX_USER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ONEX_VARIABLE_BLOB {
@@ -6609,9 +5790,6 @@ impl Default for ONEX_VARIABLE_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ONEX_VARIABLE_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OneXAuthFailure: ONEX_AUTH_STATUS = ONEX_AUTH_STATUS(4i32);
 pub const OneXAuthIdentityExplicitUser: ONEX_AUTH_IDENTITY = ONEX_AUTH_IDENTITY(3i32);
@@ -6656,9 +5834,6 @@ impl Default for WDIAG_IHV_WLAN_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WDIAG_IHV_WLAN_ID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WDIAG_IHV_WLAN_ID_FLAG_SECURITY_ENABLED: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6671,9 +5846,6 @@ impl Default for WFDSVC_CONNECTION_CAPABILITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WFDSVC_CONNECTION_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WFDSVC_CONNECTION_CAPABILITY_CLIENT: u32 = 2u32;
 pub const WFDSVC_CONNECTION_CAPABILITY_GO: u32 = 4u32;
@@ -6690,9 +5862,6 @@ impl Default for WFD_GROUP_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WFD_GROUP_ID {
-    type TypeKind = windows_core::CopyType;
 }
 pub type WFD_OPEN_SESSION_COMPLETE_CALLBACK = Option<unsafe extern "system" fn(hsessionhandle: super::super::Foundation::HANDLE, pvcontext: *const core::ffi::c_void, guidsessioninterface: windows_core::GUID, dwerror: u32, dwreasoncode: u32)>;
 #[repr(transparent)]
@@ -6726,9 +5895,6 @@ impl Default for WLAN_ASSOCIATION_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_ASSOCIATION_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_AUTH_CIPHER_PAIR_LIST {
@@ -6739,9 +5905,6 @@ impl Default for WLAN_AUTH_CIPHER_PAIR_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_AUTH_CIPHER_PAIR_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6770,9 +5933,6 @@ impl Default for WLAN_AVAILABLE_NETWORK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_AVAILABLE_NETWORK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WLAN_AVAILABLE_NETWORK_ANQP_SUPPORTED: u32 = 32u32;
 pub const WLAN_AVAILABLE_NETWORK_AUTO_CONNECT_FAILED: u32 = 256u32;
 pub const WLAN_AVAILABLE_NETWORK_CONNECTED: u32 = 1u32;
@@ -6796,9 +5956,6 @@ impl Default for WLAN_AVAILABLE_NETWORK_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_AVAILABLE_NETWORK_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_AVAILABLE_NETWORK_LIST_V2 {
@@ -6810,9 +5967,6 @@ impl Default for WLAN_AVAILABLE_NETWORK_LIST_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_AVAILABLE_NETWORK_LIST_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6841,9 +5995,6 @@ impl Default for WLAN_AVAILABLE_NETWORK_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_AVAILABLE_NETWORK_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_BSS_ENTRY {
@@ -6869,9 +6020,6 @@ impl Default for WLAN_BSS_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_BSS_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_BSS_LIST {
@@ -6883,9 +6031,6 @@ impl Default for WLAN_BSS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_BSS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLAN_CONNECTION_ADHOC_JOIN_ONLY: u32 = 2u32;
 #[repr(C)]
@@ -6901,9 +6046,6 @@ impl Default for WLAN_CONNECTION_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_CONNECTION_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLAN_CONNECTION_EAPOL_PASSTHROUGH: u32 = 8u32;
 pub const WLAN_CONNECTION_HIDDEN_NETWORK: u32 = 1u32;
@@ -6930,9 +6072,6 @@ impl Default for WLAN_CONNECTION_NOTIFICATION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_CONNECTION_NOTIFICATION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WLAN_CONNECTION_NOTIFICATION_FLAGS(pub u32);
@@ -6953,10 +6092,6 @@ impl Default for WLAN_CONNECTION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for WLAN_CONNECTION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_NetworkManagement_Ndis")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6976,10 +6111,6 @@ impl Default for WLAN_CONNECTION_PARAMETERS_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_Ndis")]
-impl windows_core::TypeKind for WLAN_CONNECTION_PARAMETERS_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WLAN_CONNECTION_PERSIST_DISCOVERY_PROFILE: u32 = 16u32;
 pub const WLAN_CONNECTION_PERSIST_DISCOVERY_PROFILE_CONNECTION_MODE_AUTO: u32 = 32u32;
 pub const WLAN_CONNECTION_PERSIST_DISCOVERY_PROFILE_OVERWRITE_EXISTING: u32 = 64u32;
@@ -6994,9 +6125,6 @@ impl Default for WLAN_COUNTRY_OR_REGION_STRING_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_COUNTRY_OR_REGION_STRING_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_DEVICE_SERVICE_GUID_LIST {
@@ -7008,9 +6136,6 @@ impl Default for WLAN_DEVICE_SERVICE_GUID_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_DEVICE_SERVICE_GUID_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7024,9 +6149,6 @@ impl Default for WLAN_DEVICE_SERVICE_NOTIFICATION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_DEVICE_SERVICE_NOTIFICATION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7042,9 +6164,6 @@ impl Default for WLAN_HOSTED_NETWORK_CONNECTION_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_HOSTED_NETWORK_CONNECTION_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_HOSTED_NETWORK_DATA_PEER_STATE_CHANGE {
@@ -7056,9 +6175,6 @@ impl Default for WLAN_HOSTED_NETWORK_DATA_PEER_STATE_CHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_HOSTED_NETWORK_DATA_PEER_STATE_CHANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7080,9 +6196,6 @@ impl Default for WLAN_HOSTED_NETWORK_PEER_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_HOSTED_NETWORK_PEER_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_HOSTED_NETWORK_RADIO_STATE {
@@ -7093,9 +6206,6 @@ impl Default for WLAN_HOSTED_NETWORK_RADIO_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_HOSTED_NETWORK_RADIO_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7110,9 +6220,6 @@ impl Default for WLAN_HOSTED_NETWORK_SECURITY_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_HOSTED_NETWORK_SECURITY_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7129,9 +6236,6 @@ impl Default for WLAN_HOSTED_NETWORK_STATE_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_HOSTED_NETWORK_STATE_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_HOSTED_NETWORK_STATUS {
@@ -7147,9 +6251,6 @@ impl Default for WLAN_HOSTED_NETWORK_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_HOSTED_NETWORK_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7169,9 +6270,6 @@ impl Default for WLAN_INTERFACE_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_INTERFACE_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_INTERFACE_INFO {
@@ -7184,9 +6282,6 @@ impl Default for WLAN_INTERFACE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_INTERFACE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_INTERFACE_INFO_LIST {
@@ -7198,9 +6293,6 @@ impl Default for WLAN_INTERFACE_INFO_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_INTERFACE_INFO_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7232,9 +6324,6 @@ impl Default for WLAN_MAC_FRAME_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_MAC_FRAME_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WLAN_MAX_NAME_LENGTH: u32 = 256u32;
 pub const WLAN_MAX_PHY_INDEX: u32 = 64u32;
 pub const WLAN_MAX_PHY_TYPE_NUMBER: u32 = 8u32;
@@ -7255,9 +6344,6 @@ impl Default for WLAN_MSM_NOTIFICATION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_MSM_NOTIFICATION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7347,9 +6433,6 @@ impl Default for WLAN_PHY_FRAME_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_PHY_FRAME_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_PHY_RADIO_STATE {
@@ -7361,9 +6444,6 @@ impl Default for WLAN_PHY_RADIO_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_PHY_RADIO_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7383,9 +6463,6 @@ impl Default for WLAN_PROFILE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_PROFILE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_PROFILE_INFO_LIST {
@@ -7397,9 +6474,6 @@ impl Default for WLAN_PROFILE_INFO_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_PROFILE_INFO_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLAN_PROFILE_USER: u32 = 2u32;
 #[repr(C)]
@@ -7413,9 +6487,6 @@ impl Default for WLAN_RADIO_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_RADIO_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_RATE_SET {
@@ -7427,9 +6498,6 @@ impl Default for WLAN_RATE_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_RATE_SET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_RAW_DATA {
@@ -7440,9 +6508,6 @@ impl Default for WLAN_RAW_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_RAW_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7456,9 +6521,6 @@ impl Default for WLAN_RAW_DATA_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_RAW_DATA_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLAN_RAW_DATA_LIST_0 {
@@ -7469,9 +6531,6 @@ impl Default for WLAN_RAW_DATA_LIST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_RAW_DATA_LIST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLAN_REASON_CODE_AC_BASE: u32 = 131072u32;
 pub const WLAN_REASON_CODE_AC_CONNECT_BASE: u32 = 163840u32;
@@ -7645,9 +6704,6 @@ impl Default for WLAN_SECURITY_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLAN_SECURITY_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WLAN_SET_EAPHOST_DATA_ALL_USERS: WLAN_SET_EAPHOST_FLAGS = WLAN_SET_EAPHOST_FLAGS(1u32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7667,9 +6723,6 @@ impl Default for WLAN_STATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLAN_STATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLAN_UI_API_INITIAL_VERSION: u32 = 1u32;
 pub const WLAN_UI_API_VERSION: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/mod.rs
@@ -532,9 +532,6 @@ impl Default for WCN_VALUE_TYPE_PRIMARY_DEVICE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WCN_VALUE_TYPE_PRIMARY_DEVICE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WCN_VALUE_TYPE_REQUEST_TYPE(pub i32);
@@ -564,7 +561,4 @@ impl Default for WCN_VENDOR_EXTENSION_SPEC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WCN_VENDOR_EXTENSION_SPEC {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectionManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectionManager/mod.rs
@@ -78,9 +78,6 @@ impl Default for NET_INTERFACE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NET_INTERFACE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NET_INTERFACE_CONTEXT_TABLE {
@@ -92,9 +89,6 @@ impl Default for NET_INTERFACE_CONTEXT_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NET_INTERFACE_CONTEXT_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NET_INTERFACE_FLAG_CONNECT_IF_NEEDED: u32 = 1u32;
 pub const NET_INTERFACE_FLAG_NONE: u32 = 0u32;
@@ -113,9 +107,6 @@ impl Default for WCM_BILLING_CYCLE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WCM_BILLING_CYCLE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WCM_CONNECTION_COST(pub i32);
@@ -131,9 +122,6 @@ impl Default for WCM_CONNECTION_COST_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WCM_CONNECTION_COST_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WCM_CONNECTION_COST_FIXED: WCM_CONNECTION_COST = WCM_CONNECTION_COST(2i32);
 pub const WCM_CONNECTION_COST_OVERDATALIMIT: WCM_CONNECTION_COST = WCM_CONNECTION_COST(65536i32);
@@ -164,9 +152,6 @@ impl Default for WCM_DATAPLAN_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WCM_DATAPLAN_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WCM_MAX_PROFILE_NAME: u32 = 256u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -182,9 +167,6 @@ impl Default for WCM_POLICY_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WCM_POLICY_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WCM_PROFILE_INFO {
@@ -197,9 +179,6 @@ impl Default for WCM_PROFILE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WCM_PROFILE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WCM_PROFILE_INFO_LIST {
@@ -210,9 +189,6 @@ impl Default for WCM_PROFILE_INFO_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WCM_PROFILE_INFO_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -233,9 +209,6 @@ impl Default for WCM_TIME_INTERVAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WCM_TIME_INTERVAL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WCM_UNKNOWN_DATAPLAN_STATUS: u32 = 4294967295u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -247,9 +220,6 @@ impl Default for WCM_USAGE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WCM_USAGE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const wcm_global_property_domain_policy: WCM_PROPERTY = WCM_PROPERTY(0i32);
 pub const wcm_global_property_minimize_policy: WCM_PROPERTY = WCM_PROPERTY(1i32);

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/mod.rs
@@ -1038,9 +1038,6 @@ impl Default for FWPM_ACTION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_ACTION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FWPM_ACTION0_0 {
@@ -1051,9 +1048,6 @@ impl Default for FWPM_ACTION0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_ACTION0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_ACTRL_ADD: u32 = 1u32;
 pub const FWPM_ACTRL_ADD_LINK: u32 = 2u32;
@@ -1089,9 +1083,6 @@ impl Default for FWPM_CALLOUT0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_CALLOUT0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWPM_CALLOUT_BUILT_IN_RESERVED_1: windows_core::GUID = windows_core::GUID::from_u128(0x779719a4_e695_47b6_a199_7999fec9163b);
 pub const FWPM_CALLOUT_BUILT_IN_RESERVED_2: windows_core::GUID = windows_core::GUID::from_u128(0xef9661b6_7c5e_48fd_a130_96678ceacc41);
 pub const FWPM_CALLOUT_BUILT_IN_RESERVED_3: windows_core::GUID = windows_core::GUID::from_u128(0x18729c7a_2f62_4be0_966f_974b21b86df1);
@@ -1108,9 +1099,6 @@ impl Default for FWPM_CALLOUT_CHANGE0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_CALLOUT_CHANGE0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub type FWPM_CALLOUT_CHANGE_CALLBACK0 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, change: *const FWPM_CALLOUT_CHANGE0)>;
 pub const FWPM_CALLOUT_EDGE_TRAVERSAL_ALE_LISTEN_V4: windows_core::GUID = windows_core::GUID::from_u128(0x33486ab5_6d5e_4e65_a00b_a7afed0ba9a1);
 pub const FWPM_CALLOUT_EDGE_TRAVERSAL_ALE_RESOURCE_ASSIGNMENT_V4: windows_core::GUID = windows_core::GUID::from_u128(0x079b1010_f1c5_4fcd_ae05_da41107abd0b);
@@ -1124,9 +1112,6 @@ impl Default for FWPM_CALLOUT_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_CALLOUT_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_CALLOUT_FLAG_PERSISTENT: u32 = 65536u32;
 pub const FWPM_CALLOUT_FLAG_REGISTERED: u32 = 262144u32;
@@ -1176,9 +1161,6 @@ impl Default for FWPM_CALLOUT_SUBSCRIPTION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_CALLOUT_SUBSCRIPTION0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWPM_CALLOUT_TCP_CHIMNEY_ACCEPT_LAYER_V4: windows_core::GUID = windows_core::GUID::from_u128(0xe183ecb2_3a7f_4b54_8ad9_76050ed880ca);
 pub const FWPM_CALLOUT_TCP_CHIMNEY_ACCEPT_LAYER_V6: windows_core::GUID = windows_core::GUID::from_u128(0x0378cf41_bf98_4603_81f2_7f12586079f6);
 pub const FWPM_CALLOUT_TCP_CHIMNEY_CONNECT_LAYER_V4: windows_core::GUID = windows_core::GUID::from_u128(0xf3e10ab3_2c25_4279_ac36_c30fc181bec4);
@@ -1210,10 +1192,6 @@ impl Default for FWPM_CLASSIFY_OPTION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_CLASSIFY_OPTION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1226,10 +1204,6 @@ impl Default for FWPM_CLASSIFY_OPTIONS0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_CLASSIFY_OPTIONS0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_CLASSIFY_OPTIONS_CONTEXT: FWPM_PROVIDER_CONTEXT_TYPE = FWPM_PROVIDER_CONTEXT_TYPE(7i32);
 pub const FWPM_CONDITION_ALE_APP_ID: windows_core::GUID = windows_core::GUID::from_u128(0xd78e1e87_8644_4ea5_9437_d809ecefc971);
@@ -1391,9 +1365,6 @@ impl Default for FWPM_CONNECTION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_CONNECTION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FWPM_CONNECTION0_0 {
@@ -1405,9 +1376,6 @@ impl Default for FWPM_CONNECTION0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_CONNECTION0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FWPM_CONNECTION0_1 {
@@ -1418,9 +1386,6 @@ impl Default for FWPM_CONNECTION0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_CONNECTION0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type FWPM_CONNECTION_CALLBACK0 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, eventtype: FWPM_CONNECTION_EVENT_TYPE, connection: *const FWPM_CONNECTION0)>;
 pub const FWPM_CONNECTION_ENUM_FLAG_QUERY_BYTES_TRANSFERRED: u32 = 1u32;
@@ -1434,9 +1399,6 @@ impl Default for FWPM_CONNECTION_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_CONNECTION_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_CONNECTION_EVENT_ADD: FWPM_CONNECTION_EVENT_TYPE = FWPM_CONNECTION_EVENT_TYPE(0i32);
 pub const FWPM_CONNECTION_EVENT_DELETE: FWPM_CONNECTION_EVENT_TYPE = FWPM_CONNECTION_EVENT_TYPE(1i32);
@@ -1456,9 +1418,6 @@ impl Default for FWPM_CONNECTION_SUBSCRIPTION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_CONNECTION_SUBSCRIPTION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_DISPLAY_DATA0 {
@@ -1469,9 +1428,6 @@ impl Default for FWPM_DISPLAY_DATA0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_DISPLAY_DATA0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type FWPM_DYNAMIC_KEYWORD_CALLBACK0 = Option<unsafe extern "system" fn(notification: *mut core::ffi::c_void, context: *mut core::ffi::c_void)>;
 pub const FWPM_ENGINE_COLLECT_NET_EVENTS: FWPM_ENGINE_OPTION = FWPM_ENGINE_OPTION(0i32);
@@ -1499,9 +1455,6 @@ impl Default for FWPM_FIELD0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_FIELD0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_FIELD_FLAGS: FWPM_FIELD_TYPE = FWPM_FIELD_TYPE(2i32);
 pub const FWPM_FIELD_IP_ADDRESS: FWPM_FIELD_TYPE = FWPM_FIELD_TYPE(1i32);
@@ -1536,10 +1489,6 @@ impl Default for FWPM_FILTER0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_FILTER0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -1553,10 +1502,6 @@ impl Default for FWPM_FILTER0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_FILTER0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_FILTER_CHANGE0 {
@@ -1568,9 +1513,6 @@ impl Default for FWPM_FILTER_CHANGE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_FILTER_CHANGE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type FWPM_FILTER_CHANGE_CALLBACK0 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, change: *const FWPM_FILTER_CHANGE0)>;
 #[repr(C)]
@@ -1586,10 +1528,6 @@ impl Default for FWPM_FILTER_CONDITION0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_FILTER_CONDITION0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -1610,10 +1548,6 @@ impl Default for FWPM_FILTER_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_FILTER_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1680,10 +1614,6 @@ impl Default for FWPM_FILTER_SUBSCRIPTION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_FILTER_SUBSCRIPTION0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWPM_GENERAL_CONTEXT: FWPM_PROVIDER_CONTEXT_TYPE = FWPM_PROVIDER_CONTEXT_TYPE(8i32);
 pub const FWPM_IPSEC_AUTHIP_MM_CONTEXT: FWPM_PROVIDER_CONTEXT_TYPE = FWPM_PROVIDER_CONTEXT_TYPE(6i32);
 pub const FWPM_IPSEC_AUTHIP_QM_TRANSPORT_CONTEXT: FWPM_PROVIDER_CONTEXT_TYPE = FWPM_PROVIDER_CONTEXT_TYPE(3i32);
@@ -1714,9 +1644,6 @@ impl Default for FWPM_LAYER0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_LAYER0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_LAYER_ALE_AUTH_CONNECT_V4: windows_core::GUID = windows_core::GUID::from_u128(0xc38d57d1_05a7_4c33_904f_7fbceee60e82);
 pub const FWPM_LAYER_ALE_AUTH_CONNECT_V4_DISCARD: windows_core::GUID = windows_core::GUID::from_u128(0xd632a801_f5ba_4ad6_96e3_607017d9836a);
@@ -1762,9 +1689,6 @@ impl Default for FWPM_LAYER_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_LAYER_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_LAYER_FLAG_BUFFERED: u32 = 8u32;
 pub const FWPM_LAYER_FLAG_BUILTIN: u32 = 2u32;
@@ -1840,9 +1764,6 @@ impl Default for FWPM_LAYER_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_LAYER_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWPM_LAYER_STREAM_PACKET_V4: windows_core::GUID = windows_core::GUID::from_u128(0xaf52d8ec_cb2d_44e5_ad92_f8dc38d2eb29);
 pub const FWPM_LAYER_STREAM_PACKET_V6: windows_core::GUID = windows_core::GUID::from_u128(0x779a8ca3_f099_468f_b5d4_83535c461c02);
 pub const FWPM_LAYER_STREAM_V4: windows_core::GUID = windows_core::GUID::from_u128(0x3b89653c_c170_49e4_b1cd_e0eeeee19a3e);
@@ -1863,10 +1784,6 @@ impl Default for FWPM_NETWORK_CONNECTION_POLICY_SETTING0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NETWORK_CONNECTION_POLICY_SETTING0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1879,10 +1796,6 @@ impl Default for FWPM_NETWORK_CONNECTION_POLICY_SETTINGS0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NETWORK_CONNECTION_POLICY_SETTINGS0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -1897,10 +1810,6 @@ impl Default for FWPM_NET_EVENT0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -1919,10 +1828,6 @@ impl Default for FWPM_NET_EVENT0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -1936,10 +1841,6 @@ impl Default for FWPM_NET_EVENT1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -1958,10 +1859,6 @@ impl Default for FWPM_NET_EVENT1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -1975,10 +1872,6 @@ impl Default for FWPM_NET_EVENT2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2001,10 +1894,6 @@ impl Default for FWPM_NET_EVENT2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2018,10 +1907,6 @@ impl Default for FWPM_NET_EVENT3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2044,10 +1929,6 @@ impl Default for FWPM_NET_EVENT3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2061,10 +1942,6 @@ impl Default for FWPM_NET_EVENT4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2087,10 +1964,6 @@ impl Default for FWPM_NET_EVENT4_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT4_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2104,10 +1977,6 @@ impl Default for FWPM_NET_EVENT5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2132,10 +2001,6 @@ impl Default for FWPM_NET_EVENT5_0 {
     }
 }
 #[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT5_0 {
-    type TypeKind = windows_core::CopyType;
-}
-#[cfg(feature = "Win32_Security")]
 pub type FWPM_NET_EVENT_CALLBACK0 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, event: *const FWPM_NET_EVENT1)>;
 #[cfg(feature = "Win32_Security")]
 pub type FWPM_NET_EVENT_CALLBACK1 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, event: *const FWPM_NET_EVENT2)>;
@@ -2157,9 +2022,6 @@ impl Default for FWPM_NET_EVENT_CAPABILITY_ALLOW0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_NET_EVENT_CAPABILITY_ALLOW0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_NET_EVENT_CAPABILITY_DROP0 {
@@ -2171,9 +2033,6 @@ impl Default for FWPM_NET_EVENT_CAPABILITY_DROP0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_NET_EVENT_CAPABILITY_DROP0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2191,9 +2050,6 @@ impl Default for FWPM_NET_EVENT_CLASSIFY_ALLOW0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_NET_EVENT_CLASSIFY_ALLOW0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_NET_EVENT_CLASSIFY_DROP0 {
@@ -2204,9 +2060,6 @@ impl Default for FWPM_NET_EVENT_CLASSIFY_DROP0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_NET_EVENT_CLASSIFY_DROP0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2223,9 +2076,6 @@ impl Default for FWPM_NET_EVENT_CLASSIFY_DROP1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_NET_EVENT_CLASSIFY_DROP1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2245,9 +2095,6 @@ impl Default for FWPM_NET_EVENT_CLASSIFY_DROP2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_NET_EVENT_CLASSIFY_DROP2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2277,9 +2124,6 @@ impl Default for FWPM_NET_EVENT_CLASSIFY_DROP_MAC0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_NET_EVENT_CLASSIFY_DROP_MAC0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2294,10 +2138,6 @@ impl Default for FWPM_NET_EVENT_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_NET_EVENT_FLAG_APP_ID_SET: u32 = 32u32;
 pub const FWPM_NET_EVENT_FLAG_EFFECTIVE_NAME_SET: u32 = 8192u32;
@@ -2335,10 +2175,6 @@ impl Default for FWPM_NET_EVENT_HEADER0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2352,10 +2188,6 @@ impl Default for FWPM_NET_EVENT_HEADER0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2368,10 +2200,6 @@ impl Default for FWPM_NET_EVENT_HEADER0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2396,10 +2224,6 @@ impl Default for FWPM_NET_EVENT_HEADER1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2412,10 +2236,6 @@ impl Default for FWPM_NET_EVENT_HEADER1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2430,10 +2250,6 @@ impl Default for FWPM_NET_EVENT_HEADER1_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER1_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2445,10 +2261,6 @@ impl Default for FWPM_NET_EVENT_HEADER1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER1_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2463,10 +2275,6 @@ impl Default for FWPM_NET_EVENT_HEADER1_2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER1_2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2478,10 +2286,6 @@ impl Default for FWPM_NET_EVENT_HEADER1_2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER1_2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2502,10 +2306,6 @@ impl Default for FWPM_NET_EVENT_HEADER1_2_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER1_2_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2531,10 +2331,6 @@ impl Default for FWPM_NET_EVENT_HEADER2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2548,10 +2344,6 @@ impl Default for FWPM_NET_EVENT_HEADER2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2564,10 +2356,6 @@ impl Default for FWPM_NET_EVENT_HEADER2_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER2_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2596,10 +2384,6 @@ impl Default for FWPM_NET_EVENT_HEADER3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2613,10 +2397,6 @@ impl Default for FWPM_NET_EVENT_HEADER3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2629,10 +2409,6 @@ impl Default for FWPM_NET_EVENT_HEADER3_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_HEADER3_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2651,9 +2427,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_EM_FAILURE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_EM_FAILURE0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2680,9 +2453,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_EM_FAILURE1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_EM_FAILURE1 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWPM_NET_EVENT_IKEEXT_EM_FAILURE_FLAG_BENIGN: u32 = 2u32;
 pub const FWPM_NET_EVENT_IKEEXT_EM_FAILURE_FLAG_MULTIPLE: u32 = 1u32;
 #[repr(C)]
@@ -2703,9 +2473,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_MM_FAILURE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_MM_FAILURE0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2731,9 +2498,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_MM_FAILURE1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_MM_FAILURE1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2761,9 +2525,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_MM_FAILURE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_MM_FAILURE2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWPM_NET_EVENT_IKEEXT_MM_FAILURE_FLAG_BENIGN: u32 = 1u32;
 pub const FWPM_NET_EVENT_IKEEXT_MM_FAILURE_FLAG_MULTIPLE: u32 = 2u32;
 #[repr(C)]
@@ -2786,10 +2547,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2802,10 +2559,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2817,10 +2570,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_QM_FAILURE0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -2844,10 +2593,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2860,10 +2605,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -2875,10 +2616,6 @@ impl Default for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_IKEEXT_QM_FAILURE1_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2894,9 +2631,6 @@ impl Default for FWPM_NET_EVENT_IPSEC_DOSP_DROP0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_NET_EVENT_IPSEC_DOSP_DROP0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FWPM_NET_EVENT_IPSEC_DOSP_DROP0_0 {
@@ -2908,9 +2642,6 @@ impl Default for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FWPM_NET_EVENT_IPSEC_DOSP_DROP0_1 {
@@ -2921,9 +2652,6 @@ impl Default for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_NET_EVENT_IPSEC_DOSP_DROP0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2938,9 +2666,6 @@ impl Default for FWPM_NET_EVENT_IPSEC_KERNEL_DROP0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_NET_EVENT_IPSEC_KERNEL_DROP0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_NET_EVENT_KEYWORD_CAPABILITY_ALLOW: u32 = 8u32;
 pub const FWPM_NET_EVENT_KEYWORD_CAPABILITY_DROP: u32 = 4u32;
@@ -2958,9 +2683,6 @@ impl Default for FWPM_NET_EVENT_LPM_PACKET_ARRIVAL0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_NET_EVENT_LPM_PACKET_ARRIVAL0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2974,10 +2696,6 @@ impl Default for FWPM_NET_EVENT_SUBSCRIPTION0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_NET_EVENT_SUBSCRIPTION0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3008,9 +2726,6 @@ impl Default for FWPM_PROVIDER0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_PROVIDER0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_PROVIDER_CHANGE0 {
@@ -3021,9 +2736,6 @@ impl Default for FWPM_PROVIDER_CHANGE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_PROVIDER_CHANGE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type FWPM_PROVIDER_CHANGE_CALLBACK0 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, change: *const FWPM_PROVIDER_CHANGE0)>;
 #[repr(C)]
@@ -3045,10 +2757,6 @@ impl Default for FWPM_PROVIDER_CONTEXT0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -3069,10 +2777,6 @@ impl Default for FWPM_PROVIDER_CONTEXT0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -3091,10 +2795,6 @@ impl Default for FWPM_PROVIDER_CONTEXT1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -3119,10 +2819,6 @@ impl Default for FWPM_PROVIDER_CONTEXT1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -3141,10 +2837,6 @@ impl Default for FWPM_PROVIDER_CONTEXT2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -3170,10 +2862,6 @@ impl Default for FWPM_PROVIDER_CONTEXT2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -3192,10 +2880,6 @@ impl Default for FWPM_PROVIDER_CONTEXT3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -3222,10 +2906,6 @@ impl Default for FWPM_PROVIDER_CONTEXT3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_PROVIDER_CONTEXT_CHANGE0 {
@@ -3238,9 +2918,6 @@ impl Default for FWPM_PROVIDER_CONTEXT_CHANGE0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT_CHANGE0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub type FWPM_PROVIDER_CONTEXT_CHANGE_CALLBACK0 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, change: *const FWPM_PROVIDER_CONTEXT_CHANGE0)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3252,9 +2929,6 @@ impl Default for FWPM_PROVIDER_CONTEXT_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_PROVIDER_CONTEXT_FLAG_DOWNLEVEL: u32 = 2u32;
 pub const FWPM_PROVIDER_CONTEXT_FLAG_PERSISTENT: u32 = 1u32;
@@ -3272,9 +2946,6 @@ impl Default for FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FWPM_PROVIDER_CONTEXT_TYPE(pub i32);
@@ -3288,9 +2959,6 @@ impl Default for FWPM_PROVIDER_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_PROVIDER_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_PROVIDER_FLAG_DISABLED: u32 = 16u32;
 pub const FWPM_PROVIDER_FLAG_PERSISTENT: u32 = 1u32;
@@ -3312,9 +2980,6 @@ impl Default for FWPM_PROVIDER_SUBSCRIPTION0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_PROVIDER_SUBSCRIPTION0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_PROVIDER_TCP_CHIMNEY_OFFLOAD: windows_core::GUID = windows_core::GUID::from_u128(0x896aa19e_9a34_4bcb_ae79_beb9127c84b9);
 pub const FWPM_PROVIDER_TCP_TEMPLATES: windows_core::GUID = windows_core::GUID::from_u128(0x76cfcd30_3394_432d_bed3_441ae50e63c3);
@@ -3345,10 +3010,6 @@ impl Default for FWPM_SESSION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWPM_SESSION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_SESSION_ENUM_TEMPLATE0 {
@@ -3358,9 +3019,6 @@ impl Default for FWPM_SESSION_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_SESSION_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_SESSION_FLAG_DYNAMIC: u32 = 1u32;
 pub const FWPM_SESSION_FLAG_RESERVED: u32 = 268435456u32;
@@ -3409,9 +3067,6 @@ impl Default for FWPM_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_SUBLAYER0 {
@@ -3427,9 +3082,6 @@ impl Default for FWPM_SUBLAYER0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_SUBLAYER0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_SUBLAYER_CHANGE0 {
@@ -3441,9 +3093,6 @@ impl Default for FWPM_SUBLAYER_CHANGE0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_SUBLAYER_CHANGE0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub type FWPM_SUBLAYER_CHANGE_CALLBACK0 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, change: *const FWPM_SUBLAYER_CHANGE0)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3454,9 +3103,6 @@ impl Default for FWPM_SUBLAYER_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_SUBLAYER_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWPM_SUBLAYER_FLAG_PERSISTENT: u32 = 1u32;
 pub const FWPM_SUBLAYER_INSPECTION: windows_core::GUID = windows_core::GUID::from_u128(0x877519e1_e6a9_41a5_81b4_8c4f118e4a60);
@@ -3485,9 +3131,6 @@ impl Default for FWPM_SUBLAYER_SUBSCRIPTION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_SUBLAYER_SUBSCRIPTION0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWPM_SUBLAYER_TCP_CHIMNEY_OFFLOAD: windows_core::GUID = windows_core::GUID::from_u128(0x337608b9_b7d5_4d5f_82f9_3618618bc058);
 pub const FWPM_SUBLAYER_TCP_TEMPLATES: windows_core::GUID = windows_core::GUID::from_u128(0x24421dcf_0ac5_4caa_9e14_50f6e3636af0);
 pub const FWPM_SUBLAYER_TEREDO: windows_core::GUID = windows_core::GUID::from_u128(0xba69dc66_5176_4979_9c89_26a7b46a8327);
@@ -3508,9 +3151,6 @@ impl Default for FWPM_SYSTEM_PORTS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_SYSTEM_PORTS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_SYSTEM_PORTS_BY_TYPE0 {
@@ -3522,9 +3162,6 @@ impl Default for FWPM_SYSTEM_PORTS_BY_TYPE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_SYSTEM_PORTS_BY_TYPE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type FWPM_SYSTEM_PORTS_CALLBACK0 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, sysports: *const FWPM_SYSTEM_PORTS0)>;
 pub const FWPM_SYSTEM_PORT_IPHTTPS_IN: FWPM_SYSTEM_PORT_TYPE = FWPM_SYSTEM_PORT_TYPE(2i32);
@@ -3551,9 +3188,6 @@ impl Default for FWPM_VSWITCH_EVENT0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_VSWITCH_EVENT0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FWPM_VSWITCH_EVENT0_0 {
@@ -3564,9 +3198,6 @@ impl Default for FWPM_VSWITCH_EVENT0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_VSWITCH_EVENT0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3579,9 +3210,6 @@ impl Default for FWPM_VSWITCH_EVENT0_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWPM_VSWITCH_EVENT0_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FWPM_VSWITCH_EVENT0_0_1 {
@@ -3593,9 +3221,6 @@ impl Default for FWPM_VSWITCH_EVENT0_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_VSWITCH_EVENT0_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type FWPM_VSWITCH_EVENT_CALLBACK0 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, vswitchevent: *const FWPM_VSWITCH_EVENT0) -> u32>;
 pub const FWPM_VSWITCH_EVENT_DISABLED_FOR_INSPECTION: FWPM_VSWITCH_EVENT_TYPE = FWPM_VSWITCH_EVENT_TYPE(3i32);
@@ -3614,9 +3239,6 @@ impl Default for FWPM_VSWITCH_EVENT_SUBSCRIPTION0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWPM_VSWITCH_EVENT_SUBSCRIPTION0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3722,9 +3344,6 @@ impl Default for FWP_BYTE_ARRAY16 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWP_BYTE_ARRAY16 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWP_BYTE_ARRAY16_TYPE: FWP_DATA_TYPE = FWP_DATA_TYPE(11i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3735,9 +3354,6 @@ impl Default for FWP_BYTE_ARRAY6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWP_BYTE_ARRAY6 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWP_BYTE_ARRAY6_SIZE: u32 = 6u32;
 pub const FWP_BYTE_ARRAY6_TYPE: FWP_DATA_TYPE = FWP_DATA_TYPE(18i32);
@@ -3751,9 +3367,6 @@ impl Default for FWP_BYTE_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWP_BYTE_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWP_BYTE_BLOB_TYPE: FWP_DATA_TYPE = FWP_DATA_TYPE(12i32);
 pub const FWP_CALLOUT_FLAG_ALLOW_L2_BATCH_CLASSIFY: u32 = 128u32;
@@ -3838,10 +3451,6 @@ impl Default for FWP_CONDITION_VALUE0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWP_CONDITION_VALUE0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -3873,10 +3482,6 @@ impl Default for FWP_CONDITION_VALUE0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWP_CONDITION_VALUE0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3964,10 +3569,6 @@ impl Default for FWP_RANGE0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWP_RANGE0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWP_RANGE_TYPE: FWP_DATA_TYPE = FWP_DATA_TYPE(258i32);
 pub const FWP_SECURITY_DESCRIPTOR_TYPE: FWP_DATA_TYPE = FWP_DATA_TYPE(14i32);
 pub const FWP_SID: FWP_DATA_TYPE = FWP_DATA_TYPE(13i32);
@@ -3988,10 +3589,6 @@ impl Default for FWP_TOKEN_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWP_TOKEN_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWP_TOKEN_INFORMATION_TYPE: FWP_DATA_TYPE = FWP_DATA_TYPE(15i32);
 pub const FWP_UINT16: FWP_DATA_TYPE = FWP_DATA_TYPE(2i32);
 pub const FWP_UINT32: FWP_DATA_TYPE = FWP_DATA_TYPE(3i32);
@@ -4009,9 +3606,6 @@ impl Default for FWP_V4_ADDR_AND_MASK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FWP_V4_ADDR_AND_MASK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FWP_V4_ADDR_MASK: FWP_DATA_TYPE = FWP_DATA_TYPE(256i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4023,9 +3617,6 @@ impl Default for FWP_V6_ADDR_AND_MASK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FWP_V6_ADDR_AND_MASK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FWP_V6_ADDR_MASK: FWP_DATA_TYPE = FWP_DATA_TYPE(257i32);
 pub const FWP_V6_ADDR_SIZE: u32 = 16u32;
@@ -4041,10 +3632,6 @@ impl Default for FWP_VALUE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWP_VALUE0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -4075,10 +3662,6 @@ impl Default for FWP_VALUE0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FWP_VALUE0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FWP_VSWITCH_NETWORK_TYPE(pub i32);
@@ -4101,9 +3684,6 @@ impl Default for IKEEXT_AUTHENTICATION_METHOD0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_AUTHENTICATION_METHOD0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_AUTHENTICATION_METHOD0_0 {
@@ -4119,9 +3699,6 @@ impl Default for IKEEXT_AUTHENTICATION_METHOD0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_AUTHENTICATION_METHOD0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IKEEXT_AUTHENTICATION_METHOD1 {
@@ -4132,9 +3709,6 @@ impl Default for IKEEXT_AUTHENTICATION_METHOD1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_AUTHENTICATION_METHOD1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4152,9 +3726,6 @@ impl Default for IKEEXT_AUTHENTICATION_METHOD1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_AUTHENTICATION_METHOD1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IKEEXT_AUTHENTICATION_METHOD2 {
@@ -4165,9 +3736,6 @@ impl Default for IKEEXT_AUTHENTICATION_METHOD2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_AUTHENTICATION_METHOD2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4185,9 +3753,6 @@ impl Default for IKEEXT_AUTHENTICATION_METHOD2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_AUTHENTICATION_METHOD2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4208,9 +3773,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_CERTIFICATE_AUTHENTICATION0_0 {
@@ -4223,9 +3785,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CERTIFICATE_AUTHENTICATION0_0_0 {
@@ -4236,9 +3795,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4252,9 +3808,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CERTIFICATE_AUTHENTICATION0_1_0 {
@@ -4265,9 +3818,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION0_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION0_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4284,9 +3834,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_CERTIFICATE_AUTHENTICATION1_0 {
@@ -4299,9 +3846,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CERTIFICATE_AUTHENTICATION1_0_0 {
@@ -4312,9 +3856,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION1_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION1_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4328,9 +3869,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION1_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION1_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CERTIFICATE_AUTHENTICATION1_1_0 {
@@ -4341,9 +3879,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION1_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION1_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4360,9 +3895,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_CERTIFICATE_AUTHENTICATION2_0 {
@@ -4375,9 +3907,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CERTIFICATE_AUTHENTICATION2_0_0 {
@@ -4388,9 +3917,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4403,9 +3929,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CERTIFICATE_AUTHENTICATION2_0_2 {
@@ -4416,9 +3939,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION2_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4432,9 +3952,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CERTIFICATE_AUTHENTICATION2_1_0 {
@@ -4445,9 +3962,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4460,9 +3974,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CERTIFICATE_AUTHENTICATION2_1_2 {
@@ -4473,9 +3984,6 @@ impl Default for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_AUTHENTICATION2_1_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4488,9 +3996,6 @@ impl Default for IKEEXT_CERTIFICATE_CREDENTIAL0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_CREDENTIAL0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4505,9 +4010,6 @@ impl Default for IKEEXT_CERTIFICATE_CREDENTIAL1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_CREDENTIAL1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CERTIFICATE_CRITERIA0 {
@@ -4521,9 +4023,6 @@ impl Default for IKEEXT_CERTIFICATE_CRITERIA0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERTIFICATE_CRITERIA0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IKEEXT_CERTIFICATE_ECDSA_P256: IKEEXT_AUTHENTICATION_METHOD_TYPE = IKEEXT_AUTHENTICATION_METHOD_TYPE(7i32);
 pub const IKEEXT_CERTIFICATE_ECDSA_P384: IKEEXT_AUTHENTICATION_METHOD_TYPE = IKEEXT_AUTHENTICATION_METHOD_TYPE(8i32);
@@ -4601,9 +4100,6 @@ impl Default for IKEEXT_CERT_EKUS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERT_EKUS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct IKEEXT_CERT_FLAGS(pub u32);
@@ -4661,9 +4157,6 @@ impl Default for IKEEXT_CERT_NAME0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CERT_NAME0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CERT_ROOT_CONFIG0 {
@@ -4674,9 +4167,6 @@ impl Default for IKEEXT_CERT_ROOT_CONFIG0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CERT_ROOT_CONFIG0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IKEEXT_CIPHER_3DES: IKEEXT_CIPHER_TYPE = IKEEXT_CIPHER_TYPE(1i32);
 pub const IKEEXT_CIPHER_AES_128: IKEEXT_CIPHER_TYPE = IKEEXT_CIPHER_TYPE(2i32);
@@ -4695,9 +4185,6 @@ impl Default for IKEEXT_CIPHER_ALGORITHM0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CIPHER_ALGORITHM0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IKEEXT_CIPHER_DES: IKEEXT_CIPHER_TYPE = IKEEXT_CIPHER_TYPE(0i32);
 #[repr(transparent)]
@@ -4718,9 +4205,6 @@ impl Default for IKEEXT_COMMON_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_COMMON_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_COMMON_STATISTICS1 {
@@ -4735,9 +4219,6 @@ impl Default for IKEEXT_COMMON_STATISTICS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_COMMON_STATISTICS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_COOKIE_PAIR0 {
@@ -4748,9 +4229,6 @@ impl Default for IKEEXT_COOKIE_PAIR0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_COOKIE_PAIR0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4764,9 +4242,6 @@ impl Default for IKEEXT_CREDENTIAL0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CREDENTIAL0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_CREDENTIAL0_0 {
@@ -4778,9 +4253,6 @@ impl Default for IKEEXT_CREDENTIAL0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CREDENTIAL0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4794,9 +4266,6 @@ impl Default for IKEEXT_CREDENTIAL1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CREDENTIAL1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_CREDENTIAL1_0 {
@@ -4808,9 +4277,6 @@ impl Default for IKEEXT_CREDENTIAL1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CREDENTIAL1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4824,9 +4290,6 @@ impl Default for IKEEXT_CREDENTIAL2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CREDENTIAL2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_CREDENTIAL2_0 {
@@ -4839,9 +4302,6 @@ impl Default for IKEEXT_CREDENTIAL2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CREDENTIAL2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CREDENTIALS0 {
@@ -4852,9 +4312,6 @@ impl Default for IKEEXT_CREDENTIALS0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CREDENTIALS0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4867,9 +4324,6 @@ impl Default for IKEEXT_CREDENTIALS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CREDENTIALS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_CREDENTIALS2 {
@@ -4880,9 +4334,6 @@ impl Default for IKEEXT_CREDENTIALS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CREDENTIALS2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4895,9 +4346,6 @@ impl Default for IKEEXT_CREDENTIAL_PAIR0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CREDENTIAL_PAIR0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IKEEXT_CREDENTIAL_PAIR1 {
@@ -4909,9 +4357,6 @@ impl Default for IKEEXT_CREDENTIAL_PAIR1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_CREDENTIAL_PAIR1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IKEEXT_CREDENTIAL_PAIR2 {
@@ -4922,9 +4367,6 @@ impl Default for IKEEXT_CREDENTIAL_PAIR2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_CREDENTIAL_PAIR2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IKEEXT_DH_ECP_256: IKEEXT_DH_GROUP = IKEEXT_DH_GROUP(4i32);
 pub const IKEEXT_DH_ECP_384: IKEEXT_DH_GROUP = IKEEXT_DH_GROUP(5i32);
@@ -4948,9 +4390,6 @@ impl Default for IKEEXT_EAP_AUTHENTICATION0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_EAP_AUTHENTICATION0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5002,9 +4441,6 @@ impl Default for IKEEXT_EM_POLICY0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_EM_POLICY0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_EM_POLICY1 {
@@ -5017,9 +4453,6 @@ impl Default for IKEEXT_EM_POLICY1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_EM_POLICY1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_EM_POLICY2 {
@@ -5031,9 +4464,6 @@ impl Default for IKEEXT_EM_POLICY2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_EM_POLICY2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5058,9 +4488,6 @@ impl Default for IKEEXT_INTEGRITY_ALGORITHM0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_INTEGRITY_ALGORITHM0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IKEEXT_INTEGRITY_MD5: IKEEXT_INTEGRITY_TYPE = IKEEXT_INTEGRITY_TYPE(0i32);
 pub const IKEEXT_INTEGRITY_SHA1: IKEEXT_INTEGRITY_TYPE = IKEEXT_INTEGRITY_TYPE(1i32);
 pub const IKEEXT_INTEGRITY_SHA_256: IKEEXT_INTEGRITY_TYPE = IKEEXT_INTEGRITY_TYPE(2i32);
@@ -5084,9 +4511,6 @@ impl Default for IKEEXT_IPV6_CGA_AUTHENTICATION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_IPV6_CGA_AUTHENTICATION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS0 {
@@ -5098,9 +4522,6 @@ impl Default for IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS1 {
@@ -5111,9 +4532,6 @@ impl Default for IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_IP_VERSION_SPECIFIC_COMMON_STATISTICS1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5142,9 +4560,6 @@ impl Default for IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS1 {
@@ -5172,9 +4587,6 @@ impl Default for IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_IP_VERSION_SPECIFIC_KEYMODULE_STATISTICS1 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IKEEXT_KERBEROS: IKEEXT_AUTHENTICATION_METHOD_TYPE = IKEEXT_AUTHENTICATION_METHOD_TYPE(2i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5186,9 +4598,6 @@ impl Default for IKEEXT_KERBEROS_AUTHENTICATION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_KERBEROS_AUTHENTICATION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_KERBEROS_AUTHENTICATION1 {
@@ -5199,9 +4608,6 @@ impl Default for IKEEXT_KERBEROS_AUTHENTICATION1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_KERBEROS_AUTHENTICATION1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5257,9 +4663,6 @@ impl Default for IKEEXT_KEYMODULE_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_KEYMODULE_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_KEYMODULE_STATISTICS1 {
@@ -5274,9 +4677,6 @@ impl Default for IKEEXT_KEYMODULE_STATISTICS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_KEYMODULE_STATISTICS1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IKEEXT_KEY_MODULE_AUTHIP: IKEEXT_KEY_MODULE_TYPE = IKEEXT_KEY_MODULE_TYPE(1i32);
 pub const IKEEXT_KEY_MODULE_IKE: IKEEXT_KEY_MODULE_TYPE = IKEEXT_KEY_MODULE_TYPE(0i32);
@@ -5305,9 +4705,6 @@ impl Default for IKEEXT_NAME_CREDENTIAL0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_NAME_CREDENTIAL0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IKEEXT_NTLM_V2: IKEEXT_AUTHENTICATION_METHOD_TYPE = IKEEXT_AUTHENTICATION_METHOD_TYPE(5i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5318,9 +4715,6 @@ impl Default for IKEEXT_NTLM_V2_AUTHENTICATION0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_NTLM_V2_AUTHENTICATION0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IKEEXT_NTLM_V2_AUTH_DONT_ACCEPT_EXPLICIT_CREDENTIALS: u32 = 1u32;
 #[repr(C)]
@@ -5340,9 +4734,6 @@ impl Default for IKEEXT_POLICY0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_POLICY0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_POLICY1 {
@@ -5361,9 +4752,6 @@ impl Default for IKEEXT_POLICY1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_POLICY1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_POLICY2 {
@@ -5381,9 +4769,6 @@ impl Default for IKEEXT_POLICY2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_POLICY2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IKEEXT_POLICY_ENABLE_IKEV2_FRAGMENTATION: u32 = 128u32;
 #[repr(transparent)]
@@ -5441,9 +4826,6 @@ impl Default for IKEEXT_PRESHARED_KEY_AUTHENTICATION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_PRESHARED_KEY_AUTHENTICATION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_PRESHARED_KEY_AUTHENTICATION1 {
@@ -5454,9 +4836,6 @@ impl Default for IKEEXT_PRESHARED_KEY_AUTHENTICATION1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_PRESHARED_KEY_AUTHENTICATION1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5508,9 +4887,6 @@ impl Default for IKEEXT_PROPOSAL0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_PROPOSAL0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IKEEXT_PSK_FLAG_LOCAL_AUTH_ONLY: IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS = IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS(1u32);
 pub const IKEEXT_PSK_FLAG_REMOTE_AUTH_ONLY: IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS = IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS(2u32);
 #[repr(transparent)]
@@ -5531,9 +4907,6 @@ impl Default for IKEEXT_RESERVED_AUTHENTICATION0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_RESERVED_AUTHENTICATION0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5591,9 +4964,6 @@ impl Default for IKEEXT_SA_DETAILS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_SA_DETAILS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_SA_DETAILS0_0 {
@@ -5603,9 +4973,6 @@ impl Default for IKEEXT_SA_DETAILS0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_SA_DETAILS0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5627,9 +4994,6 @@ impl Default for IKEEXT_SA_DETAILS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_SA_DETAILS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_SA_DETAILS1_0 {
@@ -5639,9 +5003,6 @@ impl Default for IKEEXT_SA_DETAILS1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_SA_DETAILS1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5663,9 +5024,6 @@ impl Default for IKEEXT_SA_DETAILS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_SA_DETAILS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_SA_DETAILS2_0 {
@@ -5675,9 +5033,6 @@ impl Default for IKEEXT_SA_DETAILS2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_SA_DETAILS2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -5692,10 +5047,6 @@ impl Default for IKEEXT_SA_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for IKEEXT_SA_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5718,9 +5069,6 @@ impl Default for IKEEXT_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IKEEXT_STATISTICS1 {
@@ -5733,9 +5081,6 @@ impl Default for IKEEXT_STATISTICS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_STATISTICS1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5750,9 +5095,6 @@ impl Default for IKEEXT_TRAFFIC0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_TRAFFIC0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_TRAFFIC0_0 {
@@ -5764,9 +5106,6 @@ impl Default for IKEEXT_TRAFFIC0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKEEXT_TRAFFIC0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKEEXT_TRAFFIC0_1 {
@@ -5777,9 +5116,6 @@ impl Default for IKEEXT_TRAFFIC0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKEEXT_TRAFFIC0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5793,9 +5129,6 @@ impl Default for IPSEC_ADDRESS_INFO0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_ADDRESS_INFO0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5814,9 +5147,6 @@ impl Default for IPSEC_AGGREGATE_DROP_PACKET_STATISTICS0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_AGGREGATE_DROP_PACKET_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5837,9 +5167,6 @@ impl Default for IPSEC_AGGREGATE_DROP_PACKET_STATISTICS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_AGGREGATE_DROP_PACKET_STATISTICS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_AGGREGATE_SA_STATISTICS0 {
@@ -5856,9 +5183,6 @@ impl Default for IPSEC_AGGREGATE_SA_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_AGGREGATE_SA_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_AH_DROP_PACKET_STATISTICS0 {
@@ -5871,9 +5195,6 @@ impl Default for IPSEC_AH_DROP_PACKET_STATISTICS0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_AH_DROP_PACKET_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPSEC_AUTH_AES_128: IPSEC_AUTH_TYPE = IPSEC_AUTH_TYPE(3i32);
 pub const IPSEC_AUTH_AES_192: IPSEC_AUTH_TYPE = IPSEC_AUTH_TYPE(4i32);
@@ -5888,9 +5209,6 @@ impl Default for IPSEC_AUTH_AND_CIPHER_TRANSFORM0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_AUTH_AND_CIPHER_TRANSFORM0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPSEC_AUTH_CONFIG_GCM_AES_128: u32 = 3u32;
 pub const IPSEC_AUTH_CONFIG_GCM_AES_192: u32 = 4u32;
@@ -5914,9 +5232,6 @@ impl Default for IPSEC_AUTH_TRANSFORM0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_AUTH_TRANSFORM0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_AUTH_TRANSFORM_ID0 {
@@ -5927,9 +5242,6 @@ impl Default for IPSEC_AUTH_TRANSFORM_ID0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_AUTH_TRANSFORM_ID0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5954,9 +5266,6 @@ impl Default for IPSEC_CIPHER_TRANSFORM0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_CIPHER_TRANSFORM0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_CIPHER_TRANSFORM_ID0 {
@@ -5967,9 +5276,6 @@ impl Default for IPSEC_CIPHER_TRANSFORM_ID0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_CIPHER_TRANSFORM_ID0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6054,9 +5360,6 @@ impl Default for IPSEC_DOSP_OPTIONS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_DOSP_OPTIONS0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IPSEC_DOSP_RATE_LIMIT_DISABLE_VALUE: u32 = 0u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6072,9 +5375,6 @@ impl Default for IPSEC_DOSP_STATE0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_DOSP_STATE0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_DOSP_STATE_ENUM_TEMPLATE0 {
@@ -6085,9 +5385,6 @@ impl Default for IPSEC_DOSP_STATE_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_DOSP_STATE_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6116,9 +5413,6 @@ impl Default for IPSEC_DOSP_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_DOSP_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_ESP_DROP_PACKET_STATISTICS0 {
@@ -6132,9 +5426,6 @@ impl Default for IPSEC_ESP_DROP_PACKET_STATISTICS0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_ESP_DROP_PACKET_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPSEC_FAILURE_ME: IPSEC_FAILURE_POINT = IPSEC_FAILURE_POINT(1i32);
 pub const IPSEC_FAILURE_NONE: IPSEC_FAILURE_POINT = IPSEC_FAILURE_POINT(0i32);
@@ -6156,9 +5447,6 @@ impl Default for IPSEC_GETSPI0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_GETSPI0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_GETSPI0_0 {
@@ -6168,9 +5456,6 @@ impl Default for IPSEC_GETSPI0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_GETSPI0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6185,9 +5470,6 @@ impl Default for IPSEC_GETSPI1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_GETSPI1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_GETSPI1_0 {
@@ -6197,9 +5479,6 @@ impl Default for IPSEC_GETSPI1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_GETSPI1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6216,9 +5495,6 @@ impl Default for IPSEC_ID0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_ID0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_KEYING_POLICY0 {
@@ -6229,9 +5505,6 @@ impl Default for IPSEC_KEYING_POLICY0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_KEYING_POLICY0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6245,9 +5518,6 @@ impl Default for IPSEC_KEYING_POLICY1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_KEYING_POLICY1 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IPSEC_KEYING_POLICY_FLAG_TERMINATING_MATCH: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6259,9 +5529,6 @@ impl Default for IPSEC_KEYMODULE_STATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_KEYMODULE_STATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6275,9 +5542,6 @@ impl Default for IPSEC_KEY_MANAGER0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_KEY_MANAGER0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -6294,10 +5558,6 @@ impl Default for IPSEC_KEY_MANAGER_CALLBACKS0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for IPSEC_KEY_MANAGER_CALLBACKS0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_Security")]
 pub type IPSEC_KEY_MANAGER_DICTATE_KEY0 = Option<unsafe extern "system" fn(inboundsadetails: *mut IPSEC_SA_DETAILS1, outboundsadetails: *mut IPSEC_SA_DETAILS1, keyingmodulegenkey: *mut super::super::Foundation::BOOL) -> u32>;
@@ -6387,9 +5647,6 @@ impl Default for IPSEC_PROPOSAL0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_PROPOSAL0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IPSEC_SA0 {
@@ -6401,9 +5658,6 @@ impl Default for IPSEC_SA0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_SA0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6419,9 +5673,6 @@ impl Default for IPSEC_SA0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_SA0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_SA_AUTH_AND_CIPHER_INFORMATION0 {
@@ -6433,9 +5684,6 @@ impl Default for IPSEC_SA_AUTH_AND_CIPHER_INFORMATION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_SA_AUTH_AND_CIPHER_INFORMATION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_SA_AUTH_INFORMATION0 {
@@ -6446,9 +5694,6 @@ impl Default for IPSEC_SA_AUTH_INFORMATION0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_SA_AUTH_INFORMATION0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6473,9 +5718,6 @@ impl Default for IPSEC_SA_BUNDLE0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_SA_BUNDLE0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_SA_BUNDLE0_0 {
@@ -6485,9 +5727,6 @@ impl Default for IPSEC_SA_BUNDLE0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_SA_BUNDLE0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6514,9 +5753,6 @@ impl Default for IPSEC_SA_BUNDLE1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_SA_BUNDLE1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_SA_BUNDLE1_0 {
@@ -6526,9 +5762,6 @@ impl Default for IPSEC_SA_BUNDLE1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_SA_BUNDLE1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6604,9 +5837,6 @@ impl Default for IPSEC_SA_CIPHER_INFORMATION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_SA_CIPHER_INFORMATION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6620,10 +5850,6 @@ impl Default for IPSEC_SA_CONTEXT0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for IPSEC_SA_CONTEXT0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -6639,10 +5865,6 @@ impl Default for IPSEC_SA_CONTEXT1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for IPSEC_SA_CONTEXT1 {
-    type TypeKind = windows_core::CopyType;
-}
 pub type IPSEC_SA_CONTEXT_CALLBACK0 = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, change: *const IPSEC_SA_CONTEXT_CHANGE0)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6654,9 +5876,6 @@ impl Default for IPSEC_SA_CONTEXT_CHANGE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_SA_CONTEXT_CHANGE0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -6670,10 +5889,6 @@ impl Default for IPSEC_SA_CONTEXT_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for IPSEC_SA_CONTEXT_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPSEC_SA_CONTEXT_EVENT_ADD: IPSEC_SA_CONTEXT_EVENT_TYPE0 = IPSEC_SA_CONTEXT_EVENT_TYPE0(1i32);
 pub const IPSEC_SA_CONTEXT_EVENT_DELETE: IPSEC_SA_CONTEXT_EVENT_TYPE0 = IPSEC_SA_CONTEXT_EVENT_TYPE0(2i32);
@@ -6695,10 +5910,6 @@ impl Default for IPSEC_SA_CONTEXT_SUBSCRIPTION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for IPSEC_SA_CONTEXT_SUBSCRIPTION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -6716,10 +5927,6 @@ impl Default for IPSEC_SA_DETAILS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for IPSEC_SA_DETAILS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -6731,10 +5938,6 @@ impl Default for IPSEC_SA_DETAILS0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for IPSEC_SA_DETAILS0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -6754,10 +5957,6 @@ impl Default for IPSEC_SA_DETAILS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for IPSEC_SA_DETAILS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -6770,10 +5969,6 @@ impl Default for IPSEC_SA_DETAILS1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for IPSEC_SA_DETAILS1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_SA_ENUM_TEMPLATE0 {
@@ -6783,9 +5978,6 @@ impl Default for IPSEC_SA_ENUM_TEMPLATE0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_SA_ENUM_TEMPLATE0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6797,9 +5989,6 @@ impl Default for IPSEC_SA_IDLE_TIMEOUT0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_SA_IDLE_TIMEOUT0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6813,9 +6002,6 @@ impl Default for IPSEC_SA_LIFETIME0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_SA_LIFETIME0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IPSEC_SA_TRANSFORM0 {
@@ -6826,9 +6012,6 @@ impl Default for IPSEC_SA_TRANSFORM0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_SA_TRANSFORM0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6843,9 +6026,6 @@ impl Default for IPSEC_SA_TRANSFORM0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_SA_TRANSFORM0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6862,9 +6042,6 @@ impl Default for IPSEC_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_STATISTICS1 {
@@ -6880,9 +6057,6 @@ impl Default for IPSEC_STATISTICS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_STATISTICS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_TOKEN0 {
@@ -6895,9 +6069,6 @@ impl Default for IPSEC_TOKEN0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TOKEN0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6932,9 +6103,6 @@ impl Default for IPSEC_TRAFFIC0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TRAFFIC0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TRAFFIC0_0 {
@@ -6945,9 +6113,6 @@ impl Default for IPSEC_TRAFFIC0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TRAFFIC0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6960,9 +6125,6 @@ impl Default for IPSEC_TRAFFIC0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TRAFFIC0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TRAFFIC0_2 {
@@ -6973,9 +6135,6 @@ impl Default for IPSEC_TRAFFIC0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TRAFFIC0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6996,9 +6155,6 @@ impl Default for IPSEC_TRAFFIC1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TRAFFIC1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TRAFFIC1_0 {
@@ -7009,9 +6165,6 @@ impl Default for IPSEC_TRAFFIC1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TRAFFIC1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7024,9 +6177,6 @@ impl Default for IPSEC_TRAFFIC1_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TRAFFIC1_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TRAFFIC1_2 {
@@ -7037,9 +6187,6 @@ impl Default for IPSEC_TRAFFIC1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TRAFFIC1_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7056,9 +6203,6 @@ impl Default for IPSEC_TRAFFIC_SELECTOR0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TRAFFIC_SELECTOR0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TRAFFIC_SELECTOR0_0 {
@@ -7070,9 +6214,6 @@ impl Default for IPSEC_TRAFFIC_SELECTOR0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TRAFFIC_SELECTOR0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TRAFFIC_SELECTOR0_1 {
@@ -7083,9 +6224,6 @@ impl Default for IPSEC_TRAFFIC_SELECTOR0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TRAFFIC_SELECTOR0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7100,9 +6238,6 @@ impl Default for IPSEC_TRAFFIC_SELECTOR_POLICY0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TRAFFIC_SELECTOR_POLICY0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7119,9 +6254,6 @@ impl Default for IPSEC_TRAFFIC_STATISTICS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TRAFFIC_STATISTICS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_TRAFFIC_STATISTICS1 {
@@ -7137,9 +6269,6 @@ impl Default for IPSEC_TRAFFIC_STATISTICS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TRAFFIC_STATISTICS1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7171,9 +6300,6 @@ impl Default for IPSEC_TRANSPORT_POLICY0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TRANSPORT_POLICY0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_TRANSPORT_POLICY1 {
@@ -7188,9 +6314,6 @@ impl Default for IPSEC_TRANSPORT_POLICY1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TRANSPORT_POLICY1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7207,9 +6330,6 @@ impl Default for IPSEC_TRANSPORT_POLICY2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TRANSPORT_POLICY2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IPSEC_TUNNEL_ENDPOINT0 {
@@ -7221,9 +6341,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINT0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINT0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TUNNEL_ENDPOINT0_0 {
@@ -7234,9 +6351,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINT0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINT0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7250,9 +6364,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINTS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINTS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TUNNEL_ENDPOINTS0_0 {
@@ -7264,9 +6375,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINTS0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINTS0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TUNNEL_ENDPOINTS0_1 {
@@ -7277,9 +6385,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINTS0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINTS0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7294,9 +6399,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINTS1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINTS1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TUNNEL_ENDPOINTS1_0 {
@@ -7308,9 +6410,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINTS1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINTS1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TUNNEL_ENDPOINTS1_1 {
@@ -7321,9 +6420,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINTS1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINTS1_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7341,9 +6437,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINTS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINTS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TUNNEL_ENDPOINTS2_0 {
@@ -7355,9 +6448,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINTS2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINTS2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPSEC_TUNNEL_ENDPOINTS2_1 {
@@ -7368,9 +6458,6 @@ impl Default for IPSEC_TUNNEL_ENDPOINTS2_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TUNNEL_ENDPOINTS2_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7387,9 +6474,6 @@ impl Default for IPSEC_TUNNEL_POLICY0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TUNNEL_POLICY0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IPSEC_TUNNEL_POLICY1 {
@@ -7404,9 +6488,6 @@ impl Default for IPSEC_TUNNEL_POLICY1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TUNNEL_POLICY1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7423,9 +6504,6 @@ impl Default for IPSEC_TUNNEL_POLICY2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_TUNNEL_POLICY2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7446,9 +6524,6 @@ impl Default for IPSEC_TUNNEL_POLICY3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_TUNNEL_POLICY3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_V4_UDP_ENCAPSULATION0 {
@@ -7460,9 +6535,6 @@ impl Default for IPSEC_V4_UDP_ENCAPSULATION0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPSEC_V4_UDP_ENCAPSULATION0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPSEC_VIRTUAL_IF_TUNNEL_INFO0 {
@@ -7473,7 +6545,4 @@ impl Default for IPSEC_VIRTUAL_IF_TUNNEL_INFO0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPSEC_VIRTUAL_IF_TUNNEL_INFO0 {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
@@ -102,9 +102,6 @@ impl Default for FW_DYNAMIC_KEYWORD_ADDRESS0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FW_DYNAMIC_KEYWORD_ADDRESS0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FW_DYNAMIC_KEYWORD_ADDRESS_DATA0 {
@@ -117,9 +114,6 @@ impl Default for FW_DYNAMIC_KEYWORD_ADDRESS_DATA0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FW_DYNAMIC_KEYWORD_ADDRESS_DATA0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1066,9 +1060,6 @@ impl Default for INET_FIREWALL_AC_BINARIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INET_FIREWALL_AC_BINARIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INET_FIREWALL_AC_BINARY: INET_FIREWALL_AC_CREATION_TYPE = INET_FIREWALL_AC_CREATION_TYPE(2i32);
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -1082,10 +1073,6 @@ impl Default for INET_FIREWALL_AC_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for INET_FIREWALL_AC_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -1104,10 +1091,6 @@ impl Default for INET_FIREWALL_AC_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for INET_FIREWALL_AC_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -1120,10 +1103,6 @@ impl Default for INET_FIREWALL_AC_CHANGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for INET_FIREWALL_AC_CHANGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INET_FIREWALL_AC_CHANGE_CREATE: INET_FIREWALL_AC_CHANGE_TYPE = INET_FIREWALL_AC_CHANGE_TYPE(1i32);
 pub const INET_FIREWALL_AC_CHANGE_DELETE: INET_FIREWALL_AC_CHANGE_TYPE = INET_FIREWALL_AC_CHANGE_TYPE(2i32);
@@ -1157,10 +1136,6 @@ impl Default for INET_FIREWALL_APP_CONTAINER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for INET_FIREWALL_APP_CONTAINER {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(INetConnection, INetConnection_Vtbl, 0xc08956a1_1cd3_11d1_b1c5_00805fc1270e);
 windows_core::imp::interface_hierarchy!(INetConnection, windows_core::IUnknown);
@@ -6204,9 +6179,6 @@ impl Default for NETCON_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETCON_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsNetworkVirtualization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsNetworkVirtualization/mod.rs
@@ -32,10 +32,6 @@ impl Default for WNV_CUSTOMER_ADDRESS_CHANGE_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for WNV_CUSTOMER_ADDRESS_CHANGE_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -47,10 +43,6 @@ impl Default for WNV_IP_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for WNV_IP_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -66,10 +58,6 @@ impl Default for WNV_IP_ADDRESS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for WNV_IP_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WNV_NOTIFICATION_PARAM {
@@ -82,9 +70,6 @@ impl Default for WNV_NOTIFICATION_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WNV_NOTIFICATION_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -102,10 +87,6 @@ impl Default for WNV_OBJECT_CHANGE_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for WNV_OBJECT_CHANGE_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -119,10 +100,6 @@ impl Default for WNV_OBJECT_CHANGE_PARAM_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for WNV_OBJECT_CHANGE_PARAM_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WNV_OBJECT_HEADER {
@@ -134,9 +111,6 @@ impl Default for WNV_OBJECT_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WNV_OBJECT_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -157,10 +131,6 @@ impl Default for WNV_POLICY_MISMATCH_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for WNV_POLICY_MISMATCH_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -174,10 +144,6 @@ impl Default for WNV_PROVIDER_ADDRESS_CHANGE_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for WNV_PROVIDER_ADDRESS_CHANGE_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -196,10 +162,6 @@ impl Default for WNV_REDIRECT_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for WNV_REDIRECT_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WnvCustomerAddressAdded: WNV_CA_NOTIFICATION_TYPE = WNV_CA_NOTIFICATION_TYPE(0i32);
 pub const WnvCustomerAddressDeleted: WNV_CA_NOTIFICATION_TYPE = WNV_CA_NOTIFICATION_TYPE(1i32);

--- a/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
@@ -1304,9 +1304,6 @@ impl Default for ADSPROPERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADSPROPERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ADSPROPINITPARAMS {
@@ -1321,9 +1318,6 @@ impl Default for ADSPROPINITPARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADSPROPINITPARAMS {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1368,9 +1362,6 @@ impl Default for ADSVALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADSVALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ADSVALUE_0 {
@@ -1406,9 +1397,6 @@ impl Default for ADSVALUE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADSVALUE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1454,9 +1442,6 @@ impl Default for ADS_ATTR_DEF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_ATTR_DEF {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ADS_ATTR_DELETE: u32 = 4u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1471,9 +1456,6 @@ impl Default for ADS_ATTR_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_ATTR_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ADS_ATTR_UPDATE: u32 = 2u32;
 #[repr(transparent)]
@@ -1491,9 +1473,6 @@ impl Default for ADS_BACKLINK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_BACKLINK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADS_CASEIGNORE_LIST {
@@ -1504,9 +1483,6 @@ impl Default for ADS_CASEIGNORE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_CASEIGNORE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ADS_CHASE_REFERRALS_ALWAYS: ADS_CHASE_REFERRALS_ENUM = ADS_CHASE_REFERRALS_ENUM(96i32);
 #[repr(transparent)]
@@ -1534,9 +1510,6 @@ impl Default for ADS_CLASS_DEF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_CLASS_DEF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ADS_DEREFENUM(pub i32);
@@ -1561,9 +1534,6 @@ impl Default for ADS_DN_WITH_BINARY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_DN_WITH_BINARY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADS_DN_WITH_STRING {
@@ -1575,9 +1545,6 @@ impl Default for ADS_DN_WITH_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_DN_WITH_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADS_EMAIL {
@@ -1588,9 +1555,6 @@ impl Default for ADS_EMAIL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_EMAIL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ADS_ESCAPEDMODE_DEFAULT: ADS_ESCAPE_MODE_ENUM = ADS_ESCAPE_MODE_ENUM(1i32);
 pub const ADS_ESCAPEDMODE_OFF: ADS_ESCAPE_MODE_ENUM = ADS_ESCAPE_MODE_ENUM(3i32);
@@ -1615,9 +1579,6 @@ impl Default for ADS_FAXNUMBER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_FAXNUMBER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1657,9 +1618,6 @@ impl Default for ADS_HOLD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_HOLD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ADS_NAME_INITTYPE_DOMAIN: ADS_NAME_INITTYPE_ENUM = ADS_NAME_INITTYPE_ENUM(1i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1693,9 +1651,6 @@ impl Default for ADS_NETADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_NETADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ADS_NO_AUTHENTICATION: ADS_AUTHENTICATION_ENUM = ADS_AUTHENTICATION_ENUM(16u32);
 pub const ADS_NO_REFERRAL_CHASING: ADS_AUTHENTICATION_ENUM = ADS_AUTHENTICATION_ENUM(1024u32);
 #[repr(C)]
@@ -1708,9 +1663,6 @@ impl Default for ADS_NT_SECURITY_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_NT_SECURITY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1726,9 +1678,6 @@ impl Default for ADS_OBJECT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_OBJECT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADS_OCTET_LIST {
@@ -1741,9 +1690,6 @@ impl Default for ADS_OCTET_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_OCTET_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADS_OCTET_STRING {
@@ -1754,9 +1700,6 @@ impl Default for ADS_OCTET_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_OCTET_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ADS_OPTION_ACCUMULATIVE_MODIFICATION: ADS_OPTION_ENUM = ADS_OPTION_ENUM(8i32);
 #[repr(transparent)]
@@ -1788,9 +1731,6 @@ impl Default for ADS_PATH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_PATH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ADS_PATHTYPE_ENUM(pub i32);
@@ -1806,9 +1746,6 @@ impl Default for ADS_POSTALADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_POSTALADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1832,9 +1769,6 @@ impl Default for ADS_PROV_SPECIFIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_PROV_SPECIFIC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ADS_READONLY_SERVER: ADS_AUTHENTICATION_ENUM = ADS_AUTHENTICATION_ENUM(4u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1849,9 +1783,6 @@ impl Default for ADS_REPLICAPOINTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_REPLICAPOINTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1931,9 +1862,6 @@ impl Default for ADS_SEARCHPREF_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_SEARCHPREF_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ADS_SEARCHPREF_PAGED_TIME_LIMIT: ADS_SEARCHPREF_ENUM = ADS_SEARCHPREF_ENUM(8i32);
 pub const ADS_SEARCHPREF_PAGESIZE: ADS_SEARCHPREF_ENUM = ADS_SEARCHPREF_ENUM(7i32);
 pub const ADS_SEARCHPREF_SEARCH_SCOPE: ADS_SEARCHPREF_ENUM = ADS_SEARCHPREF_ENUM(5i32);
@@ -1957,9 +1885,6 @@ impl Default for ADS_SEARCH_COLUMN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_SEARCH_COLUMN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2000,9 +1925,6 @@ impl Default for ADS_SORTKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_SORTKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ADS_STATUSENUM(pub i32);
@@ -2033,9 +1955,6 @@ impl Default for ADS_TIMESTAMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADS_TIMESTAMP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADS_TYPEDNAME {
@@ -2047,9 +1966,6 @@ impl Default for ADS_TYPEDNAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_TYPEDNAME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ADS_UF_ACCOUNTDISABLE: ADS_USER_FLAG_ENUM = ADS_USER_FLAG_ENUM(2i32);
 pub const ADS_UF_DONT_EXPIRE_PASSWD: ADS_USER_FLAG_ENUM = ADS_USER_FLAG_ENUM(65536i32);
@@ -2095,9 +2011,6 @@ impl Default for ADS_VLV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADS_VLV {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ADSystemInfo: windows_core::GUID = windows_core::GUID::from_u128(0x50b6327f_afd1_11d2_9cb9_0000f87a369e);
 pub const ADsSecurityUtility: windows_core::GUID = windows_core::GUID::from_u128(0xf270c64a_ffb8_4ae4_85fe_3a75e5347966);
@@ -2148,10 +2061,6 @@ impl Default for CQFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for CQFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2170,10 +2079,6 @@ impl Default for CQPAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for CQPAGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CQPM_CLEARFORM: u32 = 6u32;
 pub const CQPM_ENABLE: u32 = 3u32;
@@ -2210,9 +2115,6 @@ impl Default for DOMAINDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOMAINDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOMAIN_CONTROLLER_INFOA {
@@ -2230,9 +2132,6 @@ impl Default for DOMAIN_CONTROLLER_INFOA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOMAIN_CONTROLLER_INFOA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2252,9 +2151,6 @@ impl Default for DOMAIN_CONTROLLER_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOMAIN_CONTROLLER_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOMAIN_TREE {
@@ -2266,9 +2162,6 @@ impl Default for DOMAIN_TREE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOMAIN_TREE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSA_NEWOBJ_CTX_CLEANUP: u32 = 4u32;
 pub const DSA_NEWOBJ_CTX_COMMIT: u32 = 2u32;
@@ -2288,10 +2181,6 @@ impl Default for DSA_NEWOBJ_DISPINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for DSA_NEWOBJ_DISPINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSA_NOTIFY_DEL: u32 = 1u32;
 pub const DSA_NOTIFY_FLAG_ADDITIONAL_DATA: u32 = 2u32;
@@ -2322,9 +2211,6 @@ impl Default for DSBITEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSBITEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSBITEMW {
@@ -2342,9 +2228,6 @@ impl Default for DSBITEMW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSBITEMW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSBI_CHECKBOXES: u32 = 256u32;
 pub const DSBI_DONTSIGNSEAL: u32 = 33554432u32;
@@ -2392,10 +2275,6 @@ impl Default for DSBROWSEINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell")]
-impl windows_core::TypeKind for DSBROWSEINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2422,10 +2301,6 @@ impl Default for DSBROWSEINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell")]
-impl windows_core::TypeKind for DSBROWSEINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSBS_CHECKED: u32 = 1u32;
 pub const DSBS_HIDDEN: u32 = 2u32;
 pub const DSBS_ROOT: u32 = 4u32;
@@ -2446,9 +2321,6 @@ impl Default for DSCLASSCREATIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSCLASSCREATIONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSCOLUMN {
@@ -2463,9 +2335,6 @@ impl Default for DSCOLUMN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSCOLUMN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2482,9 +2351,6 @@ impl Default for DSDISPLAYSPECOPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSDISPLAYSPECOPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSDSOF_DONTSIGNSEAL: u32 = 4u32;
 pub const DSDSOF_DSAVAILABLE: u32 = 1073741824u32;
@@ -2511,9 +2377,6 @@ impl Default for DSOBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSOBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSOBJECTNAMES {
@@ -2525,9 +2388,6 @@ impl Default for DSOBJECTNAMES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSOBJECTNAMES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSOBJECT_ISCONTAINER: u32 = 1u32;
 pub const DSOBJECT_READONLYPAGES: u32 = 2147483648u32;
@@ -2576,9 +2436,6 @@ impl Default for DSOP_FILTER_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSOP_FILTER_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSOP_FILTER_GLOBAL_GROUPS_DL: u32 = 64u32;
 pub const DSOP_FILTER_GLOBAL_GROUPS_SE: u32 = 128u32;
 pub const DSOP_FILTER_INCLUDE_ADVANCED_VIEW: u32 = 1u32;
@@ -2605,9 +2462,6 @@ impl Default for DSOP_INIT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSOP_INIT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSOP_SCOPE_FLAG_DEFAULT_FILTER_COMPUTERS: u32 = 256u32;
 pub const DSOP_SCOPE_FLAG_DEFAULT_FILTER_CONTACTS: u32 = 512u32;
@@ -2637,9 +2491,6 @@ impl Default for DSOP_SCOPE_INIT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSOP_SCOPE_INIT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSOP_SCOPE_TYPE_DOWNLEVEL_JOINED_DOMAIN: u32 = 4u32;
 pub const DSOP_SCOPE_TYPE_ENTERPRISE_DOMAIN: u32 = 8u32;
 pub const DSOP_SCOPE_TYPE_EXTERNAL_DOWNLEVEL_DOMAIN: u32 = 64u32;
@@ -2662,9 +2513,6 @@ impl Default for DSOP_UPLEVEL_FILTER_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSOP_UPLEVEL_FILTER_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSPROPERTYPAGEINFO {
@@ -2674,9 +2522,6 @@ impl Default for DSPROPERTYPAGEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSPROPERTYPAGEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSPROP_ATTRCHANGED_MSG: windows_core::PCWSTR = windows_core::w!("DsPropAttrChanged");
 pub const DSPROVIDER_ADVANCED: u32 = 16u32;
@@ -2706,9 +2551,6 @@ impl Default for DSQUERYCLASSLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSQUERYCLASSLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSQUERYINITPARAMS {
@@ -2724,9 +2566,6 @@ impl Default for DSQUERYINITPARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSQUERYINITPARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2744,9 +2583,6 @@ impl Default for DSQUERYPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSQUERYPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DSROLE_MACHINE_ROLE(pub i32);
@@ -2763,9 +2599,6 @@ impl Default for DSROLE_OPERATION_STATE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSROLE_OPERATION_STATE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DSROLE_PRIMARY_DOMAIN_GUID_PRESENT: u32 = 16777216u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2781,9 +2614,6 @@ impl Default for DSROLE_PRIMARY_DOMAIN_INFO_BASIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSROLE_PRIMARY_DOMAIN_INFO_BASIC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2805,9 +2635,6 @@ impl Default for DSROLE_UPGRADE_STATUS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSROLE_UPGRADE_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DSSSF_DONTSIGNSEAL: u32 = 2u32;
 pub const DSSSF_DSAVAILABLE: u32 = 2147483648u32;
@@ -2857,9 +2684,6 @@ impl Default for DS_DOMAIN_CONTROLLER_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_DOMAIN_CONTROLLER_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_DOMAIN_CONTROLLER_INFO_1W {
@@ -2875,9 +2699,6 @@ impl Default for DS_DOMAIN_CONTROLLER_INFO_1W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_DOMAIN_CONTROLLER_INFO_1W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2902,9 +2723,6 @@ impl Default for DS_DOMAIN_CONTROLLER_INFO_2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_DOMAIN_CONTROLLER_INFO_2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_DOMAIN_CONTROLLER_INFO_2W {
@@ -2927,9 +2745,6 @@ impl Default for DS_DOMAIN_CONTROLLER_INFO_2W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_DOMAIN_CONTROLLER_INFO_2W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2955,9 +2770,6 @@ impl Default for DS_DOMAIN_CONTROLLER_INFO_3A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_DOMAIN_CONTROLLER_INFO_3A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_DOMAIN_CONTROLLER_INFO_3W {
@@ -2981,9 +2793,6 @@ impl Default for DS_DOMAIN_CONTROLLER_INFO_3W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_DOMAIN_CONTROLLER_INFO_3W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS_DOMAIN_DIRECT_INBOUND: u32 = 32u32;
 pub const DS_DOMAIN_DIRECT_OUTBOUND: u32 = 2u32;
@@ -3010,10 +2819,6 @@ impl Default for DS_DOMAIN_TRUSTSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for DS_DOMAIN_TRUSTSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3032,10 +2837,6 @@ impl Default for DS_DOMAIN_TRUSTSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for DS_DOMAIN_TRUSTSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS_DS_10_FLAG: u32 = 65536u32;
 pub const DS_DS_8_FLAG: u32 = 16384u32;
@@ -3111,9 +2912,6 @@ impl Default for DS_NAME_RESULTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_NAME_RESULTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_NAME_RESULTW {
@@ -3124,9 +2922,6 @@ impl Default for DS_NAME_RESULTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_NAME_RESULTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3140,9 +2935,6 @@ impl Default for DS_NAME_RESULT_ITEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_NAME_RESULT_ITEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_NAME_RESULT_ITEMW {
@@ -3154,9 +2946,6 @@ impl Default for DS_NAME_RESULT_ITEMW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_NAME_RESULT_ITEMW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS_NDNC_FLAG: u32 = 1024u32;
 pub const DS_NOTIFY_AFTER_SITE_RECORDS: u32 = 2u32;
@@ -3204,9 +2993,6 @@ impl Default for DS_REPL_ATTR_META_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_ATTR_META_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_ATTR_META_DATA_2 {
@@ -3222,9 +3008,6 @@ impl Default for DS_REPL_ATTR_META_DATA_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_ATTR_META_DATA_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3242,9 +3025,6 @@ impl Default for DS_REPL_ATTR_META_DATA_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_ATTR_META_DATA_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_ATTR_VALUE_META_DATA {
@@ -3256,9 +3036,6 @@ impl Default for DS_REPL_ATTR_VALUE_META_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_ATTR_VALUE_META_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3272,9 +3049,6 @@ impl Default for DS_REPL_ATTR_VALUE_META_DATA_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_ATTR_VALUE_META_DATA_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_ATTR_VALUE_META_DATA_EXT {
@@ -3287,9 +3061,6 @@ impl Default for DS_REPL_ATTR_VALUE_META_DATA_EXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_ATTR_VALUE_META_DATA_EXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_CURSOR {
@@ -3300,9 +3071,6 @@ impl Default for DS_REPL_CURSOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_CURSOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3316,9 +3084,6 @@ impl Default for DS_REPL_CURSORS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_CURSORS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_CURSORS_2 {
@@ -3330,9 +3095,6 @@ impl Default for DS_REPL_CURSORS_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_CURSORS_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3346,9 +3108,6 @@ impl Default for DS_REPL_CURSORS_3W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_CURSORS_3W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_CURSOR_2 {
@@ -3360,9 +3119,6 @@ impl Default for DS_REPL_CURSOR_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_CURSOR_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3377,9 +3133,6 @@ impl Default for DS_REPL_CURSOR_3W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_CURSOR_3W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_CURSOR_BLOB {
@@ -3392,9 +3145,6 @@ impl Default for DS_REPL_CURSOR_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_CURSOR_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS_REPL_INFO_CURSORS_2_FOR_NC: DS_REPL_INFO_TYPE = DS_REPL_INFO_TYPE(7i32);
 pub const DS_REPL_INFO_CURSORS_3_FOR_NC: DS_REPL_INFO_TYPE = DS_REPL_INFO_TYPE(8i32);
@@ -3425,9 +3175,6 @@ impl Default for DS_REPL_KCC_DSA_FAILURESW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_KCC_DSA_FAILURESW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_KCC_DSA_FAILUREW {
@@ -3442,9 +3189,6 @@ impl Default for DS_REPL_KCC_DSA_FAILUREW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_KCC_DSA_FAILUREW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_KCC_DSA_FAILUREW_BLOB {
@@ -3458,9 +3202,6 @@ impl Default for DS_REPL_KCC_DSA_FAILUREW_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_KCC_DSA_FAILUREW_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS_REPL_NBR_COMPRESS_CHANGES: u32 = 268435456u32;
 pub const DS_REPL_NBR_DISABLE_SCHEDULED_SYNC: u32 = 134217728u32;
@@ -3492,9 +3233,6 @@ impl Default for DS_REPL_NEIGHBORSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_NEIGHBORSW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_NEIGHBORW {
@@ -3519,9 +3257,6 @@ impl Default for DS_REPL_NEIGHBORW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_NEIGHBORW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3548,9 +3283,6 @@ impl Default for DS_REPL_NEIGHBORW_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_NEIGHBORW_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_OBJ_META_DATA {
@@ -3563,9 +3295,6 @@ impl Default for DS_REPL_OBJ_META_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_OBJ_META_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_OBJ_META_DATA_2 {
@@ -3577,9 +3306,6 @@ impl Default for DS_REPL_OBJ_META_DATA_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_OBJ_META_DATA_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3600,9 +3326,6 @@ impl Default for DS_REPL_OPW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_OPW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_OPW_BLOB {
@@ -3621,9 +3344,6 @@ impl Default for DS_REPL_OPW_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_OPW_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3645,9 +3365,6 @@ impl Default for DS_REPL_PENDING_OPSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_PENDING_OPSW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_QUEUE_STATISTICSW {
@@ -3663,9 +3380,6 @@ impl Default for DS_REPL_QUEUE_STATISTICSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_QUEUE_STATISTICSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3686,9 +3400,6 @@ impl Default for DS_REPL_VALUE_META_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_VALUE_META_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3711,9 +3422,6 @@ impl Default for DS_REPL_VALUE_META_DATA_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_VALUE_META_DATA_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_VALUE_META_DATA_BLOB {
@@ -3734,9 +3442,6 @@ impl Default for DS_REPL_VALUE_META_DATA_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_VALUE_META_DATA_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3762,9 +3467,6 @@ impl Default for DS_REPL_VALUE_META_DATA_BLOB_EXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPL_VALUE_META_DATA_BLOB_EXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPL_VALUE_META_DATA_EXT {
@@ -3788,9 +3490,6 @@ impl Default for DS_REPL_VALUE_META_DATA_EXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPL_VALUE_META_DATA_EXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS_REPMOD_ASYNCHRONOUS_OPERATION: u32 = 1u32;
 pub const DS_REPMOD_UPDATE_ADDRESS: u32 = 2u32;
@@ -3816,9 +3515,6 @@ impl Default for DS_REPSYNCALL_ERRINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPSYNCALL_ERRINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPSYNCALL_ERRINFOW {
@@ -3831,9 +3527,6 @@ impl Default for DS_REPSYNCALL_ERRINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPSYNCALL_ERRINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3864,9 +3557,6 @@ impl Default for DS_REPSYNCALL_SYNCA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPSYNCALL_SYNCA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPSYNCALL_SYNCW {
@@ -3881,9 +3571,6 @@ impl Default for DS_REPSYNCALL_SYNCW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPSYNCALL_SYNCW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DS_REPSYNCALL_SYNC_ADJACENT_SERVERS_ONLY: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3897,9 +3584,6 @@ impl Default for DS_REPSYNCALL_UPDATEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_REPSYNCALL_UPDATEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_REPSYNCALL_UPDATEW {
@@ -3911,9 +3595,6 @@ impl Default for DS_REPSYNCALL_UPDATEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_REPSYNCALL_UPDATEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS_REPSYNCALL_WIN32_ERROR_CONTACTING_SERVER: DS_REPSYNCALL_ERROR = DS_REPSYNCALL_ERROR(0i32);
 pub const DS_REPSYNCALL_WIN32_ERROR_REPLICATING: DS_REPSYNCALL_ERROR = DS_REPSYNCALL_ERROR(1i32);
@@ -3970,9 +3651,6 @@ impl Default for DS_SCHEMA_GUID_MAPA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DS_SCHEMA_GUID_MAPA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DS_SCHEMA_GUID_MAPW {
@@ -3984,9 +3662,6 @@ impl Default for DS_SCHEMA_GUID_MAPW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_SCHEMA_GUID_MAPW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS_SCHEMA_GUID_NOT_FOUND: u32 = 0u32;
 #[repr(C)]
@@ -4006,10 +3681,6 @@ impl Default for DS_SELECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DS_SELECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4024,10 +3695,6 @@ impl Default for DS_SELECTION_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DS_SELECTION_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DS_SELECT_SECRET_DOMAIN_6_FLAG: u32 = 2048u32;
 pub const DS_SERVICE_PRINCIPAL_NAME: DS_NAME_FORMAT = DS_NAME_FORMAT(10i32);
 pub const DS_SID_OR_SID_HISTORY_NAME: DS_NAME_FORMAT = DS_NAME_FORMAT(11i32);
@@ -4041,9 +3708,6 @@ impl Default for DS_SITE_COST_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DS_SITE_COST_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS_SPN_ADD_SPN_OP: DS_SPN_WRITE_OP = DS_SPN_WRITE_OP(0i32);
 pub const DS_SPN_DELETE_SPN_OP: DS_SPN_WRITE_OP = DS_SPN_WRITE_OP(2i32);
@@ -16124,10 +15788,6 @@ impl Default for OPENQUERYWINDOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl windows_core::TypeKind for OPENQUERYWINDOW {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub union OPENQUERYWINDOW_0 {
@@ -16145,10 +15805,6 @@ impl Default for OPENQUERYWINDOW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl windows_core::TypeKind for OPENQUERYWINDOW_0 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const OQWF_DEFAULTFORM: u32 = 2u32;
 pub const OQWF_HIDEMENUS: u32 = 1024u32;
@@ -16184,9 +15840,6 @@ impl Default for SCHEDULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCHEDULE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCHEDULE_BANDWIDTH: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16198,9 +15851,6 @@ impl Default for SCHEDULE_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCHEDULE_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCHEDULE_INTERVAL: u32 = 0u32;
 pub const SCHEDULE_PRIORITY: u32 = 2u32;

--- a/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/mod.rs
@@ -101,9 +101,6 @@ impl Default for BG_AUTH_CREDENTIALS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BG_AUTH_CREDENTIALS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union BG_AUTH_CREDENTIALS_UNION {
@@ -113,9 +110,6 @@ impl Default for BG_AUTH_CREDENTIALS_UNION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BG_AUTH_CREDENTIALS_UNION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -140,9 +134,6 @@ impl Default for BG_BASIC_CREDENTIALS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BG_BASIC_CREDENTIALS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -313,9 +304,6 @@ impl Default for BG_FILE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BG_FILE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BG_FILE_PROGRESS {
@@ -328,9 +316,6 @@ impl Default for BG_FILE_PROGRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BG_FILE_PROGRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BG_FILE_RANGE {
@@ -341,9 +326,6 @@ impl Default for BG_FILE_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BG_FILE_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BG_HTTP_REDIRECT_POLICY_ALLOW_HTTPS_TO_HTTP: u32 = 2048u32;
 pub const BG_HTTP_REDIRECT_POLICY_ALLOW_REPORT: u32 = 256u32;
@@ -374,9 +356,6 @@ impl Default for BG_JOB_PROGRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BG_JOB_PROGRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BG_JOB_PROXY_USAGE(pub i32);
@@ -394,9 +373,6 @@ impl Default for BG_JOB_REPLY_PROGRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BG_JOB_REPLY_PROGRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -421,9 +397,6 @@ impl Default for BG_JOB_TIMES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BG_JOB_TIMES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -477,9 +450,6 @@ impl Default for BITS_FILE_PROPERTY_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BITS_FILE_PROPERTY_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BITS_JOB_PROPERTY_DYNAMIC_CONTENT: BITS_JOB_PROPERTY_ID = BITS_JOB_PROPERTY_ID(3i32);
 pub const BITS_JOB_PROPERTY_HIGH_PERFORMANCE: BITS_JOB_PROPERTY_ID = BITS_JOB_PROPERTY_ID(4i32);
 #[repr(transparent)]
@@ -504,9 +474,6 @@ impl Default for BITS_JOB_PROPERTY_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BITS_JOB_PROPERTY_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -550,9 +517,6 @@ impl Default for FILESETINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILESETINFO {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
@@ -2942,9 +2942,6 @@ impl Default for CLRES_CALLBACK_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLRES_CALLBACK_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
 #[derive(Clone, Copy)]
@@ -2958,10 +2955,6 @@ impl Default for CLRES_FUNCTION_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CLRES_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
@@ -2977,10 +2970,6 @@ impl Default for CLRES_FUNCTION_TABLE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CLRES_FUNCTION_TABLE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
@@ -3003,10 +2992,6 @@ impl Default for CLRES_V1_FUNCTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CLRES_V1_FUNCTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
@@ -3031,10 +3016,6 @@ impl Default for CLRES_V2_FUNCTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CLRES_V2_FUNCTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3057,10 +3038,6 @@ impl Default for CLRES_V3_FUNCTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CLRES_V3_FUNCTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
@@ -3086,10 +3063,6 @@ impl Default for CLRES_V4_FUNCTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CLRES_V4_FUNCTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLRES_VERSION_V1_00: u32 = 256u32;
 pub const CLRES_VERSION_V2_00: u32 = 512u32;
@@ -3137,9 +3110,6 @@ impl Default for CLUSAPI_REASON_HANDLER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSAPI_REASON_HANDLER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSAPI_RESOURCE_OFFLINE_DO_NOT_UPDATE_PERSISTENT_STATE: u32 = 4u32;
 pub const CLUSAPI_RESOURCE_OFFLINE_FORCE_WITH_TERMINATION: u32 = 2u32;
@@ -3259,9 +3229,6 @@ impl Default for CLUSCTL_GROUP_GET_LAST_MOVE_TIME_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSCTL_GROUP_GET_LAST_MOVE_TIME_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSCTL_GROUP_GET_NAME: CLUSCTL_GROUP_CODES = CLUSCTL_GROUP_CODES(50331689i32);
 pub const CLUSCTL_GROUP_GET_PRIVATE_PROPERTIES: CLUSCTL_GROUP_CODES = CLUSCTL_GROUP_CODES(50331777i32);
@@ -3449,9 +3416,6 @@ impl Default for CLUSCTL_RESOURCE_STATE_CHANGE_REASON_STRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSCTL_RESOURCE_STATE_CHANGE_REASON_STRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLUSCTL_RESOURCE_STATE_CHANGE_REASON_VERSION_1: u32 = 1u32;
 pub const CLUSCTL_RESOURCE_STORAGE_GET_DIRTY: CLUSCTL_RESOURCE_CODES = CLUSCTL_RESOURCE_CODES(16777753i32);
 pub const CLUSCTL_RESOURCE_STORAGE_GET_DISKID: CLUSCTL_RESOURCE_CODES = CLUSCTL_RESOURCE_CODES(16777733i32);
@@ -3534,9 +3498,6 @@ impl Default for CLUSCTL_RESOURCE_TYPE_STORAGE_GET_AVAILABLE_DISKS_EX2_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSCTL_RESOURCE_TYPE_STORAGE_GET_AVAILABLE_DISKS_EX2_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLUSCTL_RESOURCE_TYPE_STORAGE_GET_AVAILABLE_DISKS_EX2_INT: CLUSCTL_RESOURCE_TYPE_CODES = CLUSCTL_RESOURCE_TYPE_CODES(33562593i32);
 pub const CLUSCTL_RESOURCE_TYPE_STORAGE_GET_DISKID: CLUSCTL_RESOURCE_TYPE_CODES = CLUSCTL_RESOURCE_TYPE_CODES(33554949i32);
 pub const CLUSCTL_RESOURCE_TYPE_STORAGE_GET_DRIVELETTERS: CLUSCTL_RESOURCE_TYPE_CODES = CLUSCTL_RESOURCE_TYPE_CODES(33554925i32);
@@ -3589,9 +3550,6 @@ impl Default for CLUSPROP_BINARY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_BINARY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -3631,10 +3589,6 @@ impl Default for CLUSPROP_BUFFER_HELPER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for CLUSPROP_BUFFER_HELPER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CLUSPROP_DWORD {
@@ -3646,9 +3600,6 @@ impl Default for CLUSPROP_DWORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_DWORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CLUSPROP_FILETIME {
@@ -3659,9 +3610,6 @@ impl Default for CLUSPROP_FILETIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSPROP_FILETIME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSPROP_FORMAT_BINARY: CLUSTER_PROPERTY_FORMAT = CLUSTER_PROPERTY_FORMAT(1i32);
 pub const CLUSPROP_FORMAT_DWORD: CLUSTER_PROPERTY_FORMAT = CLUSTER_PROPERTY_FORMAT(2i32);
@@ -3690,9 +3638,6 @@ impl Default for CLUSPROP_FTSET_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_FTSET_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CLUSPROP_IPADDR_ENABLENETBIOS(pub i32);
@@ -3710,9 +3655,6 @@ impl Default for CLUSPROP_LARGE_INTEGER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_LARGE_INTEGER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CLUSPROP_LIST {
@@ -3723,9 +3665,6 @@ impl Default for CLUSPROP_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSPROP_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3738,9 +3677,6 @@ impl Default for CLUSPROP_LONG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_LONG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CLUSPROP_PARTITION_INFO {
@@ -3751,9 +3687,6 @@ impl Default for CLUSPROP_PARTITION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSPROP_PARTITION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3766,9 +3699,6 @@ impl Default for CLUSPROP_PARTITION_INFO_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_PARTITION_INFO_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CLUSPROP_PARTITION_INFO_EX2 {
@@ -3779,9 +3709,6 @@ impl Default for CLUSPROP_PARTITION_INFO_EX2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSPROP_PARTITION_INFO_EX2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3806,9 +3733,6 @@ impl Default for CLUSPROP_REQUIRED_DEPENDENCY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_REQUIRED_DEPENDENCY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CLUSPROP_RESOURCE_CLASS {
@@ -3819,9 +3743,6 @@ impl Default for CLUSPROP_RESOURCE_CLASS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSPROP_RESOURCE_CLASS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3834,9 +3755,6 @@ impl Default for CLUSPROP_RESOURCE_CLASS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_RESOURCE_CLASS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CLUSPROP_SCSI_ADDRESS {
@@ -3847,9 +3765,6 @@ impl Default for CLUSPROP_SCSI_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSPROP_SCSI_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -3864,10 +3779,6 @@ impl Default for CLUSPROP_SECURITY_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for CLUSPROP_SECURITY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -3881,10 +3792,6 @@ impl Default for CLUSPROP_SECURITY_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for CLUSPROP_SECURITY_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CLUSPROP_SYNTAX {
@@ -3896,9 +3803,6 @@ impl Default for CLUSPROP_SYNTAX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_SYNTAX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUSPROP_SYNTAX_0 {
@@ -3909,9 +3813,6 @@ impl Default for CLUSPROP_SYNTAX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSPROP_SYNTAX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSPROP_SYNTAX_DISK_GUID: CLUSTER_PROPERTY_SYNTAX = CLUSTER_PROPERTY_SYNTAX(720899u32);
 pub const CLUSPROP_SYNTAX_DISK_NUMBER: CLUSTER_PROPERTY_SYNTAX = CLUSTER_PROPERTY_SYNTAX(458754u32);
@@ -3951,9 +3852,6 @@ impl Default for CLUSPROP_SZ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_SZ {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLUSPROP_TYPE_DISK_GUID: CLUSTER_PROPERTY_TYPE = CLUSTER_PROPERTY_TYPE(11i32);
 pub const CLUSPROP_TYPE_DISK_NUMBER: CLUSTER_PROPERTY_TYPE = CLUSTER_PROPERTY_TYPE(7i32);
 pub const CLUSPROP_TYPE_DISK_SERIALNUMBER: CLUSTER_PROPERTY_TYPE = CLUSTER_PROPERTY_TYPE(10i32);
@@ -3983,9 +3881,6 @@ impl Default for CLUSPROP_ULARGE_INTEGER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_ULARGE_INTEGER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CLUSPROP_VALUE {
@@ -3997,9 +3892,6 @@ impl Default for CLUSPROP_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSPROP_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CLUSPROP_WORD {
@@ -4010,9 +3902,6 @@ impl Default for CLUSPROP_WORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSPROP_WORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSREG_COMMAND_NONE: CLUSTER_REG_COMMAND = CLUSTER_REG_COMMAND(0i32);
 pub const CLUSREG_CONDITION_EXISTS: CLUSTER_REG_COMMAND = CLUSTER_REG_COMMAND(11i32);
@@ -4375,9 +4264,6 @@ impl Default for CLUSTERVERSIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTERVERSIONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUSTERVERSIONINFO_NT4 {
@@ -4393,9 +4279,6 @@ impl Default for CLUSTERVERSIONINFO_NT4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTERVERSIONINFO_NT4 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLUSTER_ADD_EVICT_DELAY: windows_core::PCWSTR = windows_core::w!("AddEvictDelay");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4409,9 +4292,6 @@ impl Default for CLUSTER_AVAILABILITY_SET_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_AVAILABILITY_SET_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSTER_AVAILABILITY_SET_CONFIG_V1: u32 = 1u32;
 #[repr(C)]
@@ -4427,9 +4307,6 @@ impl Default for CLUSTER_BATCH_COMMAND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_BATCH_COMMAND {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4619,9 +4496,6 @@ impl Default for CLUSTER_CREATE_GROUP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_CREATE_GROUP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLUSTER_CREATE_GROUP_INFO_VERSION: u32 = 1u32;
 pub const CLUSTER_CREATE_GROUP_INFO_VERSION_1: u32 = 1u32;
 pub const CLUSTER_CSA_VSS_STATE: windows_core::PCWSTR = windows_core::w!("BackupInProgress");
@@ -4652,9 +4526,6 @@ impl Default for CLUSTER_ENUM_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_ENUM_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSTER_ENUM_ITEM_VERSION: u32 = 1u32;
 pub const CLUSTER_ENUM_ITEM_VERSION_1: u32 = 1u32;
@@ -4695,9 +4566,6 @@ impl Default for CLUSTER_GROUP_ENUM_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_GROUP_ENUM_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLUSTER_GROUP_ENUM_ITEM_VERSION: u32 = 1u32;
 pub const CLUSTER_GROUP_ENUM_ITEM_VERSION_1: u32 = 1u32;
 pub const CLUSTER_GROUP_ENUM_NODES: CLUSTER_GROUP_ENUM = CLUSTER_GROUP_ENUM(2i32);
@@ -4726,9 +4594,6 @@ impl Default for CLUSTER_HEALTH_FAULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_HEALTH_FAULT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLUSTER_HEALTH_FAULT_ARGS: u32 = 7u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4740,9 +4605,6 @@ impl Default for CLUSTER_HEALTH_FAULT_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_HEALTH_FAULT_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSTER_HEALTH_FAULT_DESCRIPTION: u32 = 3u32;
 pub const CLUSTER_HEALTH_FAULT_DESCRIPTION_LABEL: windows_core::PCWSTR = windows_core::w!("Description");
@@ -4771,9 +4633,6 @@ impl Default for CLUSTER_IP_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_IP_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUSTER_MEMBERSHIP_INFO {
@@ -4785,9 +4644,6 @@ impl Default for CLUSTER_MEMBERSHIP_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_MEMBERSHIP_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4892,9 +4748,6 @@ impl Default for CLUSTER_READ_BATCH_COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_READ_BATCH_COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CLUSTER_REG_COMMAND(pub i32);
@@ -4938,9 +4791,6 @@ impl Default for CLUSTER_RESOURCE_ENUM_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_RESOURCE_ENUM_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSTER_RESOURCE_ENUM_ITEM_VERSION: u32 = 1u32;
 pub const CLUSTER_RESOURCE_ENUM_ITEM_VERSION_1: u32 = 1u32;
@@ -5003,9 +4853,6 @@ impl Default for CLUSTER_SET_PASSWORD_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_SET_PASSWORD_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLUSTER_SHARED_VOLUMES_ROOT: windows_core::PCWSTR = windows_core::w!("SharedVolumesRoot");
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5021,9 +4868,6 @@ impl Default for CLUSTER_SHARED_VOLUME_RENAME_GUID_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_SHARED_VOLUME_RENAME_GUID_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CLUSTER_SHARED_VOLUME_RENAME_INPUT {
@@ -5034,9 +4878,6 @@ impl Default for CLUSTER_SHARED_VOLUME_RENAME_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_SHARED_VOLUME_RENAME_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5049,9 +4890,6 @@ impl Default for CLUSTER_SHARED_VOLUME_RENAME_INPUT_GUID_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_SHARED_VOLUME_RENAME_INPUT_GUID_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUSTER_SHARED_VOLUME_RENAME_INPUT_NAME {
@@ -5061,9 +4899,6 @@ impl Default for CLUSTER_SHARED_VOLUME_RENAME_INPUT_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_SHARED_VOLUME_RENAME_INPUT_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5079,9 +4914,6 @@ impl Default for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME_0 {
@@ -5094,9 +4926,6 @@ impl Default for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_SHARED_VOLUME_RENAME_INPUT_VOLUME_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5116,9 +4945,6 @@ impl Default for CLUSTER_SHARED_VOLUME_STATE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_SHARED_VOLUME_STATE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUSTER_SHARED_VOLUME_STATE_INFO_EX {
@@ -5133,9 +4959,6 @@ impl Default for CLUSTER_SHARED_VOLUME_STATE_INFO_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_SHARED_VOLUME_STATE_INFO_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSTER_SHARED_VOLUME_VSS_WRITER_OPERATION_TIMEOUT: windows_core::PCWSTR = windows_core::w!("SharedVolumeVssWriterOperationTimeout");
 #[repr(transparent)]
@@ -5154,9 +4977,6 @@ impl Default for CLUSTER_VALIDATE_CSV_FILENAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_VALIDATE_CSV_FILENAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUSTER_VALIDATE_DIRECTORY {
@@ -5166,9 +4986,6 @@ impl Default for CLUSTER_VALIDATE_DIRECTORY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_VALIDATE_DIRECTORY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5180,9 +4997,6 @@ impl Default for CLUSTER_VALIDATE_NETNAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUSTER_VALIDATE_NETNAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUSTER_VALIDATE_PATH {
@@ -5192,9 +5006,6 @@ impl Default for CLUSTER_VALIDATE_PATH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_VALIDATE_PATH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUSTER_VERSION_FLAG_MIXED_MODE: u32 = 1u32;
 pub const CLUSTER_VERSION_UNKNOWN: u32 = 4294967295u32;
@@ -5250,9 +5061,6 @@ impl Default for CLUS_CHKDSK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_CHKDSK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLUS_CREATE_CRYPT_CONTAINER_NOT_FOUND: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5264,9 +5072,6 @@ impl Default for CLUS_CREATE_INFRASTRUCTURE_FILESERVER_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_CREATE_INFRASTRUCTURE_FILESERVER_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_CREATE_INFRASTRUCTURE_FILESERVER_OUTPUT {
@@ -5276,9 +5081,6 @@ impl Default for CLUS_CREATE_INFRASTRUCTURE_FILESERVER_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_CREATE_INFRASTRUCTURE_FILESERVER_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5290,9 +5092,6 @@ impl Default for CLUS_CSV_MAINTENANCE_MODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_CSV_MAINTENANCE_MODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5309,9 +5108,6 @@ impl Default for CLUS_CSV_VOLUME_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_CSV_VOLUME_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_CSV_VOLUME_NAME {
@@ -5324,9 +5120,6 @@ impl Default for CLUS_CSV_VOLUME_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_CSV_VOLUME_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_DISK_NUMBER_INFO {
@@ -5337,9 +5130,6 @@ impl Default for CLUS_DISK_NUMBER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_DISK_NUMBER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5352,9 +5142,6 @@ impl Default for CLUS_DNN_LEADER_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_DNN_LEADER_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_DNN_SODAFS_CLONE_STATUS {
@@ -5365,9 +5152,6 @@ impl Default for CLUS_DNN_SODAFS_CLONE_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_DNN_SODAFS_CLONE_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5386,9 +5170,6 @@ impl Default for CLUS_FORCE_QUORUM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_FORCE_QUORUM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_FTSET_INFO {
@@ -5399,9 +5180,6 @@ impl Default for CLUS_FTSET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_FTSET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUS_GLOBAL: u32 = 1u32;
 pub const CLUS_GROUP_DO_NOT_START: CLUS_GROUP_START_SETTING = CLUS_GROUP_START_SETTING(1i32);
@@ -5423,9 +5201,6 @@ impl Default for CLUS_MAINTENANCE_MODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_MAINTENANCE_MODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_MAINTENANCE_MODE_INFOEX {
@@ -5438,9 +5213,6 @@ impl Default for CLUS_MAINTENANCE_MODE_INFOEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_MAINTENANCE_MODE_INFOEX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUS_MODIFY: u32 = 1u32;
 pub const CLUS_NAME_RES_TYPE_CLUSTER_GROUPID: windows_core::PCWSTR = windows_core::w!("ClusterGroupId");
@@ -5468,9 +5240,6 @@ impl Default for CLUS_NETNAME_IP_INFO_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_NETNAME_IP_INFO_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_NETNAME_IP_INFO_FOR_MULTICHANNEL {
@@ -5482,9 +5251,6 @@ impl Default for CLUS_NETNAME_IP_INFO_FOR_MULTICHANNEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_NETNAME_IP_INFO_FOR_MULTICHANNEL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5499,9 +5265,6 @@ impl Default for CLUS_NETNAME_PWD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_NETNAME_PWD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_NETNAME_PWD_INFOEX {
@@ -5515,9 +5278,6 @@ impl Default for CLUS_NETNAME_PWD_INFOEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_NETNAME_PWD_INFOEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_NETNAME_VS_TOKEN_INFO {
@@ -5529,9 +5289,6 @@ impl Default for CLUS_NETNAME_VS_TOKEN_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_NETNAME_VS_TOKEN_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUS_NODE_MAJORITY_QUORUM: u32 = 0u32;
 pub const CLUS_NOT_GLOBAL: u32 = 0u32;
@@ -5563,9 +5320,6 @@ impl Default for CLUS_PARTITION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_PARTITION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_PARTITION_INFO_EX {
@@ -5587,9 +5341,6 @@ impl Default for CLUS_PARTITION_INFO_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_PARTITION_INFO_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_PARTITION_INFO_EX2 {
@@ -5602,9 +5353,6 @@ impl Default for CLUS_PARTITION_INFO_EX2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_PARTITION_INFO_EX2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_PROVIDER_STATE_CHANGE_INFO {
@@ -5616,9 +5364,6 @@ impl Default for CLUS_PROVIDER_STATE_CHANGE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_PROVIDER_STATE_CHANGE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLUS_RESCLASS_NETWORK: CLUSTER_RESOURCE_CLASS = CLUSTER_RESOURCE_CLASS(2i32);
 pub const CLUS_RESCLASS_STORAGE: CLUSTER_RESOURCE_CLASS = CLUSTER_RESOURCE_CLASS(1i32);
@@ -5648,9 +5393,6 @@ impl Default for CLUS_RESOURCE_CLASS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_RESOURCE_CLASS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CLUS_RESOURCE_CLASS_INFO_0 {
@@ -5661,9 +5403,6 @@ impl Default for CLUS_RESOURCE_CLASS_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_RESOURCE_CLASS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5676,9 +5415,6 @@ impl Default for CLUS_RESOURCE_CLASS_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_RESOURCE_CLASS_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CLUS_RESOURCE_CLASS_INFO_0_0_0 {
@@ -5689,9 +5425,6 @@ impl Default for CLUS_RESOURCE_CLASS_INFO_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_RESOURCE_CLASS_INFO_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5772,9 +5505,6 @@ impl Default for CLUS_SCSI_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_SCSI_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CLUS_SCSI_ADDRESS_0 {
@@ -5785,9 +5515,6 @@ impl Default for CLUS_SCSI_ADDRESS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_SCSI_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5802,9 +5529,6 @@ impl Default for CLUS_SCSI_ADDRESS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_SCSI_ADDRESS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_SET_MAINTENANCE_MODE_INPUT {
@@ -5816,9 +5540,6 @@ impl Default for CLUS_SET_MAINTENANCE_MODE_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_SET_MAINTENANCE_MODE_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5832,9 +5553,6 @@ impl Default for CLUS_SHARED_VOLUME_BACKUP_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_SHARED_VOLUME_BACKUP_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_STARTING_PARAMS {
@@ -5847,9 +5565,6 @@ impl Default for CLUS_STARTING_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_STARTING_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_STORAGE_GET_AVAILABLE_DRIVELETTERS {
@@ -5859,9 +5574,6 @@ impl Default for CLUS_STORAGE_GET_AVAILABLE_DRIVELETTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_STORAGE_GET_AVAILABLE_DRIVELETTERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5874,9 +5586,6 @@ impl Default for CLUS_STORAGE_REMAP_DRIVELETTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_STORAGE_REMAP_DRIVELETTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_STORAGE_SET_DRIVELETTER {
@@ -5888,9 +5597,6 @@ impl Default for CLUS_STORAGE_SET_DRIVELETTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLUS_STORAGE_SET_DRIVELETTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLUS_WORKER {
@@ -5901,9 +5607,6 @@ impl Default for CLUS_WORKER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUS_WORKER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CREATEDC_PRESENT: u32 = 2u32;
 #[repr(C)]
@@ -5924,9 +5627,6 @@ impl Default for CREATE_CLUSTER_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREATE_CLUSTER_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CREATE_CLUSTER_MAJOR_VERSION_MASK: u32 = 4294967040u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5945,9 +5645,6 @@ impl Default for CREATE_CLUSTER_NAME_ACCOUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_CLUSTER_NAME_ACCOUNT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CREATE_CLUSTER_VERSION: u32 = 1536u32;
 pub const CTCTL_GET_FAULT_DOMAIN_STATE: CLCTL_CODES = CLCTL_CODES(789i32);
@@ -6187,9 +5884,6 @@ impl Default for FILESHARE_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILESHARE_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILESHARE_CHANGE_ADD: FILESHARE_CHANGE_ENUM = FILESHARE_CHANGE_ENUM(1i32);
 pub const FILESHARE_CHANGE_DEL: FILESHARE_CHANGE_ENUM = FILESHARE_CHANGE_ENUM(2i32);
 #[repr(transparent)]
@@ -6205,9 +5899,6 @@ impl Default for FILESHARE_CHANGE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILESHARE_CHANGE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILESHARE_CHANGE_MODIFY: FILESHARE_CHANGE_ENUM = FILESHARE_CHANGE_ENUM(3i32);
 pub const FILESHARE_CHANGE_NONE: FILESHARE_CHANGE_ENUM = FILESHARE_CHANGE_ENUM(0i32);
@@ -6226,9 +5917,6 @@ impl Default for GET_OPERATION_CONTEXT_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_OPERATION_CONTEXT_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GROUPSET_READY_SETTING_APPLICATION_READY: u32 = 4u32;
 pub const GROUPSET_READY_SETTING_DELAY: u32 = 1u32;
 pub const GROUPSET_READY_SETTING_ONLINE: u32 = 2u32;
@@ -6244,9 +5932,6 @@ impl Default for GROUP_FAILURE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GROUP_FAILURE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GROUP_FAILURE_INFO_BUFFER {
@@ -6257,9 +5942,6 @@ impl Default for GROUP_FAILURE_INFO_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GROUP_FAILURE_INFO_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GROUP_FAILURE_INFO_VERSION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -13472,9 +13154,6 @@ impl Default for MONITOR_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONITOR_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MaintenanceModeTypeDisableIsAliveCheck: MAINTENANCE_MODE_TYPE_ENUM = MAINTENANCE_MODE_TYPE_ENUM(1i32);
 pub const MaintenanceModeTypeOfflineResource: MAINTENANCE_MODE_TYPE_ENUM = MAINTENANCE_MODE_TYPE_ENUM(2i32);
 pub const MaintenanceModeTypeUnclusterResource: MAINTENANCE_MODE_TYPE_ENUM = MAINTENANCE_MODE_TYPE_ENUM(3i32);
@@ -13496,9 +13175,6 @@ impl Default for NOTIFY_FILTER_AND_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NOTIFY_FILTER_AND_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NT10_MAJOR_VERSION: u32 = 9u32;
 pub const NT11_MAJOR_VERSION: u32 = 10u32;
@@ -13535,9 +13211,6 @@ impl Default for NodeUtilizationInfoElement {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NodeUtilizationInfoElement {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OperationalQuorum: CLUSTER_QUORUM_TYPE = CLUSTER_QUORUM_TYPE(0i32);
 pub type PARBITRATE_ROUTINE = Option<unsafe extern "system" fn(resource: *mut core::ffi::c_void, lostquorumresource: PQUORUM_RESOURCE_LOST) -> u32>;
@@ -13890,9 +13563,6 @@ impl Default for POST_UPGRADE_VERSION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POST_UPGRADE_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub type PQUERY_APPINSTANCE_VERSION = Option<unsafe extern "system" fn(appinstanceid: *const windows_core::GUID, instanceversionhigh: *mut u64, instanceversionlow: *mut u64, versionstatus: *mut super::super::Foundation::NTSTATUS) -> u32>;
 pub type PQUORUM_RESOURCE_LOST = Option<unsafe extern "system" fn(resource: isize)>;
 pub type PRAISE_RES_TYPE_NOTIFICATION = Option<unsafe extern "system" fn(resourcetype: windows_core::PCWSTR, ppayload: *const u8, payloadsize: u32) -> u32>;
@@ -14052,9 +13722,6 @@ impl Default for PaxosTagCStruct {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PaxosTagCStruct {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PriorityDisabled: CLUSTER_GROUP_PRIORITY = CLUSTER_GROUP_PRIORITY(0i32);
 pub const PriorityHigh: CLUSTER_GROUP_PRIORITY = CLUSTER_GROUP_PRIORITY(3000i32);
 pub const PriorityLow: CLUSTER_GROUP_PRIORITY = CLUSTER_GROUP_PRIORITY(1000i32);
@@ -14076,9 +13743,6 @@ impl Default for RESOURCE_FAILURE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESOURCE_FAILURE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RESOURCE_FAILURE_INFO_BUFFER {
@@ -14089,9 +13753,6 @@ impl Default for RESOURCE_FAILURE_INFO_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESOURCE_FAILURE_INFO_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RESOURCE_FAILURE_INFO_VERSION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -14110,9 +13771,6 @@ impl Default for RESOURCE_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESOURCE_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RESOURCE_STATUS_EX {
@@ -14128,9 +13786,6 @@ impl Default for RESOURCE_STATUS_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESOURCE_STATUS_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RESOURCE_TERMINAL_FAILURE_INFO_BUFFER {
@@ -14141,9 +13796,6 @@ impl Default for RESOURCE_TERMINAL_FAILURE_INFO_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESOURCE_TERMINAL_FAILURE_INFO_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RESTYPE_MONITOR_SHUTTING_DOWN_CLUSSVC_CRASH: u32 = 2u32;
 pub const RESTYPE_MONITOR_SHUTTING_DOWN_NODE_STOP: u32 = 1u32;
@@ -14159,9 +13811,6 @@ impl Default for RESUTIL_FILETIME_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESUTIL_FILETIME_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RESUTIL_LARGEINT_DATA {
@@ -14173,9 +13822,6 @@ impl Default for RESUTIL_LARGEINT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESUTIL_LARGEINT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -14194,9 +13840,6 @@ impl Default for RESUTIL_PROPERTY_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESUTIL_PROPERTY_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RESUTIL_PROPERTY_ITEM_0 {
@@ -14211,9 +13854,6 @@ impl Default for RESUTIL_PROPERTY_ITEM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESUTIL_PROPERTY_ITEM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RESUTIL_PROPITEM_IN_MEMORY: u32 = 8u32;
 pub const RESUTIL_PROPITEM_READ_ONLY: u32 = 1u32;
@@ -14230,9 +13870,6 @@ impl Default for RESUTIL_ULARGEINT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESUTIL_ULARGEINT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RS3_UPGRADE_VERSION: u32 = 1u32;
 pub const RS4_UPGRADE_VERSION: u32 = 2u32;
@@ -14264,9 +13901,6 @@ impl Default for ResourceUtilizationInfoElement {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ResourceUtilizationInfoElement {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RmonArbitrateResource: RESOURCE_MONITOR_STATE = RESOURCE_MONITOR_STATE(10i32);
 pub const RmonDeadlocked: RESOURCE_MONITOR_STATE = RESOURCE_MONITOR_STATE(15i32);
@@ -14315,9 +13949,6 @@ impl Default for SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP_RESULT {
@@ -14328,9 +13959,6 @@ impl Default for SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_ADD_REPLICATION_GROUP_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14343,9 +13971,6 @@ impl Default for SR_RESOURCE_TYPE_DISK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_DISK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SR_RESOURCE_TYPE_ELIGIBLE_DISKS_RESULT {
@@ -14356,9 +13981,6 @@ impl Default for SR_RESOURCE_TYPE_ELIGIBLE_DISKS_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_ELIGIBLE_DISKS_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14371,9 +13993,6 @@ impl Default for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_LOGDISKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_LOGDISKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SR_RESOURCE_TYPE_QUERY_ELIGIBLE_SOURCE_DATADISKS {
@@ -14384,9 +14003,6 @@ impl Default for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_SOURCE_DATADISKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_SOURCE_DATADISKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14401,9 +14017,6 @@ impl Default for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_TARGET_DATADISKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_QUERY_ELIGIBLE_TARGET_DATADISKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SR_RESOURCE_TYPE_REPLICATED_DISK {
@@ -14417,9 +14030,6 @@ impl Default for SR_RESOURCE_TYPE_REPLICATED_DISK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_REPLICATED_DISK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SR_RESOURCE_TYPE_REPLICATED_DISKS_RESULT {
@@ -14430,9 +14040,6 @@ impl Default for SR_RESOURCE_TYPE_REPLICATED_DISKS_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_REPLICATED_DISKS_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14445,9 +14052,6 @@ impl Default for SR_RESOURCE_TYPE_REPLICATED_PARTITION_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_REPLICATED_PARTITION_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SR_RESOURCE_TYPE_REPLICATED_PARTITION_INFO {
@@ -14458,9 +14062,6 @@ impl Default for SR_RESOURCE_TYPE_REPLICATED_PARTITION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SR_RESOURCE_TYPE_REPLICATED_PARTITION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STARTUP_EX_ROUTINE: windows_core::PCSTR = windows_core::s!("StartupEx");
 pub const STARTUP_ROUTINE: windows_core::PCSTR = windows_core::s!("Startup");
@@ -14523,9 +14124,6 @@ impl Default for WitnessTagHelper {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WitnessTagHelper {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WitnessTagUpdateHelper {
@@ -14537,9 +14135,6 @@ impl Default for WitnessTagUpdateHelper {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WitnessTagUpdateHelper {
-    type TypeKind = windows_core::CopyType;
 }
 pub const eResourceStateChangeReasonFailedMove: CLUSTER_RESOURCE_STATE_CHANGE_REASON = CLUSTER_RESOURCE_STATE_CHANGE_REASON(3i32);
 pub const eResourceStateChangeReasonFailover: CLUSTER_RESOURCE_STATE_CHANGE_REASON = CLUSTER_RESOURCE_STATE_CHANGE_REASON(2i32);

--- a/crates/libs/windows/src/Windows/Win32/Networking/HttpServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/HttpServer/mod.rs
@@ -310,9 +310,6 @@ impl Default for HTTP2_SETTINGS_LIMITS_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP2_SETTINGS_LIMITS_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP2_WINDOW_SIZE_PARAM {
@@ -322,9 +319,6 @@ impl Default for HTTP2_WINDOW_SIZE_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP2_WINDOW_SIZE_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -336,9 +330,6 @@ impl Default for HTTPAPI_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTPAPI_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -367,9 +358,6 @@ impl Default for HTTP_BANDWIDTH_LIMIT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_BANDWIDTH_LIMIT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_BINDING_INFO {
@@ -380,9 +368,6 @@ impl Default for HTTP_BINDING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_BINDING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -395,9 +380,6 @@ impl Default for HTTP_BYTE_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_BYTE_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_CACHE_POLICY {
@@ -408,9 +390,6 @@ impl Default for HTTP_CACHE_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_CACHE_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -430,9 +409,6 @@ impl Default for HTTP_CHANNEL_BIND_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_CHANNEL_BIND_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HTTP_CHANNEL_BIND_NO_SERVICE_NAME_CHECK: u32 = 2u32;
 pub const HTTP_CHANNEL_BIND_PROXY: u32 = 1u32;
 pub const HTTP_CHANNEL_BIND_PROXY_COHOSTING: u32 = 32u32;
@@ -447,9 +423,6 @@ impl Default for HTTP_CONNECTION_LIMIT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_CONNECTION_LIMIT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -467,9 +440,6 @@ impl Default for HTTP_COOKED_URL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_COOKED_URL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_CREATE_REQUEST_QUEUE_FLAG_CONTROLLER: u32 = 2u32;
 pub const HTTP_CREATE_REQUEST_QUEUE_FLAG_DELEGATION: u32 = 8u32;
@@ -489,9 +459,6 @@ impl Default for HTTP_CREATE_REQUEST_QUEUE_PROPERTY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_CREATE_REQUEST_QUEUE_PROPERTY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HTTP_DATA_CHUNK {
@@ -502,9 +469,6 @@ impl Default for HTTP_DATA_CHUNK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_DATA_CHUNK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -520,9 +484,6 @@ impl Default for HTTP_DATA_CHUNK_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_DATA_CHUNK_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_DATA_CHUNK_0_1 {
@@ -533,9 +494,6 @@ impl Default for HTTP_DATA_CHUNK_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -548,9 +506,6 @@ impl Default for HTTP_DATA_CHUNK_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_DATA_CHUNK_0_2 {
@@ -561,9 +516,6 @@ impl Default for HTTP_DATA_CHUNK_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -576,9 +528,6 @@ impl Default for HTTP_DATA_CHUNK_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_DATA_CHUNK_0_4 {
@@ -589,9 +538,6 @@ impl Default for HTTP_DATA_CHUNK_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_DATA_CHUNK_0_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -611,9 +557,6 @@ impl Default for HTTP_DELEGATE_REQUEST_PROPERTY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_DELEGATE_REQUEST_PROPERTY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HTTP_DEMAND_CBT: u32 = 4u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -630,9 +573,6 @@ impl Default for HTTP_ERROR_HEADERS_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_ERROR_HEADERS_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HTTP_FEATURE_ID(pub i32);
@@ -648,9 +588,6 @@ impl Default for HTTP_FLOWRATE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_FLOWRATE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_FLUSH_RESPONSE_FLAG_RECURSIVE: u32 = 1u32;
 #[repr(transparent)]
@@ -705,9 +642,6 @@ impl Default for HTTP_KNOWN_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_KNOWN_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_LISTEN_ENDPOINT_INFO {
@@ -718,9 +652,6 @@ impl Default for HTTP_LISTEN_ENDPOINT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_LISTEN_ENDPOINT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_LOGGING_FLAG_LOCAL_TIME_ROLLOVER: u32 = 1u32;
 pub const HTTP_LOGGING_FLAG_LOG_ERRORS_ONLY: u32 = 4u32;
@@ -751,10 +682,6 @@ impl Default for HTTP_LOGGING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for HTTP_LOGGING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HTTP_LOGGING_ROLLOVER_TYPE(pub i32);
@@ -770,9 +697,6 @@ impl Default for HTTP_LOG_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_LOG_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -815,9 +739,6 @@ impl Default for HTTP_LOG_FIELDS_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_LOG_FIELDS_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_LOG_FIELD_BYTES_RECV: u32 = 8192u32;
 pub const HTTP_LOG_FIELD_BYTES_SENT: u32 = 4096u32;
@@ -866,9 +787,6 @@ impl Default for HTTP_MULTIPLE_KNOWN_HEADERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_MULTIPLE_KNOWN_HEADERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_PERFORMANCE_PARAM {
@@ -880,9 +798,6 @@ impl Default for HTTP_PERFORMANCE_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_PERFORMANCE_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -897,9 +812,6 @@ impl Default for HTTP_PROPERTY_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_PROPERTY_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_PROTECTION_LEVEL_INFO {
@@ -910,9 +822,6 @@ impl Default for HTTP_PROTECTION_LEVEL_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_PROTECTION_LEVEL_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -928,9 +837,6 @@ impl Default for HTTP_QOS_SETTING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_QOS_SETTING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HTTP_QOS_SETTING_TYPE(pub i32);
@@ -944,9 +850,6 @@ impl Default for HTTP_QUERY_REQUEST_QUALIFIER_QUIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_QUERY_REQUEST_QUALIFIER_QUIC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_QUERY_REQUEST_QUALIFIER_TCP {
@@ -956,9 +859,6 @@ impl Default for HTTP_QUERY_REQUEST_QUALIFIER_TCP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_QUERY_REQUEST_QUALIFIER_TCP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -970,9 +870,6 @@ impl Default for HTTP_QUIC_API_TIMINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_QUIC_API_TIMINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -995,9 +892,6 @@ impl Default for HTTP_QUIC_CONNECTION_API_TIMINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_QUIC_CONNECTION_API_TIMINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1026,9 +920,6 @@ impl Default for HTTP_QUIC_STREAM_API_TIMINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_QUIC_STREAM_API_TIMINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_QUIC_STREAM_REQUEST_STATS {
@@ -1045,9 +936,6 @@ impl Default for HTTP_QUIC_STREAM_REQUEST_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_QUIC_STREAM_REQUEST_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_RECEIVE_FULL_CHAIN: u32 = 2u32;
 #[repr(transparent)]
@@ -1080,9 +968,6 @@ impl Default for HTTP_REQUEST_AUTH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_REQUEST_AUTH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HTTP_REQUEST_AUTH_TYPE(pub i32);
@@ -1098,9 +983,6 @@ impl Default for HTTP_REQUEST_CHANNEL_BIND_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_REQUEST_CHANNEL_BIND_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_REQUEST_FLAG_HTTP2: u32 = 4u32;
 pub const HTTP_REQUEST_FLAG_HTTP3: u32 = 8u32;
@@ -1120,9 +1002,6 @@ impl Default for HTTP_REQUEST_HEADERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_REQUEST_HEADERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_REQUEST_INFO {
@@ -1134,9 +1013,6 @@ impl Default for HTTP_REQUEST_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_REQUEST_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1155,9 +1031,6 @@ impl Default for HTTP_REQUEST_PROPERTY_SNI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_REQUEST_PROPERTY_SNI {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HTTP_REQUEST_PROPERTY_SNI_FLAG_NO_SNI: u32 = 2u32;
 pub const HTTP_REQUEST_PROPERTY_SNI_FLAG_SNI_USED: u32 = 1u32;
 pub const HTTP_REQUEST_PROPERTY_SNI_HOST_MAX_LENGTH: u32 = 255u32;
@@ -1171,9 +1044,6 @@ impl Default for HTTP_REQUEST_PROPERTY_STREAM_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_REQUEST_PROPERTY_STREAM_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_REQUEST_SIZING_INFO {
@@ -1186,9 +1056,6 @@ impl Default for HTTP_REQUEST_SIZING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_REQUEST_SIZING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_REQUEST_SIZING_INFO_FLAG_FIRST_REQUEST: u32 = 8u32;
 pub const HTTP_REQUEST_SIZING_INFO_FLAG_TCP_FAST_OPEN: u32 = 1u32;
@@ -1208,9 +1075,6 @@ impl Default for HTTP_REQUEST_TIMING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_REQUEST_TIMING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HTTP_REQUEST_TIMING_TYPE(pub i32);
@@ -1227,9 +1091,6 @@ impl Default for HTTP_REQUEST_TOKEN_BINDING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_REQUEST_TOKEN_BINDING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1260,10 +1121,6 @@ impl Default for HTTP_REQUEST_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_REQUEST_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1277,10 +1134,6 @@ impl Default for HTTP_REQUEST_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_REQUEST_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_RESPONSE_FLAG_MORE_ENTITY_BODY_EXISTS: u32 = 2u32;
 pub const HTTP_RESPONSE_FLAG_MULTIPLE_ENCODINGS_AVAILABLE: u32 = 1u32;
@@ -1298,9 +1151,6 @@ impl Default for HTTP_RESPONSE_HEADERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_RESPONSE_HEADERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_RESPONSE_INFO {
@@ -1312,9 +1162,6 @@ impl Default for HTTP_RESPONSE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_RESPONSE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_RESPONSE_INFO_FLAGS_PRESERVE_ORDER: u32 = 1u32;
 #[repr(transparent)]
@@ -1337,9 +1184,6 @@ impl Default for HTTP_RESPONSE_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_RESPONSE_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_RESPONSE_V2 {
@@ -1351,9 +1195,6 @@ impl Default for HTTP_RESPONSE_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_RESPONSE_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1376,9 +1217,6 @@ impl Default for HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SERVER_AUTHENTICATION_BASIC_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS {
@@ -1391,9 +1229,6 @@ impl Default for HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_SERVER_AUTHENTICATION_DIGEST_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1412,9 +1247,6 @@ impl Default for HTTP_SERVER_AUTHENTICATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SERVER_AUTHENTICATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HTTP_SERVER_PROPERTY(pub i32);
@@ -1430,9 +1262,6 @@ impl Default for HTTP_SERVICE_BINDING_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SERVICE_BINDING_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_SERVICE_BINDING_BASE {
@@ -1442,9 +1271,6 @@ impl Default for HTTP_SERVICE_BINDING_BASE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_SERVICE_BINDING_BASE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1461,9 +1287,6 @@ impl Default for HTTP_SERVICE_BINDING_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SERVICE_BINDING_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HTTP_SERVICE_CONFIG_CACHE_KEY(pub i32);
@@ -1477,9 +1300,6 @@ impl Default for HTTP_SERVICE_CONFIG_CACHE_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_CACHE_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1497,10 +1317,6 @@ impl Default for HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_IP_LISTEN_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1513,10 +1329,6 @@ impl Default for HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_IP_LISTEN_QUERY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1535,9 +1347,6 @@ impl Default for HTTP_SERVICE_CONFIG_SETTING_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SETTING_SET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1549,10 +1358,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_CCS_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_CCS_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1567,10 +1372,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_CCS_QUERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_CCS_QUERY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1587,10 +1388,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_CCS_QUERY_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_CCS_QUERY_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1604,10 +1401,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_CCS_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_CCS_SET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -1620,10 +1413,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_CCS_SET_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_CCS_SET_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_SERVICE_CONFIG_SSL_FLAG_DISABLE_HTTP2: u32 = 16u32;
 pub const HTTP_SERVICE_CONFIG_SSL_FLAG_DISABLE_LEGACY_TLS: u32 = 1024u32;
@@ -1652,10 +1441,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1667,10 +1452,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_KEY_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_KEY_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1691,9 +1472,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct HTTP_SERVICE_CONFIG_SSL_PARAM_EX {
@@ -1705,9 +1483,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_PARAM_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_PARAM_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1724,9 +1499,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_PARAM_EX_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_PARAM_EX_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1740,10 +1512,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_QUERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_QUERY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1760,10 +1528,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_QUERY_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_QUERY_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1776,10 +1540,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1794,10 +1554,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_SET_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_SET_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1810,10 +1566,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_SNI_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_SNI_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1828,10 +1580,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_SNI_QUERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_SNI_QUERY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1848,10 +1596,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_SNI_QUERY_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_SNI_QUERY_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1865,10 +1609,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_SNI_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_SNI_SET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
 #[derive(Clone, Copy)]
@@ -1881,10 +1621,6 @@ impl Default for HTTP_SERVICE_CONFIG_SSL_SNI_SET_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_SSL_SNI_SET_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1900,9 +1636,6 @@ impl Default for HTTP_SERVICE_CONFIG_TIMEOUT_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_TIMEOUT_SET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_SERVICE_CONFIG_URLACL_KEY {
@@ -1913,9 +1646,6 @@ impl Default for HTTP_SERVICE_CONFIG_URLACL_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_URLACL_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_SERVICE_CONFIG_URLACL_PARAM {
@@ -1925,9 +1655,6 @@ impl Default for HTTP_SERVICE_CONFIG_URLACL_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_URLACL_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1941,9 +1668,6 @@ impl Default for HTTP_SERVICE_CONFIG_URLACL_QUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_URLACL_QUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_SERVICE_CONFIG_URLACL_SET {
@@ -1954,9 +1678,6 @@ impl Default for HTTP_SERVICE_CONFIG_URLACL_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_SERVICE_CONFIG_URLACL_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1971,9 +1692,6 @@ impl Default for HTTP_SSL_CLIENT_CERT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_SSL_CLIENT_CERT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1992,9 +1710,6 @@ impl Default for HTTP_SSL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SSL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_SSL_PROTOCOL_INFO {
@@ -2011,9 +1726,6 @@ impl Default for HTTP_SSL_PROTOCOL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_SSL_PROTOCOL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HTTP_SSL_SERVICE_CONFIG_EX_PARAM_TYPE(pub i32);
@@ -2027,9 +1739,6 @@ impl Default for HTTP_STATE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_STATE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2047,9 +1756,6 @@ impl Default for HTTP_TIMEOUT_LIMIT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_TIMEOUT_LIMIT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_TLS_RESTRICTIONS_PARAM {
@@ -2061,9 +1767,6 @@ impl Default for HTTP_TLS_RESTRICTIONS_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_TLS_RESTRICTIONS_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_TLS_SESSION_TICKET_KEYS_PARAM {
@@ -2074,9 +1777,6 @@ impl Default for HTTP_TLS_SESSION_TICKET_KEYS_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_TLS_SESSION_TICKET_KEYS_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -2091,10 +1791,6 @@ impl Default for HTTP_TRANSPORT_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for HTTP_TRANSPORT_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_UNKNOWN_HEADER {
@@ -2107,9 +1803,6 @@ impl Default for HTTP_UNKNOWN_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_UNKNOWN_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_URL_FLAG_REMOVE_ALL: u32 = 1u32;
 #[repr(transparent)]
@@ -2125,9 +1818,6 @@ impl Default for HTTP_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_VERSION: windows_core::PCWSTR = windows_core::w!("HTTP/1.0");
 #[repr(C)]
@@ -2150,9 +1840,6 @@ impl Default for HTTP_WSK_API_TIMINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_WSK_API_TIMINGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HeaderWaitTimeout: HTTP_SERVICE_CONFIG_TIMEOUT_KEY = HTTP_SERVICE_CONFIG_TIMEOUT_KEY(1i32);
 pub const Http503ResponseVerbosityBasic: HTTP_503_RESPONSE_VERBOSITY = HTTP_503_RESPONSE_VERBOSITY(0i32);

--- a/crates/libs/windows/src/Windows/Win32/Networking/Ldap/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Ldap/mod.rs
@@ -1749,9 +1749,6 @@ impl Default for BerElement {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BerElement {
-    type TypeKind = windows_core::CopyType;
-}
 pub type DBGPRINT = Option<unsafe extern "system" fn(format: windows_core::PCSTR) -> u32>;
 pub type DEREFERENCECONNECTION = Option<unsafe extern "system" fn(primaryconnection: *mut LDAP, connectiontodereference: *mut LDAP) -> u32>;
 pub const LAPI_MAJOR_VER1: u32 = 1u32;
@@ -1786,9 +1783,6 @@ impl Default for LDAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LDAP_0 {
@@ -1802,9 +1796,6 @@ impl Default for LDAP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LDAPAPIFeatureInfoA {
@@ -1817,9 +1808,6 @@ impl Default for LDAPAPIFeatureInfoA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAPAPIFeatureInfoA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LDAPAPIFeatureInfoW {
@@ -1831,9 +1819,6 @@ impl Default for LDAPAPIFeatureInfoW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LDAPAPIFeatureInfoW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1850,9 +1835,6 @@ impl Default for LDAPAPIInfoA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAPAPIInfoA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LDAPAPIInfoW {
@@ -1868,9 +1850,6 @@ impl Default for LDAPAPIInfoW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAPAPIInfoW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LDAPControlA {
@@ -1883,9 +1862,6 @@ impl Default for LDAPControlA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAPControlA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LDAPControlW {
@@ -1897,9 +1873,6 @@ impl Default for LDAPControlW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LDAPControlW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1923,9 +1896,6 @@ impl Default for LDAPMessage {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAPMessage {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct LDAPModA {
@@ -1938,9 +1908,6 @@ impl Default for LDAPModA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAPModA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union LDAPModA_0 {
@@ -1951,9 +1918,6 @@ impl Default for LDAPModA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LDAPModA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1967,9 +1931,6 @@ impl Default for LDAPModW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAPModW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union LDAPModW_0 {
@@ -1980,9 +1941,6 @@ impl Default for LDAPModW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LDAPModW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1996,9 +1954,6 @@ impl Default for LDAPSortKeyA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAPSortKeyA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LDAPSortKeyW {
@@ -2010,9 +1965,6 @@ impl Default for LDAPSortKeyW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LDAPSortKeyW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2030,9 +1982,6 @@ impl Default for LDAPVLVInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LDAPVLVInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LDAP_ABANDON_CMD: i32 = 80i32;
 pub const LDAP_ADD_CMD: i32 = 104i32;
@@ -2060,9 +2009,6 @@ impl Default for LDAP_BERVAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LDAP_BERVAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LDAP_BIND_CMD: i32 = 96i32;
 pub const LDAP_BUSY: LDAP_RETCODE = LDAP_RETCODE(51i32);
@@ -2300,9 +2246,6 @@ impl Default for LDAP_REFERRAL_CALLBACK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAP_REFERRAL_CALLBACK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LDAP_REFERRAL_LIMIT_EXCEEDED: LDAP_RETCODE = LDAP_RETCODE(97i32);
 pub const LDAP_REFERRAL_V2: LDAP_RETCODE = LDAP_RETCODE(9i32);
 pub const LDAP_RESULTS_TOO_LARGE: LDAP_RETCODE = LDAP_RETCODE(70i32);
@@ -2432,9 +2375,6 @@ impl Default for LDAP_TIMEVAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDAP_TIMEVAL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LDAP_TTL_EXTENDED_OP_OID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.1466.101.119.1");
 pub const LDAP_TTL_EXTENDED_OP_OID_W: windows_core::PCWSTR = windows_core::w!("1.3.6.1.4.1.1466.101.119.1");
 pub const LDAP_UNAVAILABLE: LDAP_RETCODE = LDAP_RETCODE(52i32);
@@ -2466,9 +2406,6 @@ impl Default for LDAP_VERSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LDAP_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LDAP_VERSION_MAX: u32 = 3u32;
 pub const LDAP_VERSION_MIN: u32 = 2u32;

--- a/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/mod.rs
@@ -1226,9 +1226,6 @@ impl Default for NLM_DATAPLAN_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NLM_DATAPLAN_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NLM_DOMAIN_AUTHENTICATION_KIND(pub i32);
@@ -1287,9 +1284,6 @@ impl Default for NLM_SIMULATED_PROFILE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NLM_SIMULATED_PROFILE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NLM_SOCKADDR {
@@ -1299,9 +1293,6 @@ impl Default for NLM_SOCKADDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NLM_SOCKADDR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NLM_UNKNOWN_DATAPLAN_STATUS: u32 = 4294967295u32;
 #[repr(C)]
@@ -1314,8 +1305,5 @@ impl Default for NLM_USAGE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NLM_USAGE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NetworkListManager: windows_core::GUID = windows_core::GUID::from_u128(0xdcb00c01_570f_4a9b_8d69_199fdba5723b);

--- a/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/mod.rs
@@ -9,9 +9,6 @@ impl Default for FindSimilarFileIndexResults {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FindSimilarFileIndexResults {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FindSimilarResults: windows_core::GUID = windows_core::GUID::from_u128(0x96236a93_9dbc_11da_9e3f_0011114ae311);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1363,9 +1360,6 @@ impl Default for RdcBufferPointer {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RdcBufferPointer {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RdcComparator: windows_core::GUID = windows_core::GUID::from_u128(0x96236a8b_9dbc_11da_9e3f_0011114ae311);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1390,9 +1384,6 @@ impl Default for RdcNeed {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RdcNeed {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RdcNeedPointer {
@@ -1404,9 +1395,6 @@ impl Default for RdcNeedPointer {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RdcNeedPointer {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1422,9 +1410,6 @@ impl Default for RdcSignature {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RdcSignature {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RdcSignaturePointer {
@@ -1436,9 +1421,6 @@ impl Default for RdcSignaturePointer {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RdcSignaturePointer {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RdcSignatureReader: windows_core::GUID = windows_core::GUID::from_u128(0x96236a8a_9dbc_11da_9e3f_0011114ae311);
 pub const RdcSimilarityGenerator: windows_core::GUID = windows_core::GUID::from_u128(0x96236a92_9dbc_11da_9e3f_0011114ae311);
@@ -1453,9 +1435,6 @@ impl Default for SimilarityData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SimilarityData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SimilarityDumpData {
@@ -1467,9 +1446,6 @@ impl Default for SimilarityDumpData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SimilarityDumpData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SimilarityFileId {
@@ -1479,9 +1455,6 @@ impl Default for SimilarityFileId {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SimilarityFileId {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SimilarityFileIdMaxSize: u32 = 32u32;
 pub const SimilarityFileIdMinSize: u32 = 4u32;
@@ -1496,9 +1469,6 @@ impl Default for SimilarityMappedViewInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SimilarityMappedViewInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SimilarityReportProgress: windows_core::GUID = windows_core::GUID::from_u128(0x96236a8d_9dbc_11da_9e3f_0011114ae311);
 pub const SimilarityTableDumpState: windows_core::GUID = windows_core::GUID::from_u128(0x96236a8e_9dbc_11da_9e3f_0011114ae311);

--- a/crates/libs/windows/src/Windows/Win32/Networking/WebSocket/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WebSocket/mod.rs
@@ -101,9 +101,6 @@ impl Default for WEB_SOCKET_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEB_SOCKET_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WEB_SOCKET_BUFFER_1 {
@@ -116,9 +113,6 @@ impl Default for WEB_SOCKET_BUFFER_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEB_SOCKET_BUFFER_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WEB_SOCKET_BUFFER_0 {
@@ -129,9 +123,6 @@ impl Default for WEB_SOCKET_BUFFER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEB_SOCKET_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -182,9 +173,6 @@ impl Default for WEB_SOCKET_HTTP_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEB_SOCKET_HTTP_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WEB_SOCKET_INDICATE_RECEIVE_COMPLETE_ACTION: WEB_SOCKET_ACTION = WEB_SOCKET_ACTION(4i32);
 pub const WEB_SOCKET_INDICATE_SEND_COMPLETE_ACTION: WEB_SOCKET_ACTION = WEB_SOCKET_ACTION(2i32);
 pub const WEB_SOCKET_INVALID_DATA_TYPE_CLOSE_STATUS: WEB_SOCKET_CLOSE_STATUS = WEB_SOCKET_CLOSE_STATUS(1003i32);
@@ -206,9 +194,6 @@ impl Default for WEB_SOCKET_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEB_SOCKET_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinHttp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinHttp/mod.rs
@@ -447,9 +447,6 @@ impl Default for HTTP_VERSION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ICU_BROWSER_MODE: u32 = 33554432u32;
 pub const ICU_DECODE: WIN_HTTP_CREATE_URL_FLAGS = WIN_HTTP_CREATE_URL_FLAGS(268435456u32);
 pub const ICU_ENCODE_PERCENT: u32 = 4096u32;
@@ -894,9 +891,6 @@ impl Default for URL_COMPONENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for URL_COMPONENTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WINHTTP_ACCESS_TYPE(pub u32);
@@ -922,9 +916,6 @@ impl Default for WINHTTP_ASYNC_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_ASYNC_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_AUTH_SCHEME_BASIC: WINHTTP_CREDS_AUTHSCHEME = WINHTTP_CREDS_AUTHSCHEME(1u32);
 pub const WINHTTP_AUTH_SCHEME_DIGEST: u32 = 8u32;
@@ -963,9 +954,6 @@ impl Default for WINHTTP_AUTOPROXY_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_AUTOPROXY_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_AUTOPROXY_RUN_INPROCESS: u32 = 65536u32;
 pub const WINHTTP_AUTOPROXY_RUN_OUTPROCESS_ONLY: u32 = 131072u32;
@@ -1039,9 +1027,6 @@ impl Default for WINHTTP_CERTIFICATE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINHTTP_CERTIFICATE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINHTTP_CONNECTION_GROUP {
@@ -1052,9 +1037,6 @@ impl Default for WINHTTP_CONNECTION_GROUP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_CONNECTION_GROUP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
@@ -1072,11 +1054,6 @@ impl Default for WINHTTP_CONNECTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for WINHTTP_CONNECTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Networking_WinSock")]
@@ -1092,11 +1069,6 @@ impl Default for WINHTTP_CONNECTION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for WINHTTP_CONNECTION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_CONNECTION_RETRY_CONDITION_408: u32 = 1u32;
 pub const WINHTTP_CONNECTION_RETRY_CONDITION_SSL_HANDSHAKE: u32 = 2u32;
@@ -1117,9 +1089,6 @@ impl Default for WINHTTP_CREDS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINHTTP_CREDS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WINHTTP_CREDS_AUTHSCHEME(pub u32);
@@ -1139,9 +1108,6 @@ impl Default for WINHTTP_CREDS_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINHTTP_CREDS_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINHTTP_CURRENT_USER_IE_PROXY_CONFIG {
@@ -1154,9 +1120,6 @@ impl Default for WINHTTP_CURRENT_USER_IE_PROXY_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_CURRENT_USER_IE_PROXY_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_DECOMPRESSION_FLAG_DEFLATE: u32 = 2u32;
 pub const WINHTTP_DECOMPRESSION_FLAG_GZIP: u32 = 1u32;
@@ -1185,9 +1148,6 @@ impl Default for WINHTTP_EXTENDED_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINHTTP_EXTENDED_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINHTTP_EXTENDED_HEADER_0 {
@@ -1198,9 +1158,6 @@ impl Default for WINHTTP_EXTENDED_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_EXTENDED_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1213,9 +1170,6 @@ impl Default for WINHTTP_EXTENDED_HEADER_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINHTTP_EXTENDED_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WINHTTP_EXTENDED_HEADER_FLAG_UNICODE: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1227,9 +1181,6 @@ impl Default for WINHTTP_FAILED_CONNECTION_RETRIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_FAILED_CONNECTION_RETRIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_FEATURE_ADD_REQUEST_HEADERS_EX: u32 = 46u32;
 pub const WINHTTP_FEATURE_BACKGROUND_CONNECTIONS: u32 = 34u32;
@@ -1326,9 +1277,6 @@ impl Default for WINHTTP_HEADER_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINHTTP_HEADER_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINHTTP_HOST_CONNECTION_GROUP {
@@ -1341,9 +1289,6 @@ impl Default for WINHTTP_HOST_CONNECTION_GROUP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINHTTP_HOST_CONNECTION_GROUP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINHTTP_HTTP2_RECEIVE_WINDOW {
@@ -1354,9 +1299,6 @@ impl Default for WINHTTP_HTTP2_RECEIVE_WINDOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_HTTP2_RECEIVE_WINDOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_IGNORE_REQUEST_TOTAL_LENGTH: u32 = 0u32;
 #[repr(transparent)]
@@ -1380,10 +1322,6 @@ impl Default for WINHTTP_MATCH_CONNECTION_GUID {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for WINHTTP_MATCH_CONNECTION_GUID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1396,10 +1334,6 @@ impl Default for WINHTTP_MATCH_CONNECTION_GUID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for WINHTTP_MATCH_CONNECTION_GUID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_MATCH_CONNECTION_GUID_FLAGS_MASK: u32 = 1u32;
 pub const WINHTTP_MATCH_CONNECTION_GUID_FLAG_REQUIRE_MARKED_CONNECTION: u32 = 1u32;
@@ -1588,9 +1522,6 @@ impl Default for WINHTTP_PROXY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINHTTP_PROXY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINHTTP_PROXY_NETWORKING_KEY {
@@ -1600,9 +1531,6 @@ impl Default for WINHTTP_PROXY_NETWORKING_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_PROXY_NETWORKING_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_PROXY_NOTIFY_CHANGE: u32 = 1u32;
 #[repr(C)]
@@ -1615,9 +1543,6 @@ impl Default for WINHTTP_PROXY_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_PROXY_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1633,9 +1558,6 @@ impl Default for WINHTTP_PROXY_RESULT_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINHTTP_PROXY_RESULT_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINHTTP_PROXY_RESULT_EX {
@@ -1648,9 +1570,6 @@ impl Default for WINHTTP_PROXY_RESULT_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_PROXY_RESULT_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1677,9 +1596,6 @@ impl Default for WINHTTP_PROXY_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINHTTP_PROXY_SETTINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -1699,10 +1615,6 @@ impl Default for WINHTTP_PROXY_SETTINGS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for WINHTTP_PROXY_SETTINGS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1724,10 +1636,6 @@ impl Default for WINHTTP_PROXY_SETTINGS_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for WINHTTP_PROXY_SETTINGS_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -1742,10 +1650,6 @@ impl Default for WINHTTP_PROXY_SETTINGS_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for WINHTTP_PROXY_SETTINGS_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1759,10 +1663,6 @@ impl Default for WINHTTP_PROXY_SETTINGS_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for WINHTTP_PROXY_SETTINGS_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1792,9 +1692,6 @@ impl Default for WINHTTP_QUERY_CONNECTION_GROUP_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_QUERY_CONNECTION_GROUP_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_QUERY_CONTENT_BASE: u32 = 50u32;
 pub const WINHTTP_QUERY_CONTENT_DESCRIPTION: u32 = 4u32;
@@ -1884,10 +1781,6 @@ impl Default for WINHTTP_REQUEST_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for WINHTTP_REQUEST_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1902,10 +1795,6 @@ impl Default for WINHTTP_REQUEST_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for WINHTTP_REQUEST_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1929,10 +1818,6 @@ impl Default for WINHTTP_REQUEST_TIMES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for WINHTTP_REQUEST_TIMES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1945,10 +1830,6 @@ impl Default for WINHTTP_REQUEST_TIMES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for WINHTTP_REQUEST_TIMES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1978,10 +1859,6 @@ impl Default for WINHTTP_RESOLVER_CACHE_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for WINHTTP_RESOLVER_CACHE_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1998,10 +1875,6 @@ impl Default for WINHTTP_RESOLVER_CACHE_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for WINHTTP_RESOLVER_CACHE_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_RESOLVER_CACHE_CONFIG_FLAG_BYPASS_CACHE: u32 = 2u32;
 pub const WINHTTP_RESOLVER_CACHE_CONFIG_FLAG_CONN_USE_TTL: u32 = 8u32;
@@ -2023,9 +1896,6 @@ impl Default for WINHTTP_WEB_SOCKET_ASYNC_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_WEB_SOCKET_ASYNC_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_WEB_SOCKET_BINARY_FRAGMENT_BUFFER_TYPE: WINHTTP_WEB_SOCKET_BUFFER_TYPE = WINHTTP_WEB_SOCKET_BUFFER_TYPE(1i32);
 pub const WINHTTP_WEB_SOCKET_BINARY_MESSAGE_BUFFER_TYPE: WINHTTP_WEB_SOCKET_BUFFER_TYPE = WINHTTP_WEB_SOCKET_BUFFER_TYPE(0i32);
@@ -2064,9 +1934,6 @@ impl Default for WINHTTP_WEB_SOCKET_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINHTTP_WEB_SOCKET_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINHTTP_WEB_SOCKET_SUCCESS_CLOSE_STATUS: WINHTTP_WEB_SOCKET_CLOSE_STATUS = WINHTTP_WEB_SOCKET_CLOSE_STATUS(1000i32);
 pub const WINHTTP_WEB_SOCKET_UNSUPPORTED_EXTENSIONS_CLOSE_STATUS: WINHTTP_WEB_SOCKET_CLOSE_STATUS = WINHTTP_WEB_SOCKET_CLOSE_STATUS(1010i32);

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
@@ -2062,9 +2062,6 @@ impl Default for APP_CACHE_DOWNLOAD_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APP_CACHE_DOWNLOAD_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct APP_CACHE_DOWNLOAD_LIST {
@@ -2075,9 +2072,6 @@ impl Default for APP_CACHE_DOWNLOAD_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APP_CACHE_DOWNLOAD_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const APP_CACHE_ENTRY_TYPE_EXPLICIT: u32 = 2u32;
 pub const APP_CACHE_ENTRY_TYPE_FALLBACK: u32 = 4u32;
@@ -2099,9 +2093,6 @@ impl Default for APP_CACHE_GROUP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APP_CACHE_GROUP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct APP_CACHE_GROUP_LIST {
@@ -2112,9 +2103,6 @@ impl Default for APP_CACHE_GROUP_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APP_CACHE_GROUP_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const APP_CACHE_LOOKUP_NO_MASTER_ONLY: u32 = 1u32;
 #[repr(transparent)]
@@ -2147,9 +2135,6 @@ impl Default for AUTO_PROXY_SCRIPT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTO_PROXY_SCRIPT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AppCacheFinalizeStateComplete: APP_CACHE_FINALIZE_STATE = APP_CACHE_FINALIZE_STATE(2i32);
 pub const AppCacheFinalizeStateIncomplete: APP_CACHE_FINALIZE_STATE = APP_CACHE_FINALIZE_STATE(0i32);
 pub const AppCacheFinalizeStateManifestChange: APP_CACHE_FINALIZE_STATE = APP_CACHE_FINALIZE_STATE(1i32);
@@ -2166,9 +2151,6 @@ impl Default for AutoProxyHelperFunctions {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AutoProxyHelperFunctions {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2187,9 +2169,6 @@ impl Default for AutoProxyHelperVtbl {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AutoProxyHelperVtbl {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CACHEGROUP_ATTRIBUTE_BASIC: u32 = 1u32;
 pub const CACHEGROUP_ATTRIBUTE_FLAG: u32 = 2u32;
@@ -2298,9 +2277,6 @@ impl Default for COOKIE_DLG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COOKIE_DLG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const COOKIE_DONT_ALLOW: u32 = 1u32;
 pub const COOKIE_DONT_ALLOW_ALL: u32 = 8u32;
 pub const COOKIE_DOWNGRADED_CACHE_ENTRY: u32 = 16384u32;
@@ -2333,9 +2309,6 @@ impl Default for CookieDecision {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CookieDecision {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DIALENG_OperationComplete: u32 = 65536u32;
 pub const DIALENG_RedialAttempt: u32 = 65537u32;
@@ -2512,9 +2485,6 @@ impl Default for GOPHER_ABSTRACT_ATTRIBUTE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_ABSTRACT_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GOPHER_ABSTRACT_CATEGORY: windows_core::PCWSTR = windows_core::w!("+ABSTRACT");
 pub const GOPHER_ADMIN_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("Admin");
 #[repr(C)]
@@ -2528,9 +2498,6 @@ impl Default for GOPHER_ADMIN_ATTRIBUTE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_ADMIN_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GOPHER_ADMIN_CATEGORY: windows_core::PCWSTR = windows_core::w!("+ADMIN");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2542,9 +2509,6 @@ impl Default for GOPHER_ASK_ATTRIBUTE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GOPHER_ASK_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub type GOPHER_ATTRIBUTE_ENUMERATOR = Option<unsafe extern "system" fn(lpattributeinfo: *const GOPHER_ATTRIBUTE_TYPE, dwerror: u32) -> super::super::Foundation::BOOL>;
 pub const GOPHER_ATTRIBUTE_ID_ABSTRACT: u32 = 2882325526u32;
@@ -2577,9 +2541,6 @@ impl Default for GOPHER_ATTRIBUTE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union GOPHER_ATTRIBUTE_TYPE_0 {
@@ -2606,9 +2567,6 @@ impl Default for GOPHER_ATTRIBUTE_TYPE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_ATTRIBUTE_TYPE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GOPHER_CATEGORY_ID_ABSTRACT: u32 = 2882325509u32;
 pub const GOPHER_CATEGORY_ID_ADMIN: u32 = 2882325507u32;
 pub const GOPHER_CATEGORY_ID_ALL: u32 = 2882325505u32;
@@ -2632,9 +2590,6 @@ impl Default for GOPHER_FIND_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_FIND_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GOPHER_FIND_DATAW {
@@ -2649,9 +2604,6 @@ impl Default for GOPHER_FIND_DATAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GOPHER_FIND_DATAW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2668,9 +2620,6 @@ impl Default for GOPHER_GEOGRAPHICAL_LOCATION_ATTRIBUTE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_GEOGRAPHICAL_LOCATION_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GOPHER_GEOG_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("Geog");
 pub const GOPHER_INFO_CATEGORY: windows_core::PCWSTR = windows_core::w!("+INFO");
 pub const GOPHER_LOCATION_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("Loc");
@@ -2684,9 +2633,6 @@ impl Default for GOPHER_LOCATION_ATTRIBUTE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_LOCATION_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GOPHER_MOD_DATE_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("Mod-Date");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2698,9 +2644,6 @@ impl Default for GOPHER_MOD_DATE_ATTRIBUTE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_MOD_DATE_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GOPHER_ORGANIZATION_ATTRIBUTE_TYPE {
@@ -2710,9 +2653,6 @@ impl Default for GOPHER_ORGANIZATION_ATTRIBUTE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GOPHER_ORGANIZATION_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GOPHER_ORG_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("Org");
 pub const GOPHER_PROVIDER_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("Provider");
@@ -2726,9 +2666,6 @@ impl Default for GOPHER_PROVIDER_ATTRIBUTE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_PROVIDER_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GOPHER_RANGE_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("Score-range");
 pub const GOPHER_SCORE_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("Score");
 #[repr(C)]
@@ -2741,9 +2678,6 @@ impl Default for GOPHER_SCORE_ATTRIBUTE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_SCORE_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GOPHER_SCORE_RANGE_ATTRIBUTE_TYPE {
@@ -2754,9 +2688,6 @@ impl Default for GOPHER_SCORE_RANGE_ATTRIBUTE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GOPHER_SCORE_RANGE_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GOPHER_SITE_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("Site");
 #[repr(C)]
@@ -2769,9 +2700,6 @@ impl Default for GOPHER_SITE_ATTRIBUTE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_SITE_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GOPHER_TIMEZONE_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("TZ");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2782,9 +2710,6 @@ impl Default for GOPHER_TIMEZONE_ATTRIBUTE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GOPHER_TIMEZONE_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GOPHER_TREEWALK_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("treewalk");
 pub const GOPHER_TTL_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("TTL");
@@ -2797,9 +2722,6 @@ impl Default for GOPHER_TTL_ATTRIBUTE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GOPHER_TTL_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2838,9 +2760,6 @@ impl Default for GOPHER_UNKNOWN_ATTRIBUTE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GOPHER_UNKNOWN_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GOPHER_VERONICA_ATTRIBUTE_TYPE {
@@ -2850,9 +2769,6 @@ impl Default for GOPHER_VERONICA_ATTRIBUTE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GOPHER_VERONICA_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GOPHER_VERONICA_CATEGORY: windows_core::PCWSTR = windows_core::w!("+VERONICA");
 pub const GOPHER_VERSION_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("Version");
@@ -2865,9 +2781,6 @@ impl Default for GOPHER_VERSION_ATTRIBUTE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GOPHER_VERSION_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GOPHER_VIEWS_CATEGORY: windows_core::PCWSTR = windows_core::w!("+VIEWS");
 pub const GOPHER_VIEW_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("View");
@@ -2882,9 +2795,6 @@ impl Default for GOPHER_VIEW_ATTRIBUTE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GOPHER_VIEW_ATTRIBUTE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GROUPNAME_MAX_LENGTH: u32 = 120u32;
 pub const GROUP_OWNER_STORAGE_SIZE: u32 = 4u32;
@@ -2969,9 +2879,6 @@ impl Default for HTTP_PUSH_NOTIFICATION_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_PUSH_NOTIFICATION_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_PUSH_TRANSPORT_SETTING {
@@ -2982,9 +2889,6 @@ impl Default for HTTP_PUSH_TRANSPORT_SETTING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_PUSH_TRANSPORT_SETTING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -3121,9 +3025,6 @@ impl Default for HTTP_REQUEST_TIMES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_REQUEST_TIMES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HTTP_STATUS_MISDIRECTED_REQUEST: u32 = 421u32;
 pub const HTTP_VERSIONA: windows_core::PCSTR = windows_core::s!("HTTP/1.0");
 pub const HTTP_VERSIONW: windows_core::PCWSTR = windows_core::w!("HTTP/1.0");
@@ -3140,9 +3041,6 @@ impl Default for HTTP_WEB_SOCKET_ASYNC_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_WEB_SOCKET_ASYNC_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_WEB_SOCKET_BINARY_FRAGMENT_TYPE: HTTP_WEB_SOCKET_BUFFER_TYPE = HTTP_WEB_SOCKET_BUFFER_TYPE(1i32);
 pub const HTTP_WEB_SOCKET_BINARY_MESSAGE_TYPE: HTTP_WEB_SOCKET_BUFFER_TYPE = HTTP_WEB_SOCKET_BUFFER_TYPE(0i32);
@@ -3408,9 +3306,6 @@ impl Default for INTERNET_ASYNC_RESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_ASYNC_RESULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_AUTH_NOTIFY_DATA {
@@ -3423,9 +3318,6 @@ impl Default for INTERNET_AUTH_NOTIFY_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_AUTH_NOTIFY_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERNET_AUTH_SCHEME_BASIC: u32 = 0u32;
 pub const INTERNET_AUTH_SCHEME_DIGEST: u32 = 1u32;
@@ -3464,9 +3356,6 @@ impl Default for INTERNET_BUFFERSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_BUFFERSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_BUFFERSW {
@@ -3485,9 +3374,6 @@ impl Default for INTERNET_BUFFERSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_BUFFERSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3508,9 +3394,6 @@ impl Default for INTERNET_CACHE_CONFIG_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CACHE_CONFIG_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INTERNET_CACHE_CONFIG_INFOA_0 {
@@ -3522,9 +3405,6 @@ impl Default for INTERNET_CACHE_CONFIG_INFOA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CACHE_CONFIG_INFOA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_CACHE_CONFIG_INFOA_0_0 {
@@ -3535,9 +3415,6 @@ impl Default for INTERNET_CACHE_CONFIG_INFOA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_CACHE_CONFIG_INFOA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3558,9 +3435,6 @@ impl Default for INTERNET_CACHE_CONFIG_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CACHE_CONFIG_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INTERNET_CACHE_CONFIG_INFOW_0 {
@@ -3571,9 +3445,6 @@ impl Default for INTERNET_CACHE_CONFIG_INFOW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_CACHE_CONFIG_INFOW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3586,9 +3457,6 @@ impl Default for INTERNET_CACHE_CONFIG_INFOW_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CACHE_CONFIG_INFOW_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_CACHE_CONFIG_PATH_ENTRYA {
@@ -3600,9 +3468,6 @@ impl Default for INTERNET_CACHE_CONFIG_PATH_ENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CACHE_CONFIG_PATH_ENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_CACHE_CONFIG_PATH_ENTRYW {
@@ -3613,9 +3478,6 @@ impl Default for INTERNET_CACHE_CONFIG_PATH_ENTRYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_CACHE_CONFIG_PATH_ENTRYW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERNET_CACHE_CONTAINER_AUTODELETE: u32 = 2u32;
 pub const INTERNET_CACHE_CONTAINER_BLOOM_FILTER: u32 = 32u32;
@@ -3633,9 +3495,6 @@ impl Default for INTERNET_CACHE_CONTAINER_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CACHE_CONTAINER_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_CACHE_CONTAINER_INFOW {
@@ -3649,9 +3508,6 @@ impl Default for INTERNET_CACHE_CONTAINER_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_CACHE_CONTAINER_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERNET_CACHE_CONTAINER_MAP_ENABLED: u32 = 16u32;
 pub const INTERNET_CACHE_CONTAINER_NODESKTOPINIT: u32 = 8u32;
@@ -3684,9 +3540,6 @@ impl Default for INTERNET_CACHE_ENTRY_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CACHE_ENTRY_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INTERNET_CACHE_ENTRY_INFOA_0 {
@@ -3697,9 +3550,6 @@ impl Default for INTERNET_CACHE_ENTRY_INFOA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_CACHE_ENTRY_INFOA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3726,9 +3576,6 @@ impl Default for INTERNET_CACHE_ENTRY_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CACHE_ENTRY_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INTERNET_CACHE_ENTRY_INFOW_0 {
@@ -3739,9 +3586,6 @@ impl Default for INTERNET_CACHE_ENTRY_INFOW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_CACHE_ENTRY_INFOW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERNET_CACHE_FLAG_ADD_FILENAME_ONLY: u32 = 2048u32;
 pub const INTERNET_CACHE_FLAG_ALLOW_COLLISIONS: u32 = 256u32;
@@ -3765,9 +3609,6 @@ impl Default for INTERNET_CACHE_GROUP_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CACHE_GROUP_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_CACHE_GROUP_INFOW {
@@ -3784,9 +3625,6 @@ impl Default for INTERNET_CACHE_GROUP_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CACHE_GROUP_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INTERNET_CACHE_GROUP_REMOVE: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3798,9 +3636,6 @@ impl Default for INTERNET_CACHE_TIMESTAMPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_CACHE_TIMESTAMPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3816,9 +3651,6 @@ impl Default for INTERNET_CALLBACK_COOKIE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_CALLBACK_COOKIE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3837,9 +3669,6 @@ impl Default for INTERNET_CERTIFICATE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CERTIFICATE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_CONNECTED_INFO {
@@ -3850,9 +3679,6 @@ impl Default for INTERNET_CONNECTED_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_CONNECTED_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3914,9 +3740,6 @@ impl Default for INTERNET_COOKIE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_COOKIE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_COOKIE2 {
@@ -3932,9 +3755,6 @@ impl Default for INTERNET_COOKIE2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_COOKIE2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERNET_COOKIE_ALL_COOKIES: u32 = 536870912u32;
 pub const INTERNET_COOKIE_APPLY_HOST_ONLY: u32 = 32768u32;
@@ -3979,9 +3799,6 @@ impl Default for INTERNET_CREDENTIALS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CREDENTIALS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INTERNET_CREDENTIALS_0 {
@@ -3993,9 +3810,6 @@ impl Default for INTERNET_CREDENTIALS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_CREDENTIALS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_CREDENTIALS_0_0 {
@@ -4006,9 +3820,6 @@ impl Default for INTERNET_CREDENTIALS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_CREDENTIALS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERNET_CUSTOMDIAL_CAN_HANGUP: u32 = 4u32;
 pub const INTERNET_CUSTOMDIAL_CONNECT: u32 = 0u32;
@@ -4033,9 +3844,6 @@ impl Default for INTERNET_DIAGNOSTIC_SOCKET_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_DIAGNOSTIC_SOCKET_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INTERNET_DIALSTATE_DISCONNECTED: u32 = 1u32;
 pub const INTERNET_DIAL_FORCE_PROMPT: u32 = 8192u32;
 pub const INTERNET_DIAL_SHOW_OFFLINE: u32 = 16384u32;
@@ -4051,9 +3859,6 @@ impl Default for INTERNET_DOWNLOAD_MODE_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_DOWNLOAD_MODE_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_END_BROWSER_SESSION_DATA {
@@ -4064,9 +3869,6 @@ impl Default for INTERNET_END_BROWSER_SESSION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_END_BROWSER_SESSION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERNET_ERROR_BASE: u32 = 12000u32;
 pub const INTERNET_ERROR_LAST: u32 = 12192u32;
@@ -4365,9 +4167,6 @@ impl Default for INTERNET_PER_CONN_OPTIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_PER_CONN_OPTIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INTERNET_PER_CONN_OPTIONA_0 {
@@ -4380,9 +4179,6 @@ impl Default for INTERNET_PER_CONN_OPTIONA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_PER_CONN_OPTIONA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct INTERNET_PER_CONN_OPTIONW {
@@ -4393,9 +4189,6 @@ impl Default for INTERNET_PER_CONN_OPTIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_PER_CONN_OPTIONW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4408,9 +4201,6 @@ impl Default for INTERNET_PER_CONN_OPTIONW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_PER_CONN_OPTIONW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4426,9 +4216,6 @@ impl Default for INTERNET_PER_CONN_OPTION_LISTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_PER_CONN_OPTION_LISTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_PER_CONN_OPTION_LISTW {
@@ -4442,9 +4229,6 @@ impl Default for INTERNET_PER_CONN_OPTION_LISTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_PER_CONN_OPTION_LISTW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERNET_PER_CONN_PROXY_BYPASS: INTERNET_PER_CONN = INTERNET_PER_CONN(3u32);
 pub const INTERNET_PER_CONN_PROXY_SERVER: INTERNET_PER_CONN = INTERNET_PER_CONN(2u32);
@@ -4462,9 +4246,6 @@ impl Default for INTERNET_PREFETCH_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERNET_PREFETCH_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INTERNET_PRIORITY_FOREGROUND: u32 = 1000u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4477,9 +4258,6 @@ impl Default for INTERNET_PROXY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_PROXY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERNET_RAS_INSTALLED: INTERNET_CONNECTION = INTERNET_CONNECTION(16u32);
 pub const INTERNET_REQFLAG_ASYNC: u32 = 2u32;
@@ -4526,10 +4304,6 @@ impl Default for INTERNET_SECURITY_CONNECTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
-impl windows_core::TypeKind for INTERNET_SECURITY_CONNECTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4548,10 +4322,6 @@ impl Default for INTERNET_SECURITY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
-impl windows_core::TypeKind for INTERNET_SECURITY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERNET_SERVER_CONNECTION_STATE {
@@ -4568,9 +4338,6 @@ impl Default for INTERNET_SERVER_CONNECTION_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_SERVER_CONNECTION_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTERNET_SERVICE_FTP: u32 = 1u32;
 pub const INTERNET_SERVICE_GOPHER: u32 = 2u32;
@@ -4648,9 +4415,6 @@ impl Default for INTERNET_VERSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERNET_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IProofOfPossessionCookieInfoManager, IProofOfPossessionCookieInfoManager_Vtbl, 0xcdaece56_4edf_43df_b113_88e4556fa1bb);
 windows_core::imp::interface_hierarchy!(IProofOfPossessionCookieInfoManager, windows_core::IUnknown);
@@ -4742,9 +4506,6 @@ impl Default for IncomingCookieState {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IncomingCookieState {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct InternetCookieHistory {
@@ -4757,9 +4518,6 @@ impl Default for InternetCookieHistory {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for InternetCookieHistory {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4791,9 +4549,6 @@ impl Default for OutgoingCookieState {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OutgoingCookieState {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PENDING_DELETE_CACHE_ENTRY: u32 = 4194304u32;
 pub type PFN_AUTH_NOTIFY = Option<unsafe extern "system" fn(param0: usize, param1: u32, param2: *mut core::ffi::c_void) -> u32>;
@@ -4872,9 +4627,6 @@ impl Default for ProofOfPossessionCookieInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ProofOfPossessionCookieInfo {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ProofOfPossessionCookieInfoManager: windows_core::GUID = windows_core::GUID::from_u128(0xa9927f85_a304_4390_8b23_a75f1c668600);
 pub const REDIRECT_CACHE_ENTRY: u32 = 2048u32;
 pub const REGSTR_DIAL_AUTOCONNECT: windows_core::PCSTR = windows_core::s!("AutoConnect");
@@ -4931,9 +4683,6 @@ impl Default for URLCACHE_ENTRY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for URLCACHE_ENTRY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const URLHISTORY_CACHE_ENTRY: u32 = 2097152u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4962,9 +4711,6 @@ impl Default for URL_COMPONENTSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for URL_COMPONENTSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct URL_COMPONENTSW {
@@ -4989,9 +4735,6 @@ impl Default for URL_COMPONENTSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for URL_COMPONENTSW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const UrlCacheLimitTypeAppContainer: URL_CACHE_LIMIT_TYPE = URL_CACHE_LIMIT_TYPE(2i32);
 pub const UrlCacheLimitTypeAppContainerTotal: URL_CACHE_LIMIT_TYPE = URL_CACHE_LIMIT_TYPE(3i32);
 pub const UrlCacheLimitTypeIE: URL_CACHE_LIMIT_TYPE = URL_CACHE_LIMIT_TYPE(0i32);
@@ -5014,9 +4757,6 @@ impl Default for WININET_PROXY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WININET_PROXY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WININET_PROXY_INFO_LIST {
@@ -5027,9 +4767,6 @@ impl Default for WININET_PROXY_INFO_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WININET_PROXY_INFO_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -1348,9 +1348,6 @@ impl Default for AAL5_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AAL5_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AAL5_SSCS_FRAME_RELAY: u32 = 4u32;
 pub const AAL5_SSCS_NULL: u32 = 0u32;
 pub const AAL5_SSCS_SSCOP_ASSURED: u32 = 1u32;
@@ -1367,9 +1364,6 @@ impl Default for AALUSER_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AALUSER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct AAL_PARAMETERS_IE {
@@ -1381,9 +1375,6 @@ impl Default for AAL_PARAMETERS_IE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AAL_PARAMETERS_IE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AAL_PARAMETERS_IE_0 {
@@ -1394,9 +1385,6 @@ impl Default for AAL_PARAMETERS_IE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AAL_PARAMETERS_IE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1421,9 +1409,6 @@ impl Default for ADDRINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADDRINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADDRINFOEX2A {
@@ -1445,9 +1430,6 @@ impl Default for ADDRINFOEX2A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADDRINFOEX2A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1471,9 +1453,6 @@ impl Default for ADDRINFOEX2W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADDRINFOEX2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADDRINFOEX3 {
@@ -1496,9 +1475,6 @@ impl Default for ADDRINFOEX3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADDRINFOEX3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1524,9 +1500,6 @@ impl Default for ADDRINFOEX4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADDRINFOEX4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADDRINFOEX5 {
@@ -1551,9 +1524,6 @@ impl Default for ADDRINFOEX5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADDRINFOEX5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1583,9 +1553,6 @@ impl Default for ADDRINFOEX6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADDRINFOEX6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADDRINFOEXA {
@@ -1606,9 +1573,6 @@ impl Default for ADDRINFOEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADDRINFOEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADDRINFOEXW {
@@ -1628,9 +1592,6 @@ impl Default for ADDRINFOEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADDRINFOEXW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ADDRINFOEX_VERSION_2: u32 = 2u32;
 pub const ADDRINFOEX_VERSION_3: u32 = 3u32;
@@ -1654,9 +1615,6 @@ impl Default for ADDRINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADDRINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ADDRINFO_DNS_SERVER {
@@ -1671,9 +1629,6 @@ impl Default for ADDRINFO_DNS_SERVER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ADDRINFO_DNS_SERVER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ADDRINFO_DNS_SERVER_0 {
@@ -1683,9 +1638,6 @@ impl Default for ADDRINFO_DNS_SERVER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADDRINFO_DNS_SERVER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ADDR_ANY: u32 = 0u32;
 #[repr(C)]
@@ -1698,9 +1650,6 @@ impl Default for AFPROTOCOLS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AFPROTOCOLS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AF_12844: u16 = 25u16;
 pub const AF_APPLETALK: u16 = 16u16;
@@ -1784,9 +1733,6 @@ impl Default for ARP_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ARP_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ARP_HW_802: ARP_HARDWARE_TYPE = ARP_HARDWARE_TYPE(6i32);
 pub const ARP_HW_ENET: ARP_HARDWARE_TYPE = ARP_HARDWARE_TYPE(1i32);
 #[repr(transparent)]
@@ -1806,9 +1752,6 @@ impl Default for ASSOCIATE_NAMERES_CONTEXT_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ASSOCIATE_NAMERES_CONTEXT_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ATMPROTO_AAL1: u32 = 1u32;
 pub const ATMPROTO_AAL2: u32 = 2u32;
 pub const ATMPROTO_AAL34: u32 = 3u32;
@@ -1826,9 +1769,6 @@ impl Default for ATM_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATM_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ATM_ADDR_SIZE: u32 = 20u32;
 pub const ATM_AESA: u32 = 2u32;
 #[repr(C)]
@@ -1842,9 +1782,6 @@ impl Default for ATM_BHLI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATM_BHLI {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1860,9 +1797,6 @@ impl Default for ATM_BLLI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATM_BLLI {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1884,9 +1818,6 @@ impl Default for ATM_BLLI_IE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATM_BLLI_IE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ATM_BROADBAND_BEARER_CAPABILITY_IE {
@@ -1901,9 +1832,6 @@ impl Default for ATM_BROADBAND_BEARER_CAPABILITY_IE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATM_BROADBAND_BEARER_CAPABILITY_IE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ATM_CALLING_PARTY_NUMBER_IE {
@@ -1915,9 +1843,6 @@ impl Default for ATM_CALLING_PARTY_NUMBER_IE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATM_CALLING_PARTY_NUMBER_IE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1932,9 +1857,6 @@ impl Default for ATM_CAUSE_IE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATM_CAUSE_IE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ATM_CONNECTION_ID {
@@ -1946,9 +1868,6 @@ impl Default for ATM_CONNECTION_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATM_CONNECTION_ID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ATM_E164: u32 = 1u32;
 pub const ATM_NSAP: u32 = 2u32;
@@ -1963,9 +1882,6 @@ impl Default for ATM_PVC_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATM_PVC_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ATM_QOS_CLASS_IE {
@@ -1976,9 +1892,6 @@ impl Default for ATM_QOS_CLASS_IE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATM_QOS_CLASS_IE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1996,9 +1909,6 @@ impl Default for ATM_TD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATM_TD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ATM_TRAFFIC_DESCRIPTOR_IE {
@@ -2010,9 +1920,6 @@ impl Default for ATM_TRAFFIC_DESCRIPTOR_IE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATM_TRAFFIC_DESCRIPTOR_IE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2026,9 +1933,6 @@ impl Default for ATM_TRANSIT_NETWORK_SELECTION_IE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATM_TRANSIT_NETWORK_SELECTION_IE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BASE_PROTOCOL: u32 = 1u32;
 pub const BCOB_A: u32 = 1u32;
@@ -2153,9 +2057,6 @@ impl Default for CMSGHDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSGHDR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const COMP_EQUAL: WSAECOMPARATOR = WSAECOMPARATOR(0i32);
 pub const COMP_NOTLESS: WSAECOMPARATOR = WSAECOMPARATOR(1i32);
 #[repr(transparent)]
@@ -2181,9 +2082,6 @@ impl Default for CSADDR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSADDR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DE_REUSE_SOCKET: u32 = 2u32;
 pub const DL_ADDRESS_LENGTH_MAXIMUM: u32 = 32u32;
 #[repr(C)]
@@ -2196,9 +2094,6 @@ impl Default for DL_EI48 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DL_EI48 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DL_EI64 {
@@ -2208,9 +2103,6 @@ impl Default for DL_EI64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DL_EI64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2223,9 +2115,6 @@ impl Default for DL_EUI48 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DL_EUI48 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DL_EUI48_0 {
@@ -2236,9 +2125,6 @@ impl Default for DL_EUI48_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DL_EUI48_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2252,9 +2138,6 @@ impl Default for DL_EUI64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DL_EUI64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DL_EUI64_0 {
@@ -2266,9 +2149,6 @@ impl Default for DL_EUI64_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DL_EUI64_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DL_EUI64_0_0 {
@@ -2279,9 +2159,6 @@ impl Default for DL_EUI64_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DL_EUI64_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2295,9 +2172,6 @@ impl Default for DL_EUI64_0_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DL_EUI64_0_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DL_HEADER_LENGTH_MAXIMUM: u32 = 64u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2310,9 +2184,6 @@ impl Default for DL_OUI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DL_OUI {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DL_OUI_0 {
@@ -2322,9 +2193,6 @@ impl Default for DL_OUI_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DL_OUI_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2337,9 +2205,6 @@ impl Default for DL_TEREDO_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DL_TEREDO_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union DL_TEREDO_ADDRESS_0 {
@@ -2350,9 +2215,6 @@ impl Default for DL_TEREDO_ADDRESS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DL_TEREDO_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2366,9 +2228,6 @@ impl Default for DL_TEREDO_ADDRESS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DL_TEREDO_ADDRESS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DL_TEREDO_ADDRESS_PRV {
@@ -2380,9 +2239,6 @@ impl Default for DL_TEREDO_ADDRESS_PRV {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DL_TEREDO_ADDRESS_PRV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union DL_TEREDO_ADDRESS_PRV_0 {
@@ -2393,9 +2249,6 @@ impl Default for DL_TEREDO_ADDRESS_PRV_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DL_TEREDO_ADDRESS_PRV_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2413,9 +2266,6 @@ impl Default for DL_TEREDO_ADDRESS_PRV_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DL_TEREDO_ADDRESS_PRV_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -2430,10 +2280,6 @@ impl Default for DL_TUNNEL_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DL_TUNNEL_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ETHERNET_HEADER {
@@ -2446,9 +2292,6 @@ impl Default for ETHERNET_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ETHERNET_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ETHERNET_HEADER_0 {
@@ -2459,9 +2302,6 @@ impl Default for ETHERNET_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ETHERNET_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ETHERNET_TYPE_802_1AD: u32 = 34984u32;
 pub const ETHERNET_TYPE_802_1Q: u32 = 33024u32;
@@ -2504,9 +2344,6 @@ impl Default for FD_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FD_SET {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FD_SETSIZE: u32 = 64u32;
 pub const FD_WRITE: u32 = 2u32;
 pub const FD_WRITE_BIT: u32 = 1u32;
@@ -2530,9 +2367,6 @@ impl Default for FLOWSPEC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLOWSPEC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FROM_PROTOCOL_INFO: i32 = -1i32;
 pub const FallbackIndexMax: FALLBACK_INDEX = FALLBACK_INDEX(1i32);
 pub const FallbackIndexTcpFastopen: FALLBACK_INDEX = FALLBACK_INDEX(0i32);
@@ -2551,9 +2385,6 @@ impl Default for GROUP_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GROUP_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GROUP_REQ {
@@ -2564,9 +2395,6 @@ impl Default for GROUP_REQ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GROUP_REQ {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2579,9 +2407,6 @@ impl Default for GROUP_SOURCE_REQ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GROUP_SOURCE_REQ {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2596,9 +2421,6 @@ impl Default for HOSTENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HOSTENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IAS_ATTRIB_INT: u32 = 1u32;
 pub const IAS_ATTRIB_NO_ATTRIB: u32 = 0u32;
@@ -2653,9 +2475,6 @@ impl Default for ICMPV4_ADDRESS_MASK_MESSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ICMPV4_ADDRESS_MASK_MESSAGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ICMPV4_INVALID_PREFERENCE_LEVEL: u32 = 2147483648u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2668,9 +2487,6 @@ impl Default for ICMPV4_ROUTER_ADVERT_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ICMPV4_ROUTER_ADVERT_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ICMPV4_ROUTER_ADVERT_HEADER {
@@ -2681,9 +2497,6 @@ impl Default for ICMPV4_ROUTER_ADVERT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ICMPV4_ROUTER_ADVERT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ICMPV4_ROUTER_SOLICIT {
@@ -2693,9 +2506,6 @@ impl Default for ICMPV4_ROUTER_SOLICIT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ICMPV4_ROUTER_SOLICIT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2709,9 +2519,6 @@ impl Default for ICMPV4_TIMESTAMP_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ICMPV4_TIMESTAMP_MESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ICMPV6_ECHO_REQUEST_FLAG_REVERSE: u32 = 1u32;
 #[repr(C)]
@@ -2727,9 +2534,6 @@ impl Default for ICMP_ERROR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ICMP_ERROR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ICMP_HEADER {
@@ -2742,9 +2546,6 @@ impl Default for ICMP_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ICMP_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ICMP_MESSAGE {
@@ -2755,9 +2556,6 @@ impl Default for ICMP_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ICMP_MESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2770,9 +2568,6 @@ impl Default for ICMP_MESSAGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ICMP_MESSAGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IE_AALParameters: Q2931_IE_TYPE = Q2931_IE_TYPE(0i32);
 pub const IE_BHLI: Q2931_IE_TYPE = Q2931_IE_TYPE(3i32);
@@ -2807,9 +2602,6 @@ impl Default for IGMPV3_QUERY_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IGMPV3_QUERY_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IGMPV3_QUERY_HEADER_0 {
@@ -2821,9 +2613,6 @@ impl Default for IGMPV3_QUERY_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IGMPV3_QUERY_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IGMPV3_QUERY_HEADER_0_0 {
@@ -2833,9 +2622,6 @@ impl Default for IGMPV3_QUERY_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IGMPV3_QUERY_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2848,9 +2634,6 @@ impl Default for IGMPV3_QUERY_HEADER_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IGMPV3_QUERY_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IGMPV3_QUERY_HEADER_1_0 {
@@ -2860,9 +2643,6 @@ impl Default for IGMPV3_QUERY_HEADER_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IGMPV3_QUERY_HEADER_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2878,9 +2658,6 @@ impl Default for IGMPV3_REPORT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IGMPV3_REPORT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IGMPV3_REPORT_RECORD_HEADER {
@@ -2893,9 +2670,6 @@ impl Default for IGMPV3_REPORT_RECORD_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IGMPV3_REPORT_RECORD_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2910,9 +2684,6 @@ impl Default for IGMP_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IGMP_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IGMP_HEADER_0 {
@@ -2924,9 +2695,6 @@ impl Default for IGMP_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IGMP_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IGMP_HEADER_0_0 {
@@ -2936,9 +2704,6 @@ impl Default for IGMP_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IGMP_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2951,9 +2716,6 @@ impl Default for IGMP_HEADER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IGMP_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IGMP_LEAVE_GROUP_TYPE: u32 = 23u32;
 #[repr(transparent)]
@@ -2990,9 +2752,6 @@ impl Default for IN6_ADDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IN6_ADDR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IN6_ADDR_0 {
@@ -3003,9 +2762,6 @@ impl Default for IN6_ADDR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IN6_ADDR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IN6_EMBEDDEDV4_BITS_IN_BYTE: u32 = 8u32;
 pub const IN6_EMBEDDEDV4_UOCTET_POSITION: u32 = 8u32;
@@ -3020,9 +2776,6 @@ impl Default for IN6_PKTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IN6_PKTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IN6_PKTINFO_EX {
@@ -3033,9 +2786,6 @@ impl Default for IN6_PKTINFO_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IN6_PKTINFO_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INADDR_ANY: u32 = 0u32;
 pub const INADDR_BROADCAST: u32 = 4294967295u32;
@@ -3056,9 +2806,6 @@ impl Default for INET_PORT_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INET_PORT_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INET_PORT_RESERVATION_INFORMATION {
@@ -3068,9 +2815,6 @@ impl Default for INET_PORT_RESERVATION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INET_PORT_RESERVATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3083,9 +2827,6 @@ impl Default for INET_PORT_RESERVATION_INSTANCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INET_PORT_RESERVATION_INSTANCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INET_PORT_RESERVATION_TOKEN {
@@ -3095,9 +2836,6 @@ impl Default for INET_PORT_RESERVATION_TOKEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INET_PORT_RESERVATION_TOKEN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3112,9 +2850,6 @@ impl Default for INTERFACE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERFACE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERFACE_INFO_EX {
@@ -3128,9 +2863,6 @@ impl Default for INTERFACE_INFO_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERFACE_INFO_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INVALID_SOCKET: SOCKET = SOCKET(-1i32 as _);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3141,9 +2873,6 @@ impl Default for IN_ADDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IN_ADDR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3156,9 +2885,6 @@ impl Default for IN_ADDR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IN_ADDR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3173,9 +2899,6 @@ impl Default for IN_ADDR_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IN_ADDR_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IN_ADDR_0_1 {
@@ -3186,9 +2909,6 @@ impl Default for IN_ADDR_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IN_ADDR_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IN_CLASSA_HOST: u32 = 16777215u32;
 pub const IN_CLASSA_MAX: u32 = 128u32;
@@ -3215,9 +2935,6 @@ impl Default for IN_PKTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IN_PKTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IN_PKTINFO_EX {
@@ -3228,9 +2945,6 @@ impl Default for IN_PKTINFO_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IN_PKTINFO_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3244,9 +2958,6 @@ impl Default for IN_RECVERR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IN_RECVERR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IOCPARM_MASK: u32 = 127u32;
 pub const IOC_IN: u32 = 2147483648u32;
@@ -3370,9 +3081,6 @@ impl Default for IPTLS_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPTLS_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IPV4_HEADER {
@@ -3392,9 +3100,6 @@ impl Default for IPV4_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV4_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPV4_HEADER_0 {
@@ -3406,9 +3111,6 @@ impl Default for IPV4_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV4_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV4_HEADER_0_0 {
@@ -3418,9 +3120,6 @@ impl Default for IPV4_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV4_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3433,9 +3132,6 @@ impl Default for IPV4_HEADER_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV4_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV4_HEADER_1_0 {
@@ -3445,9 +3141,6 @@ impl Default for IPV4_HEADER_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV4_HEADER_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3460,9 +3153,6 @@ impl Default for IPV4_HEADER_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV4_HEADER_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV4_HEADER_2_0 {
@@ -3472,9 +3162,6 @@ impl Default for IPV4_HEADER_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV4_HEADER_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPV4_MAX_MINIMUM_MTU: u32 = 576u32;
 pub const IPV4_MINIMUM_MTU: u32 = 576u32;
@@ -3490,9 +3177,6 @@ impl Default for IPV4_OPTION_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV4_OPTION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPV4_OPTION_HEADER_0 {
@@ -3504,9 +3188,6 @@ impl Default for IPV4_OPTION_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV4_OPTION_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV4_OPTION_HEADER_0_0 {
@@ -3516,9 +3197,6 @@ impl Default for IPV4_OPTION_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV4_OPTION_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3534,9 +3212,6 @@ impl Default for IPV4_ROUTING_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV4_ROUTING_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IPV4_TIMESTAMP_OPTION {
@@ -3549,9 +3224,6 @@ impl Default for IPV4_TIMESTAMP_OPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV4_TIMESTAMP_OPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPV4_TIMESTAMP_OPTION_0 {
@@ -3563,9 +3235,6 @@ impl Default for IPV4_TIMESTAMP_OPTION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV4_TIMESTAMP_OPTION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV4_TIMESTAMP_OPTION_0_0 {
@@ -3575,9 +3244,6 @@ impl Default for IPV4_TIMESTAMP_OPTION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV4_TIMESTAMP_OPTION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPV4_VERSION: u32 = 4u32;
 pub const IPV6_ADD_IFLIST: i32 = 29i32;
@@ -3600,9 +3266,6 @@ impl Default for IPV6_EXTENSION_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV6_EXTENSION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IPV6_FLOW_LABEL_MASK: u32 = 4294905600u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3617,9 +3280,6 @@ impl Default for IPV6_FRAGMENT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV6_FRAGMENT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPV6_FRAGMENT_HEADER_0 {
@@ -3631,9 +3291,6 @@ impl Default for IPV6_FRAGMENT_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV6_FRAGMENT_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV6_FRAGMENT_HEADER_0_0 {
@@ -3643,9 +3300,6 @@ impl Default for IPV6_FRAGMENT_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV6_FRAGMENT_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPV6_FULL_TRAFFIC_CLASS_MASK: u32 = 61455u32;
 pub const IPV6_GET_IFLIST: i32 = 33i32;
@@ -3665,9 +3319,6 @@ impl Default for IPV6_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV6_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IPV6_HEADER_0 {
@@ -3679,9 +3330,6 @@ impl Default for IPV6_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV6_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV6_HEADER_0_0 {
@@ -3691,9 +3339,6 @@ impl Default for IPV6_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV6_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPV6_HOPLIMIT: i32 = 21i32;
 pub const IPV6_HOPOPTS: i32 = 1i32;
@@ -3712,9 +3357,6 @@ impl Default for IPV6_MREQ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV6_MREQ {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IPV6_MTU: i32 = 72i32;
 pub const IPV6_MTU_DISCOVER: i32 = 71i32;
 pub const IPV6_MULTICAST_HOPS: i32 = 10i32;
@@ -3731,9 +3373,6 @@ impl Default for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS_0 {
@@ -3744,9 +3383,6 @@ impl Default for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV6_NEIGHBOR_ADVERTISEMENT_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPV6_NRT_INTERFACE: i32 = 74i32;
 #[repr(C)]
@@ -3760,9 +3396,6 @@ impl Default for IPV6_OPTION_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV6_OPTION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV6_OPTION_JUMBOGRAM {
@@ -3774,9 +3407,6 @@ impl Default for IPV6_OPTION_JUMBOGRAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV6_OPTION_JUMBOGRAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV6_OPTION_ROUTER_ALERT {
@@ -3787,9 +3417,6 @@ impl Default for IPV6_OPTION_ROUTER_ALERT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV6_OPTION_ROUTER_ALERT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3814,9 +3441,6 @@ impl Default for IPV6_ROUTER_ADVERTISEMENT_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPV6_ROUTER_ADVERTISEMENT_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IPV6_ROUTER_ADVERTISEMENT_FLAGS_0 {
@@ -3826,9 +3450,6 @@ impl Default for IPV6_ROUTER_ADVERTISEMENT_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV6_ROUTER_ADVERTISEMENT_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3843,9 +3464,6 @@ impl Default for IPV6_ROUTING_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPV6_ROUTING_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPV6_RTHDR: i32 = 32i32;
 pub const IPV6_TCLASS: i32 = 39i32;
@@ -3874,9 +3492,6 @@ impl Default for IPX_ADDRESS_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPX_ADDRESS_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IPX_ADDRESS_NOTIFY: i32 = 16396i32;
 pub const IPX_DSTYPE: i32 = 16386i32;
 pub const IPX_EXTENDED_ADDRESS: i32 = 16388i32;
@@ -3899,9 +3514,6 @@ impl Default for IPX_NETNUM_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPX_NETNUM_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPX_PTYPE: i32 = 16384i32;
 pub const IPX_RECEIVE_BROADCAST: i32 = 16399i32;
@@ -3934,9 +3546,6 @@ impl Default for IPX_SPXCONNSTATUS_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IPX_SPXCONNSTATUS_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IPX_SPXGETCONNECTIONSTATUS: i32 = 16395i32;
 pub const IPX_STOPFILTERPTYPE: i32 = 16387i32;
 pub const IP_ADD_IFLIST: i32 = 29i32;
@@ -3966,9 +3575,6 @@ impl Default for IP_MREQ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IP_MREQ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IP_MREQ_SOURCE {
@@ -3980,9 +3586,6 @@ impl Default for IP_MREQ_SOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_MREQ_SOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3997,9 +3600,6 @@ impl Default for IP_MSFILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IP_MSFILTER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IP_MTU: i32 = 73i32;
 pub const IP_MTU_DISCOVER: i32 = 71i32;
@@ -4117,9 +3717,6 @@ impl Default for LINGER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LINGER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LITTLEENDIAN: u32 = 1u32;
 pub const LM_BAUD_115200: u32 = 115200u32;
 pub const LM_BAUD_1152K: u32 = 1152000u32;
@@ -4158,9 +3755,6 @@ impl Default for LM_IRPARMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LM_IRPARMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LOG2_BITS_PER_BYTE: u32 = 3u32;
 pub type LPBLOCKINGCALLBACK = Option<unsafe extern "system" fn(dwcontext: usize) -> super::super::Foundation::BOOL>;
@@ -4403,9 +3997,6 @@ impl Default for MLDV2_QUERY_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MLDV2_QUERY_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MLDV2_QUERY_HEADER_0 {
@@ -4417,9 +4008,6 @@ impl Default for MLDV2_QUERY_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MLDV2_QUERY_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MLDV2_QUERY_HEADER_0_0 {
@@ -4429,9 +4017,6 @@ impl Default for MLDV2_QUERY_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MLDV2_QUERY_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4444,9 +4029,6 @@ impl Default for MLDV2_QUERY_HEADER_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MLDV2_QUERY_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MLDV2_QUERY_HEADER_1_0 {
@@ -4456,9 +4038,6 @@ impl Default for MLDV2_QUERY_HEADER_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MLDV2_QUERY_HEADER_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4471,9 +4050,6 @@ impl Default for MLDV2_REPORT_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MLDV2_REPORT_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4488,9 +4064,6 @@ impl Default for MLDV2_REPORT_RECORD_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MLDV2_REPORT_RECORD_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MLD_HEADER {
@@ -4503,9 +4076,6 @@ impl Default for MLD_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MLD_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4541,9 +4111,6 @@ impl Default for NAPI_DOMAIN_DESCRIPTION_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NAPI_DOMAIN_DESCRIPTION_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NAPI_PROVIDER_INSTALLATION_BLOB {
@@ -4557,9 +4124,6 @@ impl Default for NAPI_PROVIDER_INSTALLATION_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NAPI_PROVIDER_INSTALLATION_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4581,9 +4145,6 @@ impl Default for ND_NEIGHBOR_ADVERT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ND_NEIGHBOR_ADVERT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ND_NEIGHBOR_SOLICIT_HEADER {
@@ -4594,9 +4155,6 @@ impl Default for ND_NEIGHBOR_SOLICIT_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ND_NEIGHBOR_SOLICIT_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4611,9 +4169,6 @@ impl Default for ND_OPTION_DNSSL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ND_OPTION_DNSSL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ND_OPTION_HDR {
@@ -4624,9 +4179,6 @@ impl Default for ND_OPTION_HDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ND_OPTION_HDR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4640,9 +4192,6 @@ impl Default for ND_OPTION_MTU {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ND_OPTION_MTU {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4661,9 +4210,6 @@ impl Default for ND_OPTION_PREFIX_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ND_OPTION_PREFIX_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ND_OPTION_PREFIX_INFO_0 {
@@ -4675,9 +4221,6 @@ impl Default for ND_OPTION_PREFIX_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ND_OPTION_PREFIX_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ND_OPTION_PREFIX_INFO_0_0 {
@@ -4687,9 +4230,6 @@ impl Default for ND_OPTION_PREFIX_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ND_OPTION_PREFIX_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4702,9 +4242,6 @@ impl Default for ND_OPTION_PREFIX_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ND_OPTION_PREFIX_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ND_OPTION_PREFIX_INFO_1_0 {
@@ -4715,9 +4252,6 @@ impl Default for ND_OPTION_PREFIX_INFO_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ND_OPTION_PREFIX_INFO_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4732,9 +4266,6 @@ impl Default for ND_OPTION_RDNSS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ND_OPTION_RDNSS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ND_OPTION_RD_HDR {
@@ -4747,9 +4278,6 @@ impl Default for ND_OPTION_RD_HDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ND_OPTION_RD_HDR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4766,9 +4294,6 @@ impl Default for ND_OPTION_ROUTE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ND_OPTION_ROUTE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ND_OPTION_ROUTE_INFO_0 {
@@ -4780,9 +4305,6 @@ impl Default for ND_OPTION_ROUTE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ND_OPTION_ROUTE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ND_OPTION_ROUTE_INFO_0_0 {
@@ -4792,9 +4314,6 @@ impl Default for ND_OPTION_ROUTE_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ND_OPTION_ROUTE_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4836,9 +4355,6 @@ impl Default for ND_REDIRECT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ND_REDIRECT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ND_ROUTER_ADVERT_HEADER {
@@ -4851,9 +4367,6 @@ impl Default for ND_ROUTER_ADVERT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ND_ROUTER_ADVERT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ND_ROUTER_SOLICIT_HEADER {
@@ -4863,9 +4376,6 @@ impl Default for ND_ROUTER_SOLICIT_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ND_ROUTER_SOLICIT_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NETBIOS_GROUP_NAME: u32 = 1u32;
 pub const NETBIOS_NAME_LENGTH: u32 = 16u32;
@@ -4892,9 +4402,6 @@ impl Default for NETRESOURCE2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETRESOURCE2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETRESOURCE2W {
@@ -4914,9 +4421,6 @@ impl Default for NETRESOURCE2W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETRESOURCE2W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NI_DGRAM: u32 = 16u32;
 pub const NI_MAXHOST: u32 = 1025u32;
@@ -4938,9 +4442,6 @@ impl Default for NLA_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NLA_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NLA_BLOB_1 {
@@ -4955,9 +4456,6 @@ impl Default for NLA_BLOB_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NLA_BLOB_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NLA_BLOB_1_3 {
@@ -4967,9 +4465,6 @@ impl Default for NLA_BLOB_1_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NLA_BLOB_1_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4985,9 +4480,6 @@ impl Default for NLA_BLOB_1_3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NLA_BLOB_1_3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NLA_BLOB_1_2 {
@@ -4998,9 +4490,6 @@ impl Default for NLA_BLOB_1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NLA_BLOB_1_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5014,9 +4503,6 @@ impl Default for NLA_BLOB_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NLA_BLOB_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NLA_BLOB_1_1 {
@@ -5026,9 +4512,6 @@ impl Default for NLA_BLOB_1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NLA_BLOB_1_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5041,9 +4524,6 @@ impl Default for NLA_BLOB_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NLA_BLOB_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5086,9 +4566,6 @@ impl Default for NL_BANDWIDTH_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NL_BANDWIDTH_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NL_DAD_STATE(pub i32);
@@ -5104,9 +4581,6 @@ impl Default for NL_INTERFACE_OFFLOAD_ROD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NL_INTERFACE_OFFLOAD_ROD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5134,9 +4608,6 @@ impl Default for NL_NETWORK_CONNECTIVITY_HINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NL_NETWORK_CONNECTIVITY_HINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NL_NETWORK_CONNECTIVITY_LEVEL_HINT(pub i32);
@@ -5151,9 +4622,6 @@ impl Default for NL_PATH_BANDWIDTH_ROD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NL_PATH_BANDWIDTH_ROD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5182,9 +4650,6 @@ impl Default for NPI_MODULEID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NPI_MODULEID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NPI_MODULEID_0 {
@@ -5195,9 +4660,6 @@ impl Default for NPI_MODULEID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NPI_MODULEID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5225,10 +4687,6 @@ impl Default for NSPV2_ROUTINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for NSPV2_ROUTINE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NSP_NOTIFY_APC: WSACOMPLETIONTYPE = WSACOMPLETIONTYPE(4i32);
 pub const NSP_NOTIFY_EVENT: WSACOMPLETIONTYPE = WSACOMPLETIONTYPE(2i32);
@@ -5258,10 +4716,6 @@ impl Default for NSP_ROUTINE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_IO"))]
-impl windows_core::TypeKind for NSP_ROUTINE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NSTYPE_DYNAMIC: u32 = 2u32;
 pub const NSTYPE_ENUMERABLE: u32 = 4u32;
 pub const NSTYPE_HIERARCHICAL: u32 = 1u32;
@@ -5283,9 +4737,6 @@ impl Default for NS_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NS_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NS_INFOW {
@@ -5297,9 +4748,6 @@ impl Default for NS_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NS_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NS_LOCALNAME: u32 = 19u32;
 pub const NS_MS: u32 = 30u32;
@@ -5326,10 +4774,6 @@ impl Default for NS_SERVICE_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for NS_SERVICE_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5342,10 +4786,6 @@ impl Default for NS_SERVICE_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for NS_SERVICE_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NS_SLP: u32 = 5u32;
 pub const NS_STDA: u32 = 31u32;
@@ -5464,9 +4904,6 @@ impl Default for PRIORITY_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRIORITY_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PROP_ADDRESSES: u32 = 256u32;
 pub const PROP_ALL: u32 = 2147483648u32;
 pub const PROP_COMMENT: u32 = 1u32;
@@ -5497,9 +4934,6 @@ impl Default for PROTOCOL_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROTOCOL_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROTOCOL_INFOW {
@@ -5517,9 +4951,6 @@ impl Default for PROTOCOL_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROTOCOL_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROTOENT {
@@ -5531,9 +4962,6 @@ impl Default for PROTOENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROTOENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROTO_IP_BBN: NL_ROUTE_PROTOCOL = NL_ROUTE_PROTOCOL(12i32);
 pub const PROTO_IP_BGP: NL_ROUTE_PROTOCOL = NL_ROUTE_PROTOCOL(14i32);
@@ -5577,9 +5005,6 @@ impl Default for Q2931_IE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Q2931_IE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Q2931_IE_TYPE(pub i32);
@@ -5594,9 +5019,6 @@ impl Default for QOS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QOS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const QOS_CLASS0: u32 = 0u32;
 pub const QOS_CLASS1: u32 = 1u32;
@@ -5613,9 +5035,6 @@ impl Default for RCVALL_IF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RCVALL_IF {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RCVALL_IPLEVEL: RCVALL_VALUE = RCVALL_VALUE(3i32);
 pub const RCVALL_OFF: RCVALL_VALUE = RCVALL_VALUE(0i32);
@@ -5637,9 +5056,6 @@ impl Default for REAL_TIME_NOTIFICATION_SETTING_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REAL_TIME_NOTIFICATION_SETTING_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REAL_TIME_NOTIFICATION_SETTING_INPUT_EX {
@@ -5652,9 +5068,6 @@ impl Default for REAL_TIME_NOTIFICATION_SETTING_INPUT_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REAL_TIME_NOTIFICATION_SETTING_INPUT_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REAL_TIME_NOTIFICATION_SETTING_OUTPUT {
@@ -5664,9 +5077,6 @@ impl Default for REAL_TIME_NOTIFICATION_SETTING_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REAL_TIME_NOTIFICATION_SETTING_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RESOURCEDISPLAYTYPE_DOMAIN: RESOURCE_DISPLAY_TYPE = RESOURCE_DISPLAY_TYPE(1u32);
 pub const RESOURCEDISPLAYTYPE_FILE: RESOURCE_DISPLAY_TYPE = RESOURCE_DISPLAY_TYPE(4u32);
@@ -5700,9 +5110,6 @@ impl Default for RIORESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RIORESULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RIO_BUF {
@@ -5714,9 +5121,6 @@ impl Default for RIO_BUF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RIO_BUF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -5733,9 +5137,6 @@ impl Default for RIO_CMSG_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RIO_CMSG_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RIO_CORRUPT_CQ: u32 = 4294967295u32;
 #[repr(transparent)]
@@ -5768,9 +5169,6 @@ impl Default for RIO_EXTENSION_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RIO_EXTENSION_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RIO_IOCP_COMPLETION: RIO_NOTIFICATION_COMPLETION_TYPE = RIO_NOTIFICATION_COMPLETION_TYPE(2i32);
 pub const RIO_MAX_CQ_SIZE: u32 = 134217728u32;
 pub const RIO_MSG_COMMIT_ONLY: u32 = 8u32;
@@ -5788,9 +5186,6 @@ impl Default for RIO_NOTIFICATION_COMPLETION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RIO_NOTIFICATION_COMPLETION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RIO_NOTIFICATION_COMPLETION_0 {
@@ -5801,9 +5196,6 @@ impl Default for RIO_NOTIFICATION_COMPLETION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RIO_NOTIFICATION_COMPLETION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5816,9 +5208,6 @@ impl Default for RIO_NOTIFICATION_COMPLETION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RIO_NOTIFICATION_COMPLETION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RIO_NOTIFICATION_COMPLETION_0_1 {
@@ -5830,9 +5219,6 @@ impl Default for RIO_NOTIFICATION_COMPLETION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RIO_NOTIFICATION_COMPLETION_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5857,9 +5243,6 @@ impl Default for RM_FEC_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RM_FEC_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RM_FLUSHCACHE: i32 = 1003i32;
 pub const RM_HIGH_SPEED_INTRANET_OPT: i32 = 1014i32;
@@ -5894,9 +5277,6 @@ impl Default for RM_RECEIVER_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RM_RECEIVER_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RM_SENDER_STATISTICS: i32 = 1005i32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5920,9 +5300,6 @@ impl Default for RM_SENDER_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RM_SENDER_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RM_SENDER_WINDOW_ADVANCE_METHOD: i32 = 1004i32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5935,9 +5312,6 @@ impl Default for RM_SEND_WINDOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RM_SEND_WINDOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RM_SEND_WINDOW_ADV_RATE: i32 = 1010i32;
 pub const RM_SET_MCAST_TTL: i32 = 1012i32;
@@ -5956,9 +5330,6 @@ impl Default for RSS_SCALABILITY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RSS_SCALABILITY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RouteProtocolBbn: NL_ROUTE_PROTOCOL = NL_ROUTE_PROTOCOL(12i32);
 pub const RouteProtocolBgp: NL_ROUTE_PROTOCOL = NL_ROUTE_PROTOCOL(14i32);
@@ -5997,9 +5368,6 @@ impl Default for SCOPE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCOPE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SCOPE_ID_0 {
@@ -6011,9 +5379,6 @@ impl Default for SCOPE_ID_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCOPE_ID_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCOPE_ID_0_0 {
@@ -6023,9 +5388,6 @@ impl Default for SCOPE_ID_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCOPE_ID_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6089,10 +5451,6 @@ impl Default for SERVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SERVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6107,10 +5465,6 @@ impl Default for SERVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SERVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6127,9 +5481,6 @@ impl Default for SERVICE_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_ADDRESSES {
@@ -6140,9 +5491,6 @@ impl Default for SERVICE_ADDRESSES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_ADDRESSES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_ADDRESS_FLAG_RPC_CN: u32 = 1u32;
 pub const SERVICE_ADDRESS_FLAG_RPC_DG: u32 = 2u32;
@@ -6159,9 +5507,6 @@ impl Default for SERVICE_ASYNC_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_ASYNC_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_DELETE_TYPE: SET_SERVICE_OPERATION = SET_SERVICE_OPERATION(5u32);
 pub const SERVICE_DEREGISTER: SET_SERVICE_OPERATION = SET_SERVICE_OPERATION(2u32);
@@ -6189,10 +5534,6 @@ impl Default for SERVICE_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SERVICE_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6214,10 +5555,6 @@ impl Default for SERVICE_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SERVICE_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SERVICE_LOCAL: u32 = 4u32;
 pub const SERVICE_MULTIPLE: u32 = 1u32;
 pub const SERVICE_REGISTER: SET_SERVICE_OPERATION = SET_SERVICE_OPERATION(1u32);
@@ -6235,9 +5572,6 @@ impl Default for SERVICE_TYPE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_TYPE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_TYPE_INFO_ABSA {
@@ -6250,9 +5584,6 @@ impl Default for SERVICE_TYPE_INFO_ABSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_TYPE_INFO_ABSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_TYPE_INFO_ABSW {
@@ -6264,9 +5595,6 @@ impl Default for SERVICE_TYPE_INFO_ABSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_TYPE_INFO_ABSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6282,9 +5610,6 @@ impl Default for SERVICE_TYPE_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_TYPE_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_TYPE_VALUE_ABSA {
@@ -6299,9 +5624,6 @@ impl Default for SERVICE_TYPE_VALUE_ABSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_TYPE_VALUE_ABSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_TYPE_VALUE_ABSW {
@@ -6315,9 +5637,6 @@ impl Default for SERVICE_TYPE_VALUE_ABSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_TYPE_VALUE_ABSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_TYPE_VALUE_CONN: windows_core::PCWSTR = windows_core::w!("ConnectionOriented");
 pub const SERVICE_TYPE_VALUE_CONNA: windows_core::PCSTR = windows_core::s!("ConnectionOriented");
@@ -6452,9 +5771,6 @@ impl Default for SNAP_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SNAP_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SNAP_OUI: u32 = 0u32;
 pub const SNAP_SSAP: u32 = 170u32;
 #[repr(C)]
@@ -6467,9 +5783,6 @@ impl Default for SOCKADDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKADDR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6484,9 +5797,6 @@ impl Default for SOCKADDR_ATM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKADDR_ATM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOCKADDR_DL {
@@ -6498,9 +5808,6 @@ impl Default for SOCKADDR_DL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKADDR_DL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6514,9 +5821,6 @@ impl Default for SOCKADDR_IN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKADDR_IN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6532,9 +5836,6 @@ impl Default for SOCKADDR_IN6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKADDR_IN6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SOCKADDR_IN6_0 {
@@ -6546,9 +5847,6 @@ impl Default for SOCKADDR_IN6_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKADDR_IN6_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOCKADDR_IN6_PAIR {
@@ -6559,9 +5857,6 @@ impl Default for SOCKADDR_IN6_PAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKADDR_IN6_PAIR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6577,9 +5872,6 @@ impl Default for SOCKADDR_IN6_W2KSP1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKADDR_IN6_W2KSP1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SOCKADDR_INET {
@@ -6591,9 +5883,6 @@ impl Default for SOCKADDR_INET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKADDR_INET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6608,9 +5897,6 @@ impl Default for SOCKADDR_IPX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKADDR_IPX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOCKADDR_IRDA {
@@ -6623,9 +5909,6 @@ impl Default for SOCKADDR_IRDA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKADDR_IRDA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOCKADDR_NB {
@@ -6637,9 +5920,6 @@ impl Default for SOCKADDR_NB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKADDR_NB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6654,9 +5934,6 @@ impl Default for SOCKADDR_STORAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKADDR_STORAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOCKADDR_STORAGE_XP {
@@ -6669,9 +5946,6 @@ impl Default for SOCKADDR_STORAGE_XP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKADDR_STORAGE_XP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6687,9 +5961,6 @@ impl Default for SOCKADDR_TP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKADDR_TP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOCKADDR_UN {
@@ -6700,9 +5971,6 @@ impl Default for SOCKADDR_UN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKADDR_UN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6718,9 +5986,6 @@ impl Default for SOCKADDR_VNS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKADDR_VNS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -6753,9 +6018,6 @@ impl Default for SOCKET_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKET_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOCKET_ADDRESS_LIST {
@@ -6766,9 +6028,6 @@ impl Default for SOCKET_ADDRESS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKET_ADDRESS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SOCKET_DEFAULT2_QM_POLICY: windows_core::GUID = windows_core::GUID::from_u128(0xaec2ef9c_3a4d_4d3e_8842_239942e39a47);
 pub const SOCKET_ERROR: i32 = -1i32;
@@ -6788,9 +6047,6 @@ impl Default for SOCKET_PEER_TARGET_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKET_PEER_TARGET_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SOCKET_PRIORITY_HINT(pub i32);
@@ -6807,10 +6063,6 @@ impl Default for SOCKET_PROCESSOR_AFFINITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for SOCKET_PROCESSOR_AFFINITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SOCKET_QUERY_IPSEC2_ABORT_CONNECTION_ON_FIELD_CHANGE: u32 = 1u32;
 pub const SOCKET_QUERY_IPSEC2_FIELD_MASK_MM_SA_ID: u32 = 1u32;
@@ -6835,9 +6087,6 @@ impl Default for SOCKET_SECURITY_QUERY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKET_SECURITY_QUERY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOCKET_SECURITY_QUERY_INFO_IPSEC2 {
@@ -6855,9 +6104,6 @@ impl Default for SOCKET_SECURITY_QUERY_INFO_IPSEC2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKET_SECURITY_QUERY_INFO_IPSEC2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOCKET_SECURITY_QUERY_TEMPLATE {
@@ -6869,9 +6115,6 @@ impl Default for SOCKET_SECURITY_QUERY_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKET_SECURITY_QUERY_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6887,9 +6130,6 @@ impl Default for SOCKET_SECURITY_QUERY_TEMPLATE_IPSEC2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOCKET_SECURITY_QUERY_TEMPLATE_IPSEC2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOCKET_SECURITY_SETTINGS {
@@ -6900,9 +6140,6 @@ impl Default for SOCKET_SECURITY_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKET_SECURITY_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6923,9 +6160,6 @@ impl Default for SOCKET_SECURITY_SETTINGS_IPSEC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCKET_SECURITY_SETTINGS_IPSEC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SOCKET_SETTINGS_ALLOW_INSECURE: u32 = 2u32;
 pub const SOCKET_SETTINGS_GUARANTEE_ENCRYPTION: u32 = 1u32;
@@ -6964,9 +6198,6 @@ impl Default for SOCK_NOTIFY_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOCK_NOTIFY_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SOCK_NOTIFY_TRIGGER_EDGE: u32 = 8u32;
 pub const SOCK_NOTIFY_TRIGGER_LEVEL: u32 = 4u32;
@@ -7071,9 +6302,6 @@ impl Default for TCP_ACK_FREQUENCY_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_ACK_FREQUENCY_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TCP_ATMARK: i32 = 8i32;
 pub const TCP_BSDURGENT: i32 = 28672i32;
 pub const TCP_CONGESTION_ALGORITHM: i32 = 12i32;
@@ -7099,9 +6327,6 @@ impl Default for TCP_HDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_HDR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TCP_ICMP_ERROR_INFO: i32 = 19i32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7122,9 +6347,6 @@ impl Default for TCP_ICW_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_ICW_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7153,9 +6375,6 @@ impl Default for TCP_INFO_v0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_INFO_v0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7194,9 +6413,6 @@ impl Default for TCP_INFO_v1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_INFO_v1 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TCP_INITIAL_RTO_DEFAULT_MAX_SYN_RETRANSMISSIONS: u32 = 0u32;
 pub const TCP_INITIAL_RTO_DEFAULT_RTT: u32 = 0u32;
 pub const TCP_INITIAL_RTO_NO_SYN_RETRANSMISSIONS: u16 = 65534u16;
@@ -7210,9 +6426,6 @@ impl Default for TCP_INITIAL_RTO_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_INITIAL_RTO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TCP_INITIAL_RTO_UNSPECIFIED_MAX_SYN_RETRANSMISSIONS: u16 = 65535u16;
 pub const TCP_KEEPALIVE: i32 = 3i32;
@@ -7241,9 +6454,6 @@ impl Default for TCP_OPT_FASTOPEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_OPT_FASTOPEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct TCP_OPT_MSS {
@@ -7255,9 +6465,6 @@ impl Default for TCP_OPT_MSS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_OPT_MSS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7271,9 +6478,6 @@ impl Default for TCP_OPT_SACK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_OPT_SACK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct TCP_OPT_SACK_0 {
@@ -7285,9 +6489,6 @@ impl Default for TCP_OPT_SACK_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_OPT_SACK_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct TCP_OPT_SACK_PERMITTED {
@@ -7298,9 +6499,6 @@ impl Default for TCP_OPT_SACK_PERMITTED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_OPT_SACK_PERMITTED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7315,9 +6513,6 @@ impl Default for TCP_OPT_TS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_OPT_TS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct TCP_OPT_UNKNOWN {
@@ -7328,9 +6523,6 @@ impl Default for TCP_OPT_UNKNOWN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_OPT_UNKNOWN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -7343,9 +6535,6 @@ impl Default for TCP_OPT_WS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_OPT_WS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TCP_STDURG: i32 = 6i32;
 pub const TCP_TIMESTAMPS: i32 = 10i32;
@@ -7384,9 +6573,6 @@ impl Default for TIMESTAMPING_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TIMESTAMPING_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TIMESTAMPING_FLAG_RX: u32 = 1u32;
 pub const TIMESTAMPING_FLAG_TX: u32 = 2u32;
 #[repr(C)]
@@ -7399,9 +6585,6 @@ impl Default for TIMEVAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TIMEVAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TNS_PLAN_CARRIER_ID_CODE: u32 = 1u32;
 pub const TNS_TYPE_NATIONAL: u32 = 64u32;
@@ -7426,9 +6609,6 @@ impl Default for TRANSMIT_FILE_BUFFERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSMIT_FILE_BUFFERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct TRANSMIT_PACKETS_ELEMENT {
@@ -7441,9 +6621,6 @@ impl Default for TRANSMIT_PACKETS_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSMIT_PACKETS_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TRANSMIT_PACKETS_ELEMENT_0 {
@@ -7454,9 +6631,6 @@ impl Default for TRANSMIT_PACKETS_ELEMENT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSMIT_PACKETS_ELEMENT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7469,9 +6643,6 @@ impl Default for TRANSMIT_PACKETS_ELEMENT_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSMIT_PACKETS_ELEMENT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSPORT_SETTING_ID {
@@ -7481,9 +6652,6 @@ impl Default for TRANSPORT_SETTING_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSPORT_SETTING_ID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TR_END_TO_END: u32 = 1u32;
 pub const TR_NOIND: u32 = 0u32;
@@ -7517,9 +6685,6 @@ impl Default for VLAN_TAG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VLAN_TAG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VLAN_TAG_0 {
@@ -7531,9 +6696,6 @@ impl Default for VLAN_TAG_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VLAN_TAG_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VLAN_TAG_0_0 {
@@ -7543,9 +6705,6 @@ impl Default for VLAN_TAG_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VLAN_TAG_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VNSPROTO_IPC: u32 = 1u32;
 pub const VNSPROTO_RELIABLE_IPC: u32 = 2u32;
@@ -7562,9 +6721,6 @@ impl Default for WCE_DEVICELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WCE_DEVICELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WCE_IRDA_DEVICE_INFO {
@@ -7576,9 +6732,6 @@ impl Default for WCE_IRDA_DEVICE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WCE_IRDA_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WCE_PF_IRDA: u32 = 22u32;
 pub const WINDOWS_AF_IRDA: u32 = 26u32;
@@ -7592,9 +6745,6 @@ impl Default for WINDOWS_DEVICELIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINDOWS_DEVICELIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7610,9 +6760,6 @@ impl Default for WINDOWS_IAS_QUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINDOWS_IAS_QUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINDOWS_IAS_QUERY_0 {
@@ -7625,9 +6772,6 @@ impl Default for WINDOWS_IAS_QUERY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINDOWS_IAS_QUERY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINDOWS_IAS_QUERY_0_0 {
@@ -7638,9 +6782,6 @@ impl Default for WINDOWS_IAS_QUERY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINDOWS_IAS_QUERY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7653,9 +6794,6 @@ impl Default for WINDOWS_IAS_QUERY_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINDOWS_IAS_QUERY_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7670,9 +6808,6 @@ impl Default for WINDOWS_IAS_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINDOWS_IAS_SET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WINDOWS_IAS_SET_0 {
@@ -7685,9 +6820,6 @@ impl Default for WINDOWS_IAS_SET_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINDOWS_IAS_SET_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINDOWS_IAS_SET_0_0 {
@@ -7698,9 +6830,6 @@ impl Default for WINDOWS_IAS_SET_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINDOWS_IAS_SET_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7713,9 +6842,6 @@ impl Default for WINDOWS_IAS_SET_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINDOWS_IAS_SET_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7730,9 +6856,6 @@ impl Default for WINDOWS_IRDA_DEVICE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINDOWS_IRDA_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINDOWS_PF_IRDA: u32 = 26u32;
 #[repr(transparent)]
@@ -7753,9 +6876,6 @@ impl Default for WSABUF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSABUF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy)]
@@ -7768,10 +6888,6 @@ impl Default for WSACOMPLETION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WSACOMPLETION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
@@ -7788,10 +6904,6 @@ impl Default for WSACOMPLETION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WSACOMPLETION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7805,10 +6917,6 @@ impl Default for WSACOMPLETION_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WSACOMPLETION_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7820,10 +6928,6 @@ impl Default for WSACOMPLETION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WSACOMPLETION_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
@@ -7839,10 +6943,6 @@ impl Default for WSACOMPLETION_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WSACOMPLETION_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7856,10 +6956,6 @@ impl Default for WSACOMPLETION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WSACOMPLETION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7882,10 +6978,6 @@ impl Default for WSADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for WSADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7903,10 +6995,6 @@ impl Default for WSADATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for WSADATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSADESCRIPTION_LEN: u32 = 256u32;
 pub const WSAEACCES: WSA_ERROR = WSA_ERROR(10013i32);
@@ -8011,9 +7099,6 @@ impl Default for WSAMSG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSAMSG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSANAMESPACE_INFOA {
@@ -8027,9 +7112,6 @@ impl Default for WSANAMESPACE_INFOA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSANAMESPACE_INFOA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -8048,10 +7130,6 @@ impl Default for WSANAMESPACE_INFOEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for WSANAMESPACE_INFOEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8069,10 +7147,6 @@ impl Default for WSANAMESPACE_INFOEXW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for WSANAMESPACE_INFOEXW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSANAMESPACE_INFOW {
@@ -8087,9 +7161,6 @@ impl Default for WSANAMESPACE_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSANAMESPACE_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSANETWORKEVENTS {
@@ -8100,9 +7171,6 @@ impl Default for WSANETWORKEVENTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSANETWORKEVENTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSANOTINITIALISED: WSA_ERROR = WSA_ERROR(10093i32);
 pub const WSANO_DATA: WSA_ERROR = WSA_ERROR(11004i32);
@@ -8121,9 +7189,6 @@ impl Default for WSANSCLASSINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSANSCLASSINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSANSCLASSINFOW {
@@ -8138,9 +7203,6 @@ impl Default for WSANSCLASSINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSANSCLASSINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSAPOLLDATA {
@@ -8154,9 +7216,6 @@ impl Default for WSAPOLLDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSAPOLLDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSAPOLLFD {
@@ -8168,9 +7227,6 @@ impl Default for WSAPOLLFD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSAPOLLFD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8219,9 +7275,6 @@ impl Default for WSAPROTOCOLCHAIN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSAPROTOCOLCHAIN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSAPROTOCOL_INFOA {
@@ -8250,9 +7303,6 @@ impl Default for WSAPROTOCOL_INFOA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSAPROTOCOL_INFOA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8283,9 +7333,6 @@ impl Default for WSAPROTOCOL_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSAPROTOCOL_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WSAPROTOCOL_LEN: u32 = 255u32;
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -8312,10 +7359,6 @@ impl Default for WSAQUERYSET2A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for WSAQUERYSET2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8340,10 +7383,6 @@ impl Default for WSAQUERYSET2W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for WSAQUERYSET2W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -8371,10 +7410,6 @@ impl Default for WSAQUERYSETA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for WSAQUERYSETA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8401,10 +7436,6 @@ impl Default for WSAQUERYSETW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for WSAQUERYSETW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8421,10 +7452,6 @@ impl Default for WSASENDMSG {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WSASENDMSG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSASERVICECLASSINFOA {
@@ -8438,9 +7465,6 @@ impl Default for WSASERVICECLASSINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSASERVICECLASSINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSASERVICECLASSINFOW {
@@ -8453,9 +7477,6 @@ impl Default for WSASERVICECLASSINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSASERVICECLASSINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSASERVICE_NOT_FOUND: WSA_ERROR = WSA_ERROR(10108i32);
 pub const WSASYSCALLFAILURE: WSA_ERROR = WSA_ERROR(10107i32);
@@ -8472,9 +7493,6 @@ impl Default for WSATHREADID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSATHREADID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WSATRY_AGAIN: WSA_ERROR = WSA_ERROR(11002i32);
 pub const WSATYPE_NOT_FOUND: WSA_ERROR = WSA_ERROR(10109i32);
 pub const WSAVERNOTSUPPORTED: WSA_ERROR = WSA_ERROR(10092i32);
@@ -8489,9 +7507,6 @@ impl Default for WSAVERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSAVERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WSA_COMPATIBILITY_BEHAVIOR_ID(pub i32);
@@ -8505,9 +7520,6 @@ impl Default for WSA_COMPATIBILITY_MODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSA_COMPATIBILITY_MODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8575,9 +7587,6 @@ impl Default for WSC_PROVIDER_AUDIT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSC_PROVIDER_AUDIT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WSC_PROVIDER_INFO_TYPE(pub i32);
@@ -8593,9 +7602,6 @@ impl Default for WSPDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSPDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSPDESCRIPTION_LEN: u32 = 255u32;
 #[repr(C)]
@@ -8639,10 +7645,6 @@ impl Default for WSPPROC_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for WSPPROC_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSPUPCALLTABLE {
@@ -8666,9 +7668,6 @@ impl Default for WSPUPCALLTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSPUPCALLTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSS_OPERATION_IN_PROGRESS: i32 = 259i32;
 pub const WsaBehaviorAll: WSA_COMPATIBILITY_BEHAVIOR_ID = WSA_COMPATIBILITY_BEHAVIOR_ID(0i32);
@@ -8728,9 +7727,6 @@ impl Default for netent {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for netent {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union sockaddr_gen {
@@ -8742,9 +7738,6 @@ impl Default for sockaddr_gen {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for sockaddr_gen {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8758,9 +7751,6 @@ impl Default for sockaddr_in6_old {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for sockaddr_in6_old {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -8779,9 +7769,6 @@ impl Default for sockproto {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for sockproto {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct tcp_keepalive {
@@ -8793,7 +7780,4 @@ impl Default for tcp_keepalive {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for tcp_keepalive {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
@@ -1145,9 +1145,6 @@ impl Default for CTAPCBOR_HYBRID_STORAGE_LINKED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CTAPCBOR_HYBRID_STORAGE_LINKED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CTAPCBOR_HYBRID_STORAGE_LINKED_DATA_CURRENT_VERSION: u32 = 1u32;
 pub const CTAPCBOR_HYBRID_STORAGE_LINKED_DATA_VERSION_1: u32 = 1u32;
 windows_core::imp::define_interface!(IContentPrefetcherTaskTrigger, IContentPrefetcherTaskTrigger_Vtbl, 0x1b35a14a_6094_4799_a60e_e474e15d4dc9);
@@ -1237,9 +1234,6 @@ impl Default for WEBAUTHN_ASSERTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_ASSERTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WEBAUTHN_ASSERTION_CURRENT_VERSION: u32 = 5u32;
 pub const WEBAUTHN_ASSERTION_VERSION_1: u32 = 1u32;
 pub const WEBAUTHN_ASSERTION_VERSION_2: u32 = 2u32;
@@ -1290,9 +1284,6 @@ impl Default for WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_CURRENT_VERSION: u32 = 7u32;
 pub const WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_1: u32 = 1u32;
 pub const WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_2: u32 = 2u32;
@@ -1330,9 +1321,6 @@ impl Default for WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_CURRENT_VERSION: u32 = 7u32;
 pub const WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_1: u32 = 1u32;
 pub const WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_VERSION_2: u32 = 2u32;
@@ -1353,9 +1341,6 @@ impl Default for WEBAUTHN_CLIENT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_CLIENT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WEBAUTHN_CLIENT_DATA_CURRENT_VERSION: u32 = 1u32;
 #[repr(C)]
@@ -1379,9 +1364,6 @@ impl Default for WEBAUTHN_COMMON_ATTESTATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_COMMON_ATTESTATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WEBAUTHN_COMMON_ATTESTATION_CURRENT_VERSION: u32 = 1u32;
 pub const WEBAUTHN_COSE_ALGORITHM_ECDSA_P256_WITH_SHA256: i32 = -7i32;
 pub const WEBAUTHN_COSE_ALGORITHM_ECDSA_P384_WITH_SHA384: i32 = -35i32;
@@ -1404,9 +1386,6 @@ impl Default for WEBAUTHN_COSE_CREDENTIAL_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_COSE_CREDENTIAL_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
@@ -1417,9 +1396,6 @@ impl Default for WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION: u32 = 1u32;
 #[repr(C)]
@@ -1435,9 +1411,6 @@ impl Default for WEBAUTHN_CREDENTIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WEBAUTHN_CREDENTIALS {
@@ -1448,9 +1421,6 @@ impl Default for WEBAUTHN_CREDENTIALS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_CREDENTIALS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1481,9 +1451,6 @@ impl Default for WEBAUTHN_CREDENTIAL_ATTESTATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_CREDENTIAL_ATTESTATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WEBAUTHN_CREDENTIAL_ATTESTATION_CURRENT_VERSION: u32 = 6u32;
 pub const WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_1: u32 = 1u32;
 pub const WEBAUTHN_CREDENTIAL_ATTESTATION_VERSION_2: u32 = 2u32;
@@ -1508,9 +1475,6 @@ impl Default for WEBAUTHN_CREDENTIAL_DETAILS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_CREDENTIAL_DETAILS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WEBAUTHN_CREDENTIAL_DETAILS_CURRENT_VERSION: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1522,9 +1486,6 @@ impl Default for WEBAUTHN_CREDENTIAL_DETAILS_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_CREDENTIAL_DETAILS_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WEBAUTHN_CREDENTIAL_DETAILS_VERSION_1: u32 = 1u32;
 pub const WEBAUTHN_CREDENTIAL_DETAILS_VERSION_2: u32 = 2u32;
@@ -1542,9 +1503,6 @@ impl Default for WEBAUTHN_CREDENTIAL_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_CREDENTIAL_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1557,9 +1515,6 @@ impl Default for WEBAUTHN_CREDENTIAL_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_CREDENTIAL_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY: windows_core::PCWSTR = windows_core::w!("public-key");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1571,9 +1526,6 @@ impl Default for WEBAUTHN_CRED_BLOB_EXTENSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_CRED_BLOB_EXTENSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WEBAUTHN_CRED_LARGE_BLOB_OPERATION_DELETE: u32 = 3u32;
 pub const WEBAUTHN_CRED_LARGE_BLOB_OPERATION_GET: u32 = 1u32;
@@ -1600,9 +1552,6 @@ impl Default for WEBAUTHN_CRED_PROTECT_EXTENSION_IN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_CRED_PROTECT_EXTENSION_IN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WEBAUTHN_CRED_WITH_HMAC_SECRET_SALT {
@@ -1614,9 +1563,6 @@ impl Default for WEBAUTHN_CRED_WITH_HMAC_SECRET_SALT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_CRED_WITH_HMAC_SECRET_SALT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WEBAUTHN_CTAP_ONE_HMAC_SECRET_LENGTH: u32 = 32u32;
 pub const WEBAUTHN_CTAP_TRANSPORT_BLE: u32 = 4u32;
@@ -1641,9 +1587,6 @@ impl Default for WEBAUTHN_EXTENSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_EXTENSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WEBAUTHN_EXTENSIONS {
@@ -1654,9 +1597,6 @@ impl Default for WEBAUTHN_EXTENSIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_EXTENSIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WEBAUTHN_EXTENSIONS_IDENTIFIER_CRED_BLOB: windows_core::PCWSTR = windows_core::w!("credBlob");
 pub const WEBAUTHN_EXTENSIONS_IDENTIFIER_CRED_PROTECT: windows_core::PCWSTR = windows_core::w!("credProtect");
@@ -1673,9 +1613,6 @@ impl Default for WEBAUTHN_GET_CREDENTIALS_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_GET_CREDENTIALS_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WEBAUTHN_GET_CREDENTIALS_OPTIONS_CURRENT_VERSION: u32 = 1u32;
 pub const WEBAUTHN_GET_CREDENTIALS_OPTIONS_VERSION_1: u32 = 1u32;
@@ -1695,9 +1632,6 @@ impl Default for WEBAUTHN_HMAC_SECRET_SALT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_HMAC_SECRET_SALT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WEBAUTHN_HMAC_SECRET_SALT_VALUES {
@@ -1709,9 +1643,6 @@ impl Default for WEBAUTHN_HMAC_SECRET_SALT_VALUES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_HMAC_SECRET_SALT_VALUES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WEBAUTHN_LARGE_BLOB_SUPPORT_NONE: u32 = 0u32;
 pub const WEBAUTHN_LARGE_BLOB_SUPPORT_PREFERRED: u32 = 2u32;
@@ -1730,9 +1661,6 @@ impl Default for WEBAUTHN_RP_ENTITY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WEBAUTHN_RP_ENTITY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WEBAUTHN_RP_ENTITY_INFORMATION_CURRENT_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1748,9 +1676,6 @@ impl Default for WEBAUTHN_USER_ENTITY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_USER_ENTITY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WEBAUTHN_USER_ENTITY_INFORMATION_CURRENT_VERSION: u32 = 1u32;
 pub const WEBAUTHN_USER_VERIFICATION_ANY: u32 = 0u32;
@@ -1771,9 +1696,6 @@ impl Default for WEBAUTHN_X5C {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEBAUTHN_X5C {
-    type TypeKind = windows_core::CopyType;
 }
 pub type WS_ABANDON_MESSAGE_CALLBACK = Option<unsafe extern "system" fn(channelinstance: *const core::ffi::c_void, message: *const WS_MESSAGE, error: *const WS_ERROR) -> windows_core::HRESULT>;
 pub type WS_ABORT_CHANNEL_CALLBACK = Option<unsafe extern "system" fn(channelinstance: *const core::ffi::c_void, error: *const WS_ERROR) -> windows_core::HRESULT>;
@@ -1798,9 +1720,6 @@ impl Default for WS_ANY_ATTRIBUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_ANY_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_ANY_ATTRIBUTES {
@@ -1811,9 +1730,6 @@ impl Default for WS_ANY_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_ANY_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_ANY_ATTRIBUTES_FIELD_MAPPING: WS_FIELD_MAPPING = WS_FIELD_MAPPING(12i32);
 pub const WS_ANY_ATTRIBUTES_TYPE: WS_TYPE = WS_TYPE(34i32);
@@ -1832,9 +1748,6 @@ impl Default for WS_ASYNC_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_ASYNC_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WS_ASYNC_FUNCTION = Option<unsafe extern "system" fn(hr: windows_core::HRESULT, callbackmodel: WS_CALLBACK_MODEL, callbackstate: *const core::ffi::c_void, next: *mut WS_ASYNC_OPERATION, asynccontext: *const WS_ASYNC_CONTEXT, error: *const WS_ERROR) -> windows_core::HRESULT>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1845,9 +1758,6 @@ impl Default for WS_ASYNC_OPERATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_ASYNC_OPERATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1863,9 +1773,6 @@ impl Default for WS_ASYNC_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_ASYNC_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_ATTRIBUTE_DESCRIPTION {
@@ -1878,9 +1785,6 @@ impl Default for WS_ATTRIBUTE_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_ATTRIBUTE_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_ATTRIBUTE_FIELD_MAPPING: WS_FIELD_MAPPING = WS_FIELD_MAPPING(1i32);
 pub const WS_ATTRIBUTE_TYPE_MAPPING: WS_TYPE_MAPPING = WS_TYPE_MAPPING(2i32);
@@ -1899,9 +1803,6 @@ impl Default for WS_BOOL_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_BOOL_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_BOOL_TYPE: WS_TYPE = WS_TYPE(0i32);
 pub const WS_BOOL_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(0i32);
 pub const WS_BUFFERED_TRANSFER_MODE: WS_TRANSFER_MODE = WS_TRANSFER_MODE(0i32);
@@ -1916,9 +1817,6 @@ impl Default for WS_BUFFERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_BUFFERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_BYTES {
@@ -1929,9 +1827,6 @@ impl Default for WS_BYTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_BYTES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1944,9 +1839,6 @@ impl Default for WS_BYTES_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_BYTES_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_BYTES_TYPE: WS_TYPE = WS_TYPE(18i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1958,9 +1850,6 @@ impl Default for WS_BYTE_ARRAY_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_BYTE_ARRAY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_BYTE_ARRAY_TYPE: WS_TYPE = WS_TYPE(24i32);
 #[repr(transparent)]
@@ -1977,9 +1866,6 @@ impl Default for WS_CALL_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_CALL_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_CALL_PROPERTY_CALL_ID: WS_CALL_PROPERTY_ID = WS_CALL_PROPERTY_ID(3i32);
 pub const WS_CALL_PROPERTY_CHECK_MUST_UNDERSTAND: WS_CALL_PROPERTY_ID = WS_CALL_PROPERTY_ID(0i32);
@@ -2000,9 +1886,6 @@ impl Default for WS_CAPI_ASYMMETRIC_SECURITY_KEY_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_CAPI_ASYMMETRIC_SECURITY_KEY_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_CAPI_ASYMMETRIC_SECURITY_KEY_HANDLE_TYPE: WS_SECURITY_KEY_HANDLE_TYPE = WS_SECURITY_KEY_HANDLE_TYPE(3i32);
 #[cfg(feature = "Win32_Security_Cryptography")]
 pub type WS_CERTIFICATE_VALIDATION_CALLBACK = Option<unsafe extern "system" fn(certcontext: *const super::super::Security::Cryptography::CERT_CONTEXT, state: *const core::ffi::c_void) -> windows_core::HRESULT>;
@@ -2019,10 +1902,6 @@ impl Default for WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WS_CERTIFICATE_VALIDATION_CALLBACK_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_CERT_CREDENTIAL {
@@ -2032,9 +1911,6 @@ impl Default for WS_CERT_CREDENTIAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_CERT_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2049,9 +1925,6 @@ impl Default for WS_CERT_ENDPOINT_IDENTITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_CERT_ENDPOINT_IDENTITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_CERT_ENDPOINT_IDENTITY_TYPE: WS_ENDPOINT_IDENTITY_TYPE = WS_ENDPOINT_IDENTITY_TYPE(5i32);
 pub const WS_CERT_FAILURE_CN_MISMATCH: i32 = 1i32;
@@ -2072,9 +1945,6 @@ impl Default for WS_CERT_MESSAGE_SECURITY_BINDING_CONSTRAINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_CERT_MESSAGE_SECURITY_BINDING_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_CERT_MESSAGE_SECURITY_BINDING_CONSTRAINT_TYPE: WS_SECURITY_BINDING_CONSTRAINT_TYPE = WS_SECURITY_BINDING_CONSTRAINT_TYPE(7i32);
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -2092,10 +1962,6 @@ impl Default for WS_CERT_SIGNED_SAML_AUTHENTICATOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WS_CERT_SIGNED_SAML_AUTHENTICATOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_CERT_SIGNED_SAML_AUTHENTICATOR_TYPE: WS_SAML_AUTHENTICATOR_TYPE = WS_SAML_AUTHENTICATOR_TYPE(1i32);
 #[repr(transparent)]
@@ -2123,9 +1989,6 @@ impl Default for WS_CHANNEL_DECODER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_CHANNEL_DECODER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_CHANNEL_ENCODER {
@@ -2142,9 +2005,6 @@ impl Default for WS_CHANNEL_ENCODER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_CHANNEL_ENCODER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_CHANNEL_PROPERTIES {
@@ -2155,9 +2015,6 @@ impl Default for WS_CHANNEL_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_CHANNEL_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2170,9 +2027,6 @@ impl Default for WS_CHANNEL_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_CHANNEL_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_CHANNEL_PROPERTY_ADDRESSING_VERSION: WS_CHANNEL_PROPERTY_ID = WS_CHANNEL_PROPERTY_ID(6i32);
 pub const WS_CHANNEL_PROPERTY_ALLOW_UNSECURED_FAULTS: WS_CHANNEL_PROPERTY_ID = WS_CHANNEL_PROPERTY_ID(46i32);
@@ -2193,9 +2047,6 @@ impl Default for WS_CHANNEL_PROPERTY_CONSTRAINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_CHANNEL_PROPERTY_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_CHANNEL_PROPERTY_CONSTRAINT_0 {
@@ -2205,9 +2056,6 @@ impl Default for WS_CHANNEL_PROPERTY_CONSTRAINT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_CHANNEL_PROPERTY_CONSTRAINT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_CHANNEL_PROPERTY_COOKIE_MODE: WS_CHANNEL_PROPERTY_ID = WS_CHANNEL_PROPERTY_ID(39i32);
 pub const WS_CHANNEL_PROPERTY_CUSTOM_CHANNEL_CALLBACKS: WS_CHANNEL_PROPERTY_ID = WS_CHANNEL_PROPERTY_ID(24i32);
@@ -2296,9 +2144,6 @@ impl Default for WS_CHAR_ARRAY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_CHAR_ARRAY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_CHAR_ARRAY_TYPE: WS_TYPE = WS_TYPE(22i32);
 pub type WS_CLOSE_CHANNEL_CALLBACK = Option<unsafe extern "system" fn(channelinstance: *const core::ffi::c_void, asynccontext: *const WS_ASYNC_CONTEXT, error: *const WS_ERROR) -> windows_core::HRESULT>;
 pub type WS_CLOSE_LISTENER_CALLBACK = Option<unsafe extern "system" fn(listenerinstance: *const core::ffi::c_void, asynccontext: *const WS_ASYNC_CONTEXT, error: *const WS_ERROR) -> windows_core::HRESULT>;
@@ -2312,9 +2157,6 @@ impl Default for WS_CONTRACT_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_CONTRACT_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2339,10 +2181,6 @@ impl Default for WS_CUSTOM_CERT_CREDENTIAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Security_Authentication_Identity", feature = "Win32_Security_Cryptography"))]
-impl windows_core::TypeKind for WS_CUSTOM_CERT_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_CUSTOM_CERT_CREDENTIAL_TYPE: WS_CERT_CREDENTIAL_TYPE = WS_CERT_CREDENTIAL_TYPE(3i32);
 pub const WS_CUSTOM_CHANNEL_BINDING: WS_CHANNEL_BINDING = WS_CHANNEL_BINDING(3i32);
@@ -2369,9 +2207,6 @@ impl Default for WS_CUSTOM_CHANNEL_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_CUSTOM_CHANNEL_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_CUSTOM_HTTP_PROXY {
@@ -2382,9 +2217,6 @@ impl Default for WS_CUSTOM_HTTP_PROXY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_CUSTOM_HTTP_PROXY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2405,9 +2237,6 @@ impl Default for WS_CUSTOM_LISTENER_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_CUSTOM_LISTENER_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_CUSTOM_TYPE: WS_TYPE = WS_TYPE(27i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2424,9 +2253,6 @@ impl Default for WS_CUSTOM_TYPE_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_CUSTOM_TYPE_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_DATETIME {
@@ -2438,9 +2264,6 @@ impl Default for WS_DATETIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_DATETIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_DATETIME_DESCRIPTION {
@@ -2451,9 +2274,6 @@ impl Default for WS_DATETIME_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_DATETIME_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2474,9 +2294,6 @@ impl Default for WS_DECIMAL_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_DECIMAL_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_DECIMAL_TYPE: WS_TYPE = WS_TYPE(11i32);
 pub const WS_DECIMAL_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(11i32);
 pub type WS_DECODER_DECODE_CALLBACK = Option<unsafe extern "system" fn(encodercontext: *const core::ffi::c_void, buffer: *mut core::ffi::c_void, maxlength: u32, length: *mut u32, asynccontext: *const WS_ASYNC_CONTEXT, error: *const WS_ERROR) -> windows_core::HRESULT>;
@@ -2494,9 +2311,6 @@ impl Default for WS_DEFAULT_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_DEFAULT_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_DEFAULT_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
@@ -2506,9 +2320,6 @@ impl Default for WS_DEFAULT_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_DEFAULT_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_DEFAULT_WINDOWS_INTEGRATED_AUTH_CREDENTIAL_TYPE: WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL_TYPE = WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL_TYPE(2i32);
 pub const WS_DESCRIPTION_TYPE: WS_TYPE = WS_TYPE(25i32);
@@ -2523,9 +2334,6 @@ impl Default for WS_DISALLOWED_USER_AGENT_SUBSTRINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_DISALLOWED_USER_AGENT_SUBSTRINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_DNS_ENDPOINT_IDENTITY {
@@ -2536,9 +2344,6 @@ impl Default for WS_DNS_ENDPOINT_IDENTITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_DNS_ENDPOINT_IDENTITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_DNS_ENDPOINT_IDENTITY_TYPE: WS_ENDPOINT_IDENTITY_TYPE = WS_ENDPOINT_IDENTITY_TYPE(1i32);
 #[repr(C)]
@@ -2551,9 +2356,6 @@ impl Default for WS_DOUBLE_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_DOUBLE_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_DOUBLE_TYPE: WS_TYPE = WS_TYPE(10i32);
 pub const WS_DOUBLE_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(10i32);
@@ -2576,9 +2378,6 @@ impl Default for WS_DURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_DURATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WS_DURATION_COMPARISON_CALLBACK = Option<unsafe extern "system" fn(duration1: *const WS_DURATION, duration2: *const WS_DURATION, result: *mut i32, error: *const WS_ERROR) -> windows_core::HRESULT>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2591,9 +2390,6 @@ impl Default for WS_DURATION_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_DURATION_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_DURATION_TYPE: WS_TYPE = WS_TYPE(32i32);
 pub const WS_DURATION_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(15i32);
@@ -2612,9 +2408,6 @@ impl Default for WS_ELEMENT_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_ELEMENT_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_ELEMENT_FIELD_MAPPING: WS_FIELD_MAPPING = WS_FIELD_MAPPING(2i32);
 pub const WS_ELEMENT_TYPE_MAPPING: WS_TYPE_MAPPING = WS_TYPE_MAPPING(1i32);
@@ -2647,9 +2440,6 @@ impl Default for WS_ENDPOINT_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_ENDPOINT_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_ENDPOINT_ADDRESS_DESCRIPTION {
@@ -2659,9 +2449,6 @@ impl Default for WS_ENDPOINT_ADDRESS_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_ENDPOINT_ADDRESS_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_ENDPOINT_ADDRESS_EXTENSION_METADATA_ADDRESS: WS_ENDPOINT_ADDRESS_EXTENSION_TYPE = WS_ENDPOINT_ADDRESS_EXTENSION_TYPE(1i32);
 #[repr(transparent)]
@@ -2677,9 +2464,6 @@ impl Default for WS_ENDPOINT_IDENTITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_ENDPOINT_IDENTITY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2697,9 +2481,6 @@ impl Default for WS_ENDPOINT_POLICY_EXTENSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_ENDPOINT_POLICY_EXTENSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_ENDPOINT_POLICY_EXTENSION_0 {
@@ -2709,9 +2490,6 @@ impl Default for WS_ENDPOINT_POLICY_EXTENSION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_ENDPOINT_POLICY_EXTENSION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_ENDPOINT_POLICY_EXTENSION_TYPE: WS_POLICY_EXTENSION_TYPE = WS_POLICY_EXTENSION_TYPE(1i32);
 #[repr(C)]
@@ -2727,9 +2505,6 @@ impl Default for WS_ENUM_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_ENUM_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_ENUM_TYPE: WS_TYPE = WS_TYPE(31i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2741,9 +2516,6 @@ impl Default for WS_ENUM_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_ENUM_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2768,9 +2540,6 @@ impl Default for WS_ERROR_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_ERROR_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2811,9 +2580,6 @@ impl Default for WS_FAULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_FAULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_FAULT_CODE {
@@ -2825,9 +2591,6 @@ impl Default for WS_FAULT_CODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_FAULT_CODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_FAULT_DESCRIPTION {
@@ -2837,9 +2600,6 @@ impl Default for WS_FAULT_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_FAULT_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2851,9 +2611,6 @@ impl Default for WS_FAULT_DETAIL_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_FAULT_DETAIL_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2875,9 +2632,6 @@ impl Default for WS_FAULT_REASON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_FAULT_REASON {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_FAULT_TO_HEADER: WS_HEADER_TYPE = WS_HEADER_TYPE(7i32);
 pub const WS_FAULT_TYPE: WS_TYPE = WS_TYPE(29i32);
@@ -2902,9 +2656,6 @@ impl Default for WS_FIELD_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_FIELD_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WS_FIELD_MAPPING(pub i32);
@@ -2923,9 +2674,6 @@ impl Default for WS_FLOAT_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_FLOAT_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_FLOAT_TYPE: WS_TYPE = WS_TYPE(9i32);
 pub const WS_FLOAT_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(9i32);
@@ -2949,9 +2697,6 @@ impl Default for WS_GUID_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_GUID_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_GUID_TYPE: WS_TYPE = WS_TYPE(14i32);
 pub const WS_GUID_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(14i32);
 #[repr(transparent)]
@@ -2974,9 +2719,6 @@ impl Default for WS_HEAP_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HEAP_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_HEAP_PROPERTY {
@@ -2988,9 +2730,6 @@ impl Default for WS_HEAP_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HEAP_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HEAP_PROPERTY_ACTUAL_SIZE: WS_HEAP_PROPERTY_ID = WS_HEAP_PROPERTY_ID(3i32);
 #[repr(transparent)]
@@ -3010,9 +2749,6 @@ impl Default for WS_HOST_NAMES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HOST_NAMES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_HTTPS_URL {
@@ -3029,9 +2765,6 @@ impl Default for WS_HTTPS_URL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTPS_URL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_HTTP_BINDING_TEMPLATE {
@@ -3041,9 +2774,6 @@ impl Default for WS_HTTP_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HTTP_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(0i32);
 pub const WS_HTTP_CHANNEL_BINDING: WS_CHANNEL_BINDING = WS_CHANNEL_BINDING(0i32);
@@ -3059,9 +2789,6 @@ impl Default for WS_HTTP_HEADER_AUTH_BINDING_TEMPLATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_HEADER_AUTH_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_HTTP_HEADER_AUTH_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(2i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3074,9 +2801,6 @@ impl Default for WS_HTTP_HEADER_AUTH_POLICY_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_HEADER_AUTH_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HTTP_HEADER_AUTH_SCHEME_BASIC: i32 = 2i32;
 pub const WS_HTTP_HEADER_AUTH_SCHEME_DIGEST: i32 = 4i32;
@@ -3095,9 +2819,6 @@ impl Default for WS_HTTP_HEADER_AUTH_SECURITY_BINDING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_HEADER_AUTH_SECURITY_BINDING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_HTTP_HEADER_AUTH_SECURITY_BINDING_CONSTRAINT {
@@ -3107,9 +2828,6 @@ impl Default for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_CONSTRAINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HTTP_HEADER_AUTH_SECURITY_BINDING_CONSTRAINT_TYPE: WS_SECURITY_BINDING_CONSTRAINT_TYPE = WS_SECURITY_BINDING_CONSTRAINT_TYPE(3i32);
 #[repr(C)]
@@ -3122,9 +2840,6 @@ impl Default for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_HTTP_HEADER_AUTH_SECURITY_BINDING_TEMPLATE {
@@ -3135,9 +2850,6 @@ impl Default for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_HEADER_AUTH_SECURITY_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HTTP_HEADER_AUTH_SECURITY_BINDING_TYPE: WS_SECURITY_BINDING_TYPE = WS_SECURITY_BINDING_TYPE(3i32);
 #[repr(transparent)]
@@ -3155,9 +2867,6 @@ impl Default for WS_HTTP_HEADER_MAPPING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_HEADER_MAPPING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HTTP_HEADER_MAPPING_COMMA_SEPARATOR: i32 = 1i32;
 pub const WS_HTTP_HEADER_MAPPING_QUOTED_VALUE: i32 = 4i32;
@@ -3177,9 +2886,6 @@ impl Default for WS_HTTP_MESSAGE_MAPPING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_MESSAGE_MAPPING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_HTTP_POLICY_DESCRIPTION {
@@ -3189,9 +2895,6 @@ impl Default for WS_HTTP_POLICY_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3211,9 +2914,6 @@ impl Default for WS_HTTP_REDIRECT_CALLBACK_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_REDIRECT_CALLBACK_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_HTTP_REQUEST_MAPPING_VERB: i32 = 2i32;
 pub const WS_HTTP_RESPONSE_MAPPING_STATUS_CODE: i32 = 1i32;
 pub const WS_HTTP_RESPONSE_MAPPING_STATUS_TEXT: i32 = 2i32;
@@ -3229,9 +2929,6 @@ impl Default for WS_HTTP_SSL_BINDING_TEMPLATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_SSL_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_HTTP_SSL_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(1i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3245,9 +2942,6 @@ impl Default for WS_HTTP_SSL_HEADER_AUTH_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_SSL_HEADER_AUTH_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HTTP_SSL_HEADER_AUTH_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(3i32);
 #[repr(C)]
@@ -3263,9 +2957,6 @@ impl Default for WS_HTTP_SSL_HEADER_AUTH_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_SSL_HEADER_AUTH_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_HTTP_SSL_KERBEROS_APREQ_BINDING_TEMPLATE {
@@ -3278,9 +2969,6 @@ impl Default for WS_HTTP_SSL_KERBEROS_APREQ_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_SSL_KERBEROS_APREQ_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HTTP_SSL_KERBEROS_APREQ_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(5i32);
 #[repr(C)]
@@ -3296,9 +2984,6 @@ impl Default for WS_HTTP_SSL_KERBEROS_APREQ_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_SSL_KERBEROS_APREQ_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE {
@@ -3312,9 +2997,6 @@ impl Default for WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(11i32);
 #[repr(C)]
@@ -3331,9 +3013,6 @@ impl Default for WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_POLICY_DESCRIPTION 
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_SSL_KERBEROS_APREQ_SECURITY_CONTEXT_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_HTTP_SSL_POLICY_DESCRIPTION {
@@ -3345,9 +3024,6 @@ impl Default for WS_HTTP_SSL_POLICY_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_SSL_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3361,9 +3037,6 @@ impl Default for WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HTTP_SSL_USERNAME_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(4i32);
 #[repr(C)]
@@ -3379,9 +3052,6 @@ impl Default for WS_HTTP_SSL_USERNAME_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_SSL_USERNAME_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
@@ -3395,9 +3065,6 @@ impl Default for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(10i32);
 #[repr(C)]
@@ -3413,9 +3080,6 @@ impl Default for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_POLICY_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_HTTP_SSL_USERNAME_SECURITY_CONTEXT_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3433,9 +3097,6 @@ impl Default for WS_HTTP_URL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_HTTP_URL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_INCLUSIVE_WITH_COMMENTS_XML_CANONICALIZATION_ALGORITHM: WS_XML_CANONICALIZATION_ALGORITHM = WS_XML_CANONICALIZATION_ALGORITHM(3i32);
 pub const WS_INCLUSIVE_XML_CANONICALIZATION_ALGORITHM: WS_XML_CANONICALIZATION_ALGORITHM = WS_XML_CANONICALIZATION_ALGORITHM(2i32);
 #[repr(C)]
@@ -3448,9 +3109,6 @@ impl Default for WS_INT16_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_INT16_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_INT16_TYPE: WS_TYPE = WS_TYPE(2i32);
 pub const WS_INT16_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(2i32);
@@ -3465,9 +3123,6 @@ impl Default for WS_INT32_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_INT32_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_INT32_TYPE: WS_TYPE = WS_TYPE(3i32);
 pub const WS_INT32_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(3i32);
 #[repr(C)]
@@ -3481,9 +3136,6 @@ impl Default for WS_INT64_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_INT64_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_INT64_TYPE: WS_TYPE = WS_TYPE(4i32);
 pub const WS_INT64_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(4i32);
 #[repr(C)]
@@ -3496,9 +3148,6 @@ impl Default for WS_INT8_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_INT8_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_INT8_TYPE: WS_TYPE = WS_TYPE(1i32);
 pub const WS_INT8_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(1i32);
@@ -3524,9 +3173,6 @@ impl Default for WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CONSTRAINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CONSTRAINT_0 {
@@ -3537,9 +3183,6 @@ impl Default for WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CONSTRAINT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CONSTRAINT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_ISSUED_TOKEN_MESSAGE_SECURITY_BINDING_CONSTRAINT_TYPE: WS_SECURITY_BINDING_CONSTRAINT_TYPE = WS_SECURITY_BINDING_CONSTRAINT_TYPE(6i32);
 pub type WS_IS_DEFAULT_VALUE_CALLBACK = Option<unsafe extern "system" fn(descriptiondata: *const core::ffi::c_void, value: *const core::ffi::c_void, defaultvalue: *const core::ffi::c_void, valuesize: u32, isdefault: *mut super::super::Foundation::BOOL, error: *const WS_ERROR) -> windows_core::HRESULT>;
@@ -3554,9 +3197,6 @@ impl Default for WS_ITEM_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_ITEM_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING {
@@ -3569,9 +3209,6 @@ impl Default for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_CONSTRAINT {
@@ -3582,9 +3219,6 @@ impl Default for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_CONSTRAINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_CONSTRAINT_TYPE: WS_SECURITY_BINDING_CONSTRAINT_TYPE = WS_SECURITY_BINDING_CONSTRAINT_TYPE(5i32);
 #[repr(C)]
@@ -3598,9 +3232,6 @@ impl Default for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_TEMPLATE {
@@ -3611,9 +3242,6 @@ impl Default for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_TYPE: WS_SECURITY_BINDING_TYPE = WS_SECURITY_BINDING_TYPE(5i32);
 #[repr(transparent)]
@@ -3633,9 +3261,6 @@ impl Default for WS_LISTENER_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_LISTENER_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_LISTENER_PROPERTY {
@@ -3647,9 +3272,6 @@ impl Default for WS_LISTENER_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_LISTENER_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_LISTENER_PROPERTY_ASYNC_CALLBACK_MODEL: WS_LISTENER_PROPERTY_ID = WS_LISTENER_PROPERTY_ID(3i32);
 pub const WS_LISTENER_PROPERTY_CHANNEL_BINDING: WS_LISTENER_PROPERTY_ID = WS_LISTENER_PROPERTY_ID(5i32);
@@ -3709,9 +3331,6 @@ impl Default for WS_MESSAGE_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_MESSAGE_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WS_MESSAGE_DONE_CALLBACK = Option<unsafe extern "system" fn(donecallbackstate: *const core::ffi::c_void)>;
 pub const WS_MESSAGE_ID_HEADER: WS_HEADER_TYPE = WS_HEADER_TYPE(3i32);
 #[repr(transparent)]
@@ -3728,9 +3347,6 @@ impl Default for WS_MESSAGE_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_MESSAGE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_MESSAGE_PROPERTY {
@@ -3742,9 +3358,6 @@ impl Default for WS_MESSAGE_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_MESSAGE_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_MESSAGE_PROPERTY_ADDRESSING_VERSION: WS_MESSAGE_PROPERTY_ID = WS_MESSAGE_PROPERTY_ID(3i32);
 pub const WS_MESSAGE_PROPERTY_BODY_READER: WS_MESSAGE_PROPERTY_ID = WS_MESSAGE_PROPERTY_ID(6i32);
@@ -3806,9 +3419,6 @@ impl Default for WS_METADATA_ENDPOINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_METADATA_ENDPOINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_METADATA_ENDPOINTS {
@@ -3819,9 +3429,6 @@ impl Default for WS_METADATA_ENDPOINTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_METADATA_ENDPOINTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3840,9 +3447,6 @@ impl Default for WS_METADATA_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_METADATA_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_METADATA_PROPERTY_HEAP_PROPERTIES: WS_METADATA_PROPERTY_ID = WS_METADATA_PROPERTY_ID(2i32);
 pub const WS_METADATA_PROPERTY_HEAP_REQUESTED_SIZE: WS_METADATA_PROPERTY_ID = WS_METADATA_PROPERTY_ID(4i32);
@@ -3889,9 +3493,6 @@ impl Default for WS_NAMEDPIPE_SSPI_TRANSPORT_SECURITY_BINDING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_NAMEDPIPE_SSPI_TRANSPORT_SECURITY_BINDING {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_NAMEDPIPE_SSPI_TRANSPORT_SECURITY_BINDING_TYPE: WS_SECURITY_BINDING_TYPE = WS_SECURITY_BINDING_TYPE(9i32);
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -3905,10 +3506,6 @@ impl Default for WS_NCRYPT_ASYMMETRIC_SECURITY_KEY_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WS_NCRYPT_ASYMMETRIC_SECURITY_KEY_HANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_NCRYPT_ASYMMETRIC_SECURITY_KEY_HANDLE_TYPE: WS_SECURITY_KEY_HANDLE_TYPE = WS_SECURITY_KEY_HANDLE_TYPE(2i32);
 #[repr(C)]
@@ -3927,9 +3524,6 @@ impl Default for WS_NETPIPE_URL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_NETPIPE_URL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_NETTCP_URL {
@@ -3946,9 +3540,6 @@ impl Default for WS_NETTCP_URL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_NETTCP_URL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_NON_RPC_LITERAL_OPERATION: WS_OPERATION_STYLE = WS_OPERATION_STYLE(0i32);
 pub const WS_NO_FIELD_MAPPING: WS_FIELD_MAPPING = WS_FIELD_MAPPING(5i32);
 #[repr(C)]
@@ -3961,9 +3552,6 @@ impl Default for WS_OPAQUE_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_OPAQUE_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_OPAQUE_WINDOWS_INTEGRATED_AUTH_CREDENTIAL_TYPE: WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL_TYPE = WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL_TYPE(3i32);
 pub type WS_OPEN_CHANNEL_CALLBACK = Option<unsafe extern "system" fn(channelinstance: *const core::ffi::c_void, endpointaddress: *const WS_ENDPOINT_ADDRESS, asynccontext: *const WS_ASYNC_CONTEXT, error: *const WS_ERROR) -> windows_core::HRESULT>;
@@ -4005,9 +3593,6 @@ impl Default for WS_OPERATION_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_OPERATION_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WS_OPERATION_FREE_STATE_CALLBACK = Option<unsafe extern "system" fn(state: *const core::ffi::c_void)>;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4023,9 +3608,6 @@ impl Default for WS_PARAMETER_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_PARAMETER_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4055,9 +3637,6 @@ impl Default for WS_POLICY_CONSTRAINTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_POLICY_CONSTRAINTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_POLICY_EXTENSION {
@@ -4067,9 +3646,6 @@ impl Default for WS_POLICY_EXTENSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_POLICY_EXTENSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4085,9 +3661,6 @@ impl Default for WS_POLICY_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_POLICY_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_POLICY_PROPERTY {
@@ -4099,9 +3672,6 @@ impl Default for WS_POLICY_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_POLICY_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4134,9 +3704,6 @@ impl Default for WS_PROXY_MESSAGE_CALLBACK_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_PROXY_MESSAGE_CALLBACK_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_PROXY_PROPERTY {
@@ -4148,9 +3715,6 @@ impl Default for WS_PROXY_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_PROXY_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_PROXY_PROPERTY_CALL_TIMEOUT: WS_PROXY_PROPERTY_ID = WS_PROXY_PROPERTY_ID(0i32);
 #[repr(transparent)]
@@ -4173,9 +3737,6 @@ impl Default for WS_RAW_SYMMETRIC_SECURITY_KEY_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_RAW_SYMMETRIC_SECURITY_KEY_HANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_RAW_SYMMETRIC_SECURITY_KEY_HANDLE_TYPE: WS_SECURITY_KEY_HANDLE_TYPE = WS_SECURITY_KEY_HANDLE_TYPE(1i32);
 pub type WS_READ_CALLBACK = Option<unsafe extern "system" fn(callbackstate: *const core::ffi::c_void, bytes: *mut core::ffi::c_void, maxsize: u32, actualsize: *mut u32, asynccontext: *const WS_ASYNC_CONTEXT, error: *const WS_ERROR) -> windows_core::HRESULT>;
@@ -4225,9 +3786,6 @@ impl Default for WS_REQUEST_SECURITY_TOKEN_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_REQUEST_SECURITY_TOKEN_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_REQUEST_SECURITY_TOKEN_PROPERTY_APPLIES_TO: WS_REQUEST_SECURITY_TOKEN_PROPERTY_ID = WS_REQUEST_SECURITY_TOKEN_PROPERTY_ID(1i32);
 pub const WS_REQUEST_SECURITY_TOKEN_PROPERTY_BEARER_KEY_TYPE_VERSION: WS_REQUEST_SECURITY_TOKEN_PROPERTY_ID = WS_REQUEST_SECURITY_TOKEN_PROPERTY_ID(13i32);
 #[repr(C)]
@@ -4243,9 +3801,6 @@ impl Default for WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT_0 {
@@ -4255,9 +3810,6 @@ impl Default for WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_REQUEST_SECURITY_TOKEN_PROPERTY_CONSTRAINT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_REQUEST_SECURITY_TOKEN_PROPERTY_EXISTING_TOKEN: WS_REQUEST_SECURITY_TOKEN_PROPERTY_ID = WS_REQUEST_SECURITY_TOKEN_PROPERTY_ID(6i32);
 #[repr(transparent)]
@@ -4288,9 +3840,6 @@ impl Default for WS_RSA_ENDPOINT_IDENTITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_RSA_ENDPOINT_IDENTITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_RSA_ENDPOINT_IDENTITY_TYPE: WS_ENDPOINT_IDENTITY_TYPE = WS_ENDPOINT_IDENTITY_TYPE(4i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4301,9 +3850,6 @@ impl Default for WS_SAML_AUTHENTICATOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SAML_AUTHENTICATOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4319,9 +3865,6 @@ impl Default for WS_SAML_MESSAGE_SECURITY_BINDING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SAML_MESSAGE_SECURITY_BINDING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SAML_MESSAGE_SECURITY_BINDING_TYPE: WS_SECURITY_BINDING_TYPE = WS_SECURITY_BINDING_TYPE(7i32);
 #[repr(transparent)]
@@ -4367,9 +3910,6 @@ impl Default for WS_SECURITY_ALGORITHM_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_ALGORITHM_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WS_SECURITY_ALGORITHM_PROPERTY_ID(pub i32);
@@ -4395,9 +3935,6 @@ impl Default for WS_SECURITY_ALGORITHM_SUITE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_ALGORITHM_SUITE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4436,9 +3973,6 @@ impl Default for WS_SECURITY_BINDING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_BINDING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SECURITY_BINDING_CONSTRAINT {
@@ -4450,9 +3984,6 @@ impl Default for WS_SECURITY_BINDING_CONSTRAINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_BINDING_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4468,9 +3999,6 @@ impl Default for WS_SECURITY_BINDING_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_BINDING_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SECURITY_BINDING_PROPERTY {
@@ -4482,9 +4010,6 @@ impl Default for WS_SECURITY_BINDING_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_BINDING_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SECURITY_BINDING_PROPERTY_ALLOWED_IMPERSONATION_LEVEL: WS_SECURITY_BINDING_PROPERTY_ID = WS_SECURITY_BINDING_PROPERTY_ID(5i32);
 pub const WS_SECURITY_BINDING_PROPERTY_ALLOW_ANONYMOUS_CLIENTS: WS_SECURITY_BINDING_PROPERTY_ID = WS_SECURITY_BINDING_PROPERTY_ID(4i32);
@@ -4503,9 +4028,6 @@ impl Default for WS_SECURITY_BINDING_PROPERTY_CONSTRAINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_BINDING_PROPERTY_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SECURITY_BINDING_PROPERTY_CONSTRAINT_0 {
@@ -4515,9 +4037,6 @@ impl Default for WS_SECURITY_BINDING_PROPERTY_CONSTRAINT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_BINDING_PROPERTY_CONSTRAINT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SECURITY_BINDING_PROPERTY_DISABLE_CERT_REVOCATION_CHECK: WS_SECURITY_BINDING_PROPERTY_ID = WS_SECURITY_BINDING_PROPERTY_ID(21i32);
 pub const WS_SECURITY_BINDING_PROPERTY_DISALLOWED_SECURE_PROTOCOLS: WS_SECURITY_BINDING_PROPERTY_ID = WS_SECURITY_BINDING_PROPERTY_ID(22i32);
@@ -4557,9 +4076,6 @@ impl Default for WS_SECURITY_CONSTRAINTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_CONSTRAINTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct WS_SECURITY_CONTEXT(pub isize);
@@ -4578,9 +4094,6 @@ impl Default for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_CONSTRAINT {
@@ -4592,9 +4105,6 @@ impl Default for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_CONSTRAINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_CONSTRAINT_TYPE: WS_SECURITY_BINDING_CONSTRAINT_TYPE = WS_SECURITY_BINDING_CONSTRAINT_TYPE(8i32);
 #[repr(C)]
@@ -4608,9 +4118,6 @@ impl Default for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_TEMPLATE {
@@ -4620,9 +4127,6 @@ impl Default for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING_TYPE: WS_SECURITY_BINDING_TYPE = WS_SECURITY_BINDING_TYPE(8i32);
 #[repr(C)]
@@ -4636,9 +4140,6 @@ impl Default for WS_SECURITY_CONTEXT_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_CONTEXT_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4658,9 +4159,6 @@ impl Default for WS_SECURITY_CONTEXT_SECURITY_BINDING_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_CONTEXT_SECURITY_BINDING_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SECURITY_CONTEXT_SECURITY_BINDING_TEMPLATE {
@@ -4671,9 +4169,6 @@ impl Default for WS_SECURITY_CONTEXT_SECURITY_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_CONTEXT_SECURITY_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4687,9 +4182,6 @@ impl Default for WS_SECURITY_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4719,9 +4211,6 @@ impl Default for WS_SECURITY_KEY_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_KEY_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WS_SECURITY_KEY_HANDLE_TYPE(pub i32);
@@ -4742,9 +4231,6 @@ impl Default for WS_SECURITY_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SECURITY_PROPERTY {
@@ -4756,9 +4242,6 @@ impl Default for WS_SECURITY_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SECURITY_PROPERTY_ALGORITHM_SUITE: WS_SECURITY_PROPERTY_ID = WS_SECURITY_PROPERTY_ID(2i32);
 pub const WS_SECURITY_PROPERTY_ALGORITHM_SUITE_NAME: WS_SECURITY_PROPERTY_ID = WS_SECURITY_PROPERTY_ID(3i32);
@@ -4775,9 +4258,6 @@ impl Default for WS_SECURITY_PROPERTY_CONSTRAINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SECURITY_PROPERTY_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SECURITY_PROPERTY_CONSTRAINT_0 {
@@ -4787,9 +4267,6 @@ impl Default for WS_SECURITY_PROPERTY_CONSTRAINT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SECURITY_PROPERTY_CONSTRAINT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SECURITY_PROPERTY_EXTENDED_PROTECTION_POLICY: WS_SECURITY_PROPERTY_ID = WS_SECURITY_PROPERTY_ID(10i32);
 pub const WS_SECURITY_PROPERTY_EXTENDED_PROTECTION_SCENARIO: WS_SECURITY_PROPERTY_ID = WS_SECURITY_PROPERTY_ID(11i32);
@@ -4852,9 +4329,6 @@ impl Default for WS_SERVICE_CONTRACT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SERVICE_CONTRACT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SERVICE_ENDPOINT {
@@ -4873,9 +4347,6 @@ impl Default for WS_SERVICE_ENDPOINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SERVICE_ENDPOINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SERVICE_ENDPOINT_METADATA {
@@ -4888,9 +4359,6 @@ impl Default for WS_SERVICE_ENDPOINT_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SERVICE_ENDPOINT_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SERVICE_ENDPOINT_PROPERTY {
@@ -4902,9 +4370,6 @@ impl Default for WS_SERVICE_ENDPOINT_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SERVICE_ENDPOINT_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SERVICE_ENDPOINT_PROPERTY_ACCEPT_CHANNEL_CALLBACK: WS_SERVICE_ENDPOINT_PROPERTY_ID = WS_SERVICE_ENDPOINT_PROPERTY_ID(0i32);
 pub const WS_SERVICE_ENDPOINT_PROPERTY_BODY_HEAP_MAX_SIZE: WS_SERVICE_ENDPOINT_PROPERTY_ID = WS_SERVICE_ENDPOINT_PROPERTY_ID(4i32);
@@ -4954,9 +4419,6 @@ impl Default for WS_SERVICE_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SERVICE_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SERVICE_METADATA_DOCUMENT {
@@ -4967,9 +4429,6 @@ impl Default for WS_SERVICE_METADATA_DOCUMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SERVICE_METADATA_DOCUMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SERVICE_OPERATION_MESSAGE_NILLABLE_ELEMENT: i32 = 1i32;
 #[repr(C)]
@@ -4984,9 +4443,6 @@ impl Default for WS_SERVICE_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SERVICE_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SERVICE_PROPERTY_ACCEPT_CALLBACK {
@@ -4997,9 +4453,6 @@ impl Default for WS_SERVICE_PROPERTY_ACCEPT_CALLBACK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SERVICE_PROPERTY_ACCEPT_CALLBACK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
@@ -5009,9 +4462,6 @@ impl Default for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SERVICE_PROPERTY_CLOSE_TIMEOUT: WS_SERVICE_PROPERTY_ID = WS_SERVICE_PROPERTY_ID(5i32);
 pub const WS_SERVICE_PROPERTY_FAULT_DISCLOSURE: WS_SERVICE_PROPERTY_ID = WS_SERVICE_PROPERTY_ID(1i32);
@@ -5049,9 +4499,6 @@ impl Default for WS_SERVICE_SECURITY_IDENTITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SERVICE_SECURITY_IDENTITIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WS_SERVICE_STUB_CALLBACK = Option<unsafe extern "system" fn(context: *const WS_OPERATION_CONTEXT, frame: *const core::ffi::c_void, callback: *const core::ffi::c_void, asynccontext: *const WS_ASYNC_CONTEXT, error: *const WS_ERROR) -> windows_core::HRESULT>;
 pub type WS_SET_CHANNEL_PROPERTY_CALLBACK = Option<unsafe extern "system" fn(channelinstance: *const core::ffi::c_void, id: WS_CHANNEL_PROPERTY_ID, value: *const core::ffi::c_void, valuesize: u32, error: *const WS_ERROR) -> windows_core::HRESULT>;
 pub type WS_SET_LISTENER_PROPERTY_CALLBACK = Option<unsafe extern "system" fn(listenerinstance: *const core::ffi::c_void, id: WS_LISTENER_PROPERTY_ID, value: *const core::ffi::c_void, valuesize: u32, error: *const WS_ERROR) -> windows_core::HRESULT>;
@@ -5074,9 +4521,6 @@ impl Default for WS_SOAPUDP_URL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SOAPUDP_URL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SPN_ENDPOINT_IDENTITY {
@@ -5087,9 +4531,6 @@ impl Default for WS_SPN_ENDPOINT_IDENTITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SPN_ENDPOINT_IDENTITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SPN_ENDPOINT_IDENTITY_TYPE: WS_ENDPOINT_IDENTITY_TYPE = WS_ENDPOINT_IDENTITY_TYPE(3i32);
 #[repr(C)]
@@ -5103,9 +4544,6 @@ impl Default for WS_SSL_TRANSPORT_SECURITY_BINDING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SSL_TRANSPORT_SECURITY_BINDING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT {
@@ -5117,9 +4555,6 @@ impl Default for WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT_0 {
@@ -5129,9 +4564,6 @@ impl Default for WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_SSL_TRANSPORT_SECURITY_BINDING_CONSTRAINT_TYPE: WS_SECURITY_BINDING_CONSTRAINT_TYPE = WS_SECURITY_BINDING_CONSTRAINT_TYPE(1i32);
 #[repr(C)]
@@ -5144,9 +4576,6 @@ impl Default for WS_SSL_TRANSPORT_SECURITY_BINDING_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SSL_TRANSPORT_SECURITY_BINDING_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_SSL_TRANSPORT_SECURITY_BINDING_TEMPLATE {
@@ -5158,9 +4587,6 @@ impl Default for WS_SSL_TRANSPORT_SECURITY_BINDING_TEMPLATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SSL_TRANSPORT_SECURITY_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_SSL_TRANSPORT_SECURITY_BINDING_TYPE: WS_SECURITY_BINDING_TYPE = WS_SECURITY_BINDING_TYPE(1i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5171,9 +4597,6 @@ impl Default for WS_SSPI_TRANSPORT_SECURITY_BINDING_POLICY_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_SSPI_TRANSPORT_SECURITY_BINDING_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_STREAMED_INPUT_TRANSFER_MODE: WS_TRANSFER_MODE = WS_TRANSFER_MODE(1i32);
 pub const WS_STREAMED_OUTPUT_TRANSFER_MODE: WS_TRANSFER_MODE = WS_TRANSFER_MODE(2i32);
@@ -5189,9 +4612,6 @@ impl Default for WS_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_STRING_DESCRIPTION {
@@ -5202,9 +4622,6 @@ impl Default for WS_STRING_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_STRING_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_STRING_TYPE: WS_TYPE = WS_TYPE(16i32);
 #[repr(C)]
@@ -5219,9 +4636,6 @@ impl Default for WS_STRING_USERNAME_CREDENTIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_STRING_USERNAME_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_STRING_USERNAME_CREDENTIAL_TYPE: WS_USERNAME_CREDENTIAL_TYPE = WS_USERNAME_CREDENTIAL_TYPE(1i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5235,9 +4649,6 @@ impl Default for WS_STRING_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_STRING_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_STRING_WINDOWS_INTEGRATED_AUTH_CREDENTIAL_TYPE: WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL_TYPE = WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL_TYPE(1i32);
 pub const WS_STRUCT_ABSTRACT: i32 = 1i32;
@@ -5260,9 +4671,6 @@ impl Default for WS_STRUCT_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_STRUCT_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_STRUCT_IGNORE_TRAILING_ELEMENT_CONTENT: i32 = 2i32;
 pub const WS_STRUCT_IGNORE_UNHANDLED_ATTRIBUTES: i32 = 4i32;
 pub const WS_STRUCT_TYPE: WS_TYPE = WS_TYPE(26i32);
@@ -5279,9 +4687,6 @@ impl Default for WS_SUBJECT_NAME_CERT_CREDENTIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_SUBJECT_NAME_CERT_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_SUBJECT_NAME_CERT_CREDENTIAL_TYPE: WS_CERT_CREDENTIAL_TYPE = WS_CERT_CREDENTIAL_TYPE(1i32);
 pub const WS_SUPPORTING_MESSAGE_SECURITY_USAGE: WS_MESSAGE_SECURITY_USAGE = WS_MESSAGE_SECURITY_USAGE(1i32);
 #[repr(C)]
@@ -5293,9 +4698,6 @@ impl Default for WS_TCP_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_TCP_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_TCP_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(6i32);
 pub const WS_TCP_CHANNEL_BINDING: WS_CHANNEL_BINDING = WS_CHANNEL_BINDING(1i32);
@@ -5309,9 +4711,6 @@ impl Default for WS_TCP_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_TCP_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_TCP_SSPI_BINDING_TEMPLATE {
@@ -5323,9 +4722,6 @@ impl Default for WS_TCP_SSPI_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_TCP_SSPI_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_TCP_SSPI_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(7i32);
 #[repr(C)]
@@ -5341,9 +4737,6 @@ impl Default for WS_TCP_SSPI_KERBEROS_APREQ_BINDING_TEMPLATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_TCP_SSPI_KERBEROS_APREQ_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_TCP_SSPI_KERBEROS_APREQ_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(9i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5358,9 +4751,6 @@ impl Default for WS_TCP_SSPI_KERBEROS_APREQ_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_TCP_SSPI_KERBEROS_APREQ_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE {
@@ -5374,9 +4764,6 @@ impl Default for WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(13i32);
 #[repr(C)]
@@ -5393,9 +4780,6 @@ impl Default for WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_POLICY_DESCRIPTION 
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_TCP_SSPI_KERBEROS_APREQ_SECURITY_CONTEXT_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_TCP_SSPI_POLICY_DESCRIPTION {
@@ -5408,9 +4792,6 @@ impl Default for WS_TCP_SSPI_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_TCP_SSPI_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING {
@@ -5422,9 +4803,6 @@ impl Default for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_CONSTRAINT {
@@ -5434,9 +4812,6 @@ impl Default for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_CONSTRAINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_CONSTRAINT_TYPE: WS_SECURITY_BINDING_CONSTRAINT_TYPE = WS_SECURITY_BINDING_CONSTRAINT_TYPE(2i32);
 #[repr(C)]
@@ -5449,9 +4824,6 @@ impl Default for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_TCP_SSPI_TRANSPORT_SECURITY_BINDING_TYPE: WS_SECURITY_BINDING_TYPE = WS_SECURITY_BINDING_TYPE(2i32);
 #[repr(C)]
@@ -5467,9 +4839,6 @@ impl Default for WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_TCP_SSPI_USERNAME_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(8i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5484,9 +4853,6 @@ impl Default for WS_TCP_SSPI_USERNAME_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_TCP_SSPI_USERNAME_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
@@ -5500,9 +4866,6 @@ impl Default for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_BINDING_TEMPLATE_TYPE: WS_BINDING_TEMPLATE_TYPE = WS_BINDING_TEMPLATE_TYPE(12i32);
 #[repr(C)]
@@ -5519,9 +4882,6 @@ impl Default for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_POLICY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_TCP_SSPI_USERNAME_SECURITY_CONTEXT_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_TEXT_FIELD_MAPPING: WS_FIELD_MAPPING = WS_FIELD_MAPPING(4i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5536,9 +4896,6 @@ impl Default for WS_THUMBPRINT_CERT_CREDENTIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_THUMBPRINT_CERT_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_THUMBPRINT_CERT_CREDENTIAL_TYPE: WS_CERT_CREDENTIAL_TYPE = WS_CERT_CREDENTIAL_TYPE(2i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5550,9 +4907,6 @@ impl Default for WS_TIMESPAN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_TIMESPAN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_TIMESPAN_DESCRIPTION {
@@ -5563,9 +4917,6 @@ impl Default for WS_TIMESPAN_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_TIMESPAN_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_TIMESPAN_TYPE: WS_TYPE = WS_TYPE(13i32);
 pub const WS_TIMESPAN_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(13i32);
@@ -5796,9 +5147,6 @@ impl Default for WS_UINT16_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_UINT16_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_UINT16_TYPE: WS_TYPE = WS_TYPE(6i32);
 pub const WS_UINT16_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(6i32);
 #[repr(C)]
@@ -5811,9 +5159,6 @@ impl Default for WS_UINT32_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_UINT32_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_UINT32_TYPE: WS_TYPE = WS_TYPE(7i32);
 pub const WS_UINT32_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(7i32);
@@ -5828,9 +5173,6 @@ impl Default for WS_UINT64_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_UINT64_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_UINT64_TYPE: WS_TYPE = WS_TYPE(8i32);
 pub const WS_UINT64_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(8i32);
 #[repr(C)]
@@ -5843,9 +5185,6 @@ impl Default for WS_UINT8_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_UINT8_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_UINT8_TYPE: WS_TYPE = WS_TYPE(5i32);
 pub const WS_UINT8_VALUE_TYPE: WS_VALUE_TYPE = WS_VALUE_TYPE(5i32);
@@ -5865,9 +5204,6 @@ impl Default for WS_UNION_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_UNION_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_UNION_FIELD_DESCRIPTION {
@@ -5878,9 +5214,6 @@ impl Default for WS_UNION_FIELD_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_UNION_FIELD_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_UNION_TYPE: WS_TYPE = WS_TYPE(33i32);
 #[repr(C)]
@@ -5894,9 +5227,6 @@ impl Default for WS_UNIQUE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_UNIQUE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_UNIQUE_ID_DESCRIPTION {
@@ -5907,9 +5237,6 @@ impl Default for WS_UNIQUE_ID_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_UNIQUE_ID_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_UNIQUE_ID_TYPE: WS_TYPE = WS_TYPE(15i32);
 #[repr(C)]
@@ -5923,9 +5250,6 @@ impl Default for WS_UNKNOWN_ENDPOINT_IDENTITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_UNKNOWN_ENDPOINT_IDENTITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_UNKNOWN_ENDPOINT_IDENTITY_TYPE: WS_ENDPOINT_IDENTITY_TYPE = WS_ENDPOINT_IDENTITY_TYPE(6i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5938,9 +5262,6 @@ impl Default for WS_UPN_ENDPOINT_IDENTITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_UPN_ENDPOINT_IDENTITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_UPN_ENDPOINT_IDENTITY_TYPE: WS_ENDPOINT_IDENTITY_TYPE = WS_ENDPOINT_IDENTITY_TYPE(2i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5951,9 +5272,6 @@ impl Default for WS_URL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_URL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_URL_FLAGS_ALLOW_HOST_WILDCARDS: i32 = 1i32;
 pub const WS_URL_FLAGS_NO_PATH_COLLAPSE: i32 = 2i32;
@@ -5976,9 +5294,6 @@ impl Default for WS_USERNAME_CREDENTIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_USERNAME_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WS_USERNAME_CREDENTIAL_TYPE(pub i32);
@@ -5996,9 +5311,6 @@ impl Default for WS_USERNAME_MESSAGE_SECURITY_BINDING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_USERNAME_MESSAGE_SECURITY_BINDING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_USERNAME_MESSAGE_SECURITY_BINDING_CONSTRAINT {
@@ -6009,9 +5321,6 @@ impl Default for WS_USERNAME_MESSAGE_SECURITY_BINDING_CONSTRAINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_USERNAME_MESSAGE_SECURITY_BINDING_CONSTRAINT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_USERNAME_MESSAGE_SECURITY_BINDING_CONSTRAINT_TYPE: WS_SECURITY_BINDING_CONSTRAINT_TYPE = WS_SECURITY_BINDING_CONSTRAINT_TYPE(4i32);
 #[repr(C)]
@@ -6024,9 +5333,6 @@ impl Default for WS_USERNAME_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_USERNAME_MESSAGE_SECURITY_BINDING_POLICY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6041,9 +5347,6 @@ impl Default for WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_USERNAME_MESSAGE_SECURITY_BINDING_TEMPLATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_USERNAME_MESSAGE_SECURITY_BINDING_TYPE: WS_SECURITY_BINDING_TYPE = WS_SECURITY_BINDING_TYPE(4i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6055,9 +5358,6 @@ impl Default for WS_UTF8_ARRAY_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_UTF8_ARRAY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_UTF8_ARRAY_TYPE: WS_TYPE = WS_TYPE(23i32);
 pub type WS_VALIDATE_PASSWORD_CALLBACK = Option<unsafe extern "system" fn(passwordvalidatorcallbackstate: *const core::ffi::c_void, username: *const WS_STRING, password: *const WS_STRING, asynccontext: *const WS_ASYNC_CONTEXT, error: *const WS_ERROR) -> windows_core::HRESULT>;
@@ -6075,9 +5375,6 @@ impl Default for WS_VOID_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_VOID_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_VOID_TYPE: WS_TYPE = WS_TYPE(30i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6088,9 +5385,6 @@ impl Default for WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6123,9 +5417,6 @@ impl Default for WS_WSZ_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_WSZ_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_WSZ_TYPE: WS_TYPE = WS_TYPE(17i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6142,9 +5433,6 @@ impl Default for WS_XML_ATTRIBUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WS_XML_ATTRIBUTE_FIELD_MAPPING: WS_FIELD_MAPPING = WS_FIELD_MAPPING(6i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6158,9 +5446,6 @@ impl Default for WS_XML_BASE64_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_BASE64_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_BOOL_TEXT {
@@ -6171,9 +5456,6 @@ impl Default for WS_XML_BOOL_TEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_BOOL_TEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -6193,9 +5475,6 @@ impl Default for WS_XML_BUFFER_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_BUFFER_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WS_XML_BUFFER_PROPERTY_ID(pub i32);
@@ -6214,9 +5493,6 @@ impl Default for WS_XML_CANONICALIZATION_INCLUSIVE_PREFIXES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_CANONICALIZATION_INCLUSIVE_PREFIXES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_CANONICALIZATION_PROPERTY {
@@ -6228,9 +5504,6 @@ impl Default for WS_XML_CANONICALIZATION_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_CANONICALIZATION_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_XML_CANONICALIZATION_PROPERTY_ALGORITHM: WS_XML_CANONICALIZATION_PROPERTY_ID = WS_XML_CANONICALIZATION_PROPERTY_ID(0i32);
 #[repr(transparent)]
@@ -6250,9 +5523,6 @@ impl Default for WS_XML_COMMENT_NODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_COMMENT_NODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_DATETIME_TEXT {
@@ -6264,9 +5534,6 @@ impl Default for WS_XML_DATETIME_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_DATETIME_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WS_XML_DECIMAL_TEXT {
@@ -6277,9 +5544,6 @@ impl Default for WS_XML_DECIMAL_TEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_DECIMAL_TEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6294,9 +5558,6 @@ impl Default for WS_XML_DICTIONARY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_DICTIONARY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_DOUBLE_TEXT {
@@ -6307,9 +5568,6 @@ impl Default for WS_XML_DOUBLE_TEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_DOUBLE_TEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6327,9 +5585,6 @@ impl Default for WS_XML_ELEMENT_NODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_ELEMENT_NODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_FLOAT_TEXT {
@@ -6340,9 +5595,6 @@ impl Default for WS_XML_FLOAT_TEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_FLOAT_TEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6355,9 +5607,6 @@ impl Default for WS_XML_GUID_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_GUID_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_INT32_TEXT {
@@ -6369,9 +5618,6 @@ impl Default for WS_XML_INT32_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_INT32_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_INT64_TEXT {
@@ -6382,9 +5628,6 @@ impl Default for WS_XML_INT64_TEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_INT64_TEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6398,9 +5641,6 @@ impl Default for WS_XML_LIST_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_LIST_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_NODE {
@@ -6410,9 +5650,6 @@ impl Default for WS_XML_NODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_NODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6424,9 +5661,6 @@ impl Default for WS_XML_NODE_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_NODE_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6450,9 +5684,6 @@ impl Default for WS_XML_QNAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_QNAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_QNAME_DESCRIPTION {
@@ -6466,9 +5697,6 @@ impl Default for WS_XML_QNAME_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_QNAME_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_QNAME_TEXT {
@@ -6481,9 +5709,6 @@ impl Default for WS_XML_QNAME_TEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_QNAME_TEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_XML_QNAME_TYPE: WS_TYPE = WS_TYPE(20i32);
 #[repr(transparent)]
@@ -6504,9 +5729,6 @@ impl Default for WS_XML_READER_BINARY_ENCODING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_READER_BINARY_ENCODING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_READER_BUFFER_INPUT {
@@ -6519,9 +5741,6 @@ impl Default for WS_XML_READER_BUFFER_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_READER_BUFFER_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_READER_ENCODING {
@@ -6531,9 +5750,6 @@ impl Default for WS_XML_READER_ENCODING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_READER_ENCODING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6551,9 +5767,6 @@ impl Default for WS_XML_READER_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_READER_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6575,9 +5788,6 @@ impl Default for WS_XML_READER_MTOM_ENCODING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_READER_MTOM_ENCODING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_READER_PROPERTIES {
@@ -6588,9 +5798,6 @@ impl Default for WS_XML_READER_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_READER_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6603,9 +5810,6 @@ impl Default for WS_XML_READER_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_READER_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_XML_READER_PROPERTY_ALLOW_FRAGMENT: WS_XML_READER_PROPERTY_ID = WS_XML_READER_PROPERTY_ID(1i32);
 pub const WS_XML_READER_PROPERTY_ALLOW_INVALID_CHARACTER_REFERENCES: WS_XML_READER_PROPERTY_ID = WS_XML_READER_PROPERTY_ID(13i32);
@@ -6635,9 +5839,6 @@ impl Default for WS_XML_READER_RAW_ENCODING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_READER_RAW_ENCODING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_READER_STREAM_INPUT {
@@ -6650,9 +5851,6 @@ impl Default for WS_XML_READER_STREAM_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_READER_STREAM_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_READER_TEXT_ENCODING {
@@ -6663,9 +5861,6 @@ impl Default for WS_XML_READER_TEXT_ENCODING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_READER_TEXT_ENCODING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6678,9 +5873,6 @@ impl Default for WS_XML_SECURITY_TOKEN_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_SECURITY_TOKEN_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_XML_SECURITY_TOKEN_PROPERTY_ATTACHED_REFERENCE: WS_XML_SECURITY_TOKEN_PROPERTY_ID = WS_XML_SECURITY_TOKEN_PROPERTY_ID(1i32);
 #[repr(transparent)]
@@ -6702,9 +5894,6 @@ impl Default for WS_XML_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_STRING_DESCRIPTION {
@@ -6715,9 +5904,6 @@ impl Default for WS_XML_STRING_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_STRING_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_XML_STRING_TYPE: WS_TYPE = WS_TYPE(19i32);
 #[repr(C)]
@@ -6730,9 +5916,6 @@ impl Default for WS_XML_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_TEXT_NODE {
@@ -6743,9 +5926,6 @@ impl Default for WS_XML_TEXT_NODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_TEXT_NODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6777,9 +5957,6 @@ impl Default for WS_XML_TIMESPAN_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_TIMESPAN_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_TOKEN_MESSAGE_SECURITY_BINDING {
@@ -6791,9 +5968,6 @@ impl Default for WS_XML_TOKEN_MESSAGE_SECURITY_BINDING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_TOKEN_MESSAGE_SECURITY_BINDING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_XML_TOKEN_MESSAGE_SECURITY_BINDING_TYPE: WS_SECURITY_BINDING_TYPE = WS_SECURITY_BINDING_TYPE(6i32);
 #[repr(C)]
@@ -6807,9 +5981,6 @@ impl Default for WS_XML_UINT64_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_UINT64_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_UNIQUE_ID_TEXT {
@@ -6820,9 +5991,6 @@ impl Default for WS_XML_UNIQUE_ID_TEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_UNIQUE_ID_TEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6836,9 +6004,6 @@ impl Default for WS_XML_UTF16_TEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_UTF16_TEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_UTF8_TEXT {
@@ -6849,9 +6014,6 @@ impl Default for WS_XML_UTF8_TEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_UTF8_TEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -6872,9 +6034,6 @@ impl Default for WS_XML_WRITER_BINARY_ENCODING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_WRITER_BINARY_ENCODING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_WRITER_BUFFER_OUTPUT {
@@ -6885,9 +6044,6 @@ impl Default for WS_XML_WRITER_BUFFER_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_WRITER_BUFFER_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_WRITER_ENCODING {
@@ -6897,9 +6053,6 @@ impl Default for WS_XML_WRITER_ENCODING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_WRITER_ENCODING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6924,9 +6077,6 @@ impl Default for WS_XML_WRITER_MTOM_ENCODING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_WRITER_MTOM_ENCODING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_WRITER_OUTPUT {
@@ -6936,9 +6086,6 @@ impl Default for WS_XML_WRITER_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_WRITER_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6956,9 +6103,6 @@ impl Default for WS_XML_WRITER_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_WRITER_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_WRITER_PROPERTY {
@@ -6970,9 +6114,6 @@ impl Default for WS_XML_WRITER_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_WRITER_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WS_XML_WRITER_PROPERTY_ALLOW_FRAGMENT: WS_XML_WRITER_PROPERTY_ID = WS_XML_WRITER_PROPERTY_ID(1i32);
 pub const WS_XML_WRITER_PROPERTY_ALLOW_INVALID_CHARACTER_REFERENCES: WS_XML_WRITER_PROPERTY_ID = WS_XML_WRITER_PROPERTY_ID(13i32);
@@ -7006,9 +6147,6 @@ impl Default for WS_XML_WRITER_RAW_ENCODING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_WRITER_RAW_ENCODING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_WRITER_STREAM_OUTPUT {
@@ -7021,9 +6159,6 @@ impl Default for WS_XML_WRITER_STREAM_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WS_XML_WRITER_STREAM_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WS_XML_WRITER_TEXT_ENCODING {
@@ -7034,7 +6169,4 @@ impl Default for WS_XML_WRITER_TEXT_ENCODING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WS_XML_WRITER_TEXT_ENCODING {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Security/AppLocker/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/AppLocker/mod.rs
@@ -79,10 +79,6 @@ impl Default for SAFER_CODE_PROPERTIES_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SAFER_CODE_PROPERTIES_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -110,10 +106,6 @@ impl Default for SAFER_CODE_PROPERTIES_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SAFER_CODE_PROPERTIES_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -177,10 +169,6 @@ impl Default for SAFER_HASH_IDENTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SAFER_HASH_IDENTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -196,10 +184,6 @@ impl Default for SAFER_HASH_IDENTIFICATION2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SAFER_HASH_IDENTIFICATION2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SAFER_IDENTIFICATION_HEADER {
@@ -212,9 +196,6 @@ impl Default for SAFER_IDENTIFICATION_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SAFER_IDENTIFICATION_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -243,9 +224,6 @@ impl Default for SAFER_PATHNAME_IDENTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SAFER_PATHNAME_IDENTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SAFER_POLICY_BLOCK_CLIENT_UI: u32 = 8192u32;
 pub const SAFER_POLICY_HASH_DUPLICATE: u32 = 262144u32;
@@ -279,9 +257,6 @@ impl Default for SAFER_URLZONE_IDENTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SAFER_URLZONE_IDENTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SRP_POLICY_APPX: windows_core::PCWSTR = windows_core::w!("APPX");
 pub const SRP_POLICY_DLL: windows_core::PCWSTR = windows_core::w!("DLL");

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -1604,9 +1604,6 @@ impl Default for AUDIT_POLICY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIT_POLICY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AUDIT_QUERY_MISC_POLICY: u32 = 64u32;
 pub const AUDIT_QUERY_SYSTEM_POLICY: u32 = 2u32;
 pub const AUDIT_QUERY_USER_POLICY: u32 = 8u32;
@@ -1719,9 +1716,6 @@ impl Default for CENTRAL_ACCESS_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CENTRAL_ACCESS_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CENTRAL_ACCESS_POLICY_ENTRY {
@@ -1741,9 +1735,6 @@ impl Default for CENTRAL_ACCESS_POLICY_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CENTRAL_ACCESS_POLICY_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CENTRAL_ACCESS_POLICY_OWNER_RIGHTS_PRESENT_FLAG: u32 = 1u32;
 pub const CENTRAL_ACCESS_POLICY_STAGED_FLAG: u32 = 65536u32;
 pub const CENTRAL_ACCESS_POLICY_STAGED_OWNER_RIGHTS_PRESENT_FLAG: u32 = 256u32;
@@ -1758,9 +1749,6 @@ impl Default for CLEAR_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLEAR_BLOCK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLEAR_BLOCK_LENGTH: u32 = 8u32;
 pub const CLOUDAP_NAME: windows_core::PCWSTR = windows_core::w!("CloudAP");
@@ -1792,9 +1780,6 @@ impl Default for CRYPTO_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTO_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CYPHER_BLOCK_LENGTH: u32 = 8u32;
 pub const CertHashInfo: KERB_CERTIFICATE_INFO_TYPE = KERB_CERTIFICATE_INFO_TYPE(1i32);
@@ -1837,9 +1822,6 @@ impl Default for DOMAIN_PASSWORD_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DOMAIN_PASSWORD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DOMAIN_PASSWORD_NO_ANON_CHANGE: DOMAIN_PASSWORD_PROPERTIES = DOMAIN_PASSWORD_PROPERTIES(2u32);
 pub const DOMAIN_PASSWORD_NO_CLEAR_CHANGE: DOMAIN_PASSWORD_PROPERTIES = DOMAIN_PASSWORD_PROPERTIES(4u32);
@@ -1900,10 +1882,6 @@ impl Default for ENCRYPTED_CREDENTIALW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Credentials")]
-impl windows_core::TypeKind for ENCRYPTED_CREDENTIALW {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_Security_Credentials")]
 pub type ENCRYPT_MESSAGE_FN = Option<unsafe extern "system" fn(param0: *mut super::super::Credentials::SecHandle, param1: u32, param2: *mut SecBufferDesc, param3: u32) -> windows_core::HRESULT>;
@@ -2161,9 +2139,6 @@ impl Default for KDC_PROXY_CACHE_ENTRY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KDC_PROXY_CACHE_ENTRY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KDC_PROXY_SETTINGS_FLAGS_FORCEPROXY: u32 = 1u32;
 pub const KDC_PROXY_SETTINGS_V1: u32 = 1u32;
 pub const KERBEROS_REVISION: u32 = 6u32;
@@ -2185,9 +2160,6 @@ impl Default for KERB_ADD_BINDING_CACHE_ENTRY_EX_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_ADD_BINDING_CACHE_ENTRY_EX_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_ADD_BINDING_CACHE_ENTRY_REQUEST {
@@ -2200,9 +2172,6 @@ impl Default for KERB_ADD_BINDING_CACHE_ENTRY_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_ADD_BINDING_CACHE_ENTRY_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2219,9 +2188,6 @@ impl Default for KERB_ADD_CREDENTIALS_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_ADD_CREDENTIALS_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_ADD_CREDENTIALS_REQUEST_EX {
@@ -2234,9 +2200,6 @@ impl Default for KERB_ADD_CREDENTIALS_REQUEST_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_ADD_CREDENTIALS_REQUEST_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_AUTH_DATA {
@@ -2248,9 +2211,6 @@ impl Default for KERB_AUTH_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_AUTH_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2269,9 +2229,6 @@ impl Default for KERB_BINDING_CACHE_ENTRY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_BINDING_CACHE_ENTRY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_CERTIFICATE_HASHINFO {
@@ -2283,9 +2240,6 @@ impl Default for KERB_CERTIFICATE_HASHINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_CERTIFICATE_HASHINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_CERTIFICATE_INFO {
@@ -2296,9 +2250,6 @@ impl Default for KERB_CERTIFICATE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_CERTIFICATE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2319,9 +2270,6 @@ impl Default for KERB_CERTIFICATE_LOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_CERTIFICATE_LOGON {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KERB_CERTIFICATE_LOGON_FLAG_CHECK_DUPLICATES: u32 = 1u32;
 pub const KERB_CERTIFICATE_LOGON_FLAG_USE_CERTIFICATE_INFO: u32 = 2u32;
 #[repr(C)]
@@ -2339,9 +2287,6 @@ impl Default for KERB_CERTIFICATE_S4U_LOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_CERTIFICATE_S4U_LOGON {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KERB_CERTIFICATE_S4U_LOGON_FLAG_CHECK_DUPLICATES: u32 = 1u32;
 pub const KERB_CERTIFICATE_S4U_LOGON_FLAG_CHECK_LOGONHOURS: u32 = 2u32;
 pub const KERB_CERTIFICATE_S4U_LOGON_FLAG_FAIL_IF_NT_AUTH_POLICY_REQUIRED: u32 = 4u32;
@@ -2357,9 +2302,6 @@ impl Default for KERB_CERTIFICATE_UNLOCK_LOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_CERTIFICATE_UNLOCK_LOGON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_CHANGEPASSWORD_REQUEST {
@@ -2374,9 +2316,6 @@ impl Default for KERB_CHANGEPASSWORD_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_CHANGEPASSWORD_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_CHECKSUM_CRC32: u32 = 1u32;
 pub const KERB_CHECKSUM_DES_MAC: i32 = -133i32;
@@ -2413,9 +2352,6 @@ impl Default for KERB_CLEANUP_MACHINE_PKINIT_CREDS_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_CLEANUP_MACHINE_PKINIT_CREDS_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_CLOUD_KERBEROS_DEBUG_DATA {
@@ -2426,9 +2362,6 @@ impl Default for KERB_CLOUD_KERBEROS_DEBUG_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_CLOUD_KERBEROS_DEBUG_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_CLOUD_KERBEROS_DEBUG_DATA_V0 {
@@ -2438,9 +2371,6 @@ impl Default for KERB_CLOUD_KERBEROS_DEBUG_DATA_V0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_CLOUD_KERBEROS_DEBUG_DATA_V0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_CLOUD_KERBEROS_DEBUG_DATA_VERSION: u32 = 1u32;
 #[repr(C)]
@@ -2453,9 +2383,6 @@ impl Default for KERB_CLOUD_KERBEROS_DEBUG_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_CLOUD_KERBEROS_DEBUG_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2470,9 +2397,6 @@ impl Default for KERB_CLOUD_KERBEROS_DEBUG_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_CLOUD_KERBEROS_DEBUG_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_CRYPTO_KEY {
@@ -2485,9 +2409,6 @@ impl Default for KERB_CRYPTO_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_CRYPTO_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_CRYPTO_KEY32 {
@@ -2499,9 +2420,6 @@ impl Default for KERB_CRYPTO_KEY32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_CRYPTO_KEY32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2526,9 +2444,6 @@ impl Default for KERB_DECRYPT_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_DECRYPT_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_DECRYPT_RESPONSE {
@@ -2538,9 +2453,6 @@ impl Default for KERB_DECRYPT_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_DECRYPT_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_ETYPE_AES128_CTS_HMAC_SHA1_96: u32 = 17u32;
 pub const KERB_ETYPE_AES128_CTS_HMAC_SHA1_96_PLAIN: i32 = -148i32;
@@ -2593,9 +2505,6 @@ impl Default for KERB_EXTERNAL_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_EXTERNAL_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_EXTERNAL_TICKET {
@@ -2621,9 +2530,6 @@ impl Default for KERB_EXTERNAL_TICKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_EXTERNAL_TICKET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_INTERACTIVE_LOGON {
@@ -2636,9 +2542,6 @@ impl Default for KERB_INTERACTIVE_LOGON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_INTERACTIVE_LOGON {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2665,9 +2568,6 @@ impl Default for KERB_INTERACTIVE_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_INTERACTIVE_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_INTERACTIVE_UNLOCK_LOGON {
@@ -2678,9 +2578,6 @@ impl Default for KERB_INTERACTIVE_UNLOCK_LOGON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_INTERACTIVE_UNLOCK_LOGON {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_LOGON_FLAG_ALLOW_EXPIRED_TICKET: u32 = 1u32;
 pub const KERB_LOGON_FLAG_REDIRECTED: u32 = 2u32;
@@ -2699,9 +2596,6 @@ impl Default for KERB_NET_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_NET_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_NET_ADDRESSES {
@@ -2712,9 +2606,6 @@ impl Default for KERB_NET_ADDRESSES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_NET_ADDRESSES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2733,9 +2624,6 @@ impl Default for KERB_PURGE_BINDING_CACHE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_PURGE_BINDING_CACHE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_PURGE_KDC_PROXY_CACHE_REQUEST {
@@ -2748,9 +2636,6 @@ impl Default for KERB_PURGE_KDC_PROXY_CACHE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_PURGE_KDC_PROXY_CACHE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_PURGE_KDC_PROXY_CACHE_RESPONSE {
@@ -2761,9 +2646,6 @@ impl Default for KERB_PURGE_KDC_PROXY_CACHE_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_PURGE_KDC_PROXY_CACHE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2778,9 +2660,6 @@ impl Default for KERB_PURGE_TKT_CACHE_EX_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_PURGE_TKT_CACHE_EX_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_PURGE_TKT_CACHE_REQUEST {
@@ -2794,9 +2673,6 @@ impl Default for KERB_PURGE_TKT_CACHE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_PURGE_TKT_CACHE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_QUERY_BINDING_CACHE_REQUEST {
@@ -2806,9 +2682,6 @@ impl Default for KERB_QUERY_BINDING_CACHE_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_QUERY_BINDING_CACHE_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2822,9 +2695,6 @@ impl Default for KERB_QUERY_BINDING_CACHE_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_QUERY_BINDING_CACHE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_QUERY_DOMAIN_EXTENDED_POLICIES_REQUEST {
@@ -2836,9 +2706,6 @@ impl Default for KERB_QUERY_DOMAIN_EXTENDED_POLICIES_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_QUERY_DOMAIN_EXTENDED_POLICIES_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2853,9 +2720,6 @@ impl Default for KERB_QUERY_DOMAIN_EXTENDED_POLICIES_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_QUERY_DOMAIN_EXTENDED_POLICIES_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KERB_QUERY_DOMAIN_EXTENDED_POLICIES_RESPONSE_FLAG_DAC_DISABLED: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2869,9 +2733,6 @@ impl Default for KERB_QUERY_KDC_PROXY_CACHE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_QUERY_KDC_PROXY_CACHE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_QUERY_KDC_PROXY_CACHE_RESPONSE {
@@ -2883,9 +2744,6 @@ impl Default for KERB_QUERY_KDC_PROXY_CACHE_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_QUERY_KDC_PROXY_CACHE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2899,9 +2757,6 @@ impl Default for KERB_QUERY_S4U2PROXY_CACHE_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_QUERY_S4U2PROXY_CACHE_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_QUERY_S4U2PROXY_CACHE_RESPONSE {
@@ -2913,9 +2768,6 @@ impl Default for KERB_QUERY_S4U2PROXY_CACHE_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_QUERY_S4U2PROXY_CACHE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2929,9 +2781,6 @@ impl Default for KERB_QUERY_TKT_CACHE_EX2_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_QUERY_TKT_CACHE_EX2_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_QUERY_TKT_CACHE_EX3_RESPONSE {
@@ -2943,9 +2792,6 @@ impl Default for KERB_QUERY_TKT_CACHE_EX3_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_QUERY_TKT_CACHE_EX3_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2959,9 +2805,6 @@ impl Default for KERB_QUERY_TKT_CACHE_EX_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_QUERY_TKT_CACHE_EX_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_QUERY_TKT_CACHE_REQUEST {
@@ -2972,9 +2815,6 @@ impl Default for KERB_QUERY_TKT_CACHE_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_QUERY_TKT_CACHE_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2987,9 +2827,6 @@ impl Default for KERB_QUERY_TKT_CACHE_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_QUERY_TKT_CACHE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_REFRESH_POLICY_KDC: u32 = 2u32;
 pub const KERB_REFRESH_POLICY_KERBEROS: u32 = 1u32;
@@ -3004,9 +2841,6 @@ impl Default for KERB_REFRESH_POLICY_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_REFRESH_POLICY_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_REFRESH_POLICY_RESPONSE {
@@ -3017,9 +2851,6 @@ impl Default for KERB_REFRESH_POLICY_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_REFRESH_POLICY_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_REFRESH_SCCRED_GETTGT: u32 = 1u32;
 pub const KERB_REFRESH_SCCRED_RELEASE: u32 = 0u32;
@@ -3035,9 +2866,6 @@ impl Default for KERB_REFRESH_SCCRED_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_REFRESH_SCCRED_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_REQUEST_ADD_CREDENTIAL: KERB_REQUEST_FLAGS = KERB_REQUEST_FLAGS(1u32);
 #[repr(transparent)]
@@ -3059,9 +2887,6 @@ impl Default for KERB_RETRIEVE_KEY_TAB_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_RETRIEVE_KEY_TAB_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_RETRIEVE_KEY_TAB_RESPONSE {
@@ -3073,9 +2898,6 @@ impl Default for KERB_RETRIEVE_KEY_TAB_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_RETRIEVE_KEY_TAB_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_RETRIEVE_TICKET_AS_KERB_CRED: u32 = 8u32;
 pub const KERB_RETRIEVE_TICKET_CACHE_TICKET: u32 = 32u32;
@@ -3103,10 +2925,6 @@ impl Default for KERB_RETRIEVE_TKT_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Credentials")]
-impl windows_core::TypeKind for KERB_RETRIEVE_TKT_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_RETRIEVE_TKT_RESPONSE {
@@ -3116,9 +2934,6 @@ impl Default for KERB_RETRIEVE_TKT_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_RETRIEVE_TKT_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3132,9 +2947,6 @@ impl Default for KERB_S4U2PROXY_CACHE_ENTRY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_S4U2PROXY_CACHE_ENTRY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_S4U2PROXY_CACHE_ENTRY_INFO_FLAG_NEGATIVE: u32 = 1u32;
 #[repr(C)]
@@ -3153,9 +2965,6 @@ impl Default for KERB_S4U2PROXY_CRED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_S4U2PROXY_CRED {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KERB_S4U2PROXY_CRED_FLAG_NEGATIVE: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3169,9 +2978,6 @@ impl Default for KERB_S4U_LOGON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_S4U_LOGON {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_S4U_LOGON_FLAG_CHECK_LOGONHOURS: u32 = 2u32;
 pub const KERB_S4U_LOGON_FLAG_IDENTIFY: u32 = 8u32;
@@ -3198,10 +3004,6 @@ impl Default for KERB_SETPASSWORD_EX_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Credentials")]
-impl windows_core::TypeKind for KERB_SETPASSWORD_EX_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Credentials")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3220,10 +3022,6 @@ impl Default for KERB_SETPASSWORD_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Credentials")]
-impl windows_core::TypeKind for KERB_SETPASSWORD_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KERB_SETPASS_USE_CREDHANDLE: u32 = 2u32;
 pub const KERB_SETPASS_USE_LOGONID: u32 = 1u32;
 #[repr(C)]
@@ -3239,9 +3037,6 @@ impl Default for KERB_SMART_CARD_LOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_SMART_CARD_LOGON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_SMART_CARD_PROFILE {
@@ -3254,9 +3049,6 @@ impl Default for KERB_SMART_CARD_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_SMART_CARD_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_SMART_CARD_UNLOCK_LOGON {
@@ -3267,9 +3059,6 @@ impl Default for KERB_SMART_CARD_UNLOCK_LOGON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_SMART_CARD_UNLOCK_LOGON {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3286,9 +3075,6 @@ impl Default for KERB_SUBMIT_TKT_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_SUBMIT_TKT_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_TICKET_CACHE_INFO {
@@ -3304,9 +3090,6 @@ impl Default for KERB_TICKET_CACHE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_TICKET_CACHE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3325,9 +3108,6 @@ impl Default for KERB_TICKET_CACHE_INFO_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_TICKET_CACHE_INFO_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3348,9 +3128,6 @@ impl Default for KERB_TICKET_CACHE_INFO_EX2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_TICKET_CACHE_INFO_EX2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3373,9 +3150,6 @@ impl Default for KERB_TICKET_CACHE_INFO_EX3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_TICKET_CACHE_INFO_EX3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3445,9 +3219,6 @@ impl Default for KERB_TICKET_LOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_TICKET_LOGON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_TICKET_PROFILE {
@@ -3459,9 +3230,6 @@ impl Default for KERB_TICKET_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERB_TICKET_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERB_TICKET_UNLOCK_LOGON {
@@ -3472,9 +3240,6 @@ impl Default for KERB_TICKET_UNLOCK_LOGON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_TICKET_UNLOCK_LOGON {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_TRANSFER_CRED_CLEANUP_CREDENTIALS: u32 = 2u32;
 #[repr(C)]
@@ -3489,9 +3254,6 @@ impl Default for KERB_TRANSFER_CRED_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERB_TRANSFER_CRED_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERB_TRANSFER_CRED_WITH_TICKETS: u32 = 1u32;
 pub const KERB_USE_DEFAULT_TICKET_FLAGS: u32 = 0u32;
@@ -3532,10 +3294,6 @@ impl Default for KSEC_LIST_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KSEC_LIST_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KSecNonPaged: KSEC_CONTEXT_TYPE = KSEC_CONTEXT_TYPE(1i32);
 pub const KSecPaged: KSEC_CONTEXT_TYPE = KSEC_CONTEXT_TYPE(0i32);
@@ -3624,9 +3382,6 @@ impl Default for LOGON_HOURS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOGON_HOURS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LOGON_LM_V2: u32 = 4096u32;
 pub const LOGON_MANAGED_SERVICE: u32 = 524288u32;
 pub const LOGON_NOENCRYPTION: MSV_SUB_AUTHENTICATION_FILTER = MSV_SUB_AUTHENTICATION_FILTER(2u32);
@@ -3675,9 +3430,6 @@ impl Default for LSA_AUTH_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_AUTH_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct LSA_AUTH_INFORMATION_AUTH_TYPE(pub u32);
@@ -3702,9 +3454,6 @@ impl Default for LSA_DISPATCH_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_DISPATCH_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LSA_ENUMERATION_INFORMATION {
@@ -3714,9 +3463,6 @@ impl Default for LSA_ENUMERATION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_ENUMERATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3729,9 +3475,6 @@ impl Default for LSA_FOREST_TRUST_BINARY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_FOREST_TRUST_BINARY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LSA_FOREST_TRUST_COLLISION_INFORMATION {
@@ -3742,9 +3485,6 @@ impl Default for LSA_FOREST_TRUST_COLLISION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_FOREST_TRUST_COLLISION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3758,9 +3498,6 @@ impl Default for LSA_FOREST_TRUST_COLLISION_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_FOREST_TRUST_COLLISION_RECORD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3777,9 +3514,6 @@ impl Default for LSA_FOREST_TRUST_DOMAIN_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_FOREST_TRUST_DOMAIN_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LSA_FOREST_TRUST_INFORMATION {
@@ -3791,9 +3525,6 @@ impl Default for LSA_FOREST_TRUST_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_FOREST_TRUST_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LSA_FOREST_TRUST_INFORMATION2 {
@@ -3804,9 +3535,6 @@ impl Default for LSA_FOREST_TRUST_INFORMATION2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_FOREST_TRUST_INFORMATION2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3821,9 +3549,6 @@ impl Default for LSA_FOREST_TRUST_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_FOREST_TRUST_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union LSA_FOREST_TRUST_RECORD_0 {
@@ -3835,9 +3560,6 @@ impl Default for LSA_FOREST_TRUST_RECORD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_FOREST_TRUST_RECORD_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3852,9 +3574,6 @@ impl Default for LSA_FOREST_TRUST_RECORD2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_FOREST_TRUST_RECORD2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union LSA_FOREST_TRUST_RECORD2_0 {
@@ -3867,9 +3586,6 @@ impl Default for LSA_FOREST_TRUST_RECORD2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_FOREST_TRUST_RECORD2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3886,9 +3602,6 @@ impl Default for LSA_FOREST_TRUST_SCANNER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_FOREST_TRUST_SCANNER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LSA_FTRECORD_DISABLED_REASONS: i32 = 65535i32;
 pub const LSA_GLOBAL_SECRET_PREFIX: windows_core::PCWSTR = windows_core::w!("G$");
@@ -3925,9 +3638,6 @@ impl Default for LSA_LAST_INTER_LOGON_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_LAST_INTER_LOGON_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LSA_LOCAL_SECRET_PREFIX: windows_core::PCWSTR = windows_core::w!("L$");
 pub const LSA_LOCAL_SECRET_PREFIX_LENGTH: u32 = 2u32;
 pub const LSA_LOOKUP_DISALLOW_CONNECTED_ACCOUNT_INTERNET_SID: u32 = 2147483648u32;
@@ -3960,9 +3670,6 @@ impl Default for LSA_OBJECT_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_OBJECT_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LSA_QUERY_CLIENT_PRELOGON_SESSION_ID: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3974,9 +3681,6 @@ impl Default for LSA_REFERENCED_DOMAIN_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_REFERENCED_DOMAIN_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LSA_SCANNER_INFO_ADMIN_ALL_FLAGS: i32 = 1i32;
 pub const LSA_SCANNER_INFO_DISABLE_AUTH_TARGET_VALIDATION: i32 = 1i32;
@@ -4055,10 +3759,6 @@ impl Default for LSA_SECPKG_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Security_Credentials", feature = "Win32_System_Threading"))]
-impl windows_core::TypeKind for LSA_SECPKG_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LSA_SECRET_MAXIMUM_COUNT: i32 = 4096i32;
 pub const LSA_SECRET_MAXIMUM_LENGTH: i32 = 512i32;
 pub const LSA_SID_DISABLED_ADMIN: i32 = 1i32;
@@ -4075,9 +3775,6 @@ impl Default for LSA_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LSA_TLN_DISABLED_ADMIN: i32 = 2i32;
 pub const LSA_TLN_DISABLED_CONFLICT: i32 = 4i32;
 pub const LSA_TLN_DISABLED_NEW: i32 = 1i32;
@@ -4091,9 +3788,6 @@ impl Default for LSA_TOKEN_INFORMATION_NULL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_TOKEN_INFORMATION_NULL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4114,9 +3808,6 @@ impl Default for LSA_TOKEN_INFORMATION_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_TOKEN_INFORMATION_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LSA_TOKEN_INFORMATION_V3 {
@@ -4136,9 +3827,6 @@ impl Default for LSA_TOKEN_INFORMATION_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_TOKEN_INFORMATION_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LSA_TRANSLATED_NAME {
@@ -4151,9 +3839,6 @@ impl Default for LSA_TRANSLATED_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_TRANSLATED_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LSA_TRANSLATED_SID {
@@ -4165,9 +3850,6 @@ impl Default for LSA_TRANSLATED_SID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_TRANSLATED_SID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4182,9 +3864,6 @@ impl Default for LSA_TRANSLATED_SID2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LSA_TRANSLATED_SID2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LSA_TRUST_INFORMATION {
@@ -4195,9 +3874,6 @@ impl Default for LSA_TRUST_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_TRUST_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4210,9 +3886,6 @@ impl Default for LSA_UNICODE_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LSA_UNICODE_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LocalUserCredKey: MSV1_0_CREDENTIAL_KEY_TYPE = MSV1_0_CREDENTIAL_KEY_TYPE(3i32);
 pub const LsaTokenInformationNull: LSA_TOKEN_INFORMATION_TYPE = LSA_TOKEN_INFORMATION_TYPE(0i32);
@@ -4253,9 +3926,6 @@ impl Default for MSV1_0_AV_PAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_AV_PAIR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MSV1_0_CHALLENGE_LENGTH: u32 = 8u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4272,9 +3942,6 @@ impl Default for MSV1_0_CHANGEPASSWORD_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_CHANGEPASSWORD_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MSV1_0_CHANGEPASSWORD_RESPONSE {
@@ -4286,9 +3953,6 @@ impl Default for MSV1_0_CHANGEPASSWORD_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSV1_0_CHANGEPASSWORD_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSV1_0_CHECK_LOGONHOURS_FOR_S4U: u32 = 262144u32;
 pub const MSV1_0_CLEARTEXT_PASSWORD_ALLOWED: MSV_SUBAUTH_LOGON_PARAMETER_CONTROL = MSV_SUBAUTH_LOGON_PARAMETER_CONTROL(2u32);
@@ -4302,9 +3966,6 @@ impl Default for MSV1_0_CREDENTIAL_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSV1_0_CREDENTIAL_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSV1_0_CREDENTIAL_KEY_LENGTH: u32 = 20u32;
 #[repr(transparent)]
@@ -4339,9 +4000,6 @@ impl Default for MSV1_0_INTERACTIVE_LOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_INTERACTIVE_LOGON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MSV1_0_INTERACTIVE_PROFILE {
@@ -4367,9 +4025,6 @@ impl Default for MSV1_0_INTERACTIVE_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_INTERACTIVE_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MSV1_0_INTERNET_DOMAIN: u32 = 524288u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4382,9 +4037,6 @@ impl Default for MSV1_0_IUM_SUPPLEMENTAL_CREDENTIAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSV1_0_IUM_SUPPLEMENTAL_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSV1_0_LANMAN_SESSION_KEY_LENGTH: u32 = 8u32;
 #[repr(C)]
@@ -4404,9 +4056,6 @@ impl Default for MSV1_0_LM20_LOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_LM20_LOGON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MSV1_0_LM20_LOGON_PROFILE {
@@ -4424,9 +4073,6 @@ impl Default for MSV1_0_LM20_LOGON_PROFILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSV1_0_LM20_LOGON_PROFILE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4453,9 +4099,6 @@ impl Default for MSV1_0_NTLM3_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_NTLM3_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MSV1_0_NTLM3_RESPONSE_LENGTH: u32 = 16u32;
 pub const MSV1_0_OWF_PASSWORD_LENGTH: u32 = 16u32;
 pub const MSV1_0_PACKAGE_NAME: windows_core::PCSTR = windows_core::s!("MICROSOFT_AUTHENTICATION_PACKAGE_V1_0");
@@ -4475,9 +4118,6 @@ impl Default for MSV1_0_PASSTHROUGH_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_PASSTHROUGH_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MSV1_0_PASSTHROUGH_RESPONSE {
@@ -4490,9 +4130,6 @@ impl Default for MSV1_0_PASSTHROUGH_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSV1_0_PASSTHROUGH_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSV1_0_PASSTHRU: MSV1_0 = MSV1_0(1u32);
 #[repr(transparent)]
@@ -4516,9 +4153,6 @@ impl Default for MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_REMOTE_SUPPLEMENTAL_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MSV1_0_RETURN_PASSWORD_EXPIRY: MSV_SUBAUTH_LOGON_PARAMETER_CONTROL = MSV_SUBAUTH_LOGON_PARAMETER_CONTROL(64u32);
 pub const MSV1_0_RETURN_PROFILE_PATH: MSV_SUBAUTH_LOGON_PARAMETER_CONTROL = MSV_SUBAUTH_LOGON_PARAMETER_CONTROL(512u32);
 pub const MSV1_0_RETURN_USER_PARAMETERS: MSV_SUBAUTH_LOGON_PARAMETER_CONTROL = MSV_SUBAUTH_LOGON_PARAMETER_CONTROL(8u32);
@@ -4535,9 +4169,6 @@ impl Default for MSV1_0_S4U_LOGON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSV1_0_S4U_LOGON {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSV1_0_S4U_LOGON_FLAG_CHECK_LOGONHOURS: u32 = 2u32;
 pub const MSV1_0_SHA_PASSWORD_LENGTH: u32 = 20u32;
@@ -4571,9 +4202,6 @@ impl Default for MSV1_0_SUBAUTH_LOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_SUBAUTH_LOGON {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MSV1_0_SUBAUTH_LOGON_HOURS: u32 = 8u32;
 pub const MSV1_0_SUBAUTH_PASSWORD: u32 = 2u32;
 pub const MSV1_0_SUBAUTH_PASSWORD_EXPIRY: u32 = 32u32;
@@ -4590,9 +4218,6 @@ impl Default for MSV1_0_SUBAUTH_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_SUBAUTH_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MSV1_0_SUBAUTH_RESPONSE {
@@ -4604,9 +4229,6 @@ impl Default for MSV1_0_SUBAUTH_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSV1_0_SUBAUTH_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSV1_0_SUBAUTH_WORKSTATIONS: u32 = 4u32;
 #[repr(C)]
@@ -4622,9 +4244,6 @@ impl Default for MSV1_0_SUPPLEMENTAL_CREDENTIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSV1_0_SUPPLEMENTAL_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MSV1_0_SUPPLEMENTAL_CREDENTIAL_V2 {
@@ -4637,9 +4256,6 @@ impl Default for MSV1_0_SUPPLEMENTAL_CREDENTIAL_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSV1_0_SUPPLEMENTAL_CREDENTIAL_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4655,9 +4271,6 @@ impl Default for MSV1_0_SUPPLEMENTAL_CREDENTIAL_V3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSV1_0_SUPPLEMENTAL_CREDENTIAL_V3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSV1_0_TRY_GUEST_ACCOUNT_ONLY: MSV_SUBAUTH_LOGON_PARAMETER_CONTROL = MSV_SUBAUTH_LOGON_PARAMETER_CONTROL(256u32);
 pub const MSV1_0_TRY_SPECIFIED_DOMAIN_ONLY: MSV_SUBAUTH_LOGON_PARAMETER_CONTROL = MSV_SUBAUTH_LOGON_PARAMETER_CONTROL(1024u32);
@@ -4684,10 +4297,6 @@ impl Default for MSV1_0_VALIDATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_PasswordManagement")]
-impl windows_core::TypeKind for MSV1_0_VALIDATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSV1_0_VALIDATION_KICKOFF_TIME: u32 = 2u32;
 pub const MSV1_0_VALIDATION_LOGOFF_TIME: u32 = 1u32;
@@ -4834,9 +4443,6 @@ impl Default for NEGOTIATE_CALLER_NAME_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NEGOTIATE_CALLER_NAME_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NEGOTIATE_CALLER_NAME_RESPONSE {
@@ -4847,9 +4453,6 @@ impl Default for NEGOTIATE_CALLER_NAME_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NEGOTIATE_CALLER_NAME_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NEGOTIATE_MAX_PREFIX: u32 = 32u32;
 #[repr(transparent)]
@@ -4870,9 +4473,6 @@ impl Default for NEGOTIATE_PACKAGE_PREFIX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NEGOTIATE_PACKAGE_PREFIX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NEGOTIATE_PACKAGE_PREFIXES {
@@ -4886,9 +4486,6 @@ impl Default for NEGOTIATE_PACKAGE_PREFIXES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NEGOTIATE_PACKAGE_PREFIXES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETLOGON_GENERIC_INFO {
@@ -4901,9 +4498,6 @@ impl Default for NETLOGON_GENERIC_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETLOGON_GENERIC_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_PasswordManagement")]
@@ -4919,10 +4513,6 @@ impl Default for NETLOGON_INTERACTIVE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_PasswordManagement")]
-impl windows_core::TypeKind for NETLOGON_INTERACTIVE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NETLOGON_LOGON_IDENTITY_INFO {
@@ -4936,9 +4526,6 @@ impl Default for NETLOGON_LOGON_IDENTITY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NETLOGON_LOGON_IDENTITY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4956,9 +4543,6 @@ impl Default for NETLOGON_NETWORK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETLOGON_NETWORK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_PasswordManagement")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4972,10 +4556,6 @@ impl Default for NETLOGON_SERVICE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_PasswordManagement")]
-impl windows_core::TypeKind for NETLOGON_SERVICE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NGC_DATA_FLAG_IS_CLOUD_TRUST_CRED: u32 = 8u32;
 pub const NGC_DATA_FLAG_IS_SMARTCARD_DATA: u32 = 4u32;
@@ -5054,9 +4634,6 @@ impl Default for PKU2U_CERTIFICATE_S4U_LOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PKU2U_CERTIFICATE_S4U_LOGON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PKU2U_CERT_BLOB {
@@ -5067,9 +4644,6 @@ impl Default for PKU2U_CERT_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PKU2U_CERT_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5084,9 +4658,6 @@ impl Default for PKU2U_CREDUI_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PKU2U_CREDUI_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5222,9 +4793,6 @@ impl Default for POLICY_ACCOUNT_DOMAIN_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICY_ACCOUNT_DOMAIN_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLICY_AUDIT_CATEGORIES_INFO {
@@ -5235,9 +4803,6 @@ impl Default for POLICY_AUDIT_CATEGORIES_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_AUDIT_CATEGORIES_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5250,9 +4815,6 @@ impl Default for POLICY_AUDIT_EVENTS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_AUDIT_EVENTS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POLICY_AUDIT_EVENT_FAILURE: i32 = 2i32;
 pub const POLICY_AUDIT_EVENT_NONE: i32 = 4i32;
@@ -5272,9 +4834,6 @@ impl Default for POLICY_AUDIT_FULL_QUERY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICY_AUDIT_FULL_QUERY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLICY_AUDIT_FULL_SET_INFO {
@@ -5284,9 +4843,6 @@ impl Default for POLICY_AUDIT_FULL_SET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_AUDIT_FULL_SET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POLICY_AUDIT_LOG_ADMIN: i32 = 512i32;
 #[repr(C)]
@@ -5304,9 +4860,6 @@ impl Default for POLICY_AUDIT_LOG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICY_AUDIT_LOG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLICY_AUDIT_SID_ARRAY {
@@ -5318,9 +4871,6 @@ impl Default for POLICY_AUDIT_SID_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICY_AUDIT_SID_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLICY_AUDIT_SUBCATEGORIES_INFO {
@@ -5331,9 +4881,6 @@ impl Default for POLICY_AUDIT_SUBCATEGORIES_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_AUDIT_SUBCATEGORIES_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POLICY_CREATE_ACCOUNT: i32 = 16i32;
 pub const POLICY_CREATE_PRIVILEGE: i32 = 64i32;
@@ -5347,9 +4894,6 @@ impl Default for POLICY_DEFAULT_QUOTA_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_DEFAULT_QUOTA_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5365,9 +4909,6 @@ impl Default for POLICY_DNS_DOMAIN_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICY_DNS_DOMAIN_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLICY_DOMAIN_EFS_INFO {
@@ -5378,9 +4919,6 @@ impl Default for POLICY_DOMAIN_EFS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_DOMAIN_EFS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5399,9 +4937,6 @@ impl Default for POLICY_DOMAIN_KERBEROS_TICKET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_DOMAIN_KERBEROS_TICKET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POLICY_GET_PRIVATE_INFORMATION: i32 = 4i32;
 #[repr(transparent)]
@@ -5422,9 +4957,6 @@ impl Default for POLICY_LSA_SERVER_ROLE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICY_LSA_SERVER_ROLE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLICY_MACHINE_ACCT_INFO {
@@ -5435,9 +4967,6 @@ impl Default for POLICY_MACHINE_ACCT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_MACHINE_ACCT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5451,9 +4980,6 @@ impl Default for POLICY_MACHINE_ACCT_INFO2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICY_MACHINE_ACCT_INFO2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLICY_MODIFICATION_INFO {
@@ -5464,9 +4990,6 @@ impl Default for POLICY_MODIFICATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_MODIFICATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POLICY_NOTIFICATION: i32 = 4096i32;
 #[repr(transparent)]
@@ -5482,9 +5005,6 @@ impl Default for POLICY_PD_ACCOUNT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICY_PD_ACCOUNT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POLICY_PRIMARY_DOMAIN_INFO {
@@ -5495,9 +5015,6 @@ impl Default for POLICY_PRIMARY_DOMAIN_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_PRIMARY_DOMAIN_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POLICY_QOS_ALLOW_LOCAL_ROOT_CERT_STORE: u32 = 32u32;
 pub const POLICY_QOS_DHCP_SERVER_ALLOWED: u32 = 128u32;
@@ -5517,9 +5034,6 @@ impl Default for POLICY_REPLICA_SOURCE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_REPLICA_SOURCE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const POLICY_SERVER_ADMIN: i32 = 1024i32;
 pub const POLICY_SET_AUDIT_REQUIREMENTS: i32 = 256i32;
@@ -5571,9 +5085,6 @@ impl Default for PctPublicKey {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PctPublicKey {
-    type TypeKind = windows_core::CopyType;
 }
 pub const Pku2uCertificateS4ULogon: PKU2U_LOGON_SUBMIT_TYPE = PKU2U_LOGON_SUBMIT_TYPE(14i32);
 pub const PolicyAccountDomainInformation: POLICY_INFORMATION_CLASS = POLICY_INFORMATION_CLASS(5i32);
@@ -5655,9 +5166,6 @@ impl Default for SAM_REGISTER_MAPPING_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SAM_REGISTER_MAPPING_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SAM_REGISTER_MAPPING_LIST {
@@ -5669,9 +5177,6 @@ impl Default for SAM_REGISTER_MAPPING_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SAM_REGISTER_MAPPING_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SAM_REGISTER_MAPPING_TABLE {
@@ -5682,9 +5187,6 @@ impl Default for SAM_REGISTER_MAPPING_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SAM_REGISTER_MAPPING_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5706,9 +5208,6 @@ impl Default for SCHANNEL_ALERT_TOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCHANNEL_ALERT_TOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SCHANNEL_ALERT_TOKEN_ALERT_TYPE(pub u32);
@@ -5725,9 +5224,6 @@ impl Default for SCHANNEL_CERT_HASH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCHANNEL_CERT_HASH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCHANNEL_CERT_HASH_STORE {
@@ -5741,9 +5237,6 @@ impl Default for SCHANNEL_CERT_HASH_STORE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCHANNEL_CERT_HASH_STORE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -5760,10 +5253,6 @@ impl Default for SCHANNEL_CLIENT_SIGNATURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SCHANNEL_CLIENT_SIGNATURE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -5789,10 +5278,6 @@ impl Default for SCHANNEL_CRED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SCHANNEL_CRED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5849,9 +5334,6 @@ impl Default for SCHANNEL_SESSION_TOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCHANNEL_SESSION_TOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SCHANNEL_SESSION_TOKEN_FLAGS(pub u32);
@@ -5871,9 +5353,6 @@ impl Default for SCH_CRED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCH_CRED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -5896,10 +5375,6 @@ impl Default for SCH_CREDENTIALS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SCH_CREDENTIALS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCH_CREDENTIALS_VERSION: u32 = 5u32;
 pub const SCH_CRED_AUTO_CRED_VALIDATION: SCHANNEL_CRED_FLAGS = SCHANNEL_CRED_FLAGS(32u32);
@@ -5937,9 +5412,6 @@ impl Default for SCH_CRED_PUBLIC_CERTCHAIN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCH_CRED_PUBLIC_CERTCHAIN {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCH_CRED_RESTRICTED_ROOTS: u32 = 8192u32;
 pub const SCH_CRED_REVOCATION_CHECK_CACHE_ONLY: u32 = 16384u32;
 pub const SCH_CRED_REVOCATION_CHECK_CHAIN: SCHANNEL_CRED_FLAGS = SCHANNEL_CRED_FLAGS(512u32);
@@ -5956,9 +5428,6 @@ impl Default for SCH_CRED_SECRET_CAPI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCH_CRED_SECRET_CAPI {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCH_CRED_SECRET_PRIVKEY {
@@ -5971,9 +5440,6 @@ impl Default for SCH_CRED_SECRET_PRIVKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCH_CRED_SECRET_PRIVKEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCH_CRED_SNI_CREDENTIAL: u32 = 524288u32;
 pub const SCH_CRED_SNI_ENABLE_OCSP: u32 = 1048576u32;
@@ -5997,9 +5463,6 @@ impl Default for SCH_EXTENSION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCH_EXTENSION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCH_MACHINE_CERT_HASH: u32 = 1u32;
 pub const SCH_MAX_EXT_SUBSCRIPTIONS: u32 = 2u32;
@@ -6063,9 +5526,6 @@ impl Default for SECPKG_APP_MODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_APP_MODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6169,9 +5629,6 @@ impl Default for SECPKG_BYTE_VECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_BYTE_VECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SECPKG_CALLFLAGS_APPCONTAINER: u32 = 1u32;
 pub const SECPKG_CALLFLAGS_APPCONTAINER_AUTHCAPABLE: u32 = 2u32;
 pub const SECPKG_CALLFLAGS_APPCONTAINER_UPNCAPABLE: u32 = 8u32;
@@ -6194,9 +5651,6 @@ impl Default for SECPKG_CALL_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_CALL_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_CALL_IN_PROC: u32 = 16u32;
 pub const SECPKG_CALL_IS_TCB: u32 = 512u32;
@@ -6221,9 +5675,6 @@ impl Default for SECPKG_CALL_PACKAGE_PIN_DC_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_CALL_PACKAGE_PIN_DC_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_CALL_PACKAGE_TRANSFER_CRED_REQUEST {
@@ -6236,9 +5687,6 @@ impl Default for SECPKG_CALL_PACKAGE_TRANSFER_CRED_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_CALL_PACKAGE_TRANSFER_CRED_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_CALL_PACKAGE_TRANSFER_CRED_REQUEST_FLAG_CLEANUP_CREDENTIALS: u32 = 2u32;
 pub const SECPKG_CALL_PACKAGE_TRANSFER_CRED_REQUEST_FLAG_OPTIMISTIC_LOGON: u32 = 1u32;
@@ -6253,9 +5701,6 @@ impl Default for SECPKG_CALL_PACKAGE_UNPIN_ALL_DCS_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_CALL_PACKAGE_UNPIN_ALL_DCS_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_CALL_PROCESS_TERM: u32 = 256u32;
 pub const SECPKG_CALL_RECURSIVE: u32 = 8u32;
@@ -6285,9 +5730,6 @@ impl Default for SECPKG_CLIENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_CLIENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_CLIENT_INFO_EX {
@@ -6308,9 +5750,6 @@ impl Default for SECPKG_CLIENT_INFO_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_CLIENT_INFO_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SECPKG_CLIENT_PROCESS_TERMINATED: u32 = 1u32;
 pub const SECPKG_CLIENT_THREAD_TERMINATED: u32 = 2u32;
 pub const SECPKG_CONTEXT_EXPORT_DELETE_OLD: EXPORT_SECURITY_CONTEXT_FLAGS = EXPORT_SECURITY_CONTEXT_FLAGS(2u32);
@@ -6326,9 +5765,6 @@ impl Default for SECPKG_CONTEXT_THUNKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_CONTEXT_THUNKS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6355,9 +5791,6 @@ impl Default for SECPKG_CREDENTIAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_CREDENTIAL_ATTRIBUTE: u32 = 0u32;
 pub const SECPKG_CREDENTIAL_FLAGS_CALLER_HAS_TCB: u32 = 1u32;
@@ -6391,9 +5824,6 @@ impl Default for SECPKG_DLL_FUNCTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_DLL_FUNCTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_EVENT_NOTIFY {
@@ -6408,9 +5838,6 @@ impl Default for SECPKG_EVENT_NOTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_EVENT_NOTIFY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_EVENT_PACKAGE_CHANGE {
@@ -6423,9 +5850,6 @@ impl Default for SECPKG_EVENT_PACKAGE_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_EVENT_PACKAGE_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_EVENT_ROLE_CHANGE {
@@ -6437,9 +5861,6 @@ impl Default for SECPKG_EVENT_ROLE_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_EVENT_ROLE_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct SECPKG_EXTENDED_INFORMATION {
@@ -6450,9 +5871,6 @@ impl Default for SECPKG_EXTENDED_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_EXTENDED_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6469,9 +5887,6 @@ impl Default for SECPKG_EXTENDED_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_EXTENDED_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SECPKG_EXTENDED_INFORMATION_CLASS(pub i32);
@@ -6485,9 +5900,6 @@ impl Default for SECPKG_EXTRA_OIDS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_EXTRA_OIDS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_FLAG_ACCEPT_WIN32_NAME: u32 = 512u32;
 pub const SECPKG_FLAG_APPCONTAINER_CHECKS: u32 = 8388608u32;
@@ -6569,10 +5981,6 @@ impl Default for SECPKG_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Security_Credentials", feature = "Win32_System_Threading"))]
-impl windows_core::TypeKind for SECPKG_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_GSS_INFO {
@@ -6583,9 +5991,6 @@ impl Default for SECPKG_GSS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_GSS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_ID_NONE: u32 = 65535u32;
 pub const SECPKG_INTERFACE_VERSION: u32 = 65536u32;
@@ -6619,10 +6024,6 @@ impl Default for SECPKG_KERNEL_FUNCTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for SECPKG_KERNEL_FUNCTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6649,10 +6050,6 @@ impl Default for SECPKG_KERNEL_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for SECPKG_KERNEL_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SECPKG_LSAMODEINIT_NAME: windows_core::PCSTR = windows_core::s!("SpLsaModeInitialize");
 pub const SECPKG_MAX_OID_LENGTH: u32 = 32u32;
 pub const SECPKG_MSVAV_FLAGS_VALID: u32 = 1u32;
@@ -6667,9 +6064,6 @@ impl Default for SECPKG_MUTUAL_AUTH_LEVEL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_MUTUAL_AUTH_LEVEL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SECPKG_NAME_TYPE(pub i32);
@@ -6683,9 +6077,6 @@ impl Default for SECPKG_NEGO2_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_NEGO2_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_NEGOTIATION_COMPLETE: u32 = 0u32;
 pub const SECPKG_NEGOTIATION_DIRECT: u32 = 3u32;
@@ -6709,9 +6100,6 @@ impl Default for SECPKG_NTLM_TARGETINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_NTLM_TARGETINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_OPTIONS_PERMANENT: u32 = 1u32;
 pub const SECPKG_OPTIONS_TYPE_LSA: SECURITY_PACKAGE_OPTIONS_TYPE = SECURITY_PACKAGE_OPTIONS_TYPE(1u32);
@@ -6739,9 +6127,6 @@ impl Default for SECPKG_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_POST_LOGON_USER_INFO {
@@ -6753,9 +6138,6 @@ impl Default for SECPKG_POST_LOGON_USER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_POST_LOGON_USER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6779,9 +6161,6 @@ impl Default for SECPKG_PRIMARY_CRED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_PRIMARY_CRED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6809,9 +6188,6 @@ impl Default for SECPKG_PRIMARY_CRED_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_PRIMARY_CRED_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SECPKG_PRIMARY_CRED_EX_FLAGS_EX_DELEGATION_TOKEN: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6830,9 +6206,6 @@ impl Default for SECPKG_REDIRECTED_LOGON_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_REDIRECTED_LOGON_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SECPKG_REDIRECTED_LOGON_GUID_INITIALIZER: windows_core::GUID = windows_core::GUID::from_u128(0xc2be5457_82eb_483e_ae4e_7468ef14d509);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6845,9 +6218,6 @@ impl Default for SECPKG_SERIALIZED_OID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_SERIALIZED_OID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6862,9 +6232,6 @@ impl Default for SECPKG_SHORT_VECTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_SHORT_VECTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_STATE_CRED_ISOLATION_ENABLED: u32 = 32u32;
 pub const SECPKG_STATE_DOMAIN_CONTROLLER: u32 = 4u32;
@@ -6885,9 +6252,6 @@ impl Default for SECPKG_SUPPLEMENTAL_CRED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_SUPPLEMENTAL_CRED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_SUPPLEMENTAL_CRED_ARRAY {
@@ -6898,9 +6262,6 @@ impl Default for SECPKG_SUPPLEMENTAL_CRED_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_SUPPLEMENTAL_CRED_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6917,9 +6278,6 @@ impl Default for SECPKG_SUPPLIED_CREDENTIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_SUPPLIED_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_SURROGATE_LOGON {
@@ -6933,9 +6291,6 @@ impl Default for SECPKG_SURROGATE_LOGON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_SURROGATE_LOGON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_SURROGATE_LOGON_ENTRY {
@@ -6946,9 +6301,6 @@ impl Default for SECPKG_SURROGATE_LOGON_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_SURROGATE_LOGON_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_SURROGATE_LOGON_VERSION_1: u32 = 1u32;
 #[repr(C)]
@@ -6961,9 +6313,6 @@ impl Default for SECPKG_TARGETINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_TARGETINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECPKG_UNICODE_ATTRIBUTE: u32 = 2147483648u32;
 pub const SECPKG_USERMODEINIT_NAME: windows_core::PCSTR = windows_core::s!("SpUserModeInitialize");
@@ -6991,9 +6340,6 @@ impl Default for SECPKG_USER_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECPKG_USER_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SECPKG_WOW_CLIENT_DLL {
@@ -7003,9 +6349,6 @@ impl Default for SECPKG_WOW_CLIENT_DLL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECPKG_WOW_CLIENT_DLL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECQOP_WRAP_NO_ENCRYPT: u32 = 2147483649u32;
 pub const SECQOP_WRAP_OOB_DATA: u32 = 1073741824u32;
@@ -7048,9 +6391,6 @@ impl Default for SECURITY_LOGON_SESSION_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURITY_LOGON_SESSION_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SECURITY_LOGON_TYPE(pub i32);
@@ -7085,9 +6425,6 @@ impl Default for SECURITY_PACKAGE_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURITY_PACKAGE_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SECURITY_PACKAGE_OPTIONS_TYPE(pub u32);
@@ -7102,9 +6439,6 @@ impl Default for SECURITY_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURITY_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECURITY_SUPPORT_PROVIDER_INTERFACE_VERSION: u32 = 1u32;
 pub const SECURITY_SUPPORT_PROVIDER_INTERFACE_VERSION_2: u32 = 2u32;
@@ -7124,9 +6458,6 @@ impl Default for SECURITY_USER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURITY_USER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_APPLICATION_PROTOCOLS {
@@ -7137,9 +6468,6 @@ impl Default for SEC_APPLICATION_PROTOCOLS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_APPLICATION_PROTOCOLS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7152,9 +6480,6 @@ impl Default for SEC_APPLICATION_PROTOCOL_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_APPLICATION_PROTOCOL_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7173,9 +6498,6 @@ impl Default for SEC_CERTIFICATE_REQUEST_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_CERTIFICATE_REQUEST_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_CHANNEL_BINDINGS {
@@ -7192,9 +6514,6 @@ impl Default for SEC_CHANNEL_BINDINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_CHANNEL_BINDINGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SEC_CHANNEL_BINDINGS_AUDIT_BINDINGS: u32 = 1u32;
 #[repr(C)]
@@ -7218,9 +6537,6 @@ impl Default for SEC_CHANNEL_BINDINGS_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_CHANNEL_BINDINGS_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_CHANNEL_BINDINGS_RESULT {
@@ -7230,9 +6546,6 @@ impl Default for SEC_CHANNEL_BINDINGS_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_CHANNEL_BINDINGS_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SEC_CHANNEL_BINDINGS_RESULT_ABSENT: u32 = 2u32;
 pub const SEC_CHANNEL_BINDINGS_RESULT_CLIENT_SUPPORT: u32 = 1u32;
@@ -7252,9 +6565,6 @@ impl Default for SEC_DTLS_MTU {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_DTLS_MTU {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_FLAGS {
@@ -7264,9 +6574,6 @@ impl Default for SEC_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub type SEC_GET_KEY_FN = Option<unsafe extern "system" fn(arg: *mut core::ffi::c_void, principal: *mut core::ffi::c_void, keyver: u32, key: *mut *mut core::ffi::c_void, status: *mut windows_core::HRESULT)>;
 #[repr(C)]
@@ -7282,9 +6589,6 @@ impl Default for SEC_NEGOTIATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_NEGOTIATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_PRESHAREDKEY {
@@ -7295,9 +6599,6 @@ impl Default for SEC_PRESHAREDKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_PRESHAREDKEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7310,9 +6611,6 @@ impl Default for SEC_PRESHAREDKEY_IDENTITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_PRESHAREDKEY_IDENTITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_SRTP_MASTER_KEY_IDENTIFIER {
@@ -7324,9 +6622,6 @@ impl Default for SEC_SRTP_MASTER_KEY_IDENTIFIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_SRTP_MASTER_KEY_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_SRTP_PROTECTION_PROFILES {
@@ -7337,9 +6632,6 @@ impl Default for SEC_SRTP_PROTECTION_PROFILES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_SRTP_PROTECTION_PROFILES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7353,9 +6645,6 @@ impl Default for SEC_TOKEN_BINDING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_TOKEN_BINDING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7376,9 +6665,6 @@ impl Default for SEC_TRAFFIC_SECRETS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_TRAFFIC_SECRETS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SEC_TRAFFIC_SECRET_TYPE(pub i32);
@@ -7397,9 +6683,6 @@ impl Default for SEC_WINNT_AUTH_IDENTITY32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_WINNT_AUTH_IDENTITY32 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SEC_WINNT_AUTH_IDENTITY_ENCRYPT_FOR_SYSTEM: u32 = 4u32;
 pub const SEC_WINNT_AUTH_IDENTITY_ENCRYPT_SAME_LOGON: u32 = 1u32;
@@ -7425,9 +6708,6 @@ impl Default for SEC_WINNT_AUTH_IDENTITY_EX2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_WINNT_AUTH_IDENTITY_EX2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_WINNT_AUTH_IDENTITY_EX32 {
@@ -7447,9 +6727,6 @@ impl Default for SEC_WINNT_AUTH_IDENTITY_EX32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_WINNT_AUTH_IDENTITY_EX32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7471,9 +6748,6 @@ impl Default for SEC_WINNT_AUTH_IDENTITY_EXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_WINNT_AUTH_IDENTITY_EXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEC_WINNT_AUTH_IDENTITY_EXW {
@@ -7493,9 +6767,6 @@ impl Default for SEC_WINNT_AUTH_IDENTITY_EXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_WINNT_AUTH_IDENTITY_EXW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SEC_WINNT_AUTH_IDENTITY_FLAGS_ID_PROVIDER: u32 = 524288u32;
 pub const SEC_WINNT_AUTH_IDENTITY_FLAGS_NULL_DOMAIN: u32 = 262144u32;
@@ -7527,10 +6798,6 @@ impl Default for SEC_WINNT_AUTH_IDENTITY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Rpc")]
-impl windows_core::TypeKind for SEC_WINNT_AUTH_IDENTITY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SEC_WINNT_AUTH_IDENTITY_MARSHALLED: u32 = 4u32;
 pub const SEC_WINNT_AUTH_IDENTITY_ONLY: u32 = 8u32;
 pub const SEC_WINNT_AUTH_IDENTITY_VERSION: u32 = 512u32;
@@ -7548,9 +6815,6 @@ impl Default for SEND_GENERIC_TLS_EXTENSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEND_GENERIC_TLS_EXTENSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SESSION_TICKET_INFO_V0: u32 = 0u32;
 pub const SESSION_TICKET_INFO_VERSION: u32 = 0u32;
@@ -7576,9 +6840,6 @@ impl Default for SE_ADT_ACCESS_REASON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SE_ADT_ACCESS_REASON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SE_ADT_CLAIMS {
@@ -7589,9 +6850,6 @@ impl Default for SE_ADT_CLAIMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SE_ADT_CLAIMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SE_ADT_OBJECT_ONLY: u32 = 1u32;
 #[repr(C)]
@@ -7606,9 +6864,6 @@ impl Default for SE_ADT_OBJECT_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SE_ADT_OBJECT_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SE_ADT_PARAMETERS_SELF_RELATIVE: u32 = 1u32;
 pub const SE_ADT_PARAMETERS_SEND_TO_LSA: u32 = 2u32;
@@ -7629,9 +6884,6 @@ impl Default for SE_ADT_PARAMETER_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SE_ADT_PARAMETER_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SE_ADT_PARAMETER_ARRAY_ENTRY {
@@ -7644,9 +6896,6 @@ impl Default for SE_ADT_PARAMETER_ARRAY_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SE_ADT_PARAMETER_ARRAY_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7665,9 +6914,6 @@ impl Default for SE_ADT_PARAMETER_ARRAY_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SE_ADT_PARAMETER_ARRAY_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SE_ADT_PARAMETER_EXTENSIBLE_AUDIT: u32 = 4u32;
 pub const SE_ADT_PARAMETER_GENERIC_AUDIT: u32 = 8u32;
@@ -7711,9 +6957,6 @@ impl Default for SL_ACTIVATION_INFO_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SL_ACTIVATION_INFO_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SL_ACTIVATION_TYPE(pub i32);
@@ -7730,9 +6973,6 @@ impl Default for SL_AD_ACTIVATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SL_AD_ACTIVATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SL_CLIENTAPI_ZONE: u32 = 61440u32;
 pub const SL_DATA_BINARY: SLDATATYPE = SLDATATYPE(3u32);
@@ -8105,9 +7345,6 @@ impl Default for SL_LICENSING_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SL_LICENSING_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SL_LICENSING_STATUS_IN_GRACE_PERIOD: SLLICENSINGSTATUS = SLLICENSINGSTATUS(2i32);
 pub const SL_LICENSING_STATUS_LAST: SLLICENSINGSTATUS = SLLICENSINGSTATUS(4i32);
 pub const SL_LICENSING_STATUS_LICENSED: SLLICENSINGSTATUS = SLLICENSINGSTATUS(1i32);
@@ -8126,9 +7363,6 @@ impl Default for SL_NONGENUINE_UI_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SL_NONGENUINE_UI_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SL_PKEY_DETECT: windows_core::PCWSTR = windows_core::w!("msft:rm/algorithm/pkey/detect");
 pub const SL_PKEY_MS2005: windows_core::PCWSTR = windows_core::w!("msft:rm/algorithm/pkey/2005");
@@ -8277,9 +7511,6 @@ impl Default for SL_SYSTEM_POLICY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SL_SYSTEM_POLICY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SL_SYSTEM_STATE_REBOOT_POLICY_FOUND: u32 = 1u32;
 pub const SL_SYSTEM_STATE_TAMPERED: u32 = 2u32;
 pub const SPP_MIGRATION_GATHER_ACTIVATED_WINDOWS_STATE: u32 = 2u32;
@@ -8325,9 +7556,6 @@ impl Default for SR_SECURITY_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SR_SECURITY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SSL2SP_NAME: windows_core::PCWSTR = windows_core::w!("Microsoft SSL 2.0");
 pub const SSL2SP_NAME_A: windows_core::PCSTR = windows_core::s!("Microsoft SSL 2.0");
 pub const SSL2SP_NAME_W: windows_core::PCWSTR = windows_core::w!("Microsoft SSL 2.0");
@@ -8350,9 +7578,6 @@ impl Default for SSL_CREDENTIAL_CERTIFICATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SSL_CREDENTIAL_CERTIFICATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub type SSL_EMPTY_CACHE_FN_A = Option<unsafe extern "system" fn(psztargetname: windows_core::PCSTR, dwflags: u32) -> super::super::super::Foundation::BOOL>;
 pub type SSL_EMPTY_CACHE_FN_W = Option<unsafe extern "system" fn(psztargetname: windows_core::PCWSTR, dwflags: u32) -> super::super::super::Foundation::BOOL>;
@@ -8378,9 +7603,6 @@ impl Default for SUBSCRIBE_GENERIC_TLS_EXTENSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SUBSCRIBE_GENERIC_TLS_EXTENSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SZ_ALG_MAX_SIZE: u32 = 64u32;
 pub const Sasl_AuthZIDForbidden: SASL_AUTHZID_STATE = SASL_AUTHZID_STATE(0i32);
@@ -8475,9 +7697,6 @@ impl Default for SecBuffer {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecBuffer {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecBufferDesc {
@@ -8489,9 +7708,6 @@ impl Default for SecBufferDesc {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecBufferDesc {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8522,9 +7738,6 @@ impl Default for SecPkgContext_AccessToken {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_AccessToken {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_ApplicationProtocol {
@@ -8538,9 +7751,6 @@ impl Default for SecPkgContext_ApplicationProtocol {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_ApplicationProtocol {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_AuthorityA {
@@ -8551,9 +7761,6 @@ impl Default for SecPkgContext_AuthorityA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_AuthorityA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_AuthorityW {
@@ -8563,9 +7770,6 @@ impl Default for SecPkgContext_AuthorityW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_AuthorityW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8578,9 +7782,6 @@ impl Default for SecPkgContext_AuthzID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_AuthzID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_Bindings {
@@ -8591,9 +7792,6 @@ impl Default for SecPkgContext_Bindings {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_Bindings {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8610,9 +7808,6 @@ impl Default for SecPkgContext_CertInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_CertInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_CertificateValidationResult {
@@ -8623,9 +7818,6 @@ impl Default for SecPkgContext_CertificateValidationResult {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_CertificateValidationResult {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8638,9 +7830,6 @@ impl Default for SecPkgContext_Certificates {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_Certificates {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8666,9 +7855,6 @@ impl Default for SecPkgContext_CipherInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_CipherInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_ClientCertPolicyResult {
@@ -8680,9 +7866,6 @@ impl Default for SecPkgContext_ClientCertPolicyResult {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_ClientCertPolicyResult {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_ClientSpecifiedTarget {
@@ -8692,9 +7875,6 @@ impl Default for SecPkgContext_ClientSpecifiedTarget {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_ClientSpecifiedTarget {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -8714,10 +7894,6 @@ impl Default for SecPkgContext_ConnectionInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SecPkgContext_ConnectionInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_ConnectionInfoEx {
@@ -8735,9 +7911,6 @@ impl Default for SecPkgContext_ConnectionInfoEx {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_ConnectionInfoEx {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_CredInfo {
@@ -8748,9 +7921,6 @@ impl Default for SecPkgContext_CredInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_CredInfo {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8763,9 +7933,6 @@ impl Default for SecPkgContext_CredentialNameA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_CredentialNameA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_CredentialNameW {
@@ -8776,9 +7943,6 @@ impl Default for SecPkgContext_CredentialNameW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_CredentialNameW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8791,9 +7955,6 @@ impl Default for SecPkgContext_DceInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_DceInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_EapKeyBlock {
@@ -8804,9 +7965,6 @@ impl Default for SecPkgContext_EapKeyBlock {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_EapKeyBlock {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8820,9 +7978,6 @@ impl Default for SecPkgContext_EapPrfInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_EapPrfInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_EarlyStart {
@@ -8833,9 +7988,6 @@ impl Default for SecPkgContext_EarlyStart {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_EarlyStart {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_Flags {
@@ -8845,9 +7997,6 @@ impl Default for SecPkgContext_Flags {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_Flags {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -8861,10 +8010,6 @@ impl Default for SecPkgContext_IssuerListInfoEx {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SecPkgContext_IssuerListInfoEx {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8880,9 +8025,6 @@ impl Default for SecPkgContext_KeyInfoA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_KeyInfoA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_KeyInfoW {
@@ -8897,9 +8039,6 @@ impl Default for SecPkgContext_KeyInfoW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_KeyInfoW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_KeyingMaterial {
@@ -8910,9 +8049,6 @@ impl Default for SecPkgContext_KeyingMaterial {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_KeyingMaterial {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8927,9 +8063,6 @@ impl Default for SecPkgContext_KeyingMaterialInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_KeyingMaterialInfo {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8946,9 +8079,6 @@ impl Default for SecPkgContext_KeyingMaterial_Inproc {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_KeyingMaterial_Inproc {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_LastClientTokenStatus {
@@ -8958,9 +8088,6 @@ impl Default for SecPkgContext_LastClientTokenStatus {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_LastClientTokenStatus {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8972,9 +8099,6 @@ impl Default for SecPkgContext_Lifespan {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_Lifespan {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8990,9 +8114,6 @@ impl Default for SecPkgContext_LocalCredentialInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_LocalCredentialInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_LogoffTime {
@@ -9002,9 +8123,6 @@ impl Default for SecPkgContext_LogoffTime {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_LogoffTime {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9017,9 +8135,6 @@ impl Default for SecPkgContext_MappedCredAttr {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_MappedCredAttr {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_NamesA {
@@ -9030,9 +8145,6 @@ impl Default for SecPkgContext_NamesA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_NamesA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_NamesW {
@@ -9042,9 +8154,6 @@ impl Default for SecPkgContext_NamesW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_NamesW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9057,9 +8166,6 @@ impl Default for SecPkgContext_NativeNamesA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_NativeNamesA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_NativeNamesW {
@@ -9070,9 +8176,6 @@ impl Default for SecPkgContext_NativeNamesW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_NativeNamesW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9089,9 +8192,6 @@ impl Default for SecPkgContext_NegoKeys {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_NegoKeys {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_NegoPackageInfo {
@@ -9102,9 +8202,6 @@ impl Default for SecPkgContext_NegoPackageInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_NegoPackageInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_NegoStatus {
@@ -9114,9 +8211,6 @@ impl Default for SecPkgContext_NegoStatus {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_NegoStatus {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9129,9 +8223,6 @@ impl Default for SecPkgContext_NegotiatedTlsExtensions {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_NegotiatedTlsExtensions {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_NegotiationInfoA {
@@ -9142,9 +8233,6 @@ impl Default for SecPkgContext_NegotiationInfoA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_NegotiationInfoA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9157,9 +8245,6 @@ impl Default for SecPkgContext_NegotiationInfoW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_NegotiationInfoW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_PackageInfoA {
@@ -9169,9 +8254,6 @@ impl Default for SecPkgContext_PackageInfoA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_PackageInfoA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9183,9 +8265,6 @@ impl Default for SecPkgContext_PackageInfoW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_PackageInfoW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_PasswordExpiry {
@@ -9195,9 +8274,6 @@ impl Default for SecPkgContext_PasswordExpiry {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_PasswordExpiry {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9211,9 +8287,6 @@ impl Default for SecPkgContext_ProtoInfoA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_ProtoInfoA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_ProtoInfoW {
@@ -9225,9 +8298,6 @@ impl Default for SecPkgContext_ProtoInfoW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_ProtoInfoW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9243,9 +8313,6 @@ impl Default for SecPkgContext_RemoteCredentialInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_RemoteCredentialInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_SaslContext {
@@ -9255,9 +8322,6 @@ impl Default for SecPkgContext_SaslContext {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_SaslContext {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9271,9 +8335,6 @@ impl Default for SecPkgContext_SessionAppData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_SessionAppData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_SessionInfo {
@@ -9286,9 +8347,6 @@ impl Default for SecPkgContext_SessionInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_SessionInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_SessionKey {
@@ -9299,9 +8357,6 @@ impl Default for SecPkgContext_SessionKey {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_SessionKey {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9316,9 +8371,6 @@ impl Default for SecPkgContext_Sizes {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_Sizes {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_SrtpParameters {
@@ -9330,9 +8382,6 @@ impl Default for SecPkgContext_SrtpParameters {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_SrtpParameters {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9348,9 +8397,6 @@ impl Default for SecPkgContext_StreamSizes {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_StreamSizes {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_SubjectAttributes {
@@ -9360,9 +8406,6 @@ impl Default for SecPkgContext_SubjectAttributes {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_SubjectAttributes {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9375,9 +8418,6 @@ impl Default for SecPkgContext_SupportedSignatures {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_SupportedSignatures {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_Target {
@@ -9389,9 +8429,6 @@ impl Default for SecPkgContext_Target {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_Target {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_TargetInformation {
@@ -9402,9 +8439,6 @@ impl Default for SecPkgContext_TargetInformation {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_TargetInformation {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9419,9 +8453,6 @@ impl Default for SecPkgContext_TokenBinding {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_TokenBinding {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_UiInfo {
@@ -9432,9 +8463,6 @@ impl Default for SecPkgContext_UiInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgContext_UiInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_UserFlags {
@@ -9444,9 +8472,6 @@ impl Default for SecPkgContext_UserFlags {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_UserFlags {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SecPkgCredClass_Ephemeral: SECPKG_CRED_CLASS = SECPKG_CRED_CLASS(10i32);
 pub const SecPkgCredClass_Explicit: SECPKG_CRED_CLASS = SECPKG_CRED_CLASS(40i32);
@@ -9463,9 +8488,6 @@ impl Default for SecPkgCred_CipherStrengths {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgCred_CipherStrengths {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9485,9 +8507,6 @@ impl Default for SecPkgCred_ClientCertPolicy {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgCred_ClientCertPolicy {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgCred_SessionTicketKey {
@@ -9501,9 +8520,6 @@ impl Default for SecPkgCred_SessionTicketKey {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgCred_SessionTicketKey {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgCred_SessionTicketKeys {
@@ -9514,9 +8530,6 @@ impl Default for SecPkgCred_SessionTicketKeys {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgCred_SessionTicketKeys {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -9531,10 +8544,6 @@ impl Default for SecPkgCred_SupportedAlgs {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SecPkgCred_SupportedAlgs {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgCred_SupportedProtocols {
@@ -9544,9 +8553,6 @@ impl Default for SecPkgCred_SupportedProtocols {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgCred_SupportedProtocols {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9558,9 +8564,6 @@ impl Default for SecPkgCredentials_Cert {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgCredentials_Cert {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9577,9 +8580,6 @@ impl Default for SecPkgCredentials_KdcProxySettingsW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgCredentials_KdcProxySettingsW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgCredentials_NamesA {
@@ -9590,9 +8590,6 @@ impl Default for SecPkgCredentials_NamesA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgCredentials_NamesA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgCredentials_NamesW {
@@ -9602,9 +8599,6 @@ impl Default for SecPkgCredentials_NamesW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgCredentials_NamesW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9618,9 +8612,6 @@ impl Default for SecPkgCredentials_SSIProviderA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgCredentials_SSIProviderA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgCredentials_SSIProviderW {
@@ -9632,9 +8623,6 @@ impl Default for SecPkgCredentials_SSIProviderW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgCredentials_SSIProviderW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9651,9 +8639,6 @@ impl Default for SecPkgInfoA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecPkgInfoA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgInfoW {
@@ -9668,9 +8653,6 @@ impl Default for SecPkgInfoW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgInfoW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SecService: SecDelegationType = SecDelegationType(1i32);
 pub const SecSessionPrimaryCred: SECPKG_SESSIONINFO_TYPE = SECPKG_SESSIONINFO_TYPE(0i32);
@@ -9728,10 +8710,6 @@ impl Default for SecurityFunctionTableA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Credentials")]
-impl windows_core::TypeKind for SecurityFunctionTableA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Credentials")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9774,10 +8752,6 @@ impl Default for SecurityFunctionTableW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Credentials")]
-impl windows_core::TypeKind for SecurityFunctionTableW {
-    type TypeKind = windows_core::CopyType;
 }
 pub type SpAcceptCredentialsFn = Option<unsafe extern "system" fn(logontype: SECURITY_LOGON_TYPE, accountname: *const LSA_UNICODE_STRING, primarycredentials: *const SECPKG_PRIMARY_CRED, supplementalcredentials: *const SECPKG_SUPPLEMENTAL_CRED) -> super::super::super::Foundation::NTSTATUS>;
 pub type SpAcceptLsaModeContextFn = Option<unsafe extern "system" fn(credentialhandle: usize, contexthandle: usize, inputbuffer: *const SecBufferDesc, contextrequirements: u32, targetdatarep: u32, newcontexthandle: *mut usize, outputbuffer: *mut SecBufferDesc, contextattributes: *mut u32, expirationtime: *mut i64, mappedcontext: *mut super::super::super::Foundation::BOOLEAN, contextdata: *mut SecBuffer) -> super::super::super::Foundation::NTSTATUS>;
@@ -9873,9 +8847,6 @@ impl Default for TLS_EXTENSION_SUBSCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TLS_EXTENSION_SUBSCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TLS_PARAMETERS {
@@ -9891,9 +8862,6 @@ impl Default for TLS_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TLS_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TLS_PARAMS_OPTIONAL: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9908,9 +8876,6 @@ impl Default for TOKENBINDING_IDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKENBINDING_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9930,9 +8895,6 @@ impl Default for TOKENBINDING_KEY_TYPES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKENBINDING_KEY_TYPES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOKENBINDING_RESULT_DATA {
@@ -9948,9 +8910,6 @@ impl Default for TOKENBINDING_RESULT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKENBINDING_RESULT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOKENBINDING_RESULT_LIST {
@@ -9961,9 +8920,6 @@ impl Default for TOKENBINDING_RESULT_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKENBINDING_RESULT_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9981,9 +8937,6 @@ impl Default for TRUSTED_CONTROLLERS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRUSTED_CONTROLLERS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRUSTED_DOMAIN_AUTH_INFORMATION {
@@ -9999,9 +8952,6 @@ impl Default for TRUSTED_DOMAIN_AUTH_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRUSTED_DOMAIN_AUTH_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRUSTED_DOMAIN_FULL_INFORMATION {
@@ -10014,9 +8964,6 @@ impl Default for TRUSTED_DOMAIN_FULL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRUSTED_DOMAIN_FULL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRUSTED_DOMAIN_FULL_INFORMATION2 {
@@ -10028,9 +8975,6 @@ impl Default for TRUSTED_DOMAIN_FULL_INFORMATION2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRUSTED_DOMAIN_FULL_INFORMATION2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10046,9 +8990,6 @@ impl Default for TRUSTED_DOMAIN_INFORMATION_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRUSTED_DOMAIN_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10067,9 +9008,6 @@ impl Default for TRUSTED_DOMAIN_INFORMATION_EX2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRUSTED_DOMAIN_INFORMATION_EX2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRUSTED_DOMAIN_NAME_INFO {
@@ -10080,9 +9018,6 @@ impl Default for TRUSTED_DOMAIN_NAME_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRUSTED_DOMAIN_NAME_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRUSTED_DOMAIN_SUPPORTED_ENCRYPTION_TYPES {
@@ -10092,9 +9027,6 @@ impl Default for TRUSTED_DOMAIN_SUPPORTED_ENCRYPTION_TYPES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRUSTED_DOMAIN_SUPPORTED_ENCRYPTION_TYPES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10119,9 +9051,6 @@ impl Default for TRUSTED_PASSWORD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRUSTED_PASSWORD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRUSTED_POSIX_OFFSET_INFO {
@@ -10131,9 +9060,6 @@ impl Default for TRUSTED_POSIX_OFFSET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRUSTED_POSIX_OFFSET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRUSTED_QUERY_AUTH: i32 = 64i32;
 pub const TRUSTED_QUERY_CONTROLLERS: i32 = 2i32;
@@ -10253,9 +9179,6 @@ impl Default for USER_ALL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_ALL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USER_ALL_PARAMETERS: u32 = 2097152u32;
 pub const USER_DONT_EXPIRE_PASSWORD: u32 = 512u32;
 pub const USER_DONT_REQUIRE_PREAUTH: u32 = 65536u32;
@@ -10281,10 +9204,6 @@ impl Default for USER_SESSION_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_PasswordManagement")]
-impl windows_core::TypeKind for USER_SESSION_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USER_SMARTCARD_REQUIRED: u32 = 4096u32;
 pub const USER_TEMP_DUPLICATE_ACCOUNT: u32 = 8u32;
@@ -10317,10 +9236,6 @@ impl Default for X509Certificate {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for X509Certificate {
-    type TypeKind = windows_core::CopyType;
 }
 pub const _FACILITY_WINDOWS_STORE: u32 = 63u32;
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
@@ -43,9 +43,6 @@ impl Default for EFFPERM_RESULT_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EFFPERM_RESULT_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 windows_core::imp::define_interface!(IEffectivePermission, IEffectivePermission_Vtbl, 0x3853dc76_9f35_407c_88a1_d19344365fbc);
 windows_core::imp::interface_hierarchy!(IEffectivePermission, windows_core::IUnknown);
 impl IEffectivePermission {
@@ -505,9 +502,6 @@ impl Default for SECURITY_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURITY_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SECURITY_OBJECT_ID_CENTRAL_ACCESS_RULE: u32 = 4u32;
 pub const SECURITY_OBJECT_ID_CENTRAL_POLICY: u32 = 3u32;
 pub const SECURITY_OBJECT_ID_OBJECT_SD: u32 = 1u32;
@@ -525,9 +519,6 @@ impl Default for SID_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SID_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SID_INFO_LIST {
@@ -538,9 +529,6 @@ impl Default for SID_INFO_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SID_INFO_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -554,9 +542,6 @@ impl Default for SI_ACCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SI_ACCESS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SI_ACCESS_CONTAINER: i32 = 262144i32;
 pub const SI_ACCESS_GENERAL: i32 = 131072i32;
@@ -585,9 +570,6 @@ impl Default for SI_INHERIT_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SI_INHERIT_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SI_MAY_WRITE: SI_OBJECT_INFO_FLAGS = SI_OBJECT_INFO_FLAGS(268435456u32);
 pub const SI_NO_ACL_PROTECT: i32 = 512i32;
 pub const SI_NO_ADDITIONAL_PERMISSION: SI_OBJECT_INFO_FLAGS = SI_OBJECT_INFO_FLAGS(2097152u32);
@@ -607,9 +589,6 @@ impl Default for SI_OBJECT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SI_OBJECT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
@@ -646,9 +646,6 @@ impl Default for ACTRL_ACCESSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTRL_ACCESSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTRL_ACCESSW {
@@ -659,9 +656,6 @@ impl Default for ACTRL_ACCESSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTRL_ACCESSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACTRL_ACCESS_ALLOWED: ACTRL_ACCESS_ENTRY_ACCESS_FLAGS = ACTRL_ACCESS_ENTRY_ACCESS_FLAGS(1u32);
 pub const ACTRL_ACCESS_DENIED: ACTRL_ACCESS_ENTRY_ACCESS_FLAGS = ACTRL_ACCESS_ENTRY_ACCESS_FLAGS(2u32);
@@ -680,9 +674,6 @@ impl Default for ACTRL_ACCESS_ENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTRL_ACCESS_ENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTRL_ACCESS_ENTRYW {
@@ -698,9 +689,6 @@ impl Default for ACTRL_ACCESS_ENTRYW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTRL_ACCESS_ENTRYW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ACTRL_ACCESS_ENTRY_ACCESS_FLAGS(pub u32);
@@ -715,9 +703,6 @@ impl Default for ACTRL_ACCESS_ENTRY_LISTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTRL_ACCESS_ENTRY_LISTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTRL_ACCESS_ENTRY_LISTW {
@@ -728,9 +713,6 @@ impl Default for ACTRL_ACCESS_ENTRY_LISTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTRL_ACCESS_ENTRY_LISTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -743,9 +725,6 @@ impl Default for ACTRL_ACCESS_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTRL_ACCESS_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTRL_ACCESS_INFOW {
@@ -756,9 +735,6 @@ impl Default for ACTRL_ACCESS_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTRL_ACCESS_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACTRL_ACCESS_NO_OPTIONS: u32 = 0u32;
 pub const ACTRL_ACCESS_PROTECTED: u32 = 1u32;
@@ -778,9 +754,6 @@ impl Default for ACTRL_CONTROL_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTRL_CONTROL_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTRL_CONTROL_INFOW {
@@ -791,9 +764,6 @@ impl Default for ACTRL_CONTROL_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTRL_CONTROL_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACTRL_DELETE: u32 = 134217728u32;
 pub const ACTRL_DIR_CREATE_CHILD: u32 = 4u32;
@@ -838,9 +808,6 @@ impl Default for ACTRL_OVERLAPPED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTRL_OVERLAPPED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ACTRL_OVERLAPPED_0 {
@@ -851,9 +818,6 @@ impl Default for ACTRL_OVERLAPPED_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTRL_OVERLAPPED_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACTRL_PERM_1: u32 = 1u32;
 pub const ACTRL_PERM_10: u32 = 512u32;
@@ -892,9 +856,6 @@ impl Default for ACTRL_PROPERTY_ENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTRL_PROPERTY_ENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTRL_PROPERTY_ENTRYW {
@@ -906,9 +867,6 @@ impl Default for ACTRL_PROPERTY_ENTRYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTRL_PROPERTY_ENTRYW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACTRL_READ_CONTROL: u32 = 268435456u32;
 pub const ACTRL_REG_CREATE_CHILD: u32 = 4u32;
@@ -967,9 +925,6 @@ impl Default for AUDIT_IP_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIT_IP_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AUDIT_OBJECT_TYPE {
@@ -983,9 +938,6 @@ impl Default for AUDIT_OBJECT_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIT_OBJECT_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AUDIT_OBJECT_TYPES {
@@ -997,9 +949,6 @@ impl Default for AUDIT_OBJECT_TYPES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIT_OBJECT_TYPES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1014,9 +963,6 @@ impl Default for AUDIT_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIT_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1035,9 +981,6 @@ impl Default for AUDIT_PARAM_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUDIT_PARAM_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AUDIT_PARAM_1 {
@@ -1048,9 +991,6 @@ impl Default for AUDIT_PARAM_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIT_PARAM_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1064,9 +1004,6 @@ impl Default for AUDIT_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIT_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1116,9 +1053,6 @@ impl Default for AUTHZ_ACCESS_REPLY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHZ_ACCESS_REPLY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AUTHZ_ACCESS_REQUEST {
@@ -1132,9 +1066,6 @@ impl Default for AUTHZ_ACCESS_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUTHZ_ACCESS_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AUTHZ_ALLOW_MULTIPLE_SOURCE_INSTANCES: u32 = 1u32;
 #[repr(transparent)]
@@ -1193,9 +1124,6 @@ impl Default for AUTHZ_AUDIT_EVENT_TYPE_LEGACY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHZ_AUDIT_EVENT_TYPE_LEGACY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct AUTHZ_AUDIT_EVENT_TYPE_OLD {
@@ -1211,9 +1139,6 @@ impl Default for AUTHZ_AUDIT_EVENT_TYPE_OLD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHZ_AUDIT_EVENT_TYPE_OLD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AUTHZ_AUDIT_EVENT_TYPE_UNION {
@@ -1223,9 +1148,6 @@ impl Default for AUTHZ_AUDIT_EVENT_TYPE_UNION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUTHZ_AUDIT_EVENT_TYPE_UNION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AUTHZ_AUDIT_INSTANCE_INFORMATION: u32 = 2u32;
 #[repr(transparent)]
@@ -1307,9 +1229,6 @@ impl Default for AUTHZ_INIT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHZ_INIT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AUTHZ_INIT_INFO_VERSION_V1: u32 = 1u32;
 pub const AUTHZ_MIGRATED_LEGACY_PUBLISHER: u32 = 2u32;
 pub const AUTHZ_NO_ALLOC_STRINGS: AUTHZ_INITIALIZE_OBJECT_ACCESS_AUDIT_EVENT_FLAGS = AUTHZ_INITIALIZE_OBJECT_ACCESS_AUDIT_EVENT_FLAGS(4u32);
@@ -1325,9 +1244,6 @@ impl Default for AUTHZ_REGISTRATION_OBJECT_TYPE_NAME_OFFSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUTHZ_REGISTRATION_OBJECT_TYPE_NAME_OFFSET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AUTHZ_REQUIRE_S4U_LOGON: u32 = 4u32;
 #[repr(transparent)]
@@ -1410,9 +1326,6 @@ impl Default for AUTHZ_RPC_INIT_INFO_CLIENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHZ_RPC_INIT_INFO_CLIENT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AUTHZ_RPC_INIT_INFO_CLIENT_VERSION_V1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1427,9 +1340,6 @@ impl Default for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_0 {
@@ -1439,9 +1349,6 @@ impl Default for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_VERSION: u32 = 1u32;
 pub const AUTHZ_SECURITY_ATTRIBUTES_INFORMATION_VERSION_V1: u32 = 1u32;
@@ -1492,9 +1399,6 @@ impl Default for AUTHZ_SECURITY_ATTRIBUTE_FQBN_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHZ_SECURITY_ATTRIBUTE_FQBN_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AUTHZ_SECURITY_ATTRIBUTE_NON_INHERITABLE: AUTHZ_SECURITY_ATTRIBUTE_FLAGS = AUTHZ_SECURITY_ATTRIBUTE_FLAGS(1u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1506,9 +1410,6 @@ impl Default for AUTHZ_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUTHZ_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1541,9 +1442,6 @@ impl Default for AUTHZ_SECURITY_ATTRIBUTE_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHZ_SECURITY_ATTRIBUTE_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AUTHZ_SECURITY_ATTRIBUTE_V1_0 {
@@ -1557,9 +1455,6 @@ impl Default for AUTHZ_SECURITY_ATTRIBUTE_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUTHZ_SECURITY_ATTRIBUTE_V1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AUTHZ_SECURITY_ATTRIBUTE_VALUE_CASE_SENSITIVE: AUTHZ_SECURITY_ATTRIBUTE_FLAGS = AUTHZ_SECURITY_ATTRIBUTE_FLAGS(2u32);
 #[repr(transparent)]
@@ -1605,9 +1500,6 @@ impl Default for AUTHZ_SOURCE_SCHEMA_REGISTRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHZ_SOURCE_SCHEMA_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AUTHZ_SOURCE_SCHEMA_REGISTRATION_0 {
@@ -1618,9 +1510,6 @@ impl Default for AUTHZ_SOURCE_SCHEMA_REGISTRATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUTHZ_SOURCE_SCHEMA_REGISTRATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AUTHZ_WPD_CATEGORY_FLAG: u32 = 16u32;
 pub const AZ_AZSTORE_DEFAULT_DOMAIN_TIMEOUT: AZ_PROP_CONSTANTS = AZ_PROP_CONSTANTS(15000i32);
@@ -1762,9 +1651,6 @@ impl Default for EXPLICIT_ACCESS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXPLICIT_ACCESS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXPLICIT_ACCESS_W {
@@ -1778,9 +1664,6 @@ impl Default for EXPLICIT_ACCESS_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXPLICIT_ACCESS_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FN_OBJECT_MGR_FUNCTS {
@@ -1790,9 +1673,6 @@ impl Default for FN_OBJECT_MGR_FUNCTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FN_OBJECT_MGR_FUNCTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub type FN_PROGRESS = Option<unsafe extern "system" fn(pobjectname: windows_core::PCWSTR, status: u32, pinvokesetting: *mut PROG_INVOKE_SETTING, args: *const core::ffi::c_void, securityset: super::super::Foundation::BOOL)>;
 pub const GRANT_ACCESS: ACCESS_MODE = ACCESS_MODE(1i32);
@@ -8834,9 +8714,6 @@ impl Default for INHERITED_FROMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INHERITED_FROMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INHERITED_FROMW {
@@ -8847,9 +8724,6 @@ impl Default for INHERITED_FROMW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INHERITED_FROMW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INHERITED_GRANDPARENT: u32 = 536870912u32;
 pub const INHERITED_PARENT: u32 = 268435456u32;
@@ -8872,9 +8746,6 @@ impl Default for OBJECTS_AND_NAME_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OBJECTS_AND_NAME_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OBJECTS_AND_NAME_W {
@@ -8889,9 +8760,6 @@ impl Default for OBJECTS_AND_NAME_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OBJECTS_AND_NAME_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OBJECTS_AND_SID {
@@ -8904,9 +8772,6 @@ impl Default for OBJECTS_AND_SID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OBJECTS_AND_SID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OLESCRIPT_E_SYNTAX: windows_core::HRESULT = windows_core::HRESULT(0x80020101_u32 as _);
 pub type PFN_AUTHZ_COMPUTE_DYNAMIC_GROUPS = Option<unsafe extern "system" fn(hauthzclientcontext: AUTHZ_CLIENT_CONTEXT_HANDLE, args: *const core::ffi::c_void, psidattrarray: *mut *mut super::SID_AND_ATTRIBUTES, psidcount: *mut u32, prestrictedsidattrarray: *mut *mut super::SID_AND_ATTRIBUTES, prestrictedsidcount: *mut u32) -> super::super::Foundation::BOOL>;
@@ -9115,9 +8980,6 @@ impl Default for TRUSTEE_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRUSTEE_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRUSTEE_ACCESSA {
@@ -9131,9 +8993,6 @@ impl Default for TRUSTEE_ACCESSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRUSTEE_ACCESSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRUSTEE_ACCESSW {
@@ -9146,9 +9005,6 @@ impl Default for TRUSTEE_ACCESSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRUSTEE_ACCESSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRUSTEE_ACCESS_ALL: i32 = -1i32;
 pub const TRUSTEE_ACCESS_ALLOWED: i32 = 1i32;
@@ -9189,8 +9045,5 @@ impl Default for TRUSTEE_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRUSTEE_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const _AUTHZ_SS_MAXSIZE: u32 = 128u32;

--- a/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/mod.rs
@@ -152,9 +152,6 @@ impl Default for SCESVC_ANALYSIS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCESVC_ANALYSIS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCESVC_ANALYSIS_LINE {
@@ -166,9 +163,6 @@ impl Default for SCESVC_ANALYSIS_LINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCESVC_ANALYSIS_LINE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -184,9 +178,6 @@ impl Default for SCESVC_CALLBACK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCESVC_CALLBACK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCESVC_CONFIGURATION_INFO {
@@ -197,9 +188,6 @@ impl Default for SCESVC_CONFIGURATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCESVC_CONFIGURATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -212,9 +200,6 @@ impl Default for SCESVC_CONFIGURATION_LINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCESVC_CONFIGURATION_LINE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCESVC_ENUMERATION_MAX: i32 = 100i32;
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Credentials/mod.rs
@@ -897,9 +897,6 @@ impl Default for BINARY_BLOB_CREDENTIAL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BINARY_BLOB_CREDENTIAL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BinaryBlobCredential: CRED_MARSHAL_TYPE = CRED_MARSHAL_TYPE(3i32);
 pub const BinaryBlobForSystem: CRED_MARSHAL_TYPE = CRED_MARSHAL_TYPE(5i32);
 #[repr(C)]
@@ -912,9 +909,6 @@ impl Default for CERT_CREDENTIAL_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_CREDENTIAL_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_HASH_LENGTH: u32 = 20u32;
 #[repr(C)]
@@ -938,9 +932,6 @@ impl Default for CREDENTIALA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREDENTIALA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CREDENTIALW {
@@ -962,9 +953,6 @@ impl Default for CREDENTIALW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREDENTIALW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CREDENTIAL_ATTRIBUTEA {
@@ -978,9 +966,6 @@ impl Default for CREDENTIAL_ATTRIBUTEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREDENTIAL_ATTRIBUTEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CREDENTIAL_ATTRIBUTEW {
@@ -993,9 +978,6 @@ impl Default for CREDENTIAL_ATTRIBUTEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREDENTIAL_ATTRIBUTEW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1016,9 +998,6 @@ impl Default for CREDENTIAL_TARGET_INFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREDENTIAL_TARGET_INFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CREDENTIAL_TARGET_INFORMATIONW {
@@ -1038,9 +1017,6 @@ impl Default for CREDENTIAL_TARGET_INFORMATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREDENTIAL_TARGET_INFORMATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CREDSPP_SUBMIT_TYPE(pub i32);
@@ -1056,9 +1032,6 @@ impl Default for CREDSSP_CRED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREDSSP_CRED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CREDSSP_CRED_EX {
@@ -1072,9 +1045,6 @@ impl Default for CREDSSP_CRED_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREDSSP_CRED_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CREDSSP_CRED_EX_VERSION: u32 = 0u32;
 pub const CREDSSP_FLAG_REDIRECT: u32 = 1u32;
@@ -1198,10 +1168,6 @@ impl Default for CREDUI_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CREDUI_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1217,10 +1183,6 @@ impl Default for CREDUI_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CREDUI_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CREDUI_MAX_CAPTION_LENGTH: u32 = 128u32;
 pub const CREDUI_MAX_DOMAIN_TARGET_LENGTH: u32 = 337u32;
@@ -1457,9 +1419,6 @@ impl Default for KeyCredentialManagerInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KeyCredentialManagerInfo {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KeyCredentialManagerOperationErrorStateCertificateFailure: KeyCredentialManagerOperationErrorStates = KeyCredentialManagerOperationErrorStates(4i32);
 pub const KeyCredentialManagerOperationErrorStateDeviceJoinFailure: KeyCredentialManagerOperationErrorStates = KeyCredentialManagerOperationErrorStates(1i32);
 pub const KeyCredentialManagerOperationErrorStateHardwareFailure: KeyCredentialManagerOperationErrorStates = KeyCredentialManagerOperationErrorStates(32i32);
@@ -1548,9 +1507,6 @@ impl Default for OPENCARDNAMEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPENCARDNAMEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OPENCARDNAMEW {
@@ -1583,9 +1539,6 @@ impl Default for OPENCARDNAMEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPENCARDNAMEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1614,10 +1567,6 @@ impl Default for OPENCARDNAME_EXA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for OPENCARDNAME_EXA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -1648,10 +1597,6 @@ impl Default for OPENCARDNAME_EXW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for OPENCARDNAME_EXW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OPENCARD_SEARCH_CRITERIAA {
@@ -1673,9 +1618,6 @@ impl Default for OPENCARD_SEARCH_CRITERIAA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPENCARD_SEARCH_CRITERIAA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1699,9 +1641,6 @@ impl Default for OPENCARD_SEARCH_CRITERIAW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPENCARD_SEARCH_CRITERIAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct READER_SEL_REQUEST {
@@ -1715,9 +1654,6 @@ impl Default for READER_SEL_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for READER_SEL_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union READER_SEL_REQUEST_0 {
@@ -1728,9 +1664,6 @@ impl Default for READER_SEL_REQUEST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for READER_SEL_REQUEST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1747,9 +1680,6 @@ impl Default for READER_SEL_REQUEST_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for READER_SEL_REQUEST_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct READER_SEL_REQUEST_0_1 {
@@ -1761,9 +1691,6 @@ impl Default for READER_SEL_REQUEST_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for READER_SEL_REQUEST_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1781,9 +1708,6 @@ impl Default for READER_SEL_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for READER_SEL_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RSR_MATCH_TYPE_ALL_CARDS: READER_SEL_REQUEST_MATCH_TYPE = READER_SEL_REQUEST_MATCH_TYPE(3i32);
 pub const RSR_MATCH_TYPE_READER_AND_CONTAINER: READER_SEL_REQUEST_MATCH_TYPE = READER_SEL_REQUEST_MATCH_TYPE(1i32);
 pub const RSR_MATCH_TYPE_SERIAL_NUMBER: READER_SEL_REQUEST_MATCH_TYPE = READER_SEL_REQUEST_MATCH_TYPE(2i32);
@@ -1800,9 +1724,6 @@ impl Default for SCARD_ATRMASK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCARD_ATRMASK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCARD_ATR_LENGTH: u32 = 33u32;
 pub const SCARD_AUDIT_CHV_FAILURE: u32 = 0u32;
@@ -1831,9 +1752,6 @@ impl Default for SCARD_IO_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCARD_IO_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCARD_LEAVE_CARD: u32 = 0u32;
 pub const SCARD_LOCAL_READERS: windows_core::PCWSTR = windows_core::w!("SCard$LocalReaders\u{0}00");
@@ -1865,9 +1783,6 @@ impl Default for SCARD_READERSTATEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCARD_READERSTATEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCARD_READERSTATEW {
@@ -1882,9 +1797,6 @@ impl Default for SCARD_READERSTATEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCARD_READERSTATEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCARD_READER_CONFISCATES: u32 = 4u32;
 pub const SCARD_READER_CONTACTLESS: u32 = 8u32;
@@ -1946,9 +1858,6 @@ impl Default for SCARD_T0_COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCARD_T0_COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCARD_T0_HEADER_LENGTH: u32 = 7u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1963,9 +1872,6 @@ impl Default for SCARD_T0_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCARD_T0_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SCARD_T0_REQUEST_0 {
@@ -1976,9 +1882,6 @@ impl Default for SCARD_T0_REQUEST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCARD_T0_REQUEST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCARD_T1_EPILOGUE_LENGTH: u32 = 2u32;
 pub const SCARD_T1_EPILOGUE_LENGTH_LRC: u32 = 1u32;
@@ -1993,9 +1896,6 @@ impl Default for SCARD_T1_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCARD_T1_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCARD_UNKNOWN: u32 = 0u32;
 pub const SCARD_UNPOWER_CARD: u32 = 2u32;
@@ -2031,9 +1931,6 @@ impl Default for SecHandle {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SecHandle {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SecPkgContext_ClientCreds {
@@ -2044,9 +1941,6 @@ impl Default for SecPkgContext_ClientCreds {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SecPkgContext_ClientCreds {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TS_SSP_NAME: windows_core::PCWSTR = windows_core::w!("TSSSP");
 pub const TS_SSP_NAME_A: windows_core::PCSTR = windows_core::s!("TSSSP");
@@ -2059,9 +1953,6 @@ impl Default for USERNAME_TARGET_CREDENTIAL_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USERNAME_TARGET_CREDENTIAL_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UsernameForPackedCredentials: CRED_MARSHAL_TYPE = CRED_MARSHAL_TYPE(4i32);
 pub const UsernameTargetCredential: CRED_MARSHAL_TYPE = CRED_MARSHAL_TYPE(2i32);

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Catalog/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Catalog/mod.rs
@@ -254,9 +254,6 @@ impl Default for CATALOG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CATALOG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPTCATATTRIBUTE {
@@ -271,9 +268,6 @@ impl Default for CRYPTCATATTRIBUTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTCATATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -327,9 +321,6 @@ impl Default for CRYPTCATCDF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTCATCDF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography_Sip")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -352,10 +343,6 @@ impl Default for CRYPTCATMEMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography_Sip")]
-impl windows_core::TypeKind for CRYPTCATMEMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPTCATSTORE {
@@ -374,9 +361,6 @@ impl Default for CRYPTCATSTORE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTCATSTORE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTCAT_ADDCATALOG_HARDLINK: u32 = 1u32;
 pub const CRYPTCAT_ADDCATALOG_NONE: u32 = 0u32;
@@ -466,10 +450,6 @@ impl Default for MS_ADDINFO_CATALOGMEMBER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography_Sip")]
-impl windows_core::TypeKind for MS_ADDINFO_CATALOGMEMBER {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PFN_CDF_PARSE_ERROR_CALLBACK = Option<unsafe extern "system" fn(dwerrorarea: u32, dwlocalerror: u32, pwszline: windows_core::PCWSTR)>;
 pub const szOID_CATALOG_LIST: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.12.1.1");

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
@@ -210,9 +210,6 @@ impl Default for CAINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CAINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CAPATHLENGTH_INFINITE: u32 = 4294967295u32;
 pub const CAPropCertificate: EnrollmentCAProperty = EnrollmentCAProperty(7i32);
 pub const CAPropCertificateTypes: EnrollmentCAProperty = EnrollmentCAProperty(6i32);
@@ -343,9 +340,6 @@ impl Default for CERTTRANSBLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERTTRANSBLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERTVIEWRESTRICTION {
@@ -359,9 +353,6 @@ impl Default for CERTVIEWRESTRICTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERTVIEWRESTRICTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -624,9 +615,6 @@ impl Default for CSEDB_RSTMAPW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CSEDB_RSTMAPW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CSRESTORE_TYPE_CATCHUP: u32 = 4u32;
 pub const CSRESTORE_TYPE_FULL: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Sip/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Sip/mod.rs
@@ -94,9 +94,6 @@ impl Default for MS_ADDINFO_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MS_ADDINFO_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MS_ADDINFO_FLAT {
@@ -107,9 +104,6 @@ impl Default for MS_ADDINFO_FLAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MS_ADDINFO_FLAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -132,9 +126,6 @@ impl Default for SIP_ADD_NEWPROVIDER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIP_ADD_NEWPROVIDER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SIP_CAP_FLAG_SEALING: u32 = 1u32;
 pub const SIP_CAP_SET_CUR_VER: u32 = 3u32;
 #[repr(C)]
@@ -150,9 +141,6 @@ impl Default for SIP_CAP_SET_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIP_CAP_SET_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct SIP_CAP_SET_V3 {
@@ -166,9 +154,6 @@ impl Default for SIP_CAP_SET_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIP_CAP_SET_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SIP_CAP_SET_V3_0 {
@@ -179,9 +164,6 @@ impl Default for SIP_CAP_SET_V3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIP_CAP_SET_V3_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SIP_CAP_SET_VERSION_2: u32 = 2u32;
 pub const SIP_CAP_SET_VERSION_3: u32 = 3u32;
@@ -203,10 +185,6 @@ impl Default for SIP_DISPATCH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography_Catalog")]
-impl windows_core::TypeKind for SIP_DISPATCH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SIP_INDIRECT_DATA {
@@ -218,9 +196,6 @@ impl Default for SIP_INDIRECT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIP_INDIRECT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SIP_MAX_MAGIC_NUMBER: u32 = 4u32;
 #[repr(C)]
@@ -252,10 +227,6 @@ impl Default for SIP_SUBJECTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography_Catalog")]
-impl windows_core::TypeKind for SIP_SUBJECTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography_Catalog")]
 #[derive(Clone, Copy)]
@@ -269,10 +240,6 @@ impl Default for SIP_SUBJECTINFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography_Catalog")]
-impl windows_core::TypeKind for SIP_SUBJECTINFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPC_MARKER_CHECK_CURRENTLY_SUPPORTED_FLAGS: u32 = 1u32;
 pub const SPC_MARKER_CHECK_SKIP_SIP_INDIRECT_DATA_FLAG: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/UI/mod.rs
@@ -93,9 +93,6 @@ impl Default for CERT_FILTER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_FILTER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_FILTER_EXTENSION_MATCH {
@@ -108,9 +105,6 @@ impl Default for CERT_FILTER_EXTENSION_MATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_FILTER_EXTENSION_MATCH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_FILTER_INCLUDE_V1_CERTS: u32 = 1u32;
 pub const CERT_FILTER_ISSUER_CERTS_ONLY: u32 = 16u32;
@@ -132,9 +126,6 @@ impl Default for CERT_SELECTUI_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_SELECTUI_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -161,9 +152,6 @@ impl Default for CERT_SELECT_STRUCT_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_SELECT_STRUCT_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -227,9 +215,6 @@ impl Default for CERT_SELECT_STRUCT_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_SELECT_STRUCT_W {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_TRUST_DO_FULL_SEARCH: u32 = 1u32;
 pub const CERT_TRUST_DO_FULL_TRUST: u32 = 5u32;
 pub const CERT_TRUST_MASK: u32 = 16777215u32;
@@ -282,9 +267,6 @@ impl Default for CERT_VERIFY_CERTIFICATE_TRUST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_VERIFY_CERTIFICATE_TRUST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -317,10 +299,6 @@ impl Default for CERT_VIEWPROPERTIES_STRUCT_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for CERT_VIEWPROPERTIES_STRUCT_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -391,10 +369,6 @@ impl Default for CERT_VIEWPROPERTIES_STRUCT_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for CERT_VIEWPROPERTIES_STRUCT_W {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CM_ADD_CERT_STORES: CERT_VIEWPROPERTIES_STRUCT_FLAGS = CERT_VIEWPROPERTIES_STRUCT_FLAGS(512u32);
 pub const CM_ENABLEHOOK: CERT_VIEWPROPERTIES_STRUCT_FLAGS = CERT_VIEWPROPERTIES_STRUCT_FLAGS(1u32);
 pub const CM_ENABLETEMPLATE: CERT_VIEWPROPERTIES_STRUCT_FLAGS = CERT_VIEWPROPERTIES_STRUCT_FLAGS(8u32);
@@ -432,9 +406,6 @@ impl Default for CRYPTUI_CERT_MGR_STRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTUI_CERT_MGR_STRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPTUI_CERT_MGR_TAB_MASK: u32 = 15u32;
 pub const CRYPTUI_DISABLE_ADDTOSTORE: CRYPTUI_VIEWCERTIFICATE_FLAGS = CRYPTUI_VIEWCERTIFICATE_FLAGS(16u32);
 pub const CRYPTUI_DISABLE_EDITPROPERTIES: CRYPTUI_VIEWCERTIFICATE_FLAGS = CRYPTUI_VIEWCERTIFICATE_FLAGS(4u32);
@@ -461,9 +432,6 @@ impl Default for CRYPTUI_INITDIALOG_STRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTUI_INITDIALOG_STRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTUI_ONLY_OPEN_ROOT_STORE: CRYPTUI_VIEWCERTIFICATE_FLAGS = CRYPTUI_VIEWCERTIFICATE_FLAGS(512u32);
 pub const CRYPTUI_SELECT_EXPIRATION_COLUMN: u64 = 32u64;
@@ -537,10 +505,6 @@ impl Default for CRYPTUI_VIEWCERTIFICATE_STRUCTA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for CRYPTUI_VIEWCERTIFICATE_STRUCTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -553,10 +517,6 @@ impl Default for CRYPTUI_VIEWCERTIFICATE_STRUCTA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for CRYPTUI_VIEWCERTIFICATE_STRUCTA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -587,10 +547,6 @@ impl Default for CRYPTUI_VIEWCERTIFICATE_STRUCTW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for CRYPTUI_VIEWCERTIFICATE_STRUCTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -603,10 +559,6 @@ impl Default for CRYPTUI_VIEWCERTIFICATE_STRUCTW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip", feature = "Win32_Security_WinTrust", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for CRYPTUI_VIEWCERTIFICATE_STRUCTW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTUI_WARN_REMOTE_TRUST: CRYPTUI_VIEWCERTIFICATE_FLAGS = CRYPTUI_VIEWCERTIFICATE_FLAGS(4096u32);
 pub const CRYPTUI_WARN_UNTRUSTED_ROOT: CRYPTUI_VIEWCERTIFICATE_FLAGS = CRYPTUI_VIEWCERTIFICATE_FLAGS(1024u32);
@@ -633,9 +585,6 @@ impl Default for CRYPTUI_WIZ_DIGITAL_SIGN_BLOB_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTUI_WIZ_DIGITAL_SIGN_BLOB_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPTUI_WIZ_DIGITAL_SIGN_CERT: CRYPTUI_WIZ_DIGITAL_SIGN = CRYPTUI_WIZ_DIGITAL_SIGN(1u32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -650,9 +599,6 @@ impl Default for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO_0 {
@@ -663,9 +609,6 @@ impl Default for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTUI_WIZ_DIGITAL_SIGN_CERT_PVK_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTUI_WIZ_DIGITAL_SIGN_COMMERCIAL: CRYPTUI_WIZ_DIGITAL_SIGN_SIG_TYPE = CRYPTUI_WIZ_DIGITAL_SIGN_SIG_TYPE(1u32);
 #[repr(C)]
@@ -679,9 +622,6 @@ impl Default for CRYPTUI_WIZ_DIGITAL_SIGN_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTUI_WIZ_DIGITAL_SIGN_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTUI_WIZ_DIGITAL_SIGN_EXCLUDE_PAGE_HASHES: u32 = 2u32;
 #[repr(C)]
@@ -702,9 +642,6 @@ impl Default for CRYPTUI_WIZ_DIGITAL_SIGN_EXTENDED_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTUI_WIZ_DIGITAL_SIGN_EXTENDED_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPTUI_WIZ_DIGITAL_SIGN_INCLUDE_PAGE_HASHES: u32 = 4u32;
 pub const CRYPTUI_WIZ_DIGITAL_SIGN_INDIVIDUAL: CRYPTUI_WIZ_DIGITAL_SIGN_SIG_TYPE = CRYPTUI_WIZ_DIGITAL_SIGN_SIG_TYPE(2u32);
 #[repr(C)]
@@ -724,9 +661,6 @@ impl Default for CRYPTUI_WIZ_DIGITAL_SIGN_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTUI_WIZ_DIGITAL_SIGN_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CRYPTUI_WIZ_DIGITAL_SIGN_INFO_0 {
@@ -737,9 +671,6 @@ impl Default for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -752,9 +683,6 @@ impl Default for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTUI_WIZ_DIGITAL_SIGN_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTUI_WIZ_DIGITAL_SIGN_NONE: CRYPTUI_WIZ_DIGITAL_SIGN = CRYPTUI_WIZ_DIGITAL_SIGN(0u32);
 pub const CRYPTUI_WIZ_DIGITAL_SIGN_PVK: CRYPTUI_WIZ_DIGITAL_SIGN = CRYPTUI_WIZ_DIGITAL_SIGN(3u32);
@@ -771,9 +699,6 @@ impl Default for CRYPTUI_WIZ_DIGITAL_SIGN_PVK_FILE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTUI_WIZ_DIGITAL_SIGN_PVK_FILE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -797,9 +722,6 @@ impl Default for CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTUI_WIZ_DIGITAL_SIGN_STORE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CRYPTUI_WIZ_DIGITAL_SIGN_SUBJECT(pub u32);
@@ -820,9 +742,6 @@ impl Default for CRYPTUI_WIZ_EXPORT_CERTCONTEXT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTUI_WIZ_EXPORT_CERTCONTEXT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTUI_WIZ_EXPORT_CERT_CONTEXT: CRYPTUI_WIZ_EXPORT_SUBJECT = CRYPTUI_WIZ_EXPORT_SUBJECT(1u32);
 pub const CRYPTUI_WIZ_EXPORT_CERT_STORE: CRYPTUI_WIZ_EXPORT_SUBJECT = CRYPTUI_WIZ_EXPORT_SUBJECT(4u32);
@@ -854,9 +773,6 @@ impl Default for CRYPTUI_WIZ_EXPORT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTUI_WIZ_EXPORT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CRYPTUI_WIZ_EXPORT_INFO_0 {
@@ -869,9 +785,6 @@ impl Default for CRYPTUI_WIZ_EXPORT_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTUI_WIZ_EXPORT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTUI_WIZ_EXPORT_NO_DELETE_PRIVATE_KEY: CRYPTUI_WIZ_FLAGS = CRYPTUI_WIZ_FLAGS(512u32);
 pub const CRYPTUI_WIZ_EXPORT_PRIVATE_KEY: CRYPTUI_WIZ_FLAGS = CRYPTUI_WIZ_FLAGS(256u32);
@@ -934,9 +847,6 @@ impl Default for CRYPTUI_WIZ_IMPORT_SRC_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTUI_WIZ_IMPORT_SRC_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CRYPTUI_WIZ_IMPORT_SRC_INFO_0 {
@@ -950,9 +860,6 @@ impl Default for CRYPTUI_WIZ_IMPORT_SRC_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTUI_WIZ_IMPORT_SRC_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTUI_WIZ_IMPORT_SUBJECT_CERT_CONTEXT: CRYPTUI_WIZ_IMPORT_SUBJECT_OPTION = CRYPTUI_WIZ_IMPORT_SUBJECT_OPTION(2u32);
 pub const CRYPTUI_WIZ_IMPORT_SUBJECT_CERT_STORE: CRYPTUI_WIZ_IMPORT_SUBJECT_OPTION = CRYPTUI_WIZ_IMPORT_SUBJECT_OPTION(5u32);
@@ -985,9 +892,6 @@ impl Default for CTL_MODIFY_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CTL_MODIFY_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CTL_MODIFY_REQUEST_ADD_NOT_TRUSTED: CTL_MODIFY_REQUEST_OPERATION = CTL_MODIFY_REQUEST_OPERATION(1u32);
 pub const CTL_MODIFY_REQUEST_ADD_TRUSTED: CTL_MODIFY_REQUEST_OPERATION = CTL_MODIFY_REQUEST_OPERATION(3u32);

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
@@ -3117,9 +3117,6 @@ impl Default for AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_STATUS {
@@ -3130,9 +3127,6 @@ impl Default for AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUTHENTICODE_EXTRA_CERT_CHAIN_POLICY_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3145,9 +3139,6 @@ impl Default for AUTHENTICODE_TS_EXTRA_CERT_CHAIN_POLICY_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUTHENTICODE_TS_EXTRA_CERT_CHAIN_POLICY_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AUTHTYPE_CLIENT: HTTPSPOLICY_CALLBACK_DATA_AUTH_TYPE = HTTPSPOLICY_CALLBACK_DATA_AUTH_TYPE(1u32);
 pub const AUTHTYPE_SERVER: HTTPSPOLICY_CALLBACK_DATA_AUTH_TYPE = HTTPSPOLICY_CALLBACK_DATA_AUTH_TYPE(2u32);
@@ -3192,9 +3183,6 @@ impl Default for BCRYPT_ALGORITHM_IDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_ALGORITHM_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_ALGORITHM_NAME: windows_core::PCWSTR = windows_core::w!("AlgorithmName");
 #[repr(transparent)]
@@ -3252,9 +3240,6 @@ impl Default for BCRYPT_ASYMMETRIC_ENCRYPTION_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_ASYMMETRIC_ENCRYPTION_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_ASYMMETRIC_ENCRYPTION_INTERFACE: BCRYPT_INTERFACE = BCRYPT_INTERFACE(3u32);
 pub const BCRYPT_ASYMMETRIC_ENCRYPTION_OPERATION: BCRYPT_OPERATION = BCRYPT_OPERATION(4u32);
 #[repr(C)]
@@ -3278,9 +3263,6 @@ impl Default for BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO_VERSION: u32 = 1u32;
 pub const BCRYPT_AUTH_MODE_CHAIN_CALLS_FLAG: u32 = 1u32;
@@ -3323,9 +3305,6 @@ impl Default for BCRYPT_CIPHER_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_CIPHER_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_CIPHER_INTERFACE: BCRYPT_INTERFACE = BCRYPT_INTERFACE(1u32);
 pub const BCRYPT_CIPHER_OPERATION: BCRYPT_OPERATION = BCRYPT_OPERATION(1u32);
 pub const BCRYPT_COPY_AFTER_PADDING_CHECK_FAILURE_FLAG: u32 = 256u32;
@@ -3350,9 +3329,6 @@ impl Default for BCRYPT_DH_KEY_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_DH_KEY_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BCRYPT_DH_KEY_BLOB_MAGIC(pub u32);
@@ -3369,9 +3345,6 @@ impl Default for BCRYPT_DH_PARAMETER_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_DH_PARAMETER_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_DH_PRIVATE_BLOB: windows_core::PCWSTR = windows_core::w!("DHPRIVATEBLOB");
 pub const BCRYPT_DH_PRIVATE_MAGIC: BCRYPT_DH_KEY_BLOB_MAGIC = BCRYPT_DH_KEY_BLOB_MAGIC(1448101956u32);
@@ -3393,9 +3366,6 @@ impl Default for BCRYPT_DSA_KEY_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_DSA_KEY_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BCRYPT_DSA_KEY_BLOB_V2 {
@@ -3411,9 +3381,6 @@ impl Default for BCRYPT_DSA_KEY_BLOB_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_DSA_KEY_BLOB_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3436,9 +3403,6 @@ impl Default for BCRYPT_DSA_PARAMETER_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_DSA_PARAMETER_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BCRYPT_DSA_PARAMETER_HEADER_V2 {
@@ -3455,9 +3419,6 @@ impl Default for BCRYPT_DSA_PARAMETER_HEADER_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_DSA_PARAMETER_HEADER_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_DSA_PRIVATE_BLOB: windows_core::PCWSTR = windows_core::w!("DSAPRIVATEBLOB");
 pub const BCRYPT_DSA_PRIVATE_MAGIC: BCRYPT_DSA_MAGIC = BCRYPT_DSA_MAGIC(1448104772u32);
@@ -3482,9 +3443,6 @@ impl Default for BCRYPT_ECCFULLKEY_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_ECCFULLKEY_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_ECCFULLPRIVATE_BLOB: windows_core::PCWSTR = windows_core::w!("ECCFULLPRIVATEBLOB");
 pub const BCRYPT_ECCFULLPUBLIC_BLOB: windows_core::PCWSTR = windows_core::w!("ECCFULLPUBLICBLOB");
 #[repr(C)]
@@ -3497,9 +3455,6 @@ impl Default for BCRYPT_ECCKEY_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_ECCKEY_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_ECCPRIVATE_BLOB: windows_core::PCWSTR = windows_core::w!("ECCPRIVATEBLOB");
 pub const BCRYPT_ECCPUBLIC_BLOB: windows_core::PCWSTR = windows_core::w!("ECCPUBLICBLOB");
@@ -3530,9 +3485,6 @@ impl Default for BCRYPT_ECC_CURVE_NAMES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_ECC_CURVE_NAMES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_ECC_CURVE_NAME_LIST: windows_core::PCWSTR = windows_core::w!("ECCCurveNameList");
 pub const BCRYPT_ECC_CURVE_NISTP192: windows_core::PCWSTR = windows_core::w!("nistP192");
@@ -3582,9 +3534,6 @@ impl Default for BCRYPT_ECC_PARAMETER_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_ECC_PARAMETER_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_ECC_PARAMETER_HEADER_V1: u32 = 1u32;
 pub const BCRYPT_ECC_PRIME_MONTGOMERY_CURVE: ECC_CURVE_TYPE_ENUM = ECC_CURVE_TYPE_ENUM(3i32);
@@ -3701,9 +3650,6 @@ impl Default for BCRYPT_HASH_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_HASH_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BCRYPT_HASH_HANDLE(pub *mut core::ffi::c_void);
@@ -3773,9 +3719,6 @@ impl Default for BCRYPT_INTERFACE_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_INTERFACE_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_IS_IFX_TPM_WEAK_KEY: windows_core::PCWSTR = windows_core::w!("IsIfxTpmWeakKey");
 pub const BCRYPT_IS_KEYED_HASH: windows_core::PCWSTR = windows_core::w!("IsKeyedHash");
 pub const BCRYPT_IS_REUSABLE_HASH: windows_core::PCWSTR = windows_core::w!("IsReusableHash");
@@ -3795,9 +3738,6 @@ impl Default for BCRYPT_KEY_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_KEY_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_KEY_DATA_BLOB: windows_core::PCWSTR = windows_core::w!("KeyDataBlob");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3810,9 +3750,6 @@ impl Default for BCRYPT_KEY_DATA_BLOB_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_KEY_DATA_BLOB_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_KEY_DATA_BLOB_MAGIC: u32 = 1296188491u32;
 pub const BCRYPT_KEY_DATA_BLOB_VERSION1: u32 = 1u32;
@@ -3835,9 +3772,6 @@ impl Default for BCRYPT_KEY_DERIVATION_FUNCTION_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_KEY_DERIVATION_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_KEY_DERIVATION_INTERFACE: u32 = 7u32;
 pub const BCRYPT_KEY_DERIVATION_OPERATION: u32 = 64u32;
@@ -3886,9 +3820,6 @@ impl Default for BCRYPT_KEY_LENGTHS_STRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_KEY_LENGTHS_STRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_KEY_OBJECT_LENGTH: windows_core::PCWSTR = windows_core::w!("KeyObjectLength");
 pub const BCRYPT_KEY_STRENGTH: windows_core::PCWSTR = windows_core::w!("KeyStrength");
 pub const BCRYPT_KEY_VALIDATION_RANGE: u32 = 16u32;
@@ -3915,9 +3846,6 @@ impl Default for BCRYPT_MULTI_HASH_OPERATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_MULTI_HASH_OPERATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_MULTI_OBJECT_LENGTH: windows_core::PCWSTR = windows_core::w!("MultiObjectLength");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3929,9 +3857,6 @@ impl Default for BCRYPT_MULTI_OBJECT_LENGTH_STRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_MULTI_OBJECT_LENGTH_STRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3950,9 +3875,6 @@ impl Default for BCRYPT_OAEP_PADDING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_OAEP_PADDING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_OBJECT_ALIGNMENT: u32 = 16u32;
 pub const BCRYPT_OBJECT_LENGTH: windows_core::PCWSTR = windows_core::w!("ObjectLength");
 #[repr(C)]
@@ -3966,9 +3888,6 @@ impl Default for BCRYPT_OID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_OID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BCRYPT_OID_LIST {
@@ -3979,9 +3898,6 @@ impl Default for BCRYPT_OID_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_OID_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_OPAQUE_KEY_BLOB: windows_core::PCWSTR = windows_core::w!("OpaqueKeyBlob");
 #[repr(transparent)]
@@ -4077,9 +3993,6 @@ impl Default for BCRYPT_PKCS1_PADDING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_PKCS1_PADDING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_PRIMITIVE_TYPE: windows_core::PCWSTR = windows_core::w!("PrimitiveType");
 pub const BCRYPT_PRIVATE_KEY: windows_core::PCWSTR = windows_core::w!("PrivKeyVal");
 pub const BCRYPT_PRIVATE_KEY_BLOB: windows_core::PCWSTR = windows_core::w!("PRIVATEBLOB");
@@ -4095,9 +4008,6 @@ impl Default for BCRYPT_PROVIDER_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_PROVIDER_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_PROV_DISPATCH: BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS = BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS(1u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4109,9 +4019,6 @@ impl Default for BCRYPT_PSS_PADDING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_PSS_PADDING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_PUBLIC_KEY_BLOB: windows_core::PCWSTR = windows_core::w!("PUBLICBLOB");
 pub const BCRYPT_PUBLIC_KEY_FLAG: u32 = 1u32;
@@ -4180,9 +4087,6 @@ impl Default for BCRYPT_RNG_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_RNG_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_RNG_INTERFACE: BCRYPT_INTERFACE = BCRYPT_INTERFACE(6u32);
 pub const BCRYPT_RNG_OPERATION: BCRYPT_OPERATION = BCRYPT_OPERATION(32u32);
 pub const BCRYPT_RNG_USE_ENTROPY_IN_BUFFER: BCRYPTGENRANDOM_FLAGS = BCRYPTGENRANDOM_FLAGS(1u32);
@@ -4202,9 +4106,6 @@ impl Default for BCRYPT_RSAKEY_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_RSAKEY_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4238,9 +4139,6 @@ impl Default for BCRYPT_SECRET_AGREEMENT_FUNCTION_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCRYPT_SECRET_AGREEMENT_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BCRYPT_SECRET_AGREEMENT_INTERFACE: BCRYPT_INTERFACE = BCRYPT_INTERFACE(4u32);
 pub const BCRYPT_SECRET_AGREEMENT_OPERATION: BCRYPT_OPERATION = BCRYPT_OPERATION(8u32);
@@ -4304,9 +4202,6 @@ impl Default for BCRYPT_SIGNATURE_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCRYPT_SIGNATURE_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BCRYPT_SIGNATURE_INTERFACE: BCRYPT_INTERFACE = BCRYPT_INTERFACE(5u32);
 pub const BCRYPT_SIGNATURE_LENGTH: windows_core::PCWSTR = windows_core::w!("SignatureLength");
 pub const BCRYPT_SIGNATURE_OPERATION: BCRYPT_OPERATION = BCRYPT_OPERATION(16u32);
@@ -4342,9 +4237,6 @@ impl Default for BCryptBuffer {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BCryptBuffer {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BCryptBufferDesc {
@@ -4356,9 +4248,6 @@ impl Default for BCryptBufferDesc {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BCryptBufferDesc {
-    type TypeKind = windows_core::CopyType;
 }
 pub type BCryptCloseAlgorithmProviderFn = Option<unsafe extern "system" fn(halgorithm: BCRYPT_ALG_HANDLE, dwflags: u32) -> super::super::Foundation::NTSTATUS>;
 pub type BCryptCreateHashFn = Option<unsafe extern "system" fn(halgorithm: BCRYPT_ALG_HANDLE, phhash: *mut BCRYPT_HASH_HANDLE, pbhashobject: *mut u8, cbhashobject: u32, pbsecret: *const u8, cbsecret: u32, dwflags: u32) -> super::super::Foundation::NTSTATUS>;
@@ -4464,9 +4353,6 @@ impl Default for CARD_AUTHENTICATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CARD_AUTHENTICATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CARD_AUTHENTICATE_CURRENT_VERSION: u32 = 7u32;
 pub const CARD_AUTHENTICATE_GENERATE_SESSION_PIN: u32 = 268435456u32;
 pub const CARD_AUTHENTICATE_PIN_CHALLENGE_RESPONSE: u32 = 1u32;
@@ -4483,9 +4369,6 @@ impl Default for CARD_AUTHENTICATE_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CARD_AUTHENTICATE_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CARD_AUTHENTICATE_RESPONSE_CURRENT_VERSION: u32 = 7u32;
 pub const CARD_AUTHENTICATE_RESPONSE_VERSION_SEVEN: u32 = 7u32;
@@ -4506,9 +4389,6 @@ impl Default for CARD_CACHE_FILE_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CARD_CACHE_FILE_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CARD_CAPABILITIES {
@@ -4520,9 +4400,6 @@ impl Default for CARD_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CARD_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CARD_CAPABILITIES_CURRENT_VERSION: u32 = 1u32;
 pub const CARD_CHAIN_MODE_CBC: windows_core::PCWSTR = windows_core::w!("ChainingModeCBC");
@@ -4543,9 +4420,6 @@ impl Default for CARD_CHANGE_AUTHENTICATOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CARD_CHANGE_AUTHENTICATOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CARD_CHANGE_AUTHENTICATOR_CURRENT_VERSION: u32 = 7u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4557,9 +4431,6 @@ impl Default for CARD_CHANGE_AUTHENTICATOR_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CARD_CHANGE_AUTHENTICATOR_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CARD_CHANGE_AUTHENTICATOR_RESPONSE_CURRENT_VERSION: u32 = 7u32;
 pub const CARD_CHANGE_AUTHENTICATOR_RESPONSE_VERSION_SEVEN: u32 = 7u32;
@@ -4639,9 +4510,6 @@ impl Default for CARD_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CARD_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CARD_DATA_CURRENT_VERSION: u32 = 7u32;
 pub const CARD_DATA_VALUE_UNKNOWN: u32 = 4294967295u32;
 pub const CARD_DATA_VERSION_FIVE: u32 = 5u32;
@@ -4667,9 +4535,6 @@ impl Default for CARD_DERIVE_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CARD_DERIVE_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CARD_DERIVE_KEY_CURRENT_VERSION: u32 = 2u32;
 pub const CARD_DERIVE_KEY_VERSION: u32 = 1u32;
 pub const CARD_DERIVE_KEY_VERSION_TWO: u32 = 2u32;
@@ -4690,9 +4555,6 @@ impl Default for CARD_DH_AGREEMENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CARD_DH_AGREEMENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CARD_DH_AGREEMENT_INFO_VERSION: u32 = 2u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4707,9 +4569,6 @@ impl Default for CARD_ENCRYPTED_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CARD_ENCRYPTED_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4726,9 +4585,6 @@ impl Default for CARD_FILE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CARD_FILE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CARD_FILE_INFO_CURRENT_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4742,9 +4598,6 @@ impl Default for CARD_FREE_SPACE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CARD_FREE_SPACE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CARD_FREE_SPACE_INFO_CURRENT_VERSION: u32 = 1u32;
 #[repr(C)]
@@ -4762,9 +4615,6 @@ impl Default for CARD_IMPORT_KEYPAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CARD_IMPORT_KEYPAIR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CARD_IMPORT_KEYPAIR_CURRENT_VERSION: u32 = 7u32;
 pub const CARD_IMPORT_KEYPAIR_VERSION_SEVEN: u32 = 7u32;
@@ -4785,9 +4635,6 @@ impl Default for CARD_KEY_SIZES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CARD_KEY_SIZES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CARD_KEY_SIZES_CURRENT_VERSION: u32 = 1u32;
 pub const CARD_PADDING_INFO_PRESENT: u32 = 1073741824u32;
@@ -4815,9 +4662,6 @@ impl Default for CARD_RSA_DECRYPT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CARD_RSA_DECRYPT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CARD_RSA_KEY_DECRYPT_INFO_CURRENT_VERSION: u32 = 2u32;
 pub const CARD_RSA_KEY_DECRYPT_INFO_VERSION_ONE: u32 = 1u32;
 pub const CARD_RSA_KEY_DECRYPT_INFO_VERSION_TWO: u32 = 2u32;
@@ -4841,9 +4685,6 @@ impl Default for CARD_SIGNING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CARD_SIGNING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CARD_SIGNING_INFO_BASIC_VERSION: u32 = 1u32;
 pub const CARD_SIGNING_INFO_CURRENT_VERSION: u32 = 2u32;
@@ -4871,9 +4712,6 @@ impl Default for CERTIFICATE_CHAIN_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERTIFICATE_CHAIN_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CERT_ACCESS_DESCRIPTION {
@@ -4884,9 +4722,6 @@ impl Default for CERT_ACCESS_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_ACCESS_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_ACCESS_STATE_GP_SYSTEM_STORE_FLAG: u32 = 8u32;
 pub const CERT_ACCESS_STATE_LM_SYSTEM_STORE_FLAG: u32 = 4u32;
@@ -4907,9 +4742,6 @@ impl Default for CERT_ALT_NAME_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_ALT_NAME_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CERT_ALT_NAME_ENTRY_0 {
@@ -4926,9 +4758,6 @@ impl Default for CERT_ALT_NAME_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_ALT_NAME_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_ALT_NAME_ENTRY_ERR_INDEX_MASK: u32 = 255u32;
 pub const CERT_ALT_NAME_ENTRY_ERR_INDEX_SHIFT: u32 = 16u32;
 #[repr(C)]
@@ -4941,9 +4770,6 @@ impl Default for CERT_ALT_NAME_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_ALT_NAME_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_ALT_NAME_VALUE_ERR_INDEX_MASK: u32 = 65535u32;
 pub const CERT_ALT_NAME_VALUE_ERR_INDEX_SHIFT: u32 = 0u32;
@@ -4961,9 +4787,6 @@ impl Default for CERT_AUTHORITY_INFO_ACCESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_AUTHORITY_INFO_ACCESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_AUTHORITY_INFO_ACCESS_PROP_ID: u32 = 68u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4977,9 +4800,6 @@ impl Default for CERT_AUTHORITY_KEY_ID2_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_AUTHORITY_KEY_ID2_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_AUTHORITY_KEY_ID_INFO {
@@ -4991,9 +4811,6 @@ impl Default for CERT_AUTHORITY_KEY_ID_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_AUTHORITY_KEY_ID_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_AUTH_ROOT_AUTO_UPDATE_DISABLE_PARTIAL_CHAIN_LOGGING_FLAG: u32 = 2u32;
 pub const CERT_AUTH_ROOT_AUTO_UPDATE_DISABLE_UNTRUSTED_ROOT_LOGGING_FLAG: u32 = 1u32;
@@ -5026,9 +4843,6 @@ impl Default for CERT_BASIC_CONSTRAINTS2_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_BASIC_CONSTRAINTS2_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_BASIC_CONSTRAINTS_INFO {
@@ -5043,9 +4857,6 @@ impl Default for CERT_BASIC_CONSTRAINTS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_BASIC_CONSTRAINTS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CERT_BIOMETRIC_DATA {
@@ -5058,9 +4869,6 @@ impl Default for CERT_BIOMETRIC_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_BIOMETRIC_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CERT_BIOMETRIC_DATA_0 {
@@ -5071,9 +4879,6 @@ impl Default for CERT_BIOMETRIC_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_BIOMETRIC_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5088,9 +4893,6 @@ impl Default for CERT_BIOMETRIC_EXT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_BIOMETRIC_EXT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_BIOMETRIC_OID_DATA_CHOICE: CERT_BIOMETRIC_DATA_TYPE = CERT_BIOMETRIC_DATA_TYPE(2u32);
 pub const CERT_BIOMETRIC_PICTURE_TYPE: u32 = 0u32;
@@ -5114,9 +4916,6 @@ impl Default for CERT_CHAIN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_CHAIN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_CHAIN_AUTO_CURRENT_USER: u32 = 1u32;
 pub const CERT_CHAIN_AUTO_FLAGS_VALUE_NAME: windows_core::PCWSTR = windows_core::w!("AutoFlags");
@@ -5156,9 +4955,6 @@ impl Default for CERT_CHAIN_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_CHAIN_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_CHAIN_CRL_VALIDITY_EXT_PERIOD_HOURS_DEFAULT: u32 = 12u32;
 pub const CERT_CHAIN_CRL_VALIDITY_EXT_PERIOD_HOURS_VALUE_NAME: windows_core::PCWSTR = windows_core::w!("CRLValidityExtensionPeriod");
@@ -5204,9 +5000,6 @@ impl Default for CERT_CHAIN_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_CHAIN_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_CHAIN_ENABLE_ALL_EKU_HYGIENE_FLAG: u32 = 131072u32;
 pub const CERT_CHAIN_ENABLE_CACHE_AUTO_UPDATE: u32 = 16u32;
 pub const CERT_CHAIN_ENABLE_CODE_SIGNING_HYGIENE_FLAG: u32 = 16777216u32;
@@ -5245,9 +5038,6 @@ impl Default for CERT_CHAIN_ENGINE_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_CHAIN_ENGINE_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG: u32 = 1u32;
 pub const CERT_CHAIN_FIND_BY_ISSUER: u32 = 1u32;
 pub const CERT_CHAIN_FIND_BY_ISSUER_CACHE_ONLY_FLAG: CERT_FIND_CHAIN_IN_STORE_FLAGS = CERT_FIND_CHAIN_IN_STORE_FLAGS(32768u32);
@@ -5272,9 +5062,6 @@ impl Default for CERT_CHAIN_FIND_BY_ISSUER_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_CHAIN_FIND_BY_ISSUER_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_CHAIN_HAS_MOTW: u32 = 16384u32;
 pub const CERT_CHAIN_MAX_AIA_URL_COUNT_IN_CERT_DEFAULT: u32 = 5u32;
@@ -5318,9 +5105,6 @@ impl Default for CERT_CHAIN_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_CHAIN_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_CHAIN_POLICY_ALLOW_TESTROOT_FLAG: CERT_CHAIN_POLICY_FLAGS = CERT_CHAIN_POLICY_FLAGS(32768u32);
 pub const CERT_CHAIN_POLICY_ALLOW_UNKNOWN_CA_FLAG: CERT_CHAIN_POLICY_FLAGS = CERT_CHAIN_POLICY_FLAGS(16u32);
@@ -5395,9 +5179,6 @@ impl Default for CERT_CHAIN_POLICY_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_CHAIN_POLICY_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_CHAIN_POLICY_SSL: windows_core::PCSTR = windows_core::PCSTR(4i32 as _);
 pub const CERT_CHAIN_POLICY_SSL_F12: windows_core::PCSTR = windows_core::PCSTR(9i32 as _);
 pub const CERT_CHAIN_POLICY_SSL_F12_ERROR_LEVEL: u32 = 2u32;
@@ -5426,9 +5207,6 @@ impl Default for CERT_CHAIN_POLICY_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_CHAIN_POLICY_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_CHAIN_POLICY_THIRD_PARTY_ROOT: windows_core::PCSTR = windows_core::PCSTR(11i32 as _);
 pub const CERT_CHAIN_POLICY_TRUST_TESTROOT_FLAG: CERT_CHAIN_POLICY_FLAGS = CERT_CHAIN_POLICY_FLAGS(16384u32);
@@ -5502,9 +5280,6 @@ impl Default for CERT_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_CONTEXT_REVOCATION_TYPE: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5525,9 +5300,6 @@ impl Default for CERT_CREATE_CONTEXT_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_CREATE_CONTEXT_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_CREATE_CONTEXT_SORTED_FLAG: u32 = 2u32;
 #[repr(transparent)]
@@ -5579,9 +5351,6 @@ impl Default for CERT_CRL_CONTEXT_PAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_CRL_CONTEXT_PAIR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_CRL_SIGN_KEY_USAGE: u32 = 2u32;
 pub const CERT_CROSS_CERT_DIST_POINTS_PROP_ID: u32 = 23u32;
 pub const CERT_CTL_USAGE_PROP_ID: u32 = 9u32;
@@ -5601,9 +5370,6 @@ impl Default for CERT_DH_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_DH_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_DIGITAL_SIGNATURE_KEY_USAGE: u32 = 128u32;
 pub const CERT_DISABLE_PIN_RULES_AUTO_UPDATE_VALUE_NAME: windows_core::PCWSTR = windows_core::w!("DisablePinRulesAutoUpdate");
@@ -5630,9 +5396,6 @@ impl Default for CERT_DSS_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_DSS_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_DSS_R_LEN: u32 = 20u32;
 pub const CERT_DSS_S_LEN: u32 = 20u32;
 #[repr(C)]
@@ -5645,9 +5408,6 @@ impl Default for CERT_ECC_SIGNATURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_ECC_SIGNATURE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_EFSBLOB_VALUE_NAME: windows_core::PCWSTR = windows_core::w!("EFSBlob");
 pub const CERT_EFS_PROP_ID: u32 = 17u32;
@@ -5671,9 +5431,6 @@ impl Default for CERT_EXTENSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_EXTENSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_EXTENSIONS {
@@ -5684,9 +5441,6 @@ impl Default for CERT_EXTENSIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_EXTENSIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_FILE_HASH_USE_TYPE: u32 = 1u32;
 pub const CERT_FILE_STORE_COMMIT_ENABLE_FLAG: u32 = 65536u32;
@@ -5821,9 +5575,6 @@ impl Default for CERT_FORTEZZA_DATA_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_FORTEZZA_DATA_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_FORTEZZA_DATA_PROP_ID: u32 = 18u32;
 pub const CERT_FRIENDLY_NAME_PROP_ID: u32 = 11u32;
 #[repr(C)]
@@ -5839,9 +5590,6 @@ impl Default for CERT_GENERAL_SUBTREE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_GENERAL_SUBTREE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_GROUP_POLICY_SYSTEM_STORE_REGPATH: windows_core::PCWSTR = windows_core::w!("Software\\Policies\\Microsoft\\SystemCertificates");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5854,9 +5602,6 @@ impl Default for CERT_HASHED_URL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_HASHED_URL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_HASH_PROP_ID: u32 = 3u32;
 pub const CERT_HCRYPTPROV_OR_NCRYPT_KEY_HANDLE_PROP_ID: u32 = 79u32;
@@ -5872,9 +5617,6 @@ impl Default for CERT_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CERT_ID_0 {
@@ -5886,9 +5628,6 @@ impl Default for CERT_ID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_ID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_ID_ISSUER_SERIAL_NUMBER: CERT_ID_OPTION = CERT_ID_OPTION(1u32);
 pub const CERT_ID_KEY_IDENTIFIER: CERT_ID_OPTION = CERT_ID_OPTION(2u32);
@@ -5919,9 +5658,6 @@ impl Default for CERT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_INFO_EXTENSION_FLAG: u32 = 11u32;
 pub const CERT_INFO_ISSUER_FLAG: u32 = 4u32;
 pub const CERT_INFO_ISSUER_UNIQUE_ID_FLAG: u32 = 9u32;
@@ -5949,9 +5685,6 @@ impl Default for CERT_ISSUER_SERIAL_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_ISSUER_SERIAL_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_ISSUER_SERIAL_NUMBER_MD5_HASH_PROP_ID: u32 = 28u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5964,9 +5697,6 @@ impl Default for CERT_KEYGEN_REQUEST_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_KEYGEN_REQUEST_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_KEYGEN_REQUEST_V1: u32 = 0u32;
 pub const CERT_KEY_AGREEMENT_KEY_USAGE: u32 = 8u32;
@@ -5982,9 +5712,6 @@ impl Default for CERT_KEY_ATTRIBUTES_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_KEY_ATTRIBUTES_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_KEY_CERT_SIGN_KEY_USAGE: u32 = 4u32;
 pub const CERT_KEY_CLASSIFICATION_PROP_ID: u32 = 120u32;
 #[repr(C)]
@@ -5999,9 +5726,6 @@ impl Default for CERT_KEY_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_KEY_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CERT_KEY_CONTEXT_0 {
@@ -6012,9 +5736,6 @@ impl Default for CERT_KEY_CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_KEY_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_KEY_CONTEXT_PROP_ID: u32 = 5u32;
 pub const CERT_KEY_ENCIPHERMENT_KEY_USAGE: u32 = 32u32;
@@ -6038,9 +5759,6 @@ impl Default for CERT_KEY_USAGE_RESTRICTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_KEY_USAGE_RESTRICTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_LAST_RESERVED_PROP_ID: u32 = 32767u32;
 pub const CERT_LAST_USER_PROP_ID: u32 = 65535u32;
 pub const CERT_LDAP_STORE_AREC_EXCLUSIVE_FLAG: u32 = 131072u32;
@@ -6056,9 +5774,6 @@ impl Default for CERT_LDAP_STORE_OPENED_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_LDAP_STORE_OPENED_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_LDAP_STORE_SIGN_FLAG: u32 = 65536u32;
 pub const CERT_LDAP_STORE_UNBIND_FLAG: u32 = 524288u32;
 pub const CERT_LOCAL_MACHINE_SYSTEM_STORE_REGPATH: windows_core::PCWSTR = windows_core::w!("Software\\Microsoft\\SystemCertificates");
@@ -6073,9 +5788,6 @@ impl Default for CERT_LOGOTYPE_AUDIO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_LOGOTYPE_AUDIO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_LOGOTYPE_AUDIO_INFO {
@@ -6089,9 +5801,6 @@ impl Default for CERT_LOGOTYPE_AUDIO_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_LOGOTYPE_AUDIO_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_LOGOTYPE_BITS_IMAGE_RESOLUTION_CHOICE: CERT_LOGOTYPE_CHOICE = CERT_LOGOTYPE_CHOICE(1u32);
 #[repr(transparent)]
@@ -6111,9 +5820,6 @@ impl Default for CERT_LOGOTYPE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_LOGOTYPE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_LOGOTYPE_DETAILS {
@@ -6125,9 +5831,6 @@ impl Default for CERT_LOGOTYPE_DETAILS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_LOGOTYPE_DETAILS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_LOGOTYPE_DIRECT_INFO_CHOICE: CERT_LOGOTYPE_OPTION = CERT_LOGOTYPE_OPTION(1u32);
 #[repr(C)]
@@ -6145,9 +5848,6 @@ impl Default for CERT_LOGOTYPE_EXT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_LOGOTYPE_EXT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_LOGOTYPE_GRAY_SCALE_IMAGE_INFO_CHOICE: CERT_LOGOTYPE_IMAGE_INFO_TYPE = CERT_LOGOTYPE_IMAGE_INFO_TYPE(1u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6159,9 +5859,6 @@ impl Default for CERT_LOGOTYPE_IMAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_LOGOTYPE_IMAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6179,9 +5876,6 @@ impl Default for CERT_LOGOTYPE_IMAGE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_LOGOTYPE_IMAGE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CERT_LOGOTYPE_IMAGE_INFO_0 {
@@ -6192,9 +5886,6 @@ impl Default for CERT_LOGOTYPE_IMAGE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_LOGOTYPE_IMAGE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6211,9 +5902,6 @@ impl Default for CERT_LOGOTYPE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_LOGOTYPE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CERT_LOGOTYPE_INFO_0 {
@@ -6224,9 +5912,6 @@ impl Default for CERT_LOGOTYPE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_LOGOTYPE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_LOGOTYPE_NO_IMAGE_RESOLUTION_CHOICE: CERT_LOGOTYPE_CHOICE = CERT_LOGOTYPE_CHOICE(0u32);
 #[repr(transparent)]
@@ -6242,9 +5927,6 @@ impl Default for CERT_LOGOTYPE_REFERENCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_LOGOTYPE_REFERENCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_LOGOTYPE_TABLE_SIZE_IMAGE_RESOLUTION_CHOICE: CERT_LOGOTYPE_CHOICE = CERT_LOGOTYPE_CHOICE(2u32);
 pub const CERT_MD5_HASH_PROP_ID: u32 = 4u32;
@@ -6262,9 +5944,6 @@ impl Default for CERT_NAME_CONSTRAINTS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_NAME_CONSTRAINTS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_NAME_DISABLE_IE4_UTF8_FLAG: u32 = 65536u32;
 pub const CERT_NAME_DNS_TYPE: u32 = 6u32;
 pub const CERT_NAME_EMAIL_TYPE: u32 = 1u32;
@@ -6279,9 +5958,6 @@ impl Default for CERT_NAME_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_NAME_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_NAME_ISSUER_FLAG: u32 = 1u32;
 pub const CERT_NAME_RDN_TYPE: u32 = 2u32;
@@ -6312,9 +5988,6 @@ impl Default for CERT_NAME_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_NAME_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_NCRYPT_KEY_HANDLE_PROP_ID: u32 = 78u32;
 pub const CERT_NCRYPT_KEY_HANDLE_TRANSFER_PROP_ID: u32 = 99u32;
@@ -6382,9 +6055,6 @@ impl Default for CERT_OR_CRL_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_OR_CRL_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_OR_CRL_BUNDLE {
@@ -6395,9 +6065,6 @@ impl Default for CERT_OR_CRL_BUNDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_OR_CRL_BUNDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6410,9 +6077,6 @@ impl Default for CERT_OTHER_LOGOTYPE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_OTHER_LOGOTYPE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_OTHER_NAME {
@@ -6424,9 +6088,6 @@ impl Default for CERT_OTHER_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_OTHER_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_PAIR {
@@ -6437,9 +6098,6 @@ impl Default for CERT_PAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_PAIR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_PHYSICAL_STORE_ADD_ENABLE_FLAG: u32 = 1u32;
 pub const CERT_PHYSICAL_STORE_AUTH_ROOT_NAME: windows_core::PCWSTR = windows_core::w!(".AuthRoot");
@@ -6462,9 +6120,6 @@ impl Default for CERT_PHYSICAL_STORE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_PHYSICAL_STORE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_PHYSICAL_STORE_INSERT_COMPUTER_NAME_ENABLE_FLAG: u32 = 8u32;
 pub const CERT_PHYSICAL_STORE_LOCAL_MACHINE_GROUP_POLICY_NAME: windows_core::PCWSTR = windows_core::w!(".LocalMachineGroupPolicy");
@@ -6492,9 +6147,6 @@ impl Default for CERT_POLICIES_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_POLICIES_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_POLICY95_QUALIFIER1 {
@@ -6509,9 +6161,6 @@ impl Default for CERT_POLICY95_QUALIFIER1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_POLICY95_QUALIFIER1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_POLICY_CONSTRAINTS_INFO {
@@ -6525,9 +6174,6 @@ impl Default for CERT_POLICY_CONSTRAINTS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_POLICY_CONSTRAINTS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_POLICY_ID {
@@ -6538,9 +6184,6 @@ impl Default for CERT_POLICY_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_POLICY_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6554,9 +6197,6 @@ impl Default for CERT_POLICY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_POLICY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_POLICY_MAPPING {
@@ -6567,9 +6207,6 @@ impl Default for CERT_POLICY_MAPPING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_POLICY_MAPPING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6582,9 +6219,6 @@ impl Default for CERT_POLICY_MAPPINGS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_POLICY_MAPPINGS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_POLICY_QUALIFIER_INFO {
@@ -6595,9 +6229,6 @@ impl Default for CERT_POLICY_QUALIFIER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_POLICY_QUALIFIER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6611,9 +6242,6 @@ impl Default for CERT_POLICY_QUALIFIER_NOTICE_REFERENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_POLICY_QUALIFIER_NOTICE_REFERENCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_POLICY_QUALIFIER_USER_NOTICE {
@@ -6625,9 +6253,6 @@ impl Default for CERT_POLICY_QUALIFIER_USER_NOTICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_POLICY_QUALIFIER_USER_NOTICE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_PRIVATE_KEY_VALIDITY {
@@ -6638,9 +6263,6 @@ impl Default for CERT_PRIVATE_KEY_VALIDITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_PRIVATE_KEY_VALIDITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_PROT_ROOT_DISABLE_CURRENT_USER_FLAG: u32 = 1u32;
 pub const CERT_PROT_ROOT_DISABLE_LM_AUTH_FLAG: u32 = 8u32;
@@ -6666,9 +6288,6 @@ impl Default for CERT_PUBLIC_KEY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_PUBLIC_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_PUB_KEY_CNG_ALG_BIT_LENGTH_PROP_ID: u32 = 93u32;
 pub const CERT_PVK_FILE_PROP_ID: u32 = 12u32;
 #[repr(C)]
@@ -6682,9 +6301,6 @@ impl Default for CERT_QC_STATEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_QC_STATEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_QC_STATEMENTS_EXT_INFO {
@@ -6695,9 +6311,6 @@ impl Default for CERT_QC_STATEMENTS_EXT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_QC_STATEMENTS_EXT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_QUERY_CONTENT_CERT: CERT_QUERY_CONTENT_TYPE = CERT_QUERY_CONTENT_TYPE(1u32);
 pub const CERT_QUERY_CONTENT_CERT_PAIR: CERT_QUERY_CONTENT_TYPE = CERT_QUERY_CONTENT_TYPE(13u32);
@@ -6800,9 +6413,6 @@ impl Default for CERT_RDN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_RDN {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_RDN_ANY_TYPE: CERT_RDN_ATTR_VALUE_TYPE = CERT_RDN_ATTR_VALUE_TYPE(0i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6815,9 +6425,6 @@ impl Default for CERT_RDN_ATTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_RDN_ATTR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6861,10 +6468,6 @@ impl Default for CERT_REGISTRY_STORE_CLIENT_GPT_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CERT_REGISTRY_STORE_CLIENT_GPT_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_REGISTRY_STORE_EXTERNAL_FLAG: u32 = 1048576u32;
 pub const CERT_REGISTRY_STORE_LM_GPT_FLAG: u32 = 16777216u32;
 pub const CERT_REGISTRY_STORE_MY_IE_DIRTY_FLAG: u32 = 524288u32;
@@ -6883,10 +6486,6 @@ impl Default for CERT_REGISTRY_STORE_ROAMING_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CERT_REGISTRY_STORE_ROAMING_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_REGISTRY_STORE_SERIALIZED_FLAG: u32 = 131072u32;
 pub const CERT_RENEWAL_PROP_ID: u32 = 64u32;
 #[repr(C)]
@@ -6902,9 +6501,6 @@ impl Default for CERT_REQUEST_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_REQUEST_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_REQUEST_ORIGINATOR_PROP_ID: u32 = 71u32;
 pub const CERT_REQUEST_V1: u32 = 0u32;
@@ -6933,9 +6529,6 @@ impl Default for CERT_REVOCATION_CHAIN_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_REVOCATION_CHAIN_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_REVOCATION_CRL_INFO {
@@ -6949,9 +6542,6 @@ impl Default for CERT_REVOCATION_CRL_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_REVOCATION_CRL_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6969,9 +6559,6 @@ impl Default for CERT_REVOCATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_REVOCATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_REVOCATION_PARA {
@@ -6987,9 +6574,6 @@ impl Default for CERT_REVOCATION_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_REVOCATION_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_REVOCATION_STATUS {
@@ -7004,9 +6588,6 @@ impl Default for CERT_REVOCATION_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_REVOCATION_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7097,9 +6678,6 @@ impl Default for CERT_SELECT_CHAIN_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_SELECT_CHAIN_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_SELECT_CRITERIA {
@@ -7111,9 +6689,6 @@ impl Default for CERT_SELECT_CRITERIA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_SELECT_CRITERIA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7142,9 +6717,6 @@ impl Default for CERT_SERVER_OCSP_RESPONSE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_SERVER_OCSP_RESPONSE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_SERVER_OCSP_RESPONSE_OPEN_PARA {
@@ -7159,9 +6731,6 @@ impl Default for CERT_SERVER_OCSP_RESPONSE_OPEN_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_SERVER_OCSP_RESPONSE_OPEN_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_SERVER_OCSP_RESPONSE_OPEN_PARA_READ_FLAG: u32 = 1u32;
 pub const CERT_SERVER_OCSP_RESPONSE_OPEN_PARA_WRITE_FLAG: u32 = 2u32;
@@ -7184,9 +6753,6 @@ impl Default for CERT_SIGNED_CONTENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_SIGNED_CONTENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_SIGN_HASH_CNG_ALG_PROP_ID: u32 = 89u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7203,9 +6769,6 @@ impl Default for CERT_SIMPLE_CHAIN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_SIMPLE_CHAIN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_SIMPLE_NAME_STR: CERT_STRING_TYPE = CERT_STRING_TYPE(1u32);
 pub const CERT_SMART_CARD_DATA_PROP_ID: u32 = 16u32;
@@ -7283,9 +6846,6 @@ impl Default for CERT_STORE_PROV_FIND_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_STORE_PROV_FIND_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CERT_STORE_PROV_FLAGS(pub u32);
@@ -7343,9 +6903,6 @@ impl Default for CERT_STORE_PROV_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_STORE_PROV_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_STORE_PROV_LDAP: i32 = 16i32;
 pub const CERT_STORE_PROV_LDAP_W: windows_core::PCSTR = windows_core::PCSTR(16i32 as _);
@@ -7457,9 +7014,6 @@ impl Default for CERT_STRONG_SIGN_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_STRONG_SIGN_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CERT_STRONG_SIGN_PARA_0 {
@@ -7472,9 +7026,6 @@ impl Default for CERT_STRONG_SIGN_PARA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_STRONG_SIGN_PARA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_STRONG_SIGN_SERIALIZED_INFO {
@@ -7486,9 +7037,6 @@ impl Default for CERT_STRONG_SIGN_SERIALIZED_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_STRONG_SIGN_SERIALIZED_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_STRONG_SIGN_SERIALIZED_INFO_CHOICE: u32 = 1u32;
 pub const CERT_SUBJECT_DISABLE_CRL_PROP_ID: u32 = 86u32;
@@ -7509,9 +7057,6 @@ impl Default for CERT_SUPPORTED_ALGORITHM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_SUPPORTED_ALGORITHM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_SYSTEM_STORE_CURRENT_SERVICE_ID: u32 = 4u32;
 pub const CERT_SYSTEM_STORE_CURRENT_USER: u32 = 65536u32;
 pub const CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY_ID: u32 = 7u32;
@@ -7529,9 +7074,6 @@ impl Default for CERT_SYSTEM_STORE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_SYSTEM_STORE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_SYSTEM_STORE_LOCAL_MACHINE: u32 = 131072u32;
 pub const CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE_ID: u32 = 9u32;
@@ -7555,10 +7097,6 @@ impl Default for CERT_SYSTEM_STORE_RELOCATE_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CERT_SYSTEM_STORE_RELOCATE_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
 #[derive(Clone, Copy)]
@@ -7571,10 +7109,6 @@ impl Default for CERT_SYSTEM_STORE_RELOCATE_PARA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CERT_SYSTEM_STORE_RELOCATE_PARA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
@@ -7589,10 +7123,6 @@ impl Default for CERT_SYSTEM_STORE_RELOCATE_PARA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for CERT_SYSTEM_STORE_RELOCATE_PARA_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_SYSTEM_STORE_SERVICES_ID: u32 = 5u32;
 pub const CERT_SYSTEM_STORE_UNPROTECTED_FLAG: u32 = 1073741824u32;
@@ -7610,9 +7140,6 @@ impl Default for CERT_TEMPLATE_EXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_TEMPLATE_EXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_TIMESTAMP_HASH_USE_TYPE: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7625,9 +7152,6 @@ impl Default for CERT_TPM_SPECIFICATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_TPM_SPECIFICATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_TRUST_AUTO_UPDATE_CA_REVOCATION: u32 = 16u32;
 pub const CERT_TRUST_AUTO_UPDATE_END_REVOCATION: u32 = 32u32;
@@ -7683,9 +7207,6 @@ impl Default for CERT_TRUST_LIST_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_TRUST_LIST_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_TRUST_NO_ERROR: u32 = 0u32;
 pub const CERT_TRUST_NO_ISSUANCE_CHAIN_POLICY: u32 = 33554432u32;
 pub const CERT_TRUST_NO_OCSP_FAILOVER_TO_CRL: u32 = 64u32;
@@ -7713,9 +7234,6 @@ impl Default for CERT_TRUST_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_TRUST_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CERT_UNICODE_ATTR_ERR_INDEX_MASK: u32 = 63u32;
 pub const CERT_UNICODE_ATTR_ERR_INDEX_SHIFT: u32 = 16u32;
 pub const CERT_UNICODE_IS_RDN_ATTRS_FLAG: u32 = 1u32;
@@ -7733,9 +7251,6 @@ impl Default for CERT_USAGE_MATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_USAGE_MATCH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_V1: u32 = 0u32;
 pub const CERT_V2: u32 = 1u32;
@@ -7766,9 +7281,6 @@ impl Default for CERT_X942_DH_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CERT_X942_DH_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CERT_X942_DH_VALIDATION_PARAMS {
@@ -7779,9 +7291,6 @@ impl Default for CERT_X942_DH_VALIDATION_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CERT_X942_DH_VALIDATION_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CERT_XML_NAME_STR: u32 = 4u32;
 #[repr(transparent)]
@@ -7800,9 +7309,6 @@ impl Default for CLAIMLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLAIMLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLMD_FILE_TAG_CARD_AUTH_CERT: u32 = 6275329u32;
 pub const CLMD_FILE_TAG_CARD_CAPABILITY_CONTAINER: u32 = 6275335u32;
@@ -7831,9 +7337,6 @@ impl Default for CLMD_PIV_CERT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLMD_PIV_CERT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLMD_PIV_CERT_DATA_CURRENT_VERSION: u32 = 0u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7849,9 +7352,6 @@ impl Default for CLMD_PIV_GENERATE_ASYMMETRIC_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLMD_PIV_GENERATE_ASYMMETRIC_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLMD_PIV_GENERATE_ASYMMETRIC_KEY_CURRENT_VERSION: u32 = 0u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7865,9 +7365,6 @@ impl Default for CLMD_PIV_PUBLIC_KEY_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLMD_PIV_PUBLIC_KEY_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLMD_PIV_PUBLIC_KEY_DATA_CURRENT_VERSION: u32 = 0u32;
 pub const CMC_ADD_ATTRIBUTES: windows_core::PCSTR = windows_core::PCSTR(63i32 as _);
@@ -7885,9 +7382,6 @@ impl Default for CMC_ADD_ATTRIBUTES_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMC_ADD_ATTRIBUTES_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CMC_ADD_EXTENSIONS: windows_core::PCSTR = windows_core::PCSTR(62i32 as _);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7902,9 +7396,6 @@ impl Default for CMC_ADD_EXTENSIONS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMC_ADD_EXTENSIONS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMC_DATA: windows_core::PCSTR = windows_core::PCSTR(59i32 as _);
 #[repr(C)]
@@ -7923,9 +7414,6 @@ impl Default for CMC_DATA_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMC_DATA_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMC_FAIL_BAD_ALG: u32 = 0u32;
 pub const CMC_FAIL_BAD_CERT_ID: u32 = 4u32;
@@ -7954,9 +7442,6 @@ impl Default for CMC_PEND_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMC_PEND_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CMC_RESPONSE: windows_core::PCSTR = windows_core::PCSTR(60i32 as _);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7972,9 +7457,6 @@ impl Default for CMC_RESPONSE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMC_RESPONSE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMC_STATUS: windows_core::PCSTR = windows_core::PCSTR(61i32 as _);
 pub const CMC_STATUS_CONFIRM_REQUIRED: u32 = 5u32;
@@ -7994,9 +7476,6 @@ impl Default for CMC_STATUS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMC_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMC_STATUS_INFO_0 {
@@ -8007,9 +7486,6 @@ impl Default for CMC_STATUS_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMC_STATUS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMC_STATUS_NO_SUPPORT: u32 = 4u32;
 pub const CMC_STATUS_PENDING: u32 = 3u32;
@@ -8025,9 +7501,6 @@ impl Default for CMC_TAGGED_ATTRIBUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMC_TAGGED_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CMC_TAGGED_CERT_REQUEST {
@@ -8038,9 +7511,6 @@ impl Default for CMC_TAGGED_CERT_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMC_TAGGED_CERT_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMC_TAGGED_CERT_REQUEST_CHOICE: u32 = 1u32;
 #[repr(C)]
@@ -8054,9 +7524,6 @@ impl Default for CMC_TAGGED_CONTENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMC_TAGGED_CONTENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CMC_TAGGED_OTHER_MSG {
@@ -8069,9 +7536,6 @@ impl Default for CMC_TAGGED_OTHER_MSG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMC_TAGGED_OTHER_MSG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CMC_TAGGED_REQUEST {
@@ -8083,9 +7547,6 @@ impl Default for CMC_TAGGED_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMC_TAGGED_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMC_TAGGED_REQUEST_0 {
@@ -8095,9 +7556,6 @@ impl Default for CMC_TAGGED_REQUEST_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMC_TAGGED_REQUEST_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSCEPSetup: windows_core::GUID = windows_core::GUID::from_u128(0xaa4f5c02_8e7c_49c4_94fa_67a5cc5eadb4);
 pub const CMSG_ATTR_CERT_COUNT_PARAM: u32 = 31u32;
@@ -8123,9 +7581,6 @@ impl Default for CMSG_CMS_RECIPIENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_CMS_RECIPIENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_CMS_RECIPIENT_INFO_0 {
@@ -8137,9 +7592,6 @@ impl Default for CMSG_CMS_RECIPIENT_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_CMS_RECIPIENT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_CMS_RECIPIENT_INFO_PARAM: u32 = 36u32;
 #[repr(C)]
@@ -8157,9 +7609,6 @@ impl Default for CMSG_CMS_SIGNER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_CMS_SIGNER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_CMS_SIGNER_INFO_PARAM: u32 = 39u32;
 #[repr(C)]
@@ -8179,9 +7628,6 @@ impl Default for CMSG_CNG_CONTENT_DECRYPT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_CNG_CONTENT_DECRYPT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_COMPUTED_HASH_PARAM: u32 = 22u32;
 pub const CMSG_CONTENTS_OCTETS_FLAG: u32 = 16u32;
@@ -8211,9 +7657,6 @@ impl Default for CMSG_CONTENT_ENCRYPT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_CONTENT_ENCRYPT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_CONTENT_ENCRYPT_INFO_0 {
@@ -8224,9 +7667,6 @@ impl Default for CMSG_CONTENT_ENCRYPT_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_CONTENT_ENCRYPT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_CONTENT_ENCRYPT_PAD_ENCODED_LEN_FLAG: u32 = 1u32;
 pub const CMSG_CONTENT_ENCRYPT_RELEASE_CONTEXT_FLAG: u32 = 32768u32;
@@ -8252,9 +7692,6 @@ impl Default for CMSG_CTRL_ADD_SIGNER_UNAUTH_ATTR_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_CTRL_ADD_SIGNER_UNAUTH_ATTR_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CMSG_CTRL_DECRYPT: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8269,9 +7706,6 @@ impl Default for CMSG_CTRL_DECRYPT_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_CTRL_DECRYPT_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_CTRL_DECRYPT_PARA_0 {
@@ -8282,9 +7716,6 @@ impl Default for CMSG_CTRL_DECRYPT_PARA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_CTRL_DECRYPT_PARA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_CTRL_DEL_ATTR_CERT: u32 = 15u32;
 pub const CMSG_CTRL_DEL_CERT: u32 = 11u32;
@@ -8302,9 +7733,6 @@ impl Default for CMSG_CTRL_DEL_SIGNER_UNAUTH_ATTR_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_CTRL_DEL_SIGNER_UNAUTH_ATTR_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_CTRL_ENABLE_STRONG_SIGNATURE: u32 = 21u32;
 pub const CMSG_CTRL_KEY_AGREE_DECRYPT: u32 = 17u32;
@@ -8324,9 +7752,6 @@ impl Default for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_CTRL_KEY_AGREE_DECRYPT_PARA_0 {
@@ -8337,9 +7762,6 @@ impl Default for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_CTRL_KEY_AGREE_DECRYPT_PARA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_CTRL_KEY_TRANS_DECRYPT: u32 = 16u32;
 #[repr(C)]
@@ -8356,9 +7778,6 @@ impl Default for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_CTRL_KEY_TRANS_DECRYPT_PARA_0 {
@@ -8369,9 +7788,6 @@ impl Default for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_CTRL_KEY_TRANS_DECRYPT_PARA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_CTRL_MAIL_LIST_DECRYPT: u32 = 18u32;
 #[repr(C)]
@@ -8389,9 +7805,6 @@ impl Default for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_CTRL_MAIL_LIST_DECRYPT_PARA_0 {
@@ -8402,9 +7815,6 @@ impl Default for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_CTRL_MAIL_LIST_DECRYPT_PARA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_CTRL_VERIFY_HASH: u32 = 5u32;
 pub const CMSG_CTRL_VERIFY_SIGNATURE: u32 = 1u32;
@@ -8422,9 +7832,6 @@ impl Default for CMSG_CTRL_VERIFY_SIGNATURE_EX_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_CTRL_VERIFY_SIGNATURE_EX_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_DATA: CRYPT_MSG_TYPE = CRYPT_MSG_TYPE(1u32);
 pub const CMSG_DEFAULT_INSTALLABLE_FUNC_OID: windows_core::PCSTR = windows_core::PCSTR(1i32 as _);
@@ -8448,9 +7855,6 @@ impl Default for CMSG_ENCRYPTED_ENCODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_ENCRYPTED_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CMSG_ENCRYPT_PARAM: u32 = 26u32;
 pub const CMSG_ENVELOPED: CRYPT_MSG_TYPE = CRYPT_MSG_TYPE(3u32);
 pub const CMSG_ENVELOPED_DATA_CMS_VERSION: u32 = 2u32;
@@ -8471,9 +7875,6 @@ impl Default for CMSG_ENVELOPED_ENCODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_ENVELOPED_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_ENVELOPED_RECIPIENT_V0: u32 = 0u32;
 pub const CMSG_ENVELOPED_RECIPIENT_V2: u32 = 2u32;
@@ -8497,9 +7898,6 @@ impl Default for CMSG_HASHED_ENCODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_HASHED_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_HASH_ALGORITHM_PARAM: u32 = 20u32;
 pub const CMSG_HASH_DATA_PARAM: u32 = 21u32;
@@ -8529,9 +7927,6 @@ impl Default for CMSG_KEY_AGREE_ENCRYPT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_KEY_AGREE_ENCRYPT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_KEY_AGREE_ENCRYPT_INFO_0 {
@@ -8542,9 +7937,6 @@ impl Default for CMSG_KEY_AGREE_ENCRYPT_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_KEY_AGREE_ENCRYPT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_KEY_AGREE_EPHEMERAL_KEY_CHOICE: CMSG_KEY_AGREE_OPTION = CMSG_KEY_AGREE_OPTION(1u32);
 #[repr(C)]
@@ -8557,9 +7949,6 @@ impl Default for CMSG_KEY_AGREE_KEY_ENCRYPT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_KEY_AGREE_KEY_ENCRYPT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8591,9 +7980,6 @@ impl Default for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO_0 {
@@ -8604,9 +7990,6 @@ impl Default for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_KEY_AGREE_RECIPIENT_ENCODE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8624,9 +8007,6 @@ impl Default for CMSG_KEY_AGREE_RECIPIENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_KEY_AGREE_RECIPIENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_KEY_AGREE_RECIPIENT_INFO_0 {
@@ -8637,9 +8017,6 @@ impl Default for CMSG_KEY_AGREE_RECIPIENT_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_KEY_AGREE_RECIPIENT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_KEY_AGREE_STATIC_KEY_CHOICE: CMSG_KEY_AGREE_OPTION = CMSG_KEY_AGREE_OPTION(2u32);
 pub const CMSG_KEY_AGREE_VERSION: u32 = 3u32;
@@ -8660,9 +8037,6 @@ impl Default for CMSG_KEY_TRANS_ENCRYPT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_KEY_TRANS_ENCRYPT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CMSG_KEY_TRANS_PKCS_1_5_VERSION: u32 = 0u32;
 pub const CMSG_KEY_TRANS_RECIPIENT: u32 = 1u32;
 #[repr(C)]
@@ -8680,9 +8054,6 @@ impl Default for CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_KEY_TRANS_RECIPIENT_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CMSG_KEY_TRANS_RECIPIENT_INFO {
@@ -8695,9 +8066,6 @@ impl Default for CMSG_KEY_TRANS_RECIPIENT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_KEY_TRANS_RECIPIENT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_LENGTH_ONLY_FLAG: u32 = 2u32;
 pub const CMSG_MAIL_LIST_ENCRYPT_FREE_OBJID_FLAG: u32 = 2u32;
@@ -8715,9 +8083,6 @@ impl Default for CMSG_MAIL_LIST_ENCRYPT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_MAIL_LIST_ENCRYPT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_MAIL_LIST_HANDLE_KEY_CHOICE: u32 = 1u32;
 pub const CMSG_MAIL_LIST_RECIPIENT: u32 = 3u32;
@@ -8739,9 +8104,6 @@ impl Default for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO_0 {
@@ -8752,9 +8114,6 @@ impl Default for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_MAIL_LIST_RECIPIENT_ENCODE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8770,9 +8129,6 @@ impl Default for CMSG_MAIL_LIST_RECIPIENT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_MAIL_LIST_RECIPIENT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_MAIL_LIST_VERSION: u32 = 4u32;
 pub const CMSG_MAX_LENGTH_FLAG: u32 = 32u32;
@@ -8810,9 +8166,6 @@ impl Default for CMSG_RC2_AUX_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_RC2_AUX_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CMSG_RC4_AUX_INFO {
@@ -8823,9 +8176,6 @@ impl Default for CMSG_RC4_AUX_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_RC4_AUX_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_RC4_NO_SALT_FLAG: u32 = 1073741824u32;
 pub const CMSG_RECIPIENT_COUNT_PARAM: u32 = 17u32;
@@ -8840,9 +8190,6 @@ impl Default for CMSG_RECIPIENT_ENCODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_RECIPIENT_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_RECIPIENT_ENCODE_INFO_0 {
@@ -8854,9 +8201,6 @@ impl Default for CMSG_RECIPIENT_ENCODE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_RECIPIENT_ENCODE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8872,9 +8216,6 @@ impl Default for CMSG_RECIPIENT_ENCRYPTED_KEY_ENCODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_RECIPIENT_ENCRYPTED_KEY_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CMSG_RECIPIENT_ENCRYPTED_KEY_INFO {
@@ -8887,9 +8228,6 @@ impl Default for CMSG_RECIPIENT_ENCRYPTED_KEY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_RECIPIENT_ENCRYPTED_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_RECIPIENT_INDEX_PARAM: u32 = 18u32;
 pub const CMSG_RECIPIENT_INFO_PARAM: u32 = 19u32;
@@ -8906,9 +8244,6 @@ impl Default for CMSG_SIGNED_AND_ENVELOPED_ENCODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_SIGNED_AND_ENVELOPED_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_SIGNED_DATA_CMS_VERSION: u32 = 3u32;
 pub const CMSG_SIGNED_DATA_NO_SIGN_FLAG: u32 = 128u32;
@@ -8930,9 +8265,6 @@ impl Default for CMSG_SIGNED_ENCODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_SIGNED_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_SIGNER_AUTH_ATTR_PARAM: u32 = 9u32;
 pub const CMSG_SIGNER_CERT_ID_PARAM: u32 = 38u32;
@@ -8957,9 +8289,6 @@ impl Default for CMSG_SIGNER_ENCODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_SIGNER_ENCODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CMSG_SIGNER_ENCODE_INFO_0 {
@@ -8970,9 +8299,6 @@ impl Default for CMSG_SIGNER_ENCODE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_SIGNER_ENCODE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_SIGNER_HASH_ALGORITHM_PARAM: u32 = 8u32;
 #[repr(C)]
@@ -8992,9 +8318,6 @@ impl Default for CMSG_SIGNER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_SIGNER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CMSG_SIGNER_INFO_CMS_VERSION: u32 = 3u32;
 pub const CMSG_SIGNER_INFO_PARAM: u32 = 6u32;
 pub const CMSG_SIGNER_INFO_PKCS_1_5_VERSION: u32 = 1u32;
@@ -9013,9 +8336,6 @@ impl Default for CMSG_SP3_COMPATIBLE_AUX_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMSG_SP3_COMPATIBLE_AUX_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CMSG_SP3_COMPATIBLE_ENCRYPT_FLAG: u32 = 2147483648u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9028,9 +8348,6 @@ impl Default for CMSG_STREAM_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMSG_STREAM_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMSG_TRUSTED_SIGNER_FLAG: u32 = 1u32;
 pub const CMSG_TYPE_PARAM: u32 = 1u32;
@@ -9056,9 +8373,6 @@ impl Default for CMS_DH_KEY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMS_DH_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CMS_KEY_INFO {
@@ -9071,9 +8385,6 @@ impl Default for CMS_KEY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMS_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CMS_SIGNER_INFO: windows_core::PCSTR = windows_core::PCSTR(501i32 as _);
 pub const CNG_RSA_PRIVATE_KEY_BLOB: windows_core::PCSTR = windows_core::PCSTR(83i32 as _);
@@ -9093,9 +8404,6 @@ impl Default for CONTAINER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONTAINER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CONTAINER_INFO_CURRENT_VERSION: u32 = 1u32;
 pub const CONTAINER_MAP_DEFAULT_CONTAINER: u32 = 2u32;
 #[repr(C)]
@@ -9111,9 +8419,6 @@ impl Default for CONTAINER_MAP_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONTAINER_MAP_RECORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONTAINER_MAP_VALID_CONTAINER: u32 = 1u32;
 pub const CONTEXT_OID_CAPI2_ANY: windows_core::PCSTR = windows_core::PCSTR(5i32 as _);
@@ -9134,9 +8439,6 @@ impl Default for CPS_URLS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CPS_URLS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CP_CACHE_MODE_GLOBAL_CACHE: u32 = 1u32;
 pub const CP_CACHE_MODE_NO_CACHE: u32 = 3u32;
@@ -9190,9 +8492,6 @@ impl Default for CRL_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRL_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CRL_DIST_POINT {
@@ -9205,9 +8504,6 @@ impl Default for CRL_DIST_POINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRL_DIST_POINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRL_DIST_POINTS_INFO {
@@ -9218,9 +8514,6 @@ impl Default for CRL_DIST_POINTS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRL_DIST_POINTS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRL_DIST_POINT_ERR_CRL_ISSUER_BIT: i32 = -2147483648i32;
 pub const CRL_DIST_POINT_ERR_INDEX_MASK: u32 = 127u32;
@@ -9238,9 +8531,6 @@ impl Default for CRL_DIST_POINT_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRL_DIST_POINT_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CRL_DIST_POINT_NAME_0 {
@@ -9250,9 +8540,6 @@ impl Default for CRL_DIST_POINT_NAME_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRL_DIST_POINT_NAME_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRL_DIST_POINT_NO_NAME: u32 = 0u32;
 #[repr(C)]
@@ -9267,9 +8554,6 @@ impl Default for CRL_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRL_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRL_FIND_ANY: u32 = 0u32;
 pub const CRL_FIND_EXISTING: u32 = 2u32;
@@ -9290,9 +8574,6 @@ impl Default for CRL_FIND_ISSUED_FOR_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRL_FIND_ISSUED_FOR_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRL_FIND_ISSUED_FOR_SET_STRONG_PROPERTIES_FLAG: u32 = 16u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9312,9 +8593,6 @@ impl Default for CRL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CRL_ISSUING_DIST_POINT {
@@ -9328,9 +8606,6 @@ impl Default for CRL_ISSUING_DIST_POINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRL_ISSUING_DIST_POINT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRL_REASON_AA_COMPROMISE: u32 = 10u32;
 pub const CRL_REASON_AA_COMPROMISE_FLAG: u32 = 128u32;
@@ -9363,9 +8638,6 @@ impl Default for CRL_REVOCATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRL_REVOCATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRL_V1: u32 = 0u32;
 pub const CRL_V2: u32 = 1u32;
 #[repr(C)]
@@ -9379,9 +8651,6 @@ impl Default for CROSS_CERT_DIST_POINTS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CROSS_CERT_DIST_POINTS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CROSS_CERT_DIST_POINT_ERR_INDEX_MASK: u32 = 255u32;
 pub const CROSS_CERT_DIST_POINT_ERR_INDEX_SHIFT: u32 = 24u32;
@@ -9434,9 +8703,6 @@ impl Default for CRYPTNET_URL_CACHE_FLUSH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTNET_URL_CACHE_FLUSH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPTNET_URL_CACHE_PRE_FETCH_AUTOROOT_CAB: u32 = 5u32;
 pub const CRYPTNET_URL_CACHE_PRE_FETCH_BLOB: u32 = 1u32;
 pub const CRYPTNET_URL_CACHE_PRE_FETCH_CRL: u32 = 2u32;
@@ -9457,9 +8723,6 @@ impl Default for CRYPTNET_URL_CACHE_PRE_FETCH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTNET_URL_CACHE_PRE_FETCH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPTNET_URL_CACHE_PRE_FETCH_NONE: u32 = 0u32;
 pub const CRYPTNET_URL_CACHE_PRE_FETCH_OCSP: u32 = 3u32;
 pub const CRYPTNET_URL_CACHE_PRE_FETCH_PIN_RULES_CAB: u32 = 7u32;
@@ -9479,9 +8742,6 @@ impl Default for CRYPTNET_URL_CACHE_RESPONSE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPTNET_URL_CACHE_RESPONSE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPTNET_URL_CACHE_RESPONSE_NONE: u32 = 0u32;
 pub const CRYPTNET_URL_CACHE_RESPONSE_VALIDATED: u32 = 32768u32;
@@ -9510,9 +8770,6 @@ impl Default for CRYPTPROTECT_PROMPTSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPTPROTECT_PROMPTSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPTPROTECT_PROMPT_ON_PROTECT: u32 = 2u32;
 pub const CRYPTPROTECT_PROMPT_ON_UNPROTECT: u32 = 1u32;
 pub const CRYPTPROTECT_PROMPT_REQUIRE_STRONG: u32 = 16u32;
@@ -9531,9 +8788,6 @@ impl Default for CRYPT_3DES_KEY_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_3DES_KEY_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_ACCUMULATIVE_TIMEOUT: u32 = 2048u32;
 pub const CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG: CRYPT_ACQUIRE_FLAGS = CRYPT_ACQUIRE_FLAGS(65536u32);
@@ -9596,9 +8850,6 @@ impl Default for CRYPT_AES_128_KEY_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_AES_128_KEY_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_AES_256_KEY_STATE {
@@ -9613,9 +8864,6 @@ impl Default for CRYPT_AES_256_KEY_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_AES_256_KEY_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_AIA_RETRIEVAL: u32 = 524288u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9627,9 +8875,6 @@ impl Default for CRYPT_ALGORITHM_IDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_ALGORITHM_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_ALL_FUNCTIONS: BCRYPT_RESOLVE_PROVIDERS_FLAGS = BCRYPT_RESOLVE_PROVIDERS_FLAGS(1u32);
 pub const CRYPT_ALL_PROVIDERS: BCRYPT_RESOLVE_PROVIDERS_FLAGS = BCRYPT_RESOLVE_PROVIDERS_FLAGS(2u32);
@@ -9649,9 +8894,6 @@ impl Default for CRYPT_ASYNC_RETRIEVAL_COMPLETION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_ASYNC_RETRIEVAL_COMPLETION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_ATTRIBUTE {
@@ -9664,9 +8906,6 @@ impl Default for CRYPT_ATTRIBUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_ATTRIBUTES {
@@ -9678,9 +8917,6 @@ impl Default for CRYPT_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_ATTRIBUTE_TYPE_VALUE {
@@ -9691,9 +8927,6 @@ impl Default for CRYPT_ATTRIBUTE_TYPE_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_ATTRIBUTE_TYPE_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9707,9 +8940,6 @@ impl Default for CRYPT_BIT_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_BIT_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_BLOB_ARRAY {
@@ -9720,9 +8950,6 @@ impl Default for CRYPT_BLOB_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_BLOB_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_BLOB_VER3: CRYPT_KEY_FLAGS = CRYPT_KEY_FLAGS(128u32);
 pub const CRYPT_CACHE_ONLY_RETRIEVAL: u32 = 2u32;
@@ -9738,9 +8965,6 @@ impl Default for CRYPT_CONTENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_CONTENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_CONTENT_INFO_SEQUENCE_OF_ANY {
@@ -9753,9 +8977,6 @@ impl Default for CRYPT_CONTENT_INFO_SEQUENCE_OF_ANY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_CONTENT_INFO_SEQUENCE_OF_ANY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_CONTEXTS {
@@ -9767,9 +8988,6 @@ impl Default for CRYPT_CONTEXTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_CONTEXTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_CONTEXT_CONFIG {
@@ -9780,9 +8998,6 @@ impl Default for CRYPT_CONTEXT_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_CONTEXT_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9831,9 +9046,6 @@ impl Default for CRYPT_CONTEXT_FUNCTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_CONTEXT_FUNCTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_CONTEXT_FUNCTION_CONFIG {
@@ -9845,9 +9057,6 @@ impl Default for CRYPT_CONTEXT_FUNCTION_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_CONTEXT_FUNCTION_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_CONTEXT_FUNCTION_PROVIDERS {
@@ -9858,9 +9067,6 @@ impl Default for CRYPT_CONTEXT_FUNCTION_PROVIDERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_CONTEXT_FUNCTION_PROVIDERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_CREATE_IV: CRYPT_KEY_FLAGS = CRYPT_KEY_FLAGS(512u32);
 pub const CRYPT_CREATE_NEW_FLUSH_ENTRY: u32 = 268435456u32;
@@ -9877,9 +9083,6 @@ impl Default for CRYPT_CREDENTIALS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_CREDENTIALS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_CSP_PROVIDER {
@@ -9891,9 +9094,6 @@ impl Default for CRYPT_CSP_PROVIDER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_CSP_PROVIDER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_DATA_KEY: CRYPT_KEY_FLAGS = CRYPT_KEY_FLAGS(2048u32);
 pub const CRYPT_DECODE_ALLOC_FLAG: u32 = 32768u32;
@@ -9913,9 +9113,6 @@ impl Default for CRYPT_DECODE_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_DECODE_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_DECODE_SHARE_OID_STRING_FLAG: u32 = 4u32;
 pub const CRYPT_DECODE_TO_BE_SIGNED_FLAG: u32 = 2u32;
 pub const CRYPT_DECRYPT: u32 = 2u32;
@@ -9931,9 +9128,6 @@ impl Default for CRYPT_DECRYPT_MESSAGE_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_DECRYPT_MESSAGE_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_DECRYPT_RSA_NO_PADDING_CHECK: u32 = 32u32;
 pub const CRYPT_DEFAULT_CONTAINER_OPTIONAL: u32 = 128u32;
@@ -9988,9 +9182,6 @@ impl Default for CRYPT_DEFAULT_CONTEXT_MULTI_OID_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_DEFAULT_CONTEXT_MULTI_OID_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_DEFAULT_CONTEXT_PROCESS_FLAG: CRYPT_DEFAULT_CONTEXT_FLAGS = CRYPT_DEFAULT_CONTEXT_FLAGS(2u32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10012,9 +9203,6 @@ impl Default for CRYPT_DES_KEY_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_DES_KEY_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_DOMAIN: BCRYPT_TABLE = BCRYPT_TABLE(2u32);
 pub const CRYPT_DONT_CACHE_RESULT: u32 = 8u32;
 pub const CRYPT_DONT_CHECK_TIME_VALIDITY: u32 = 512u32;
@@ -10031,9 +9219,6 @@ impl Default for CRYPT_ECC_CMS_SHARED_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_ECC_CMS_SHARED_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_ECC_CMS_SHARED_INFO_SUPPPUBINFO_BYTE_LENGTH: u32 = 4u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10047,9 +9232,6 @@ impl Default for CRYPT_ECC_PRIVATE_KEY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_ECC_PRIVATE_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_ECC_PRIVATE_KEY_INFO_v1: u32 = 1u32;
 pub const CRYPT_ENABLE_FILE_RETRIEVAL: u32 = 134217728u32;
@@ -10107,9 +9289,6 @@ impl Default for CRYPT_ENCODE_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_ENCODE_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_ENCRYPT: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10121,9 +9300,6 @@ impl Default for CRYPT_ENCRYPTED_PRIVATE_KEY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_ENCRYPTED_PRIVATE_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_ENCRYPT_ALG_OID_GROUP_ID: u32 = 2u32;
 #[repr(C)]
@@ -10142,9 +9318,6 @@ impl Default for CRYPT_ENCRYPT_MESSAGE_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_ENCRYPT_MESSAGE_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_ENHKEY_USAGE_OID_GROUP_ID: u32 = 7u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10156,9 +9329,6 @@ impl Default for CRYPT_ENROLLMENT_NAME_VALUE_PAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_ENROLLMENT_NAME_VALUE_PAIR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_EXCLUSIVE: CRYPT_CONTEXT_CONFIG_FLAGS = CRYPT_CONTEXT_CONFIG_FLAGS(1u32);
 pub const CRYPT_EXPORT: u32 = 4u32;
@@ -10212,9 +9382,6 @@ impl Default for CRYPT_GET_TIME_VALID_OBJECT_EXTRA_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_GET_TIME_VALID_OBJECT_EXTRA_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CRYPT_GET_URL_FLAGS(pub u32);
@@ -10267,9 +9434,6 @@ impl Default for CRYPT_HASH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_HASH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_HASH_MESSAGE_PARA {
@@ -10284,9 +9448,6 @@ impl Default for CRYPT_HASH_MESSAGE_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_HASH_MESSAGE_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_HTTP_POST_RETRIEVAL: u32 = 1048576u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10298,9 +9459,6 @@ impl Default for CRYPT_IMAGE_REF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_IMAGE_REF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10349,9 +9507,6 @@ impl Default for CRYPT_IMAGE_REG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_IMAGE_REG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_IMPL_HARDWARE: u32 = 1u32;
 pub const CRYPT_IMPL_MIXED: u32 = 3u32;
@@ -10409,9 +9564,6 @@ impl Default for CRYPT_INTEGER_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_INTEGER_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_INTERFACE_REG {
@@ -10424,9 +9576,6 @@ impl Default for CRYPT_INTERFACE_REG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_INTERFACE_REG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_IPSEC_HMAC_KEY: CRYPT_KEY_FLAGS = CRYPT_KEY_FLAGS(256u32);
 pub const CRYPT_KDF_OID_GROUP_ID: u32 = 10u32;
@@ -10491,9 +9640,6 @@ impl Default for CRYPT_KEY_PROV_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_KEY_PROV_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_KEY_PROV_PARAM {
@@ -10506,9 +9652,6 @@ impl Default for CRYPT_KEY_PROV_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_KEY_PROV_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10526,9 +9669,6 @@ impl Default for CRYPT_KEY_SIGN_MESSAGE_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_KEY_SIGN_MESSAGE_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CRYPT_KEY_SIGN_MESSAGE_PARA_0 {
@@ -10539,9 +9679,6 @@ impl Default for CRYPT_KEY_SIGN_MESSAGE_PARA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_KEY_SIGN_MESSAGE_PARA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10554,9 +9691,6 @@ impl Default for CRYPT_KEY_VERIFY_MESSAGE_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_KEY_VERIFY_MESSAGE_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_KM: BCRYPT_QUERY_PROVIDER_MODE = BCRYPT_QUERY_PROVIDER_MODE(2u32);
 pub const CRYPT_LAST_ALG_OID_GROUP_ID: u32 = 4u32;
@@ -10584,9 +9718,6 @@ impl Default for CRYPT_MASK_GEN_ALGORITHM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_MASK_GEN_ALGORITHM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_MATCH_ANY_ENCODING_TYPE: u32 = 4294967295u32;
 pub const CRYPT_MAX_PROVIDER_ID: u32 = 999u32;
@@ -10637,9 +9768,6 @@ impl Default for CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_OBJECT_LOCATOR_PROVIDER_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_OBJECT_LOCATOR_RELEASE_DLL_UNLOAD: CRYPT_OBJECT_LOCATOR_RELEASE_REASON = CRYPT_OBJECT_LOCATOR_RELEASE_REASON(4u32);
 pub const CRYPT_OBJECT_LOCATOR_RELEASE_PROCESS_EXIT: CRYPT_OBJECT_LOCATOR_RELEASE_REASON = CRYPT_OBJECT_LOCATOR_RELEASE_REASON(3u32);
 #[repr(transparent)]
@@ -10658,9 +9786,6 @@ impl Default for CRYPT_OBJID_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_OBJID_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_OCSP_ONLY_RETRIEVAL: u32 = 16777216u32;
 pub const CRYPT_OFFLINE_CHECK_RETRIEVAL: u32 = 16384u32;
@@ -10691,9 +9816,6 @@ impl Default for CRYPT_OID_FUNC_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_OID_FUNC_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_OID_IMPORT_PRIVATE_KEY_INFO_FUNC: windows_core::PCSTR = windows_core::s!("CryptDllImportPrivateKeyInfoEx");
 pub const CRYPT_OID_IMPORT_PUBLIC_KEY_INFO_EX2_FUNC: windows_core::PCSTR = windows_core::s!("CryptDllImportPublicKeyInfoEx2");
 pub const CRYPT_OID_IMPORT_PUBLIC_KEY_INFO_FUNC: windows_core::PCSTR = windows_core::s!("CryptDllImportPublicKeyInfoEx");
@@ -10712,9 +9834,6 @@ impl Default for CRYPT_OID_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_OID_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CRYPT_OID_INFO_0 {
@@ -10726,9 +9845,6 @@ impl Default for CRYPT_OID_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_OID_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_OID_INFO_ALGID_KEY: u32 = 3u32;
 pub const CRYPT_OID_INFO_CNG_ALGID_KEY: u32 = 5u32;
@@ -10792,9 +9908,6 @@ impl Default for CRYPT_PASSWORD_CREDENTIALSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_PASSWORD_CREDENTIALSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_PASSWORD_CREDENTIALSW {
@@ -10807,9 +9920,6 @@ impl Default for CRYPT_PASSWORD_CREDENTIALSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_PASSWORD_CREDENTIALSW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_PKCS12_PBE_PARAMS {
@@ -10820,9 +9930,6 @@ impl Default for CRYPT_PKCS12_PBE_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_PKCS12_PBE_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10838,9 +9945,6 @@ impl Default for CRYPT_PKCS8_EXPORT_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_PKCS8_EXPORT_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_PKCS8_IMPORT_PARAMS {
@@ -10854,9 +9958,6 @@ impl Default for CRYPT_PKCS8_IMPORT_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_PKCS8_IMPORT_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_POLICY_OID_GROUP_ID: u32 = 8u32;
 pub const CRYPT_PREGEN: CRYPT_KEY_FLAGS = CRYPT_KEY_FLAGS(64u32);
@@ -10875,9 +9976,6 @@ impl Default for CRYPT_PRIVATE_KEY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_PRIVATE_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_PROCESS_ISOLATE: CRYPT_IMAGE_REF_FLAGS = CRYPT_IMAGE_REF_FLAGS(65536u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10891,9 +9989,6 @@ impl Default for CRYPT_PROPERTY_REF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_PROPERTY_REF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_PROVIDERS {
@@ -10904,9 +9999,6 @@ impl Default for CRYPT_PROVIDERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_PROVIDERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_PROVIDER_IOCTL__GET_SCHANNEL_INTERFACE: u32 = 4145180u32;
 #[repr(C)]
@@ -10925,9 +10017,6 @@ impl Default for CRYPT_PROVIDER_REF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_PROVIDER_REF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_PROVIDER_REFS {
@@ -10938,9 +10027,6 @@ impl Default for CRYPT_PROVIDER_REFS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_PROVIDER_REFS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10955,9 +10041,6 @@ impl Default for CRYPT_PROVIDER_REG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_PROVIDER_REG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_PROVSTRUC_VERSION_V3: u32 = 3u32;
 pub const CRYPT_PROXY_CACHE_RETRIEVAL: u32 = 2097152u32;
 #[repr(C)]
@@ -10970,9 +10053,6 @@ impl Default for CRYPT_PSOURCE_ALGORITHM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_PSOURCE_ALGORITHM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_PSTORE: u32 = 2u32;
 pub const CRYPT_PUBKEY_ALG_OID_GROUP_ID: u32 = 3u32;
@@ -10993,9 +10073,6 @@ impl Default for CRYPT_RC2_CBC_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_RC2_CBC_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_RC4_KEY_STATE {
@@ -11008,9 +10085,6 @@ impl Default for CRYPT_RC4_KEY_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_RC4_KEY_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_RDN_ATTR_OID_GROUP_ID: u32 = 5u32;
 pub const CRYPT_READ: u32 = 8u32;
@@ -11038,9 +10112,6 @@ impl Default for CRYPT_RETRIEVE_AUX_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_RETRIEVE_AUX_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_RETRIEVE_MAX_ERROR_CONTENT_LENGTH: u32 = 4096u32;
 pub const CRYPT_RETRIEVE_MULTIPLE_OBJECTS: u32 = 1u32;
 pub type CRYPT_RETURN_HWND = Option<unsafe extern "system" fn(phwnd: *mut super::super::Foundation::HWND)>;
@@ -11056,9 +10127,6 @@ impl Default for CRYPT_RSAES_OAEP_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_RSAES_OAEP_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_RSA_SSA_PSS_PARAMETERS {
@@ -11072,9 +10140,6 @@ impl Default for CRYPT_RSA_SSA_PSS_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_RSA_SSA_PSS_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_SECRETDIGEST: u32 = 1u32;
 pub const CRYPT_SEC_DESCR: u32 = 1u32;
 #[repr(C)]
@@ -11087,9 +10152,6 @@ impl Default for CRYPT_SEQUENCE_OF_ANY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_SEQUENCE_OF_ANY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_SERVER: u32 = 1024u32;
 #[repr(transparent)]
@@ -11127,9 +10189,6 @@ impl Default for CRYPT_SIGN_MESSAGE_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_SIGN_MESSAGE_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_SIG_RESOURCE: windows_core::PCWSTR = windows_core::w!("#666");
 pub const CRYPT_SIG_RESOURCE_NUMBER: u32 = 666u32;
 pub const CRYPT_SIG_RESOURCE_VERSION: u32 = 256u32;
@@ -11145,9 +10204,6 @@ impl Default for CRYPT_SMART_CARD_ROOT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_SMART_CARD_ROOT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_SMIME_CAPABILITIES {
@@ -11159,9 +10215,6 @@ impl Default for CRYPT_SMIME_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_SMIME_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_SMIME_CAPABILITY {
@@ -11172,9 +10225,6 @@ impl Default for CRYPT_SMIME_CAPABILITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_SMIME_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_SORTED_CTL_ENCODE_HASHED_SUBJECT_IDENTIFIER_FLAG: u32 = 65536u32;
 pub const CRYPT_SSL2_FALLBACK: CRYPT_KEY_FLAGS = CRYPT_KEY_FLAGS(2u32);
@@ -11218,9 +10268,6 @@ impl Default for CRYPT_TIMESTAMP_ACCURACY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_TIMESTAMP_ACCURACY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_TIMESTAMP_CONTEXT {
@@ -11232,9 +10279,6 @@ impl Default for CRYPT_TIMESTAMP_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_TIMESTAMP_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11257,9 +10301,6 @@ impl Default for CRYPT_TIMESTAMP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_TIMESTAMP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_TIMESTAMP_PARA {
@@ -11273,9 +10314,6 @@ impl Default for CRYPT_TIMESTAMP_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_TIMESTAMP_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11294,9 +10332,6 @@ impl Default for CRYPT_TIMESTAMP_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_TIMESTAMP_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_TIMESTAMP_RESPONSE {
@@ -11310,9 +10345,6 @@ impl Default for CRYPT_TIMESTAMP_RESPONSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_TIMESTAMP_RESPONSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11334,9 +10366,6 @@ impl Default for CRYPT_TIME_STAMP_REQUEST_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_TIME_STAMP_REQUEST_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_TYPE2_FORMAT: u32 = 2u32;
 pub const CRYPT_UI_PROMPT: u32 = 4u32;
 pub const CRYPT_UM: BCRYPT_QUERY_PROVIDER_MODE = BCRYPT_QUERY_PROVIDER_MODE(1u32);
@@ -11357,9 +10386,6 @@ impl Default for CRYPT_URL_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_URL_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_URL_INFO {
@@ -11372,9 +10398,6 @@ impl Default for CRYPT_URL_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_URL_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_USERDATA: u32 = 1u32;
 pub const CRYPT_USER_DEFAULT: u32 = 2u32;
@@ -11404,9 +10427,6 @@ impl Default for CRYPT_VERIFY_CERT_SIGN_STRONG_PROPERTIES_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_VERIFY_CERT_SIGN_STRONG_PROPERTIES_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_VERIFY_CERT_SIGN_SUBJECT_BLOB: u32 = 1u32;
 pub const CRYPT_VERIFY_CERT_SIGN_SUBJECT_CERT: u32 = 2u32;
 pub const CRYPT_VERIFY_CERT_SIGN_SUBJECT_CRL: u32 = 3u32;
@@ -11422,9 +10442,6 @@ impl Default for CRYPT_VERIFY_CERT_SIGN_WEAK_HASH_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_VERIFY_CERT_SIGN_WEAK_HASH_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_VERIFY_CONTEXT_SIGNATURE: u32 = 32u32;
 pub const CRYPT_VERIFY_DATA_HASH: u32 = 64u32;
@@ -11443,9 +10460,6 @@ impl Default for CRYPT_VERIFY_MESSAGE_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_VERIFY_MESSAGE_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_VOLATILE: CRYPT_KEY_FLAGS = CRYPT_KEY_FLAGS(4096u32);
 pub const CRYPT_WIRE_ONLY_RETRIEVAL: u32 = 4u32;
@@ -11466,9 +10480,6 @@ impl Default for CRYPT_X942_OTHER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_X942_OTHER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_XML_ALGORITHM {
@@ -11480,9 +10491,6 @@ impl Default for CRYPT_XML_ALGORITHM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_ALGORITHM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11503,9 +10511,6 @@ impl Default for CRYPT_XML_ALGORITHM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_ALGORITHM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_XML_ALGORITHM_INFO_FIND_BY_CNG_ALGID: u32 = 3u32;
 pub const CRYPT_XML_ALGORITHM_INFO_FIND_BY_CNG_SIGN_ALGID: u32 = 4u32;
 pub const CRYPT_XML_ALGORITHM_INFO_FIND_BY_NAME: u32 = 2u32;
@@ -11521,9 +10526,6 @@ impl Default for CRYPT_XML_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_XML_BLOB_MAX: u32 = 2147483640u32;
 #[repr(transparent)]
@@ -11551,9 +10553,6 @@ impl Default for CRYPT_XML_CRYPTOGRAPHIC_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_CRYPTOGRAPHIC_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_XML_DATA_BLOB {
@@ -11564,9 +10563,6 @@ impl Default for CRYPT_XML_DATA_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_DATA_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11580,9 +10576,6 @@ impl Default for CRYPT_XML_DATA_PROVIDER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_DATA_PROVIDER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_XML_DIGEST_REFERENCE_DATA_TRANSFORMED: u32 = 1u32;
 pub const CRYPT_XML_DIGEST_VALUE_MAX: u32 = 128u32;
@@ -11599,9 +10592,6 @@ impl Default for CRYPT_XML_DOC_CTXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_DOC_CTXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_XML_E_ALGORITHM: windows_core::HRESULT = windows_core::HRESULT(0x80092104_u32 as _);
 pub const CRYPT_XML_E_BASE: windows_core::HRESULT = windows_core::HRESULT(0x80092100_u32 as _);
@@ -11651,9 +10641,6 @@ impl Default for CRYPT_XML_ISSUER_SERIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_ISSUER_SERIAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_XML_KEYINFO_PARAM {
@@ -11670,9 +10657,6 @@ impl Default for CRYPT_XML_KEYINFO_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_KEYINFO_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11704,9 +10688,6 @@ impl Default for CRYPT_XML_KEY_DSA_KEY_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_KEY_DSA_KEY_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_XML_KEY_ECDSA_KEY_VALUE {
@@ -11719,9 +10700,6 @@ impl Default for CRYPT_XML_KEY_ECDSA_KEY_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_KEY_ECDSA_KEY_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11737,9 +10715,6 @@ impl Default for CRYPT_XML_KEY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CRYPT_XML_KEY_INFO_ITEM {
@@ -11750,9 +10725,6 @@ impl Default for CRYPT_XML_KEY_INFO_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_KEY_INFO_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11768,9 +10740,6 @@ impl Default for CRYPT_XML_KEY_INFO_ITEM_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_KEY_INFO_ITEM_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_XML_KEY_RSA_KEY_VALUE {
@@ -11782,9 +10751,6 @@ impl Default for CRYPT_XML_KEY_RSA_KEY_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_KEY_RSA_KEY_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CRYPT_XML_KEY_VALUE {
@@ -11795,9 +10761,6 @@ impl Default for CRYPT_XML_KEY_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_KEY_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11811,9 +10774,6 @@ impl Default for CRYPT_XML_KEY_VALUE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_KEY_VALUE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11838,9 +10798,6 @@ impl Default for CRYPT_XML_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_XML_OBJECTS_MAX: u32 = 256u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11853,9 +10810,6 @@ impl Default for CRYPT_XML_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_XML_PROPERTY_DOC_DECLARATION: CRYPT_XML_PROPERTY_ID = CRYPT_XML_PROPERTY_ID(4i32);
 #[repr(transparent)]
@@ -11883,9 +10837,6 @@ impl Default for CRYPT_XML_REFERENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_REFERENCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_XML_REFERENCES {
@@ -11896,9 +10847,6 @@ impl Default for CRYPT_XML_REFERENCES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_REFERENCES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_XML_REFERENCES_MAX: u32 = 32760u32;
 #[repr(C)]
@@ -11918,9 +10866,6 @@ impl Default for CRYPT_XML_SIGNATURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_SIGNATURE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_XML_SIGNATURES_MAX: u32 = 16u32;
 pub const CRYPT_XML_SIGNATURE_VALUE_MAX: u32 = 2048u32;
 #[repr(C)]
@@ -11939,9 +10884,6 @@ impl Default for CRYPT_XML_SIGNED_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_SIGNED_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_XML_SIGN_ADD_KEYVALUE: CRYPT_XML_FLAGS = CRYPT_XML_FLAGS(1u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11954,9 +10896,6 @@ impl Default for CRYPT_XML_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRYPT_XML_STATUS_DIGESTING: CRYPT_XML_STATUS_INFO_STATUS = CRYPT_XML_STATUS_INFO_STATUS(4u32);
 pub const CRYPT_XML_STATUS_DIGEST_VALID: CRYPT_XML_STATUS_INFO_STATUS = CRYPT_XML_STATUS_INFO_STATUS(8u32);
@@ -11988,9 +10927,6 @@ impl Default for CRYPT_XML_TRANSFORM_CHAIN_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_TRANSFORM_CHAIN_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12042,9 +10978,6 @@ impl Default for CRYPT_XML_TRANSFORM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_TRANSFORM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRYPT_XML_TRANSFORM_MAX: u32 = 16u32;
 pub const CRYPT_XML_TRANSFORM_ON_NODESET: CRYPT_XML_TRANSFORM_FLAGS = CRYPT_XML_TRANSFORM_FLAGS(2u32);
 pub const CRYPT_XML_TRANSFORM_ON_STREAM: CRYPT_XML_TRANSFORM_FLAGS = CRYPT_XML_TRANSFORM_FLAGS(1u32);
@@ -12060,9 +10993,6 @@ impl Default for CRYPT_XML_X509DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_XML_X509DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CRYPT_XML_X509DATA_ITEM {
@@ -12073,9 +11003,6 @@ impl Default for CRYPT_XML_X509DATA_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_X509DATA_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -12091,9 +11018,6 @@ impl Default for CRYPT_XML_X509DATA_ITEM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_XML_X509DATA_ITEM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12119,9 +11043,6 @@ impl Default for CTL_ANY_SUBJECT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CTL_ANY_SUBJECT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CTL_ANY_SUBJECT_TYPE: u32 = 1u32;
 pub const CTL_CERT_SUBJECT_TYPE: u32 = 2u32;
 #[repr(C)]
@@ -12141,9 +11062,6 @@ impl Default for CTL_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CTL_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CTL_ENTRY {
@@ -12155,9 +11073,6 @@ impl Default for CTL_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CTL_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CTL_ENTRY_FROM_PROP_CHAIN_FLAG: u32 = 1u32;
 pub const CTL_FIND_ANY: CERT_FIND_TYPE = CERT_FIND_TYPE(0u32);
@@ -12180,9 +11095,6 @@ impl Default for CTL_FIND_SUBJECT_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CTL_FIND_SUBJECT_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CTL_FIND_USAGE: CERT_FIND_TYPE = CERT_FIND_TYPE(3u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12196,9 +11108,6 @@ impl Default for CTL_FIND_USAGE_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CTL_FIND_USAGE_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12220,9 +11129,6 @@ impl Default for CTL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CTL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CTL_USAGE {
@@ -12234,9 +11140,6 @@ impl Default for CTL_USAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CTL_USAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CTL_USAGE_MATCH {
@@ -12247,9 +11150,6 @@ impl Default for CTL_USAGE_MATCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CTL_USAGE_MATCH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CTL_V1: u32 = 0u32;
 #[repr(C)]
@@ -12267,9 +11167,6 @@ impl Default for CTL_VERIFY_USAGE_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CTL_VERIFY_USAGE_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CTL_VERIFY_USAGE_STATUS {
@@ -12285,9 +11182,6 @@ impl Default for CTL_VERIFY_USAGE_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CTL_VERIFY_USAGE_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CUR_BLOB_VERSION: u32 = 2u32;
 pub const CUR_OFFLOAD_VERSION: u32 = 1u32;
@@ -12325,9 +11219,6 @@ impl Default for DSSSEED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSSSEED {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DTLS1_0_PROTOCOL_VERSION: u32 = 65279u32;
 pub const DTLS1_2_PROTOCOL_VERSION: u32 = 65277u32;
 pub const DigitalSignaturePin: SECRET_PURPOSE = SECRET_PURPOSE(1i32);
@@ -12355,9 +11246,6 @@ impl Default for ENDPOINTADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENDPOINTADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENDPOINTADDRESS2 {
@@ -12370,9 +11258,6 @@ impl Default for ENDPOINTADDRESS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENDPOINTADDRESS2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENUM_CEPSETUPPROP_AUTHENTICATION: CEPSetupProperty = CEPSetupProperty(0i32);
 pub const ENUM_CEPSETUPPROP_CAINFORMATION: MSCEPSetupProperty = MSCEPSetupProperty(11i32);
@@ -12428,9 +11313,6 @@ impl Default for EV_EXTRA_CERT_CHAIN_POLICY_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EV_EXTRA_CERT_CHAIN_POLICY_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EV_EXTRA_CERT_CHAIN_POLICY_STATUS {
@@ -12442,9 +11324,6 @@ impl Default for EV_EXTRA_CERT_CHAIN_POLICY_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EV_EXTRA_CERT_CHAIN_POLICY_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EXPORT_PRIVATE_KEYS: u32 = 4u32;
 pub const EXPO_OFFLOAD_FUNC_NAME: windows_core::PCSTR = windows_core::s!("OffloadModExpo");
@@ -12495,9 +11374,6 @@ impl Default for GENERIC_XML_TOKEN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GENERIC_XML_TOKEN {
-    type TypeKind = windows_core::CopyType;
 }
 pub type GetAsymmetricEncryptionInterfaceFn = Option<unsafe extern "system" fn(pszprovidername: windows_core::PCWSTR, pszalgid: windows_core::PCWSTR, ppfunctiontable: *mut *mut BCRYPT_ASYMMETRIC_ENCRYPTION_FUNCTION_TABLE, dwflags: u32) -> super::super::Foundation::NTSTATUS>;
 pub type GetCipherInterfaceFn = Option<unsafe extern "system" fn(pszprovidername: windows_core::PCWSTR, pszalgid: windows_core::PCWSTR, ppfunctiontable: *mut *mut BCRYPT_CIPHER_FUNCTION_TABLE, dwflags: u32) -> super::super::Foundation::NTSTATUS>;
@@ -12624,9 +11500,6 @@ impl Default for HMAC_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HMAC_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HP_ALGID: u32 = 1u32;
 pub const HP_HASHSIZE: u32 = 4u32;
 pub const HP_HASHVAL: CRYPT_SET_HASH_PARAM = CRYPT_SET_HASH_PARAM(2u32);
@@ -12649,9 +11522,6 @@ impl Default for HTTPSPolicyCallbackData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTPSPolicyCallbackData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union HTTPSPolicyCallbackData_0 {
@@ -12662,9 +11532,6 @@ impl Default for HTTPSPolicyCallbackData_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTPSPolicyCallbackData_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13803,9 +12670,6 @@ impl Default for INFORMATIONCARD_ASYMMETRIC_CRYPTO_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INFORMATIONCARD_ASYMMETRIC_CRYPTO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INFORMATIONCARD_CRYPTO_HANDLE {
@@ -13818,9 +12682,6 @@ impl Default for INFORMATIONCARD_CRYPTO_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INFORMATIONCARD_CRYPTO_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INFORMATIONCARD_HASH_CRYPTO_PARAMETERS {
@@ -13831,9 +12692,6 @@ impl Default for INFORMATIONCARD_HASH_CRYPTO_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INFORMATIONCARD_HASH_CRYPTO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13846,9 +12704,6 @@ impl Default for INFORMATIONCARD_SYMMETRIC_CRYPTO_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INFORMATIONCARD_SYMMETRIC_CRYPTO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13863,9 +12718,6 @@ impl Default for INFORMATIONCARD_TRANSFORM_CRYPTO_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INFORMATIONCARD_TRANSFORM_CRYPTO_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INTERNATIONAL_USAGE: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13878,9 +12730,6 @@ impl Default for InFileSignatureResource {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for InFileSignatureResource {
-    type TypeKind = windows_core::CopyType;
 }
 pub const InvalidAc: CARD_FILE_ACCESS_CONDITION = CARD_FILE_ACCESS_CONDITION(0i32);
 pub const InvalidDirAc: CARD_DIRECTORY_ACCESS_CONDITION = CARD_DIRECTORY_ACCESS_CONDITION(0i32);
@@ -13919,9 +12768,6 @@ impl Default for KEY_TYPE_SUBTYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_TYPE_SUBTYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KP_ADMIN_PIN: u32 = 31u32;
 pub const KP_ALGID: CRYPT_KEY_PARAM_ID = CRYPT_KEY_PARAM_ID(7u32);
@@ -14095,9 +12941,6 @@ impl Default for NCRYPT_ALLOC_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_ALLOC_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_ALLOW_ALL_USAGES: u32 = 16777215u32;
 pub const NCRYPT_ALLOW_ARCHIVING_FLAG: u32 = 4u32;
 pub const NCRYPT_ALLOW_DECRYPT_FLAG: u32 = 1u32;
@@ -14140,9 +12983,6 @@ impl Default for NCRYPT_CIPHER_PADDING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_CIPHER_PADDING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_CLAIM_AUTHORITY_AND_SUBJECT: u32 = 3u32;
 pub const NCRYPT_CLAIM_AUTHORITY_ONLY: u32 = 1u32;
@@ -14187,9 +13027,6 @@ impl Default for NCRYPT_EXPORTED_ISOLATED_KEY_ENVELOPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_EXPORTED_ISOLATED_KEY_ENVELOPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NCRYPT_EXPORTED_ISOLATED_KEY_HEADER {
@@ -14206,9 +13043,6 @@ impl Default for NCRYPT_EXPORTED_ISOLATED_KEY_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_EXPORTED_ISOLATED_KEY_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_EXPORTED_ISOLATED_KEY_HEADER_CURRENT_VERSION: u32 = 0u32;
 pub const NCRYPT_EXPORTED_ISOLATED_KEY_HEADER_V0: u32 = 0u32;
@@ -14304,9 +13138,6 @@ impl Default for NCRYPT_ISOLATED_KEY_ATTESTED_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_ISOLATED_KEY_ATTESTED_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_ISOLATED_KEY_ATTESTED_ATTRIBUTES_CURRENT_VERSION: u32 = 0u32;
 pub const NCRYPT_ISOLATED_KEY_ATTESTED_ATTRIBUTES_V0: u32 = 0u32;
 pub const NCRYPT_ISOLATED_KEY_ENVELOPE_BLOB: windows_core::PCWSTR = windows_core::w!("ISOLATED_KEY_ENVELOPE");
@@ -14328,9 +13159,6 @@ impl Default for NCRYPT_KEY_ACCESS_POLICY_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_KEY_ACCESS_POLICY_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_KEY_ACCESS_POLICY_PROPERTY: windows_core::PCWSTR = windows_core::w!("Key Access Policy");
 pub const NCRYPT_KEY_ACCESS_POLICY_VERSION: u32 = 1u32;
 pub const NCRYPT_KEY_ATTEST_MAGIC: u32 = 1146110283u32;
@@ -14348,9 +13176,6 @@ impl Default for NCRYPT_KEY_ATTEST_PADDING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_KEY_ATTEST_PADDING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NCRYPT_KEY_BLOB_HEADER {
@@ -14363,9 +13188,6 @@ impl Default for NCRYPT_KEY_BLOB_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_KEY_BLOB_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_KEY_DERIVATION_GROUP: windows_core::PCWSTR = windows_core::w!("KEY_DERIVATION");
 pub const NCRYPT_KEY_DERIVATION_INTERFACE: u32 = 7u32;
@@ -14447,9 +13269,6 @@ impl Default for NCRYPT_KEY_STORAGE_FUNCTION_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_KEY_STORAGE_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_KEY_STORAGE_INTERFACE: BCRYPT_INTERFACE = BCRYPT_INTERFACE(65537u32);
 pub const NCRYPT_KEY_TYPE_PROPERTY: windows_core::PCWSTR = windows_core::w!("Key Type");
@@ -14543,9 +13362,6 @@ impl Default for NCRYPT_PCP_HMAC_AUTH_SIGNATURE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_PCP_HMAC_AUTH_SIGNATURE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_PCP_HMAC_AUTH_TICKET: windows_core::PCWSTR = windows_core::w!("PCP_HMAC_AUTH_TICKET");
 pub const NCRYPT_PCP_IDENTITY_KEY: u32 = 8u32;
 pub const NCRYPT_PCP_INTERMEDIATE_CA_EKCERT_PROPERTY: windows_core::PCWSTR = windows_core::w!("PCP_INTERMEDIATE_CA_EKCERT");
@@ -14578,9 +13394,6 @@ impl Default for NCRYPT_PCP_RAW_POLICYDIGEST_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_PCP_RAW_POLICYDIGEST_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_PCP_RAW_POLICYDIGEST_PROPERTY: windows_core::PCWSTR = windows_core::w!("PCP_RAW_POLICYDIGEST");
 pub const NCRYPT_PCP_RSA_EKCERT_PROPERTY: windows_core::PCWSTR = windows_core::w!("PCP_RSA_EKCERT");
 pub const NCRYPT_PCP_RSA_EKNVCERT_PROPERTY: windows_core::PCWSTR = windows_core::w!("PCP_RSA_EKNVCERT");
@@ -14610,9 +13423,6 @@ impl Default for NCRYPT_PCP_TPM_FW_VERSION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_PCP_TPM_FW_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_PCP_TPM_FW_VERSION_PROPERTY: windows_core::PCWSTR = windows_core::w!("PCP_TPM_FW_VERSION");
 pub const NCRYPT_PCP_TPM_IFX_RSA_KEYGEN_PROHIBITED_PROPERTY: windows_core::PCWSTR = windows_core::w!("PCP_TPM_IFX_RSA_KEYGEN_PROHIBITED");
 pub const NCRYPT_PCP_TPM_IFX_RSA_KEYGEN_VULNERABILITY_PROPERTY: windows_core::PCWSTR = windows_core::w!("PCP_TPM_IFX_RSA_KEYGEN_VULNERABILITY");
@@ -14632,9 +13442,6 @@ impl Default for NCRYPT_PCP_TPM_WEB_AUTHN_ATTESTATION_STATEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_PCP_TPM_WEB_AUTHN_ATTESTATION_STATEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_PCP_USAGEAUTH_PROPERTY: windows_core::PCWSTR = windows_core::w!("PCP_USAGEAUTH");
 pub const NCRYPT_PERSIST_FLAG: NCRYPT_FLAGS = NCRYPT_FLAGS(2147483648u32);
@@ -14667,9 +13474,6 @@ impl Default for NCRYPT_PLATFORM_ATTEST_PADDING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_PLATFORM_ATTEST_PADDING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_PREFER_VIRTUAL_ISOLATION_FLAG: u32 = 65536u32;
 pub const NCRYPT_PROTECTED_KEY_BLOB: windows_core::PCWSTR = windows_core::w!("ProtectedKeyBlob");
 pub const NCRYPT_PROTECTED_KEY_BLOB_MAGIC: u32 = 1263817296u32;
@@ -14685,9 +13489,6 @@ impl Default for NCRYPT_PROTECT_STREAM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_PROTECT_STREAM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NCRYPT_PROTECT_STREAM_INFO_EX {
@@ -14698,9 +13499,6 @@ impl Default for NCRYPT_PROTECT_STREAM_INFO_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_PROTECT_STREAM_INFO_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_PROTECT_TO_LOCAL_SYSTEM: u32 = 32768u32;
 pub const NCRYPT_PROVIDER_HANDLE_PROPERTY: windows_core::PCWSTR = windows_core::w!("Provider Handle");
@@ -14788,9 +13586,6 @@ impl Default for NCRYPT_SSL_CIPHER_LENGTHS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_SSL_CIPHER_LENGTHS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_SSL_CIPHER_LENGTHS_BLOCK_PADDING: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14814,9 +13609,6 @@ impl Default for NCRYPT_SSL_CIPHER_SUITE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_SSL_CIPHER_SUITE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14843,9 +13635,6 @@ impl Default for NCRYPT_SSL_CIPHER_SUITE_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_SSL_CIPHER_SUITE_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_SSL_CIPHER_SUITE_EX_VERSION: u32 = 1u32;
 pub const NCRYPT_SSL_CLIENT_FLAG: u32 = 1u32;
 pub const NCRYPT_SSL_EAP_FAST_ID: u32 = 3u32;
@@ -14866,9 +13655,6 @@ impl Default for NCRYPT_SSL_ECC_CURVE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_SSL_ECC_CURVE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_SSL_EXTERNAL_PSK_FLAG: u32 = 1u32;
 #[repr(C)]
@@ -14922,9 +13708,6 @@ impl Default for NCRYPT_SSL_FUNCTION_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_SSL_FUNCTION_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_SSL_MAX_NAME_SIZE: u32 = 64u32;
 pub const NCRYPT_SSL_RESUMPTION_PSK_FLAG: u32 = 2u32;
 pub const NCRYPT_SSL_SERVER_FLAG: u32 = 2u32;
@@ -14943,9 +13726,6 @@ impl Default for NCRYPT_SUPPORTED_LENGTHS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_SUPPORTED_LENGTHS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_TPM12_PROVIDER: u32 = 65536u32;
 pub const NCRYPT_TPM_LOADABLE_KEY_BLOB: windows_core::PCWSTR = windows_core::w!("PcpTpmProtectedKeyBlob");
 #[repr(C)]
@@ -14961,9 +13741,6 @@ impl Default for NCRYPT_TPM_LOADABLE_KEY_BLOB_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_TPM_LOADABLE_KEY_BLOB_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_TPM_LOADABLE_KEY_BLOB_MAGIC: u32 = 1297371211u32;
 pub const NCRYPT_TPM_PAD_PSS_IGNORE_SALT: u32 = 32u32;
@@ -14981,9 +13758,6 @@ impl Default for NCRYPT_TPM_PLATFORM_ATTESTATION_STATEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_TPM_PLATFORM_ATTESTATION_STATEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_TPM_PLATFORM_ATTESTATION_STATEMENT_CURRENT_VERSION: u32 = 0u32;
 pub const NCRYPT_TPM_PLATFORM_ATTESTATION_STATEMENT_V0: u32 = 0u32;
@@ -15008,9 +13782,6 @@ impl Default for NCRYPT_UI_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_UI_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NCRYPT_UI_POLICY_BLOB {
@@ -15024,9 +13795,6 @@ impl Default for NCRYPT_UI_POLICY_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_UI_POLICY_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_UI_POLICY_PROPERTY: windows_core::PCWSTR = windows_core::w!("UI Policy");
 pub const NCRYPT_UI_PROTECT_KEY_FLAG: u32 = 1u32;
@@ -15057,9 +13825,6 @@ impl Default for NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIONS_CURRENT_VERSION: u32 = 0u32;
 pub const NCRYPT_VSM_KEY_ATTESTATION_CLAIM_RESTRICTIONS_V0: u32 = 0u32;
 #[repr(C)]
@@ -15075,9 +13840,6 @@ impl Default for NCRYPT_VSM_KEY_ATTESTATION_STATEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCRYPT_VSM_KEY_ATTESTATION_STATEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NCRYPT_VSM_KEY_ATTESTATION_STATEMENT_CURRENT_VERSION: u32 = 0u32;
 pub const NCRYPT_VSM_KEY_ATTESTATION_STATEMENT_V0: u32 = 0u32;
@@ -15095,9 +13857,6 @@ impl Default for NCryptAlgorithmName {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCryptAlgorithmName {
-    type TypeKind = windows_core::CopyType;
 }
 pub type NCryptCreateClaimFn = Option<unsafe extern "system" fn(hprov: NCRYPT_PROV_HANDLE, hsubjectkey: NCRYPT_KEY_HANDLE, hauthoritykey: NCRYPT_KEY_HANDLE, dwclaimtype: u32, pparameterlist: *const BCryptBufferDesc, pbclaimblob: *mut u8, cbclaimblob: u32, pcbresult: *mut u32, dwflags: u32) -> windows_core::HRESULT>;
 pub type NCryptCreatePersistedKeyFn = Option<unsafe extern "system" fn(hprovider: NCRYPT_PROV_HANDLE, phkey: *mut NCRYPT_KEY_HANDLE, pszalgid: windows_core::PCWSTR, pszkeyname: windows_core::PCWSTR, dwlegacykeyspec: u32, dwflags: u32) -> windows_core::HRESULT>;
@@ -15132,9 +13891,6 @@ impl Default for NCryptKeyName {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NCryptKeyName {
-    type TypeKind = windows_core::CopyType;
-}
 pub type NCryptNotifyChangeKeyFn = Option<unsafe extern "system" fn(hprovider: NCRYPT_PROV_HANDLE, phevent: *mut super::super::Foundation::HANDLE, dwflags: u32) -> windows_core::HRESULT>;
 pub type NCryptOpenKeyFn = Option<unsafe extern "system" fn(hprovider: NCRYPT_PROV_HANDLE, phkey: *mut NCRYPT_KEY_HANDLE, pszkeyname: windows_core::PCWSTR, dwlegacykeyspec: u32, dwflags: u32) -> windows_core::HRESULT>;
 pub type NCryptOpenStorageProviderFn = Option<unsafe extern "system" fn(phprovider: *mut NCRYPT_PROV_HANDLE, pszprovidername: windows_core::PCWSTR, dwflags: u32) -> windows_core::HRESULT>;
@@ -15149,9 +13905,6 @@ impl Default for NCryptProviderName {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCryptProviderName {
-    type TypeKind = windows_core::CopyType;
 }
 pub type NCryptSecretAgreementFn = Option<unsafe extern "system" fn(hprovider: NCRYPT_PROV_HANDLE, hprivkey: NCRYPT_KEY_HANDLE, hpubkey: NCRYPT_KEY_HANDLE, phagreedsecret: *mut NCRYPT_SECRET_HANDLE, dwflags: u32) -> windows_core::HRESULT>;
 pub type NCryptSetKeyPropertyFn = Option<unsafe extern "system" fn(hprovider: NCRYPT_PROV_HANDLE, hkey: NCRYPT_KEY_HANDLE, pszproperty: windows_core::PCWSTR, pbinput: *const u8, cbinput: u32, dwflags: u32) -> windows_core::HRESULT>;
@@ -15187,9 +13940,6 @@ impl Default for OCSP_BASIC_RESPONSE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OCSP_BASIC_RESPONSE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union OCSP_BASIC_RESPONSE_ENTRY_0 {
@@ -15199,9 +13949,6 @@ impl Default for OCSP_BASIC_RESPONSE_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OCSP_BASIC_RESPONSE_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -15220,9 +13967,6 @@ impl Default for OCSP_BASIC_RESPONSE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OCSP_BASIC_RESPONSE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union OCSP_BASIC_RESPONSE_INFO_0 {
@@ -15233,9 +13977,6 @@ impl Default for OCSP_BASIC_RESPONSE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OCSP_BASIC_RESPONSE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OCSP_BASIC_RESPONSE_V1: u32 = 0u32;
 pub const OCSP_BASIC_REVOKED_CERT_STATUS: u32 = 1u32;
@@ -15250,9 +13991,6 @@ impl Default for OCSP_BASIC_REVOKED_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OCSP_BASIC_REVOKED_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OCSP_BASIC_SIGNED_RESPONSE: windows_core::PCSTR = windows_core::PCSTR(68i32 as _);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15264,9 +14002,6 @@ impl Default for OCSP_BASIC_SIGNED_RESPONSE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OCSP_BASIC_SIGNED_RESPONSE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OCSP_BASIC_UNKNOWN_CERT_STATUS: u32 = 2u32;
 #[repr(C)]
@@ -15281,9 +14016,6 @@ impl Default for OCSP_CERT_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OCSP_CERT_ID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OCSP_INTERNAL_ERROR_RESPONSE: u32 = 2u32;
 pub const OCSP_MALFORMED_REQUEST_RESPONSE: u32 = 1u32;
@@ -15300,9 +14032,6 @@ impl Default for OCSP_REQUEST_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OCSP_REQUEST_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OCSP_REQUEST_INFO {
@@ -15318,9 +14047,6 @@ impl Default for OCSP_REQUEST_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OCSP_REQUEST_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OCSP_REQUEST_V1: u32 = 0u32;
 pub const OCSP_RESPONSE: windows_core::PCSTR = windows_core::PCSTR(67i32 as _);
 #[repr(C)]
@@ -15335,9 +14061,6 @@ impl Default for OCSP_RESPONSE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OCSP_RESPONSE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OCSP_SIGNATURE_INFO {
@@ -15351,9 +14074,6 @@ impl Default for OCSP_SIGNATURE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OCSP_SIGNATURE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OCSP_SIGNED_REQUEST: windows_core::PCSTR = windows_core::PCSTR(65i32 as _);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15365,9 +14085,6 @@ impl Default for OCSP_SIGNED_REQUEST_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OCSP_SIGNED_REQUEST_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OCSP_SIG_REQUIRED_RESPONSE: u32 = 5u32;
 pub const OCSP_SUCCESSFUL_RESPONSE: u32 = 0u32;
@@ -15386,9 +14103,6 @@ impl Default for OFFLOAD_PRIVATE_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OFFLOAD_PRIVATE_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPAQUEKEYBLOB: u32 = 9u32;
 pub type PCRYPT_DECRYPT_PRIVATE_KEY_FUNC = Option<unsafe extern "system" fn(algorithm: CRYPT_ALGORITHM_IDENTIFIER, encryptedprivatekey: CRYPT_INTEGER_BLOB, pbcleartextkey: *mut u8, pcbcleartextkey: *mut u32, pvoiddecryptfunc: *const core::ffi::c_void) -> super::super::Foundation::BOOL>;
@@ -15547,9 +14261,6 @@ impl Default for PIN_CACHE_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PIN_CACHE_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PIN_CACHE_POLICY_CURRENT_VERSION: u32 = 6u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -15571,9 +14282,6 @@ impl Default for PIN_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PIN_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PIN_INFO_CURRENT_VERSION: u32 = 6u32;
 pub const PIN_INFO_REQUIRE_SECURE_ENTRY: u32 = 1u32;
@@ -15611,9 +14319,6 @@ impl Default for PKCS12_PBES2_EXPORT_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PKCS12_PBES2_EXPORT_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PKCS12_PBKDF2_ID_HMAC_SHA1: windows_core::PCSTR = windows_core::s!("1.2.840.113549.2.7");
 pub const PKCS12_PBKDF2_ID_HMAC_SHA256: windows_core::PCSTR = windows_core::s!("1.2.840.113549.2.9");
@@ -15657,9 +14362,6 @@ impl Default for POLICY_ELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POLICY_ELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PP_ADMIN_PIN: u32 = 31u32;
 pub const PP_APPLI_CERT: u32 = 18u32;
@@ -15725,9 +14427,6 @@ impl Default for PRIVKEYVER3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRIVKEYVER3 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PROV_DH_SCHANNEL: u32 = 18u32;
 pub const PROV_DSS: u32 = 3u32;
 pub const PROV_DSS_DH: u32 = 13u32;
@@ -15748,9 +14447,6 @@ impl Default for PROV_ENUMALGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROV_ENUMALGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROV_ENUMALGS_EX {
@@ -15768,9 +14464,6 @@ impl Default for PROV_ENUMALGS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROV_ENUMALGS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROV_FORTEZZA: u32 = 4u32;
 pub const PROV_INTEL_SEC: u32 = 22u32;
@@ -15799,9 +14492,6 @@ impl Default for PUBKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PUBKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PUBKEYVER3 {
@@ -15815,9 +14505,6 @@ impl Default for PUBKEYVER3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PUBKEYVER3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PUBLICKEYBLOB: u32 = 6u32;
 pub const PUBLICKEYBLOBEX: u32 = 10u32;
@@ -15833,9 +14520,6 @@ impl Default for PUBLICKEYSTRUC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PUBLICKEYSTRUC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PVK_TYPE_FILE_NAME: SIGNER_PRIVATE_KEY_CHOICE = SIGNER_PRIVATE_KEY_CHOICE(1u32);
 pub const PVK_TYPE_KEYCONTAINER: SIGNER_PRIVATE_KEY_CHOICE = SIGNER_PRIVATE_KEY_CHOICE(2u32);
@@ -15871,9 +14555,6 @@ impl Default for RECIPIENTPOLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RECIPIENTPOLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RECIPIENTPOLICY2 {
@@ -15889,9 +14570,6 @@ impl Default for RECIPIENTPOLICY2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RECIPIENTPOLICY2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RECIPIENTPOLICYV1: u32 = 1u32;
 pub const RECIPIENTPOLICYV2: u32 = 2u32;
@@ -15914,9 +14592,6 @@ impl Default for ROOT_INFO_LUID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ROOT_INFO_LUID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RSA1024BIT_KEY: u32 = 67108864u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15929,9 +14604,6 @@ impl Default for RSAPUBKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RSAPUBKEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RSA_CSP_PUBLICKEYBLOB: windows_core::PCSTR = windows_core::PCSTR(19i32 as _);
 pub const SCARD_PROVIDER_CARD_MODULE: u32 = 2147483649u32;
@@ -15948,9 +14620,6 @@ impl Default for SCHANNEL_ALG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCHANNEL_ALG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCHANNEL_ENC_KEY: u32 = 1u32;
 pub const SCHANNEL_MAC_KEY: u32 = 0u32;
@@ -15977,9 +14646,6 @@ impl Default for SIGNER_ATTR_AUTHCODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_ATTR_AUTHCODE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SIGNER_AUTHCODE_ATTR: SIGNER_SIGNATURE_ATTRIBUTE_CHOICE = SIGNER_SIGNATURE_ATTRIBUTE_CHOICE(1u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -15995,9 +14661,6 @@ impl Default for SIGNER_BLOB_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_BLOB_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct SIGNER_CERT {
@@ -16011,9 +14674,6 @@ impl Default for SIGNER_CERT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_CERT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SIGNER_CERT_0 {
@@ -16025,9 +14685,6 @@ impl Default for SIGNER_CERT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIGNER_CERT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -16088,9 +14745,6 @@ impl Default for SIGNER_CERT_STORE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_CERT_STORE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SIGNER_CONTEXT {
@@ -16102,9 +14756,6 @@ impl Default for SIGNER_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIGNER_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -16122,9 +14773,6 @@ impl Default for SIGNER_DIGEST_SIGN_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_DIGEST_SIGN_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SIGNER_DIGEST_SIGN_INFO_0 {
@@ -16138,9 +14786,6 @@ impl Default for SIGNER_DIGEST_SIGN_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_DIGEST_SIGN_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SIGNER_DIGEST_SIGN_INFO_V1 {
@@ -16152,9 +14797,6 @@ impl Default for SIGNER_DIGEST_SIGN_INFO_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIGNER_DIGEST_SIGN_INFO_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16169,9 +14811,6 @@ impl Default for SIGNER_DIGEST_SIGN_INFO_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_DIGEST_SIGN_INFO_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SIGNER_FILE_INFO {
@@ -16183,9 +14822,6 @@ impl Default for SIGNER_FILE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIGNER_FILE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SIGNER_NO_ATTR: SIGNER_SIGNATURE_ATTRIBUTE_CHOICE = SIGNER_SIGNATURE_ATTRIBUTE_CHOICE(0u32);
 #[repr(transparent)]
@@ -16206,9 +14842,6 @@ impl Default for SIGNER_PROVIDER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_PROVIDER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SIGNER_PROVIDER_INFO_0 {
@@ -16219,9 +14852,6 @@ impl Default for SIGNER_PROVIDER_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIGNER_PROVIDER_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -16241,9 +14871,6 @@ impl Default for SIGNER_SIGNATURE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_SIGNATURE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SIGNER_SIGNATURE_INFO_0 {
@@ -16253,9 +14880,6 @@ impl Default for SIGNER_SIGNATURE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIGNER_SIGNATURE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -16306,9 +14930,6 @@ impl Default for SIGNER_SPC_CHAIN_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_SPC_CHAIN_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SIGNER_SUBJECT_BLOB: SIGNER_SUBJECT_CHOICE = SIGNER_SUBJECT_CHOICE(2u32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -16327,9 +14948,6 @@ impl Default for SIGNER_SUBJECT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SIGNER_SUBJECT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SIGNER_SUBJECT_INFO_0 {
@@ -16340,9 +14958,6 @@ impl Default for SIGNER_SUBJECT_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIGNER_SUBJECT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SIGNER_TIMESTAMP_AUTHENTICODE: SIGNER_TIMESTAMP_FLAGS = SIGNER_TIMESTAMP_FLAGS(1u32);
 #[repr(transparent)]
@@ -16381,9 +14996,6 @@ impl Default for SSL_ECCKEY_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SSL_ECCKEY_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SSL_ECCPUBLIC_BLOB: windows_core::PCWSTR = windows_core::w!("SSLECCPUBLICBLOB");
 pub const SSL_ECDSA_ALGORITHM: windows_core::PCWSTR = windows_core::w!("ECDSA");
 pub const SSL_F12_ERROR_TEXT_LENGTH: u32 = 256u32;
@@ -16401,9 +15013,6 @@ impl Default for SSL_F12_EXTRA_CERT_CHAIN_POLICY_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SSL_F12_EXTRA_CERT_CHAIN_POLICY_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SSL_HPKP_HEADER_COUNT: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -16417,9 +15026,6 @@ impl Default for SSL_HPKP_HEADER_EXTRA_CERT_CHAIN_POLICY_PARA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SSL_HPKP_HEADER_EXTRA_CERT_CHAIN_POLICY_PARA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SSL_HPKP_PKP_HEADER_INDEX: u32 = 0u32;
 pub const SSL_HPKP_PKP_RO_HEADER_INDEX: u32 = 1u32;
@@ -16436,9 +15042,6 @@ impl Default for SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_PARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_PARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_STATUS {
@@ -16450,9 +15053,6 @@ impl Default for SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SSL_KEY_PIN_EXTRA_CERT_CHAIN_POLICY_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SSL_KEY_TYPE_PROPERTY: windows_core::PCWSTR = windows_core::w!("KEYTYPE");
 pub const SSL_OBJECT_LOCATOR_CERT_VALIDATION_CONFIG_FUNC: windows_core::PCSTR = windows_core::s!("SslObjectLocatorInitializeCertValidationConfig");
@@ -16630,9 +15230,6 @@ impl Default for VTableProvStruc {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VTableProvStruc {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VTableProvStrucW {
@@ -16648,9 +15245,6 @@ impl Default for VTableProvStrucW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VTableProvStrucW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const X509_ALGORITHM_IDENTIFIER: windows_core::PCSTR = windows_core::PCSTR(74i32 as _);
 pub const X509_ALTERNATE_NAME: windows_core::PCSTR = windows_core::PCSTR(12i32 as _);

--- a/crates/libs/windows/src/Windows/Win32/Security/DiagnosticDataQuery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/DiagnosticDataQuery/mod.rs
@@ -222,9 +222,6 @@ impl Default for DIAGNOSTIC_DATA_EVENT_BINARY_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIAGNOSTIC_DATA_EVENT_BINARY_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIAGNOSTIC_DATA_EVENT_CATEGORY_DESCRIPTION {
@@ -236,9 +233,6 @@ impl Default for DIAGNOSTIC_DATA_EVENT_CATEGORY_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIAGNOSTIC_DATA_EVENT_CATEGORY_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIAGNOSTIC_DATA_EVENT_PRODUCER_DESCRIPTION {
@@ -248,9 +242,6 @@ impl Default for DIAGNOSTIC_DATA_EVENT_PRODUCER_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIAGNOSTIC_DATA_EVENT_PRODUCER_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -264,9 +255,6 @@ impl Default for DIAGNOSTIC_DATA_EVENT_TAG_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIAGNOSTIC_DATA_EVENT_TAG_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIAGNOSTIC_DATA_EVENT_TAG_STATS {
@@ -277,9 +265,6 @@ impl Default for DIAGNOSTIC_DATA_EVENT_TAG_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIAGNOSTIC_DATA_EVENT_TAG_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -292,9 +277,6 @@ impl Default for DIAGNOSTIC_DATA_EVENT_TRANSCRIPT_CONFIGURATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIAGNOSTIC_DATA_EVENT_TRANSCRIPT_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -309,9 +291,6 @@ impl Default for DIAGNOSTIC_DATA_GENERAL_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIAGNOSTIC_DATA_GENERAL_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -336,9 +315,6 @@ impl Default for DIAGNOSTIC_DATA_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIAGNOSTIC_DATA_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIAGNOSTIC_DATA_SEARCH_CRITERIA {
@@ -355,9 +331,6 @@ impl Default for DIAGNOSTIC_DATA_SEARCH_CRITERIA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIAGNOSTIC_DATA_SEARCH_CRITERIA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -385,9 +358,6 @@ impl Default for DIAGNOSTIC_REPORT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIAGNOSTIC_REPORT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIAGNOSTIC_REPORT_PARAMETER {
@@ -399,9 +369,6 @@ impl Default for DIAGNOSTIC_REPORT_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DIAGNOSTIC_REPORT_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DIAGNOSTIC_REPORT_SIGNATURE {
@@ -412,9 +379,6 @@ impl Default for DIAGNOSTIC_REPORT_SIGNATURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DIAGNOSTIC_REPORT_SIGNATURE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/mod.rs
@@ -133,9 +133,6 @@ impl Default for FILE_UNPROTECT_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_UNPROTECT_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTHREAD_NETWORK_CONTEXT {
@@ -146,9 +143,6 @@ impl Default for HTHREAD_NETWORK_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTHREAD_NETWORK_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IProtectionPolicyManagerInterop, IProtectionPolicyManagerInterop_Vtbl, 0x4652651d_c1fe_4ba1_9f0a_c0f56596f721);
 windows_core::imp::interface_hierarchy!(IProtectionPolicyManagerInterop, windows_core::IUnknown, windows_core::IInspectable);

--- a/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/mod.rs
@@ -240,9 +240,6 @@ impl Default for EAPHOST_AUTH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAPHOST_AUTH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct EAPHOST_AUTH_STATUS(pub i32);
@@ -266,9 +263,6 @@ impl Default for EAPHOST_IDENTITY_UI_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAPHOST_IDENTITY_UI_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EAPHOST_INTERACTIVE_UI_PARAMS {
@@ -284,9 +278,6 @@ impl Default for EAPHOST_INTERACTIVE_UI_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAPHOST_INTERACTIVE_UI_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EAPHOST_METHOD_API_VERSION: u32 = 1u32;
 pub const EAPHOST_PEER_API_VERSION: u32 = 1u32;
 #[repr(C)]
@@ -301,9 +292,6 @@ impl Default for EAP_ATTRIBUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EAP_ATTRIBUTES {
@@ -314,9 +302,6 @@ impl Default for EAP_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EAP_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -342,9 +327,6 @@ impl Default for EAP_AUTHENTICATOR_METHOD_ROUTINES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_AUTHENTICATOR_METHOD_ROUTINES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct EAP_AUTHENTICATOR_SEND_TIMEOUT(pub i32);
@@ -368,9 +350,6 @@ impl Default for EAP_CONFIG_INPUT_FIELD_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_CONFIG_INPUT_FIELD_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EAP_CONFIG_INPUT_FIELD_DATA {
@@ -386,9 +365,6 @@ impl Default for EAP_CONFIG_INPUT_FIELD_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EAP_CONFIG_INPUT_FIELD_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EAP_CONFIG_INPUT_FIELD_PROPS_DEFAULT: u32 = 0u32;
 pub const EAP_CONFIG_INPUT_FIELD_PROPS_NON_DISPLAYABLE: u32 = 1u32;
@@ -408,9 +384,6 @@ impl Default for EAP_CRED_EXPIRY_REQ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_CRED_EXPIRY_REQ {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EAP_EMPTY_CREDENTIAL: EapCredentialType = EapCredentialType(0i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -428,9 +401,6 @@ impl Default for EAP_ERROR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EAP_ERROR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EAP_E_AUTHENTICATION_FAILED: u32 = 2151809045u32;
 pub const EAP_E_CERT_STORE_INACCESSIBLE: u32 = 2151809040u32;
@@ -513,9 +483,6 @@ impl Default for EAP_INTERACTIVE_UI_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_INTERACTIVE_UI_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct EAP_INTERACTIVE_UI_DATA_TYPE(pub i32);
@@ -549,9 +516,6 @@ impl Default for EAP_METHOD_AUTHENTICATOR_RESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_METHOD_AUTHENTICATOR_RESULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EAP_METHOD_INFO {
@@ -566,9 +530,6 @@ impl Default for EAP_METHOD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_METHOD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EAP_METHOD_INFO_ARRAY {
@@ -580,9 +541,6 @@ impl Default for EAP_METHOD_INFO_ARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_METHOD_INFO_ARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EAP_METHOD_INFO_ARRAY_EX {
@@ -593,9 +551,6 @@ impl Default for EAP_METHOD_INFO_ARRAY_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EAP_METHOD_INFO_ARRAY_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -611,9 +566,6 @@ impl Default for EAP_METHOD_INFO_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_METHOD_INFO_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EAP_METHOD_INVALID_PACKET: u32 = 2151809047u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -627,9 +579,6 @@ impl Default for EAP_METHOD_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_METHOD_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EAP_METHOD_PROPERTY_ARRAY {
@@ -640,9 +589,6 @@ impl Default for EAP_METHOD_PROPERTY_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EAP_METHOD_PROPERTY_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -659,9 +605,6 @@ impl Default for EAP_METHOD_PROPERTY_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_METHOD_PROPERTY_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EAP_METHOD_PROPERTY_VALUE_BOOL {
@@ -672,9 +615,6 @@ impl Default for EAP_METHOD_PROPERTY_VALUE_BOOL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EAP_METHOD_PROPERTY_VALUE_BOOL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -687,9 +627,6 @@ impl Default for EAP_METHOD_PROPERTY_VALUE_DWORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_METHOD_PROPERTY_VALUE_DWORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EAP_METHOD_PROPERTY_VALUE_STRING {
@@ -700,9 +637,6 @@ impl Default for EAP_METHOD_PROPERTY_VALUE_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EAP_METHOD_PROPERTY_VALUE_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -717,9 +651,6 @@ impl Default for EAP_METHOD_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EAP_METHOD_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EAP_PEER_FLAG_GUEST_ACCESS: u32 = 64u32;
 pub const EAP_PEER_FLAG_HEALTH_STATE_CHANGE: u32 = 32768u32;
@@ -747,9 +678,6 @@ impl Default for EAP_PEER_METHOD_ROUTINES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_PEER_METHOD_ROUTINES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EAP_PEER_VALUENAME_CONFIGUI: windows_core::PCWSTR = windows_core::w!("PeerConfigUIPath");
 pub const EAP_PEER_VALUENAME_DLL_PATH: windows_core::PCWSTR = windows_core::w!("PeerDllPath");
 pub const EAP_PEER_VALUENAME_FRIENDLY_NAME: windows_core::PCWSTR = windows_core::w!("PeerFriendlyName");
@@ -773,9 +701,6 @@ impl Default for EAP_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EAP_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EAP_UI_DATA_FORMAT {
@@ -787,9 +712,6 @@ impl Default for EAP_UI_DATA_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EAP_UI_DATA_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EAP_UI_INPUT_FIELD_PROPS_DEFAULT: u32 = 0u32;
 pub const EAP_UI_INPUT_FIELD_PROPS_NON_DISPLAYABLE: u32 = 1u32;
@@ -808,9 +730,6 @@ impl Default for EapCertificateCredential {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EapCertificateCredential {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -847,9 +766,6 @@ impl Default for EapCredential {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EapCredential {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct EapCredentialType(pub i32);
@@ -864,9 +780,6 @@ impl Default for EapCredentialTypeData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EapCredentialTypeData {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EapHostAuthFailed: EAPHOST_AUTH_STATUS = EAPHOST_AUTH_STATUS(6i32);
 pub const EapHostAuthIdentityExchange: EAPHOST_AUTH_STATUS = EAPHOST_AUTH_STATUS(2i32);
@@ -903,9 +816,6 @@ impl Default for EapHostPeerMethodResult {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EapHostPeerMethodResult {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EapHostPeerMethodResultAltSuccessReceived: EapHostPeerMethodResultReason = EapHostPeerMethodResultReason(1i32);
 pub const EapHostPeerMethodResultFromMethod: EapHostPeerMethodResultReason = EapHostPeerMethodResultReason(3i32);
 #[repr(transparent)]
@@ -935,9 +845,6 @@ impl Default for EapPacket {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EapPacket {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EapPeerMethodOutput {
@@ -948,9 +855,6 @@ impl Default for EapPeerMethodOutput {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EapPeerMethodOutput {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -984,10 +888,6 @@ impl Default for EapPeerMethodResult {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for EapPeerMethodResult {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EapPeerMethodResultFailure: EapPeerMethodResultReason = EapPeerMethodResultReason(3i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1004,9 +904,6 @@ impl Default for EapSimCredential {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EapSimCredential {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EapUsernamePasswordCredential {
@@ -1017,9 +914,6 @@ impl Default for EapUsernamePasswordCredential {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EapUsernamePasswordCredential {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FACILITY_EAP_MESSAGE: u32 = 2114u32;
 pub const GUID_EapHost_Cause_CertStoreInaccessible: windows_core::GUID = windows_core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000004);
@@ -1478,9 +1372,6 @@ impl Default for LEGACY_IDENTITY_UI_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LEGACY_IDENTITY_UI_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LEGACY_INTERACTIVE_UI_PARAMS {
@@ -1495,9 +1386,6 @@ impl Default for LEGACY_INTERACTIVE_UI_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LEGACY_INTERACTIVE_UI_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MAXEAPCODE: u32 = 4u32;
 pub const MAX_EAP_CONFIG_INPUT_FIELD_LENGTH: u32 = 256u32;
@@ -1517,10 +1405,6 @@ impl Default for NgcTicketContext {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for NgcTicketContext {
-    type TypeKind = windows_core::CopyType;
-}
 pub type NotificationHandler = Option<unsafe extern "system" fn(connectionid: windows_core::GUID, pcontextdata: *mut core::ffi::c_void)>;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1539,9 +1423,6 @@ impl Default for PPP_EAP_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPP_EAP_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1573,9 +1454,6 @@ impl Default for PPP_EAP_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPP_EAP_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1602,10 +1480,6 @@ impl Default for PPP_EAP_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for PPP_EAP_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPP_EAP_PACKET {
@@ -1619,9 +1493,6 @@ impl Default for PPP_EAP_PACKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPP_EAP_PACKET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RAS_AUTH_ATTRIBUTE {
@@ -1633,9 +1504,6 @@ impl Default for RAS_AUTH_ATTRIBUTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAS_AUTH_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Isolation/mod.rs
@@ -258,7 +258,4 @@ impl Default for IsolatedAppLauncherTelemetryParameters {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IsolatedAppLauncherTelemetryParameters {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WDAG_CLIPBOARD_TAG: windows_core::PCWSTR = windows_core::w!("CrossIsolatedEnvironmentContent");

--- a/crates/libs/windows/src/Windows/Win32/Security/NetworkAccessProtection/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/NetworkAccessProtection/mod.rs
@@ -11,9 +11,6 @@ impl Default for CorrelationId {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CorrelationId {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CountedString {
@@ -24,9 +21,6 @@ impl Default for CountedString {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CountedString {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -44,9 +38,6 @@ impl Default for FailureCategoryMapping {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FailureCategoryMapping {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FixupInfo {
@@ -59,9 +50,6 @@ impl Default for FixupInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FixupInfo {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -76,9 +64,6 @@ impl Default for Ipv4Address {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for Ipv4Address {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Ipv6Address {
@@ -88,9 +73,6 @@ impl Default for Ipv6Address {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for Ipv6Address {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -104,9 +86,6 @@ impl Default for IsolationInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IsolationInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IsolationInfoEx {
@@ -119,9 +98,6 @@ impl Default for IsolationInfoEx {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IsolationInfoEx {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -144,9 +120,6 @@ impl Default for NapComponentRegistrationInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NapComponentRegistrationInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NapNotifyType(pub i32);
@@ -164,9 +137,6 @@ impl Default for NetworkSoH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NetworkSoH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PrivateData {
@@ -177,9 +147,6 @@ impl Default for PrivateData {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PrivateData {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -195,9 +162,6 @@ impl Default for ResultCodes {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ResultCodes {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SoH {
@@ -208,9 +172,6 @@ impl Default for SoH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SoH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -224,9 +185,6 @@ impl Default for SoHAttribute {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SoHAttribute {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SystemHealthAgentState {
@@ -239,9 +197,6 @@ impl Default for SystemHealthAgentState {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SystemHealthAgentState {
-    type TypeKind = windows_core::CopyType;
 }
 pub const extendedIsolationStateInfected: ExtendedIsolationState = ExtendedIsolationState(2i32);
 pub const extendedIsolationStateNoData: ExtendedIsolationState = ExtendedIsolationState(0i32);

--- a/crates/libs/windows/src/Windows/Win32/Security/WinTrust/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/WinTrust/mod.rs
@@ -119,9 +119,6 @@ impl Default for CAT_MEMBERINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CAT_MEMBERINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CAT_MEMBERINFO2 {
@@ -132,9 +129,6 @@ impl Default for CAT_MEMBERINFO2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CAT_MEMBERINFO2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CAT_MEMBERINFO2_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.12.2.3");
 pub const CAT_MEMBERINFO2_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2223i32 as _);
@@ -153,10 +147,6 @@ impl Default for CAT_NAMEVALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for CAT_NAMEVALUE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CAT_NAMEVALUE_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.12.2.1");
 pub const CAT_NAMEVALUE_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2221i32 as _);
@@ -187,10 +177,6 @@ impl Default for CONFIG_CI_PROV_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for CONFIG_CI_PROV_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONFIG_CI_PROV_INFO_RESULT {
@@ -203,9 +189,6 @@ impl Default for CONFIG_CI_PROV_INFO_RESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONFIG_CI_PROV_INFO_RESULT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -222,9 +205,6 @@ impl Default for CONFIG_CI_PROV_INFO_RESULT2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONFIG_CI_PROV_INFO_RESULT2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CPD_CHOICE_SIP: u32 = 1u32;
 pub const CPD_RETURN_LOWER_QUALITY_CHAINS: u32 = 1048576u32;
@@ -263,10 +243,6 @@ impl Default for CRYPT_PROVIDER_CERT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for CRYPT_PROVIDER_CERT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
@@ -312,10 +288,6 @@ impl Default for CRYPT_PROVIDER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl windows_core::TypeKind for CRYPT_PROVIDER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 #[derive(Clone, Copy)]
@@ -327,10 +299,6 @@ impl Default for CRYPT_PROVIDER_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl windows_core::TypeKind for CRYPT_PROVIDER_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -344,9 +312,6 @@ impl Default for CRYPT_PROVIDER_DEFUSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_PROVIDER_DEFUSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
@@ -375,10 +340,6 @@ impl Default for CRYPT_PROVIDER_FUNCTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl windows_core::TypeKind for CRYPT_PROVIDER_FUNCTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_PROVIDER_PRIVDATA {
@@ -391,9 +352,6 @@ impl Default for CRYPT_PROVIDER_PRIVDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_PROVIDER_PRIVDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -408,9 +366,6 @@ impl Default for CRYPT_PROVIDER_REGDEFUSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_PROVIDER_REGDEFUSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -432,10 +387,6 @@ impl Default for CRYPT_PROVIDER_SGNR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for CRYPT_PROVIDER_SGNR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -460,10 +411,6 @@ impl Default for CRYPT_PROVIDER_SIGSTATE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for CRYPT_PROVIDER_SIGSTATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_PROVUI_DATA {
@@ -482,9 +429,6 @@ impl Default for CRYPT_PROVUI_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_PROVUI_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -501,10 +445,6 @@ impl Default for CRYPT_PROVUI_FUNCS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl windows_core::TypeKind for CRYPT_PROVUI_FUNCS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -524,9 +464,6 @@ impl Default for CRYPT_REGISTER_ACTIONID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CRYPT_REGISTER_ACTIONID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CRYPT_TRUST_REG_ENTRY {
@@ -538,9 +475,6 @@ impl Default for CRYPT_TRUST_REG_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CRYPT_TRUST_REG_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DRIVER_ACTION_VERIFY: windows_core::GUID = windows_core::GUID::from_u128(0xf750e6c3_38ee_11d1_85e5_00c04fc295ee);
 pub const DRIVER_CLEANUPPOLICY_FUNCTION: windows_core::PCWSTR = windows_core::w!("DriverCleanupPolicy");
@@ -569,10 +503,6 @@ impl Default for DRIVER_VER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for DRIVER_VER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVER_VER_MAJORMINOR {
@@ -583,9 +513,6 @@ impl Default for DRIVER_VER_MAJORMINOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVER_VER_MAJORMINOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DWACTION_ALLOCANDFILL: WINTRUST_GET_DEFAULT_FOR_USAGE_ACTION = WINTRUST_GET_DEFAULT_FOR_USAGE_ACTION(1u32);
 pub const DWACTION_FREE: WINTRUST_GET_DEFAULT_FOR_USAGE_ACTION = WINTRUST_GET_DEFAULT_FOR_USAGE_ACTION(2u32);
@@ -605,9 +532,6 @@ impl Default for INTENT_TO_SEAL_ATTRIBUTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTENT_TO_SEAL_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INTENT_TO_SEAL_ATTRIBUTE_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2010i32 as _);
 pub const OFFICESIGN_ACTION_VERIFY: windows_core::GUID = windows_core::GUID::from_u128(0x5555c2cd_17fb_11d1_85c4_00c04fc295ee);
@@ -664,10 +588,6 @@ impl Default for PROVDATA_SIP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl windows_core::TypeKind for PROVDATA_SIP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -683,10 +603,6 @@ impl Default for SEALING_SIGNATURE_ATTRIBUTE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SEALING_SIGNATURE_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SEALING_SIGNATURE_ATTRIBUTE_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2011i32 as _);
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -701,10 +617,6 @@ impl Default for SEALING_TIMESTAMP_ATTRIBUTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SEALING_TIMESTAMP_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SEALING_TIMESTAMP_ATTRIBUTE_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2012i32 as _);
 pub const SGNR_TYPE_TIMESTAMP: u32 = 16u32;
@@ -726,9 +638,6 @@ impl Default for SPC_FINANCIAL_CRITERIA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPC_FINANCIAL_CRITERIA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SPC_FINANCIAL_CRITERIA_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.2.1.27");
 pub const SPC_FINANCIAL_CRITERIA_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2002i32 as _);
 pub const SPC_GLUE_RDN_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.2.1.25");
@@ -748,10 +657,6 @@ impl Default for SPC_IMAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SPC_IMAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -765,10 +670,6 @@ impl Default for SPC_INDIRECT_DATA_CONTENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SPC_INDIRECT_DATA_CONTENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPC_INDIRECT_DATA_CONTENT_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2003i32 as _);
 pub const SPC_INDIRECT_DATA_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.2.1.4");
@@ -788,10 +689,6 @@ impl Default for SPC_LINK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SPC_LINK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy)]
@@ -805,10 +702,6 @@ impl Default for SPC_LINK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SPC_LINK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPC_LINK_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.2.1.28");
 pub const SPC_LINK_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2005i32 as _);
@@ -829,10 +722,6 @@ impl Default for SPC_PE_IMAGE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SPC_PE_IMAGE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SPC_PE_IMAGE_DATA_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.2.1.15");
 pub const SPC_PE_IMAGE_DATA_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2004i32 as _);
 pub const SPC_PE_IMAGE_PAGE_HASHES_V1_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.2.3.1");
@@ -852,10 +741,6 @@ impl Default for SPC_SERIALIZED_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SPC_SERIALIZED_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPC_SIGINFO {
@@ -871,9 +756,6 @@ impl Default for SPC_SIGINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPC_SIGINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPC_SIGINFO_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.2.1.30");
 pub const SPC_SIGINFO_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2130i32 as _);
@@ -892,10 +774,6 @@ impl Default for SPC_SP_AGENCY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SPC_SP_AGENCY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SPC_SP_AGENCY_INFO_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.2.1.10");
 pub const SPC_SP_AGENCY_INFO_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2000i32 as _);
 #[repr(C)]
@@ -912,10 +790,6 @@ impl Default for SPC_SP_OPUS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for SPC_SP_OPUS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SPC_SP_OPUS_INFO_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.2.1.12");
 pub const SPC_SP_OPUS_INFO_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2007i32 as _);
 #[repr(C)]
@@ -928,9 +802,6 @@ impl Default for SPC_STATEMENT_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPC_STATEMENT_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPC_STATEMENT_TYPE_OBJID: windows_core::PCSTR = windows_core::s!("1.3.6.1.4.1.311.2.1.11");
 pub const SPC_STATEMENT_TYPE_STRUCT: windows_core::PCSTR = windows_core::PCSTR(2006i32 as _);
@@ -995,9 +866,6 @@ impl Default for WINTRUST_BLOB_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINTRUST_BLOB_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1019,10 +887,6 @@ impl Default for WINTRUST_CATALOG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WINTRUST_CATALOG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1040,10 +904,6 @@ impl Default for WINTRUST_CERT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WINTRUST_CERT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINTRUST_CONFIG_REGPATH: windows_core::PCWSTR = windows_core::w!("Software\\Microsoft\\Cryptography\\Wintrust\\Config");
 #[repr(C)]
@@ -1070,10 +930,6 @@ impl Default for WINTRUST_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WINTRUST_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy)]
@@ -1089,10 +945,6 @@ impl Default for WINTRUST_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WINTRUST_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1158,9 +1010,6 @@ impl Default for WINTRUST_FILE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINTRUST_FILE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WINTRUST_GET_DEFAULT_FOR_USAGE_ACTION(pub u32);
@@ -1220,10 +1069,6 @@ impl Default for WINTRUST_SGNR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WINTRUST_SGNR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1240,10 +1085,6 @@ impl Default for WINTRUST_SIGNATURE_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WINTRUST_SIGNATURE_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1294,9 +1135,6 @@ impl Default for WIN_CERTIFICATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIN_CERTIFICATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WIN_CERT_REVISION_1_0: u32 = 256u32;
 pub const WIN_CERT_REVISION_2_0: u32 = 512u32;
 pub const WIN_CERT_TYPE_PKCS_SIGNED_DATA: u32 = 2u32;
@@ -1317,9 +1155,6 @@ impl Default for WIN_SPUB_TRUSTED_PUBLISHER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIN_SPUB_TRUSTED_PUBLISHER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIN_TRUST_ACTDATA_CONTEXT_WITH_SUBJECT {
@@ -1332,9 +1167,6 @@ impl Default for WIN_TRUST_ACTDATA_CONTEXT_WITH_SUBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIN_TRUST_ACTDATA_CONTEXT_WITH_SUBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIN_TRUST_ACTDATA_SUBJECT_ONLY {
@@ -1345,9 +1177,6 @@ impl Default for WIN_TRUST_ACTDATA_SUBJECT_ONLY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIN_TRUST_ACTDATA_SUBJECT_ONLY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1360,9 +1189,6 @@ impl Default for WIN_TRUST_SUBJECT_FILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIN_TRUST_SUBJECT_FILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIN_TRUST_SUBJECT_FILE_AND_DISPLAY {
@@ -1374,9 +1200,6 @@ impl Default for WIN_TRUST_SUBJECT_FILE_AND_DISPLAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIN_TRUST_SUBJECT_FILE_AND_DISPLAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIN_TRUST_SUBJTYPE_CABINET: windows_core::GUID = windows_core::GUID::from_u128(0xd17c5374_a392_11cf_9df5_00aa00c184e0);
 pub const WIN_TRUST_SUBJTYPE_CABINETEX: windows_core::GUID = windows_core::GUID::from_u128(0x6f458114_c2f1_11cf_8a69_00aa006c3706);
@@ -1425,10 +1248,6 @@ impl Default for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy)]
@@ -1441,10 +1260,6 @@ impl Default for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WTD_GENERIC_CHAIN_POLICY_CREATE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
@@ -1462,10 +1277,6 @@ impl Default for WTD_GENERIC_CHAIN_POLICY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl windows_core::TypeKind for WTD_GENERIC_CHAIN_POLICY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
 #[derive(Clone, Copy)]
@@ -1478,10 +1289,6 @@ impl Default for WTD_GENERIC_CHAIN_POLICY_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Security_Cryptography_Catalog", feature = "Win32_Security_Cryptography_Sip"))]
-impl windows_core::TypeKind for WTD_GENERIC_CHAIN_POLICY_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -1501,10 +1308,6 @@ impl Default for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
 #[derive(Clone, Copy)]
@@ -1517,10 +1320,6 @@ impl Default for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for WTD_GENERIC_CHAIN_POLICY_SIGNER_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTD_HASH_ONLY_FLAG: WINTRUST_DATA_PROVIDER_FLAGS = WINTRUST_DATA_PROVIDER_FLAGS(512u32);
 pub const WTD_LIFETIME_SIGNING_FLAG: WINTRUST_DATA_PROVIDER_FLAGS = WINTRUST_DATA_PROVIDER_FLAGS(2048u32);

--- a/crates/libs/windows/src/Windows/Win32/Security/WinWlx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/WinWlx/mod.rs
@@ -50,9 +50,6 @@ impl Default for WLX_CLIENT_CREDENTIALS_INFO_V1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLX_CLIENT_CREDENTIALS_INFO_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLX_CLIENT_CREDENTIALS_INFO_V2_0 {
@@ -67,9 +64,6 @@ impl Default for WLX_CLIENT_CREDENTIALS_INFO_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLX_CLIENT_CREDENTIALS_INFO_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLX_CONSOLESWITCHCREDENTIAL_TYPE_V1_0: u32 = 1u32;
 #[repr(C)]
@@ -108,9 +102,6 @@ impl Default for WLX_CONSOLESWITCH_CREDENTIALS_INFO_V1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLX_CONSOLESWITCH_CREDENTIALS_INFO_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WLX_CREATE_INSTANCE_ONLY: u32 = 1u32;
 pub const WLX_CREATE_USER: u32 = 2u32;
 pub const WLX_CREDENTIAL_TYPE_V1_0: u32 = 1u32;
@@ -130,10 +121,6 @@ impl Default for WLX_DESKTOP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_StationsAndDesktops")]
-impl windows_core::TypeKind for WLX_DESKTOP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLX_DESKTOP_HANDLE: u32 = 2u32;
 pub const WLX_DESKTOP_NAME: u32 = 1u32;
@@ -161,10 +148,6 @@ impl Default for WLX_DISPATCH_VERSION_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for WLX_DISPATCH_VERSION_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -194,10 +177,6 @@ impl Default for WLX_DISPATCH_VERSION_1_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for WLX_DISPATCH_VERSION_1_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -226,10 +205,6 @@ impl Default for WLX_DISPATCH_VERSION_1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for WLX_DISPATCH_VERSION_1_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -266,10 +241,6 @@ impl Default for WLX_DISPATCH_VERSION_1_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for WLX_DISPATCH_VERSION_1_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -309,10 +280,6 @@ impl Default for WLX_DISPATCH_VERSION_1_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_StationsAndDesktops", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for WLX_DISPATCH_VERSION_1_4 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WLX_DLG_INPUT_TIMEOUT: u32 = 102u32;
 pub const WLX_DLG_SAS: u32 = 101u32;
 pub const WLX_DLG_SCREEN_SAVER_TIMEOUT: u32 = 103u32;
@@ -330,9 +297,6 @@ impl Default for WLX_MPR_NOTIFY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLX_MPR_NOTIFY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_StationsAndDesktops")]
@@ -352,10 +316,6 @@ impl Default for WLX_NOTIFICATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_StationsAndDesktops")]
-impl windows_core::TypeKind for WLX_NOTIFICATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLX_OPTION_CONTEXT_POINTER: u32 = 2u32;
 pub const WLX_OPTION_DISPATCH_TABLE_SIZE: u32 = 65539u32;
@@ -379,9 +339,6 @@ impl Default for WLX_PROFILE_V1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLX_PROFILE_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WLX_PROFILE_V2_0 {
@@ -396,9 +353,6 @@ impl Default for WLX_PROFILE_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLX_PROFILE_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLX_SAS_ACTION_DELAYED_FORCE_LOGOFF: u32 = 16u32;
 pub const WLX_SAS_ACTION_FORCE_LOGOFF: u32 = 9u32;
@@ -442,9 +396,6 @@ impl Default for WLX_SC_NOTIFICATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WLX_SC_NOTIFICATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WLX_SHUTDOWN_TYPE(pub u32);
@@ -459,9 +410,6 @@ impl Default for WLX_TERMINAL_SERVICES_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLX_TERMINAL_SERVICES_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLX_VERSION_1_0: u32 = 65536u32;
 pub const WLX_VERSION_1_1: u32 = 65537u32;

--- a/crates/libs/windows/src/Windows/Win32/Security/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/mod.rs
@@ -1123,9 +1123,6 @@ impl Default for ACCESS_ALLOWED_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACCESS_ALLOWED_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACCESS_ALLOWED_CALLBACK_ACE {
@@ -1137,9 +1134,6 @@ impl Default for ACCESS_ALLOWED_CALLBACK_ACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACCESS_ALLOWED_CALLBACK_ACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1156,9 +1150,6 @@ impl Default for ACCESS_ALLOWED_CALLBACK_OBJECT_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACCESS_ALLOWED_CALLBACK_OBJECT_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACCESS_ALLOWED_OBJECT_ACE {
@@ -1174,9 +1165,6 @@ impl Default for ACCESS_ALLOWED_OBJECT_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACCESS_ALLOWED_OBJECT_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACCESS_DENIED_ACE {
@@ -1189,9 +1177,6 @@ impl Default for ACCESS_DENIED_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACCESS_DENIED_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACCESS_DENIED_CALLBACK_ACE {
@@ -1203,9 +1188,6 @@ impl Default for ACCESS_DENIED_CALLBACK_ACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACCESS_DENIED_CALLBACK_ACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1222,9 +1204,6 @@ impl Default for ACCESS_DENIED_CALLBACK_OBJECT_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACCESS_DENIED_CALLBACK_OBJECT_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACCESS_DENIED_OBJECT_ACE {
@@ -1240,9 +1219,6 @@ impl Default for ACCESS_DENIED_OBJECT_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACCESS_DENIED_OBJECT_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACCESS_REASONS {
@@ -1252,9 +1228,6 @@ impl Default for ACCESS_REASONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACCESS_REASONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1304,9 +1277,6 @@ impl Default for ACE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ACE_INHERITED_OBJECT_TYPE_PRESENT: SYSTEM_AUDIT_OBJECT_ACE_FLAGS = SYSTEM_AUDIT_OBJECT_ACE_FLAGS(2u32);
 pub const ACE_OBJECT_TYPE_PRESENT: SYSTEM_AUDIT_OBJECT_ACE_FLAGS = SYSTEM_AUDIT_OBJECT_ACE_FLAGS(1u32);
 #[repr(transparent)]
@@ -1326,9 +1296,6 @@ impl Default for ACL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ACL_INFORMATION_CLASS(pub i32);
@@ -1344,9 +1311,6 @@ impl Default for ACL_REVISION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACL_REVISION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACL_SIZE_INFORMATION {
@@ -1358,9 +1322,6 @@ impl Default for ACL_SIZE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACL_SIZE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ATTRIBUTE_SECURITY_INFORMATION: OBJECT_SECURITY_INFORMATION = OBJECT_SECURITY_INFORMATION(32u32);
 #[repr(transparent)]
@@ -1384,9 +1345,6 @@ impl Default for CLAIM_SECURITY_ATTRIBUTES_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLAIM_SECURITY_ATTRIBUTES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CLAIM_SECURITY_ATTRIBUTES_INFORMATION_0 {
@@ -1396,9 +1354,6 @@ impl Default for CLAIM_SECURITY_ATTRIBUTES_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLAIM_SECURITY_ATTRIBUTES_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLAIM_SECURITY_ATTRIBUTE_DISABLED: CLAIM_SECURITY_ATTRIBUTE_FLAGS = CLAIM_SECURITY_ATTRIBUTE_FLAGS(16u32);
 pub const CLAIM_SECURITY_ATTRIBUTE_DISABLED_BY_DEFAULT: CLAIM_SECURITY_ATTRIBUTE_FLAGS = CLAIM_SECURITY_ATTRIBUTE_FLAGS(8u32);
@@ -1449,9 +1404,6 @@ impl Default for CLAIM_SECURITY_ATTRIBUTE_FQBN_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLAIM_SECURITY_ATTRIBUTE_FQBN_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLAIM_SECURITY_ATTRIBUTE_MANDATORY: CLAIM_SECURITY_ATTRIBUTE_FLAGS = CLAIM_SECURITY_ATTRIBUTE_FLAGS(32u32);
 pub const CLAIM_SECURITY_ATTRIBUTE_NON_INHERITABLE: CLAIM_SECURITY_ATTRIBUTE_FLAGS = CLAIM_SECURITY_ATTRIBUTE_FLAGS(1u32);
 #[repr(C)]
@@ -1464,9 +1416,6 @@ impl Default for CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1483,9 +1432,6 @@ impl Default for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1_0 {
@@ -1499,9 +1445,6 @@ impl Default for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLAIM_SECURITY_ATTRIBUTE_TYPE_BOOLEAN: CLAIM_SECURITY_ATTRIBUTE_VALUE_TYPE = CLAIM_SECURITY_ATTRIBUTE_VALUE_TYPE(6u16);
 pub const CLAIM_SECURITY_ATTRIBUTE_TYPE_FQBN: CLAIM_SECURITY_ATTRIBUTE_VALUE_TYPE = CLAIM_SECURITY_ATTRIBUTE_VALUE_TYPE(4u16);
@@ -1526,9 +1469,6 @@ impl Default for CLAIM_SECURITY_ATTRIBUTE_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLAIM_SECURITY_ATTRIBUTE_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CLAIM_SECURITY_ATTRIBUTE_V1_0 {
@@ -1542,9 +1482,6 @@ impl Default for CLAIM_SECURITY_ATTRIBUTE_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLAIM_SECURITY_ATTRIBUTE_V1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLAIM_SECURITY_ATTRIBUTE_VALUE_CASE_SENSITIVE: CLAIM_SECURITY_ATTRIBUTE_FLAGS = CLAIM_SECURITY_ATTRIBUTE_FLAGS(2u32);
 #[repr(transparent)]
@@ -1615,9 +1552,6 @@ impl Default for GENERIC_MAPPING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GENERIC_MAPPING {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GROUP_SECURITY_INFORMATION: OBJECT_SECURITY_INFORMATION = OBJECT_SECURITY_INFORMATION(2u32);
 pub const INHERITED_ACE: ACE_FLAGS = ACE_FLAGS(16u32);
 pub const INHERIT_NO_PROPAGATE: ACE_FLAGS = ACE_FLAGS(4u32);
@@ -1634,9 +1568,6 @@ impl Default for LLFILETIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LLFILETIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union LLFILETIME_0 {
@@ -1647,9 +1578,6 @@ impl Default for LLFILETIME_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LLFILETIME_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1678,9 +1606,6 @@ impl Default for LUID_AND_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LUID_AND_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1776,9 +1701,6 @@ impl Default for OBJECT_TYPE_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OBJECT_TYPE_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OWNER_SECURITY_INFORMATION: OBJECT_SECURITY_INFORMATION = OBJECT_SECURITY_INFORMATION(1u32);
 pub type PLSA_AP_CALL_PACKAGE_UNTRUSTED = Option<unsafe extern "system" fn(clientrequest: *const *const core::ffi::c_void, protocolsubmitbuffer: *const core::ffi::c_void, clientbufferbase: *const core::ffi::c_void, submitbufferlength: u32, protocolreturnbuffer: *mut *mut core::ffi::c_void, returnbufferlength: *mut u32, protocolstatus: *mut i32) -> super::Foundation::NTSTATUS>;
 #[repr(C)]
@@ -1792,9 +1714,6 @@ impl Default for PRIVILEGE_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRIVILEGE_SET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROTECTED_DACL_SECURITY_INFORMATION: OBJECT_SECURITY_INFORMATION = OBJECT_SECURITY_INFORMATION(2147483648u32);
 pub const PROTECTED_SACL_SECURITY_INFORMATION: OBJECT_SECURITY_INFORMATION = OBJECT_SECURITY_INFORMATION(1073741824u32);
@@ -1845,9 +1764,6 @@ impl Default for QUOTA_LIMITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUOTA_LIMITS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SACL_SECURITY_INFORMATION: OBJECT_SECURITY_INFORMATION = OBJECT_SECURITY_INFORMATION(8u32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1879,9 +1795,6 @@ impl Default for SECURITY_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURITY_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECURITY_AUTHENTICATION_AUTHORITY: SID_IDENTIFIER_AUTHORITY = SID_IDENTIFIER_AUTHORITY { Value: [0, 0, 0, 0, 0, 18] };
 #[repr(transparent)]
@@ -1933,9 +1846,6 @@ impl Default for SECURITY_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURITY_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SECURITY_CREATOR_SID_AUTHORITY: SID_IDENTIFIER_AUTHORITY = SID_IDENTIFIER_AUTHORITY { Value: [0, 0, 0, 0, 0, 3] };
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1952,9 +1862,6 @@ impl Default for SECURITY_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURITY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2008,9 +1915,6 @@ impl Default for SECURITY_DESCRIPTOR_RELATIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURITY_DESCRIPTOR_RELATIVE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SECURITY_DYNAMIC_TRACKING: super::Foundation::BOOLEAN = super::Foundation::BOOLEAN(1u8);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2034,9 +1938,6 @@ impl Default for SECURITY_QUALITY_OF_SERVICE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SECURITY_QUALITY_OF_SERVICE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECURITY_RESOURCE_MANAGER_AUTHORITY: SID_IDENTIFIER_AUTHORITY = SID_IDENTIFIER_AUTHORITY { Value: [0, 0, 0, 0, 0, 9] };
 pub const SECURITY_SCOPED_POLICY_ID_AUTHORITY: SID_IDENTIFIER_AUTHORITY = SID_IDENTIFIER_AUTHORITY { Value: [0, 0, 0, 0, 0, 17] };
@@ -2069,9 +1970,6 @@ impl Default for SE_ACCESS_REPLY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SE_ACCESS_REPLY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SE_ACCESS_REQUEST {
@@ -2088,9 +1986,6 @@ impl Default for SE_ACCESS_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SE_ACCESS_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SE_ASSIGNPRIMARYTOKEN_NAME: windows_core::PCWSTR = windows_core::w!("SeAssignPrimaryTokenPrivilege");
 pub const SE_AUDIT_NAME: windows_core::PCWSTR = windows_core::w!("SeAuditPrivilege");
@@ -2123,9 +2018,6 @@ impl Default for SE_IMPERSONATION_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SE_IMPERSONATION_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SE_INCREASE_QUOTA_NAME: windows_core::PCWSTR = windows_core::w!("SeIncreaseQuotaPrivilege");
 pub const SE_INC_BASE_PRIORITY_NAME: windows_core::PCWSTR = windows_core::w!("SeIncreaseBasePriorityPrivilege");
@@ -2161,9 +2053,6 @@ impl Default for SE_SECURITY_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SE_SECURITY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SE_SECURITY_NAME: windows_core::PCWSTR = windows_core::w!("SeSecurityPrivilege");
 pub const SE_SELF_RELATIVE: SECURITY_DESCRIPTOR_CONTROL = SECURITY_DESCRIPTOR_CONTROL(32768u16);
 pub const SE_SHUTDOWN_NAME: windows_core::PCWSTR = windows_core::w!("SeShutdownPrivilege");
@@ -2177,9 +2066,6 @@ impl Default for SE_SID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SE_SID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SE_SYNC_AGENT_NAME: windows_core::PCWSTR = windows_core::w!("SeSyncAgentPrivilege");
 pub const SE_SYSTEMTIME_NAME: windows_core::PCWSTR = windows_core::w!("SeSystemtimePrivilege");
@@ -2204,9 +2090,6 @@ impl Default for SID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SID_AND_ATTRIBUTES {
@@ -2217,9 +2100,6 @@ impl Default for SID_AND_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SID_AND_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2233,9 +2113,6 @@ impl Default for SID_AND_ATTRIBUTES_HASH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SID_AND_ATTRIBUTES_HASH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SID_IDENTIFIER_AUTHORITY {
@@ -2245,9 +2122,6 @@ impl Default for SID_IDENTIFIER_AUTHORITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SID_IDENTIFIER_AUTHORITY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2271,9 +2145,6 @@ impl Default for SYSTEM_ACCESS_FILTER_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_ACCESS_FILTER_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_ALARM_ACE {
@@ -2286,9 +2157,6 @@ impl Default for SYSTEM_ALARM_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_ALARM_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_ALARM_CALLBACK_ACE {
@@ -2300,9 +2168,6 @@ impl Default for SYSTEM_ALARM_CALLBACK_ACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_ALARM_CALLBACK_ACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2319,9 +2184,6 @@ impl Default for SYSTEM_ALARM_CALLBACK_OBJECT_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_ALARM_CALLBACK_OBJECT_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_ALARM_OBJECT_ACE {
@@ -2337,9 +2199,6 @@ impl Default for SYSTEM_ALARM_OBJECT_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_ALARM_OBJECT_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_AUDIT_ACE {
@@ -2352,9 +2211,6 @@ impl Default for SYSTEM_AUDIT_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_AUDIT_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_AUDIT_CALLBACK_ACE {
@@ -2366,9 +2222,6 @@ impl Default for SYSTEM_AUDIT_CALLBACK_ACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_AUDIT_CALLBACK_ACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2385,9 +2238,6 @@ impl Default for SYSTEM_AUDIT_CALLBACK_OBJECT_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_AUDIT_CALLBACK_OBJECT_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_AUDIT_OBJECT_ACE {
@@ -2402,9 +2252,6 @@ impl Default for SYSTEM_AUDIT_OBJECT_ACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_AUDIT_OBJECT_ACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2454,9 +2301,6 @@ impl Default for SYSTEM_MANDATORY_LABEL_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_MANDATORY_LABEL_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_PROCESS_TRUST_LABEL_ACE {
@@ -2468,9 +2312,6 @@ impl Default for SYSTEM_PROCESS_TRUST_LABEL_ACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_PROCESS_TRUST_LABEL_ACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2484,9 +2325,6 @@ impl Default for SYSTEM_RESOURCE_ATTRIBUTE_ACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_RESOURCE_ATTRIBUTE_ACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_SCOPED_POLICY_ID_ACE {
@@ -2498,9 +2336,6 @@ impl Default for SYSTEM_SCOPED_POLICY_ID_ACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_SCOPED_POLICY_ID_ACE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SecurityAnonymous: SECURITY_IMPERSONATION_LEVEL = SECURITY_IMPERSONATION_LEVEL(0i32);
 pub const SecurityDelegation: SECURITY_IMPERSONATION_LEVEL = SECURITY_IMPERSONATION_LEVEL(3i32);
@@ -2538,9 +2373,6 @@ impl Default for TOKEN_ACCESS_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKEN_ACCESS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2596,9 +2428,6 @@ impl Default for TOKEN_APPCONTAINER_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_APPCONTAINER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TOKEN_ASSIGN_PRIMARY: TOKEN_ACCESS_MASK = TOKEN_ACCESS_MASK(1u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2609,9 +2438,6 @@ impl Default for TOKEN_AUDIT_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKEN_AUDIT_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2626,9 +2452,6 @@ impl Default for TOKEN_CONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_CONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOKEN_DEFAULT_DACL {
@@ -2638,9 +2461,6 @@ impl Default for TOKEN_DEFAULT_DACL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKEN_DEFAULT_DACL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TOKEN_DELETE: TOKEN_ACCESS_MASK = TOKEN_ACCESS_MASK(65536u32);
 #[repr(C)]
@@ -2653,9 +2473,6 @@ impl Default for TOKEN_DEVICE_CLAIMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_DEVICE_CLAIMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TOKEN_DUPLICATE: TOKEN_ACCESS_MASK = TOKEN_ACCESS_MASK(2u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2666,9 +2483,6 @@ impl Default for TOKEN_ELEVATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKEN_ELEVATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2684,9 +2498,6 @@ impl Default for TOKEN_GROUPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKEN_GROUPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2707,9 +2518,6 @@ impl Default for TOKEN_GROUPS_AND_PRIVILEGES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_GROUPS_AND_PRIVILEGES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TOKEN_IMPERSONATE: TOKEN_ACCESS_MASK = TOKEN_ACCESS_MASK(4u32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2724,9 +2532,6 @@ impl Default for TOKEN_LINKED_TOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_LINKED_TOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOKEN_MANDATORY_LABEL {
@@ -2737,9 +2542,6 @@ impl Default for TOKEN_MANDATORY_LABEL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_MANDATORY_LABEL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOKEN_MANDATORY_POLICY {
@@ -2749,9 +2551,6 @@ impl Default for TOKEN_MANDATORY_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKEN_MANDATORY_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2770,9 +2569,6 @@ impl Default for TOKEN_ORIGIN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_ORIGIN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOKEN_OWNER {
@@ -2782,9 +2578,6 @@ impl Default for TOKEN_OWNER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKEN_OWNER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2796,9 +2589,6 @@ impl Default for TOKEN_PRIMARY_GROUP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_PRIMARY_GROUP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOKEN_PRIVILEGES {
@@ -2809,9 +2599,6 @@ impl Default for TOKEN_PRIVILEGES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKEN_PRIVILEGES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2864,9 +2651,6 @@ impl Default for TOKEN_SOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_SOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOKEN_STATISTICS {
@@ -2886,9 +2670,6 @@ impl Default for TOKEN_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TOKEN_TRUST_CONSTRAINT_MASK: TOKEN_ACCESS_MASK = TOKEN_ACCESS_MASK(131096u32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2903,9 +2684,6 @@ impl Default for TOKEN_USER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_USER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOKEN_USER_CLAIMS {
@@ -2915,9 +2693,6 @@ impl Default for TOKEN_USER_CLAIMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOKEN_USER_CLAIMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TOKEN_WRITE: TOKEN_ACCESS_MASK = TOKEN_ACCESS_MASK(131296u32);
 pub const TOKEN_WRITE_DAC: TOKEN_ACCESS_MASK = TOKEN_ACCESS_MASK(262144u32);

--- a/crates/libs/windows/src/Windows/Win32/Storage/Cabinets/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Cabinets/mod.rs
@@ -89,9 +89,6 @@ impl Default for CCAB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CCAB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ERF {
@@ -103,9 +100,6 @@ impl Default for ERF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ERF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -137,9 +131,6 @@ impl Default for FDICABINETINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FDICABINETINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FDICREATE_CPU_TYPE(pub i32);
@@ -155,9 +146,6 @@ impl Default for FDIDECRYPT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FDIDECRYPT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FDIDECRYPT_0 {
@@ -169,9 +157,6 @@ impl Default for FDIDECRYPT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FDIDECRYPT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -185,9 +170,6 @@ impl Default for FDIDECRYPT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FDIDECRYPT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -204,9 +186,6 @@ impl Default for FDIDECRYPT_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FDIDECRYPT_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FDIDECRYPT_0_1 {
@@ -218,9 +197,6 @@ impl Default for FDIDECRYPT_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FDIDECRYPT_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -263,9 +239,6 @@ impl Default for FDINOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FDINOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FDINOTIFICATIONTYPE(pub i32);
@@ -282,10 +255,6 @@ impl Default for FDISPILLFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FDISPILLFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -298,10 +267,6 @@ impl Default for FDISPILLFILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FDISPILLFILE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INCLUDED_FCI: u32 = 1u32;
 pub const INCLUDED_FDI: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
@@ -574,10 +574,6 @@ impl Default for CF_CALLBACK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_CorrelationVector")]
-impl windows_core::TypeKind for CF_CALLBACK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CF_CALLBACK_OPEN_COMPLETION_FLAGS(pub i32);
@@ -628,9 +624,6 @@ impl Default for CF_CALLBACK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CF_CALLBACK_PARAMETERS_0 {
@@ -652,9 +645,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CF_CALLBACK_PARAMETERS_0_0 {
@@ -666,9 +656,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CF_CALLBACK_PARAMETERS_0_0_0 {
@@ -678,9 +665,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -693,9 +677,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_0_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_0_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CF_CALLBACK_PARAMETERS_0_5 {
@@ -705,9 +686,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -720,9 +698,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CF_CALLBACK_PARAMETERS_0_6 {
@@ -734,9 +709,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CF_CALLBACK_PARAMETERS_0_9 {
@@ -747,9 +719,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_9 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CF_CALLBACK_PARAMETERS_0_8 {
@@ -759,9 +728,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_8 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -779,9 +745,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CF_CALLBACK_PARAMETERS_0_3 {
@@ -793,9 +756,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CF_CALLBACK_PARAMETERS_0_4 {
@@ -805,9 +765,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -820,9 +777,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_11 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_11 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CF_CALLBACK_PARAMETERS_0_10 {
@@ -833,9 +787,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_10 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_10 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -849,9 +800,6 @@ impl Default for CF_CALLBACK_PARAMETERS_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_CALLBACK_PARAMETERS_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_CorrelationVector")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -864,10 +812,6 @@ impl Default for CF_CALLBACK_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_CorrelationVector")]
-impl windows_core::TypeKind for CF_CALLBACK_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1190,9 +1134,6 @@ impl Default for CF_FILE_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_FILE_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1205,10 +1146,6 @@ impl Default for CF_FS_METADATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_FS_METADATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1295,9 +1232,6 @@ impl Default for CF_HYDRATION_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_HYDRATION_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CF_HYDRATION_POLICY_ALWAYS_FULL: CF_HYDRATION_POLICY_PRIMARY = CF_HYDRATION_POLICY_PRIMARY(3u16);
 pub const CF_HYDRATION_POLICY_FULL: CF_HYDRATION_POLICY_PRIMARY = CF_HYDRATION_POLICY_PRIMARY(2u16);
@@ -1613,10 +1547,6 @@ impl Default for CF_OPERATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_CorrelationVector")]
-impl windows_core::TypeKind for CF_OPERATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
@@ -1629,10 +1559,6 @@ impl Default for CF_OPERATION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -1653,10 +1579,6 @@ impl Default for CF_OPERATION_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1671,10 +1593,6 @@ impl Default for CF_OPERATION_PARAMETERS_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -1691,10 +1609,6 @@ impl Default for CF_OPERATION_PARAMETERS_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1708,10 +1622,6 @@ impl Default for CF_OPERATION_PARAMETERS_0_7 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1724,10 +1634,6 @@ impl Default for CF_OPERATION_PARAMETERS_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -1743,10 +1649,6 @@ impl Default for CF_OPERATION_PARAMETERS_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -1764,10 +1666,6 @@ impl Default for CF_OPERATION_PARAMETERS_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1783,10 +1681,6 @@ impl Default for CF_OPERATION_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -1804,10 +1698,6 @@ impl Default for CF_OPERATION_PARAMETERS_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_OPERATION_PARAMETERS_0_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1994,9 +1884,6 @@ impl Default for CF_PLACEHOLDER_BASIC_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_PLACEHOLDER_BASIC_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CF_PLACEHOLDER_CREATE_FLAGS(pub i32);
@@ -2056,10 +1943,6 @@ impl Default for CF_PLACEHOLDER_CREATE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CF_PLACEHOLDER_CREATE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CF_PLACEHOLDER_INFO_BASIC: CF_PLACEHOLDER_INFO_CLASS = CF_PLACEHOLDER_INFO_CLASS(0i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2097,9 +1980,6 @@ impl Default for CF_PLACEHOLDER_STANDARD_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_PLACEHOLDER_STANDARD_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2157,9 +2037,6 @@ impl Default for CF_PLATFORM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_PLATFORM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CF_POPULATION_POLICY {
@@ -2170,9 +2047,6 @@ impl Default for CF_POPULATION_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_POPULATION_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CF_POPULATION_POLICY_ALWAYS_FULL: CF_POPULATION_POLICY_PRIMARY = CF_POPULATION_POLICY_PRIMARY(3u16);
 pub const CF_POPULATION_POLICY_FULL: CF_POPULATION_POLICY_PRIMARY = CF_POPULATION_POLICY_PRIMARY(2u16);
@@ -2232,9 +2106,6 @@ impl Default for CF_PROCESS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_PROCESS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CF_PROVIDER_STATUS_CLEAR_FLAGS: CF_SYNC_PROVIDER_STATUS = CF_SYNC_PROVIDER_STATUS(2147483648u32);
 pub const CF_PROVIDER_STATUS_CONNECTIVITY_LOST: CF_SYNC_PROVIDER_STATUS = CF_SYNC_PROVIDER_STATUS(64u32);
@@ -2417,9 +2288,6 @@ impl Default for CF_SYNC_POLICIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_SYNC_POLICIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CF_SYNC_PROVIDER_STATUS(pub u32);
@@ -2473,9 +2341,6 @@ impl Default for CF_SYNC_REGISTRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_SYNC_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CF_SYNC_ROOT_BASIC_INFO {
@@ -2485,9 +2350,6 @@ impl Default for CF_SYNC_ROOT_BASIC_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_SYNC_ROOT_BASIC_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CF_SYNC_ROOT_INFO_BASIC: CF_SYNC_ROOT_INFO_CLASS = CF_SYNC_ROOT_INFO_CLASS(0i32);
 #[repr(transparent)]
@@ -2506,9 +2368,6 @@ impl Default for CF_SYNC_ROOT_PROVIDER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_SYNC_ROOT_PROVIDER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2529,9 +2388,6 @@ impl Default for CF_SYNC_ROOT_STANDARD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CF_SYNC_ROOT_STANDARD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CF_SYNC_STATUS {
@@ -2546,9 +2402,6 @@ impl Default for CF_SYNC_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CF_SYNC_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Compression/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Compression/mod.rs
@@ -105,9 +105,6 @@ impl Default for COMPRESS_ALLOCATION_ROUTINES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMPRESS_ALLOCATION_ROUTINES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct COMPRESS_INFORMATION_CLASS(pub i32);

--- a/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/mod.rs
@@ -9,9 +9,6 @@ impl Default for DDP_FILE_EXTENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDP_FILE_EXTENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DEDUP_BACKUP_SUPPORT_PARAM_TYPE(pub i32);
@@ -29,9 +26,6 @@ impl Default for DEDUP_CHUNK_INFO_HASH32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEDUP_CHUNK_INFO_HASH32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEDUP_CONTAINER_EXTENT {
@@ -43,9 +37,6 @@ impl Default for DEDUP_CONTAINER_EXTENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEDUP_CONTAINER_EXTENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEDUP_PT_AvgChunkSizeBytes: DEDUP_SET_PARAM_TYPE = DEDUP_SET_PARAM_TYPE(3i32);
 pub const DEDUP_PT_DisableStrongHashComputation: DEDUP_SET_PARAM_TYPE = DEDUP_SET_PARAM_TYPE(5i32);
@@ -70,9 +61,6 @@ impl Default for DedupChunk {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DedupChunk {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -125,9 +113,6 @@ impl Default for DedupHash {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DedupHash {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DedupHashingAlgorithm(pub i32);
@@ -146,9 +131,6 @@ impl Default for DedupStream {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DedupStream {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DedupStreamEntry {
@@ -160,9 +142,6 @@ impl Default for DedupStreamEntry {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DedupStreamEntry {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IDedupBackupSupport, IDedupBackupSupport_Vtbl, 0xc719d963_2b2d_415e_acf7_7eb7ca596ff4);
 windows_core::imp::interface_hierarchy!(IDedupBackupSupport, windows_core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/Storage/DistributedFileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DistributedFileSystem/mod.rs
@@ -224,9 +224,6 @@ impl Default for DFS_GET_PKT_ENTRY_STATE_ARG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_GET_PKT_ENTRY_STATE_ARG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_1 {
@@ -236,9 +233,6 @@ impl Default for DFS_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -250,9 +244,6 @@ impl Default for DFS_INFO_100 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_INFO_100 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_101 {
@@ -263,9 +254,6 @@ impl Default for DFS_INFO_101 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_INFO_101 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_102 {
@@ -275,9 +263,6 @@ impl Default for DFS_INFO_102 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_INFO_102 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -290,9 +275,6 @@ impl Default for DFS_INFO_103 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_INFO_103 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_104 {
@@ -302,9 +284,6 @@ impl Default for DFS_INFO_104 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_INFO_104 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -320,9 +299,6 @@ impl Default for DFS_INFO_105 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_INFO_105 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_106 {
@@ -333,9 +309,6 @@ impl Default for DFS_INFO_106 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_INFO_106 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -355,10 +328,6 @@ impl Default for DFS_INFO_107 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for DFS_INFO_107 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -372,10 +341,6 @@ impl Default for DFS_INFO_150 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for DFS_INFO_150 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -387,10 +352,6 @@ impl Default for DFS_INFO_1_32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DFS_INFO_1_32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -405,9 +366,6 @@ impl Default for DFS_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_200 {
@@ -417,9 +375,6 @@ impl Default for DFS_INFO_200 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_INFO_200 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -436,10 +391,6 @@ impl Default for DFS_INFO_2_32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DFS_INFO_2_32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_3 {
@@ -454,9 +405,6 @@ impl Default for DFS_INFO_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_INFO_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_300 {
@@ -467,9 +415,6 @@ impl Default for DFS_INFO_300 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_INFO_300 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -487,10 +432,6 @@ impl Default for DFS_INFO_3_32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DFS_INFO_3_32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_4 {
@@ -506,9 +447,6 @@ impl Default for DFS_INFO_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_INFO_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -528,10 +466,6 @@ impl Default for DFS_INFO_4_32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DFS_INFO_4_32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_5 {
@@ -549,9 +483,6 @@ impl Default for DFS_INFO_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_INFO_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_50 {
@@ -563,9 +494,6 @@ impl Default for DFS_INFO_50 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_INFO_50 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -585,9 +513,6 @@ impl Default for DFS_INFO_6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_INFO_6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_INFO_7 {
@@ -597,9 +522,6 @@ impl Default for DFS_INFO_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_INFO_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -622,10 +544,6 @@ impl Default for DFS_INFO_8 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for DFS_INFO_8 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -647,10 +565,6 @@ impl Default for DFS_INFO_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for DFS_INFO_9 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DFS_MOVE_FLAG_REPLACE_IF_EXISTS: u32 = 1u32;
 #[repr(transparent)]
@@ -677,9 +591,6 @@ impl Default for DFS_SITELIST_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_SITELIST_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_SITENAME_INFO {
@@ -690,9 +601,6 @@ impl Default for DFS_SITENAME_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_SITENAME_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DFS_SITE_PRIMARY: u32 = 1u32;
 pub const DFS_STORAGE_FLAVOR_UNUSED2: u32 = 768u32;
@@ -708,9 +616,6 @@ impl Default for DFS_STORAGE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_STORAGE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -725,10 +630,6 @@ impl Default for DFS_STORAGE_INFO_0_32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DFS_STORAGE_INFO_0_32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_STORAGE_INFO_1 {
@@ -741,9 +642,6 @@ impl Default for DFS_STORAGE_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_STORAGE_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DFS_STORAGE_STATES: u32 = 15u32;
 pub const DFS_STORAGE_STATE_ACTIVE: u32 = 4u32;
@@ -764,9 +662,6 @@ impl Default for DFS_SUPPORTED_NAMESPACE_VERSION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DFS_SUPPORTED_NAMESPACE_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DFS_TARGET_PRIORITY {
@@ -778,9 +673,6 @@ impl Default for DFS_TARGET_PRIORITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFS_TARGET_PRIORITY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/mod.rs
@@ -8,9 +8,6 @@ impl Default for ACT_AUTHORIZATION_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACT_AUTHORIZATION_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ACT_AUTHORIZATION_STATE_VALUE(pub i32);
@@ -124,9 +121,6 @@ impl Default for ENHANCED_STORAGE_PASSWORD_SILO_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENHANCED_STORAGE_PASSWORD_SILO_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENHANCED_STORAGE_PROPERTY_ADMIN_HINT: super::super::Foundation::PROPERTYKEY = super::super::Foundation::PROPERTYKEY { fmtid: windows_core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2011 };
 pub const ENHANCED_STORAGE_PROPERTY_AUTHENTICATION_STATE: super::super::Foundation::PROPERTYKEY = super::super::Foundation::PROPERTYKEY { fmtid: windows_core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 1006 };
@@ -1902,9 +1896,6 @@ impl Default for SILO_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SILO_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGEPROVIDERSTATE_ERROR: u32 = 7u32;
 pub const STORAGEPROVIDERSTATE_EXCLUDED: u32 = 9u32;

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -2998,9 +2998,6 @@ impl Default for BY_HANDLE_FILE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BY_HANDLE_FILE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BusType1394: STORAGE_BUS_TYPE = STORAGE_BUS_TYPE(4i32);
 pub const BusTypeAta: STORAGE_BUS_TYPE = STORAGE_BUS_TYPE(3i32);
 pub const BusTypeAtapi: STORAGE_BUS_TYPE = STORAGE_BUS_TYPE(2i32);
@@ -3107,9 +3104,6 @@ impl Default for CLFS_LOG_NAME_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_LOG_NAME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLFS_MARSHALLING_FLAG_DISABLE_BUFF_INIT: u32 = 1u32;
 pub const CLFS_MARSHALLING_FLAG_NONE: u32 = 0u32;
 pub const CLFS_MAX_CONTAINER_INFO: u32 = 256u32;
@@ -3125,9 +3119,6 @@ impl Default for CLFS_MGMT_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLFS_MGMT_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3145,9 +3136,6 @@ impl Default for CLFS_MGMT_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLFS_MGMT_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3168,9 +3156,6 @@ impl Default for CLFS_MGMT_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLFS_MGMT_POLICY_0_6 {
@@ -3181,9 +3166,6 @@ impl Default for CLFS_MGMT_POLICY_0_6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLFS_MGMT_POLICY_0_5 {
@@ -3193,9 +3175,6 @@ impl Default for CLFS_MGMT_POLICY_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3208,9 +3187,6 @@ impl Default for CLFS_MGMT_POLICY_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLFS_MGMT_POLICY_0_4 {
@@ -3222,9 +3198,6 @@ impl Default for CLFS_MGMT_POLICY_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLFS_MGMT_POLICY_0_0 {
@@ -3235,9 +3208,6 @@ impl Default for CLFS_MGMT_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLFS_MGMT_POLICY_0_1 {
@@ -3247,9 +3217,6 @@ impl Default for CLFS_MGMT_POLICY_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3262,9 +3229,6 @@ impl Default for CLFS_MGMT_POLICY_0_9 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLFS_MGMT_POLICY_0_7 {
@@ -3276,9 +3240,6 @@ impl Default for CLFS_MGMT_POLICY_0_7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLFS_MGMT_POLICY_0_2 {
@@ -3289,9 +3250,6 @@ impl Default for CLFS_MGMT_POLICY_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLFS_MGMT_POLICY_0_8 {
@@ -3301,9 +3259,6 @@ impl Default for CLFS_MGMT_POLICY_0_8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLFS_MGMT_POLICY_0_8 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3320,9 +3275,6 @@ impl Default for CLFS_NODE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_NODE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLFS_PHYSICAL_LSN_INFORMATION {
@@ -3334,9 +3286,6 @@ impl Default for CLFS_PHYSICAL_LSN_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLFS_PHYSICAL_LSN_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLFS_SCAN_BACKWARD: u8 = 4u8;
 pub const CLFS_SCAN_BUFFERED: u8 = 32u8;
@@ -3354,9 +3303,6 @@ impl Default for CLFS_STREAM_ID_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLFS_STREAM_ID_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLSID_DiskQuotaControl: windows_core::GUID = windows_core::GUID::from_u128(0x7988b571_ec89_11cf_9c00_00aa00a14f56);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3369,9 +3315,6 @@ impl Default for CLS_ARCHIVE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLS_ARCHIVE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3392,9 +3335,6 @@ impl Default for CLS_CONTAINER_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLS_CONTAINER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3425,9 +3365,6 @@ impl Default for CLS_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CLS_IOSTATS_CLASS(pub i32);
@@ -3445,9 +3382,6 @@ impl Default for CLS_IO_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLS_IO_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLS_IO_STATISTICS_HEADER {
@@ -3462,9 +3396,6 @@ impl Default for CLS_IO_STATISTICS_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLS_IO_STATISTICS_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CLS_LOG_INFORMATION_CLASS(pub i32);
@@ -3477,9 +3408,6 @@ impl Default for CLS_LSN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLS_LSN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3497,9 +3425,6 @@ impl Default for CLS_SCAN_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLS_SCAN_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLS_WRITE_ENTRY {
@@ -3510,9 +3435,6 @@ impl Default for CLS_WRITE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLS_WRITE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3533,9 +3455,6 @@ impl Default for CONNECTION_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONNECTION_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONNECTION_INFO_1 {
@@ -3551,9 +3470,6 @@ impl Default for CONNECTION_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONNECTION_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COPYFILE2_CALLBACK_CHUNK_FINISHED: COPYFILE2_MESSAGE_TYPE = COPYFILE2_MESSAGE_TYPE(2i32);
 pub const COPYFILE2_CALLBACK_CHUNK_STARTED: COPYFILE2_MESSAGE_TYPE = COPYFILE2_MESSAGE_TYPE(1i32);
@@ -3580,9 +3496,6 @@ impl Default for COPYFILE2_EXTENDED_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COPYFILE2_EXTENDED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COPYFILE2_EXTENDED_PARAMETERS_V2 {
@@ -3601,9 +3514,6 @@ impl Default for COPYFILE2_EXTENDED_PARAMETERS_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COPYFILE2_EXTENDED_PARAMETERS_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const COPYFILE2_IO_CYCLE_SIZE_MAX: u32 = 1073741824u32;
 pub const COPYFILE2_IO_CYCLE_SIZE_MIN: u32 = 4096u32;
 pub const COPYFILE2_IO_RATE_MIN: u32 = 512u32;
@@ -3619,9 +3529,6 @@ impl Default for COPYFILE2_MESSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COPYFILE2_MESSAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union COPYFILE2_MESSAGE_0 {
@@ -3636,9 +3543,6 @@ impl Default for COPYFILE2_MESSAGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3659,9 +3563,6 @@ impl Default for COPYFILE2_MESSAGE_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COPYFILE2_MESSAGE_0_0 {
@@ -3678,9 +3579,6 @@ impl Default for COPYFILE2_MESSAGE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3700,9 +3598,6 @@ impl Default for COPYFILE2_MESSAGE_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COPYFILE2_MESSAGE_0_4 {
@@ -3712,9 +3607,6 @@ impl Default for COPYFILE2_MESSAGE_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3733,9 +3625,6 @@ impl Default for COPYFILE2_MESSAGE_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COPYFILE2_MESSAGE_0_2 {
@@ -3750,9 +3639,6 @@ impl Default for COPYFILE2_MESSAGE_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COPYFILE2_MESSAGE_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3920,10 +3806,6 @@ impl Default for CREATEFILE2_EXTENDED_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for CREATEFILE2_EXTENDED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CREATE_ALWAYS: FILE_CREATION_DISPOSITION = FILE_CREATION_DISPOSITION(2u32);
 pub const CREATE_NEW: FILE_CREATION_DISPOSITION = FILE_CREATION_DISPOSITION(1u32);
 #[repr(transparent)]
@@ -4066,9 +3948,6 @@ impl Default for DISKQUOTA_USER_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISKQUOTA_USER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_SPACE_INFORMATION {
@@ -4091,9 +3970,6 @@ impl Default for DISK_SPACE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_SPACE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EA_CONTAINER_NAME: windows_core::PCSTR = windows_core::s!("ContainerName");
 pub const EA_CONTAINER_SIZE: windows_core::PCSTR = windows_core::s!("ContainerSize");
 #[repr(C)]
@@ -4108,9 +3984,6 @@ impl Default for EFS_CERTIFICATE_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EFS_CERTIFICATE_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EFS_COMPATIBILITY_INFO {
@@ -4120,9 +3993,6 @@ impl Default for EFS_COMPATIBILITY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EFS_COMPATIBILITY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EFS_COMPATIBILITY_VERSION_NCRYPT_PROTECTOR: u32 = 5u32;
 pub const EFS_COMPATIBILITY_VERSION_PFILE_PROTECTOR: u32 = 6u32;
@@ -4138,9 +4008,6 @@ impl Default for EFS_DECRYPTION_STATUS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EFS_DECRYPTION_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EFS_EFS_SUBVER_EFS_CERT: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4153,9 +4020,6 @@ impl Default for EFS_ENCRYPTION_STATUS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EFS_ENCRYPTION_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EFS_HASH_BLOB {
@@ -4166,9 +4030,6 @@ impl Default for EFS_HASH_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EFS_HASH_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -4184,10 +4045,6 @@ impl Default for EFS_KEY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for EFS_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EFS_METADATA_ADD_USER: u32 = 1u32;
 pub const EFS_METADATA_GENERAL_OP: u32 = 8u32;
@@ -4207,9 +4064,6 @@ impl Default for EFS_PIN_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EFS_PIN_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EFS_RPC_BLOB {
@@ -4220,9 +4074,6 @@ impl Default for EFS_RPC_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EFS_RPC_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EFS_SUBVER_UNKNOWN: u32 = 0u32;
 #[repr(C)]
@@ -4235,9 +4086,6 @@ impl Default for EFS_VERSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EFS_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -4254,10 +4102,6 @@ impl Default for ENCRYPTED_FILE_METADATA_SIGNATURE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for ENCRYPTED_FILE_METADATA_SIGNATURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4271,10 +4115,6 @@ impl Default for ENCRYPTION_CERTIFICATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for ENCRYPTION_CERTIFICATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -4291,10 +4131,6 @@ impl Default for ENCRYPTION_CERTIFICATE_HASH {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for ENCRYPTION_CERTIFICATE_HASH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4308,10 +4144,6 @@ impl Default for ENCRYPTION_CERTIFICATE_HASH_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for ENCRYPTION_CERTIFICATE_HASH_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4324,10 +4156,6 @@ impl Default for ENCRYPTION_CERTIFICATE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for ENCRYPTION_CERTIFICATE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -4343,10 +4171,6 @@ impl Default for ENCRYPTION_PROTECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for ENCRYPTION_PROTECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4359,10 +4183,6 @@ impl Default for ENCRYPTION_PROTECTOR_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for ENCRYPTION_PROTECTOR_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENLISTMENT_MAXIMUM_OPTION: u32 = 1u32;
 pub const ENLISTMENT_OBJECT_PATH: windows_core::PCWSTR = windows_core::w!("\\Enlistment\\");
@@ -4391,9 +4211,6 @@ impl Default for FH_OVERLAPPED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FH_OVERLAPPED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4451,9 +4268,6 @@ impl Default for FILE_ALIGNMENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_ALIGNMENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_ALLOCATION_INFO {
@@ -4463,9 +4277,6 @@ impl Default for FILE_ALLOCATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ALLOCATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_ALL_ACCESS: FILE_ACCESS_RIGHTS = FILE_ACCESS_RIGHTS(2032127u32);
 pub const FILE_APPEND_DATA: FILE_ACCESS_RIGHTS = FILE_ACCESS_RIGHTS(4u32);
@@ -4499,9 +4310,6 @@ impl Default for FILE_ATTRIBUTE_TAG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_ATTRIBUTE_TAG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_ATTRIBUTE_TEMPORARY: FILE_FLAGS_AND_ATTRIBUTES = FILE_FLAGS_AND_ATTRIBUTES(256u32);
 pub const FILE_ATTRIBUTE_UNPINNED: FILE_FLAGS_AND_ATTRIBUTES = FILE_FLAGS_AND_ATTRIBUTES(1048576u32);
 pub const FILE_ATTRIBUTE_VIRTUAL: FILE_FLAGS_AND_ATTRIBUTES = FILE_FLAGS_AND_ATTRIBUTES(65536u32);
@@ -4519,9 +4327,6 @@ impl Default for FILE_BASIC_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_BASIC_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_BEGIN: SET_FILE_POINTER_MOVE_METHOD = SET_FILE_POINTER_MOVE_METHOD(0u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4532,9 +4337,6 @@ impl Default for FILE_CASE_SENSITIVE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_CASE_SENSITIVE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4550,9 +4352,6 @@ impl Default for FILE_COMPRESSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_COMPRESSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_CREATE_PIPE_INSTANCE: FILE_ACCESS_RIGHTS = FILE_ACCESS_RIGHTS(4u32);
 #[repr(transparent)]
@@ -4583,9 +4382,6 @@ impl Default for FILE_DISPOSITION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_DISPOSITION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_DISPOSITION_INFO_EX {
@@ -4595,9 +4391,6 @@ impl Default for FILE_DISPOSITION_INFO_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_DISPOSITION_INFO_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4613,9 +4406,6 @@ impl Default for FILE_END_OF_FILE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_END_OF_FILE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_EXECUTE: FILE_ACCESS_RIGHTS = FILE_ACCESS_RIGHTS(32u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4627,9 +4417,6 @@ impl Default for FILE_EXTENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_EXTENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4707,9 +4494,6 @@ impl Default for FILE_FULL_DIR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_FULL_DIR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_GENERIC_EXECUTE: FILE_ACCESS_RIGHTS = FILE_ACCESS_RIGHTS(1179808u32);
 pub const FILE_GENERIC_READ: FILE_ACCESS_RIGHTS = FILE_ACCESS_RIGHTS(1179785u32);
 pub const FILE_GENERIC_WRITE: FILE_ACCESS_RIGHTS = FILE_ACCESS_RIGHTS(1179926u32);
@@ -4722,9 +4506,6 @@ impl Default for FILE_ID_128 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ID_128 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4750,9 +4531,6 @@ impl Default for FILE_ID_BOTH_DIR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_ID_BOTH_DIR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct FILE_ID_DESCRIPTOR {
@@ -4765,9 +4543,6 @@ impl Default for FILE_ID_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_ID_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILE_ID_DESCRIPTOR_0 {
@@ -4779,9 +4554,6 @@ impl Default for FILE_ID_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ID_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4806,9 +4578,6 @@ impl Default for FILE_ID_EXTD_DIR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_ID_EXTD_DIR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_ID_INFO {
@@ -4819,9 +4588,6 @@ impl Default for FILE_ID_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ID_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4836,9 +4602,6 @@ impl Default for FILE_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_INFO_3 {
@@ -4852,9 +4615,6 @@ impl Default for FILE_INFO_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_INFO_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4905,9 +4665,6 @@ impl Default for FILE_IO_PRIORITY_HINT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_IO_PRIORITY_HINT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_LIST_DIRECTORY: FILE_ACCESS_RIGHTS = FILE_ACCESS_RIGHTS(1u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4919,9 +4676,6 @@ impl Default for FILE_NAME_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_NAME_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_NAME_NORMALIZED: GETFINALPATHNAMEBYHANDLE_FLAGS = GETFINALPATHNAMEBYHANDLE_FLAGS(0u32);
 pub const FILE_NAME_OPENED: GETFINALPATHNAMEBYHANDLE_FLAGS = GETFINALPATHNAMEBYHANDLE_FLAGS(8u32);
@@ -4992,9 +4746,6 @@ impl Default for FILE_NOTIFY_EXTENDED_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_NOTIFY_EXTENDED_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILE_NOTIFY_EXTENDED_INFORMATION_0 {
@@ -5005,9 +4756,6 @@ impl Default for FILE_NOTIFY_EXTENDED_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_NOTIFY_EXTENDED_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5021,9 +4769,6 @@ impl Default for FILE_NOTIFY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_NOTIFY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_PROVIDER_COMPRESSION_LZX: u32 = 1u32;
 pub const FILE_PROVIDER_COMPRESSION_XPRESS16K: u32 = 3u32;
@@ -5051,9 +4796,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_REMOTE_PROTOCOL_INFO_0 {
@@ -5063,9 +4805,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5078,9 +4817,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_REMOTE_PROTOCOL_INFO_1_0 {
@@ -5092,9 +4828,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFO_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFO_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_REMOTE_PROTOCOL_INFO_1_0_0 {
@@ -5104,9 +4837,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFO_1_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFO_1_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5118,9 +4848,6 @@ impl Default for FILE_REMOTE_PROTOCOL_INFO_1_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_REMOTE_PROTOCOL_INFO_1_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5135,9 +4862,6 @@ impl Default for FILE_RENAME_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_RENAME_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILE_RENAME_INFO_0 {
@@ -5149,9 +4873,6 @@ impl Default for FILE_RENAME_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_RENAME_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILE_SEGMENT_ELEMENT {
@@ -5162,9 +4883,6 @@ impl Default for FILE_SEGMENT_ELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_SEGMENT_ELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_SHARE_DELETE: FILE_SHARE_MODE = FILE_SHARE_MODE(4u32);
 #[repr(transparent)]
@@ -5220,9 +4938,6 @@ impl Default for FILE_STANDARD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_STANDARD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_STORAGE_INFO {
@@ -5239,9 +4954,6 @@ impl Default for FILE_STORAGE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_STORAGE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_STREAM_INFO {
@@ -5255,9 +4967,6 @@ impl Default for FILE_STREAM_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_STREAM_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_TRAVERSE: FILE_ACCESS_RIGHTS = FILE_ACCESS_RIGHTS(32u32);
 #[repr(transparent)]
@@ -5370,9 +5079,6 @@ impl Default for FIO_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FIO_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FileAlignmentInfo: FILE_INFO_BY_HANDLE_CLASS = FILE_INFO_BY_HANDLE_CLASS(17i32);
 pub const FileAllocationInfo: FILE_INFO_BY_HANDLE_CLASS = FILE_INFO_BY_HANDLE_CLASS(5i32);
@@ -6197,9 +5903,6 @@ impl Default for IORING_BUFFER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IORING_BUFFER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IORING_BUFFER_REF {
@@ -6211,9 +5914,6 @@ impl Default for IORING_BUFFER_REF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IORING_BUFFER_REF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IORING_BUFFER_REF_0 {
@@ -6224,9 +5924,6 @@ impl Default for IORING_BUFFER_REF_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IORING_BUFFER_REF_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6241,9 +5938,6 @@ impl Default for IORING_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IORING_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IORING_CQE {
@@ -6255,9 +5949,6 @@ impl Default for IORING_CQE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IORING_CQE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6306,9 +5997,6 @@ impl Default for IORING_CREATE_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IORING_CREATE_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6397,9 +6085,6 @@ impl Default for IORING_HANDLE_REF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IORING_HANDLE_REF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IORING_HANDLE_REF_0 {
@@ -6410,9 +6095,6 @@ impl Default for IORING_HANDLE_REF_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IORING_HANDLE_REF_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6426,9 +6108,6 @@ impl Default for IORING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IORING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IORING_OP_CANCEL: IORING_OP_CODE = IORING_OP_CODE(4i32);
 #[repr(transparent)]
@@ -6455,9 +6134,6 @@ impl Default for IORING_REGISTERED_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IORING_REGISTERED_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6520,9 +6196,6 @@ impl Default for KCRM_MARSHAL_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KCRM_MARSHAL_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KCRM_PROTOCOL_BLOB {
@@ -6536,9 +6209,6 @@ impl Default for KCRM_PROTOCOL_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KCRM_PROTOCOL_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6554,9 +6224,6 @@ impl Default for KCRM_TRANSACTION_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KCRM_TRANSACTION_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KTM_MARSHAL_BLOB_VERSION_MAJOR: u32 = 1u32;
 pub const KTM_MARSHAL_BLOB_VERSION_MINOR: u32 = 1u32;
@@ -6610,9 +6277,6 @@ impl Default for LOG_MANAGEMENT_CALLBACKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LOG_MANAGEMENT_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LOG_POLICY_OVERWRITE: u32 = 1u32;
 pub const LOG_POLICY_PERSIST: u32 = 2u32;
@@ -6727,9 +6391,6 @@ impl Default for MediaLabelInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MediaLabelInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NAME_CACHE_CONTEXT {
@@ -6739,9 +6400,6 @@ impl Default for NAME_CACHE_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NAME_CACHE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMSMLI_MAXAPPDESCR: u32 = 256u32;
 pub const NTMSMLI_MAXIDSIZE: u32 = 256u32;
@@ -6761,9 +6419,6 @@ impl Default for NTMS_ALLOCATION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_ALLOCATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_APPLICATIONNAME_LENGTH: u32 = 64u32;
 pub const NTMS_ASYNCOP_MOUNT: NtmsAsyncOperations = NtmsAsyncOperations(1i32);
@@ -6788,9 +6443,6 @@ impl Default for NTMS_ASYNC_IO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_ASYNC_IO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NTMS_BARCODESTATE_OK: NtmsBarCodeState = NtmsBarCodeState(1i32);
 pub const NTMS_BARCODESTATE_UNREADABLE: NtmsBarCodeState = NtmsBarCodeState(2i32);
 pub const NTMS_BARCODE_LENGTH: u32 = 64u32;
@@ -6814,9 +6466,6 @@ impl Default for NTMS_CHANGERINFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_CHANGERINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_CHANGERINFORMATIONW {
@@ -6836,9 +6485,6 @@ impl Default for NTMS_CHANGERINFORMATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_CHANGERINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_CHANGERTYPEINFORMATIONA {
@@ -6851,9 +6497,6 @@ impl Default for NTMS_CHANGERTYPEINFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_CHANGERTYPEINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_CHANGERTYPEINFORMATIONW {
@@ -6865,9 +6508,6 @@ impl Default for NTMS_CHANGERTYPEINFORMATIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_CHANGERTYPEINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_CHANGER_TYPE: NtmsObjectsTypes = NtmsObjectsTypes(3i32);
 pub const NTMS_COMPUTER: NtmsObjectsTypes = NtmsObjectsTypes(4i32);
@@ -6884,9 +6524,6 @@ impl Default for NTMS_COMPUTERINFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_COMPUTERINFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_COMPUTERNAME_LENGTH: u32 = 64u32;
 pub const NTMS_CONTROL_ACCESS: NtmsAccessMask = NtmsAccessMask(4i32);
@@ -6925,9 +6562,6 @@ impl Default for NTMS_DRIVEINFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_DRIVEINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_DRIVEINFORMATIONW {
@@ -6953,9 +6587,6 @@ impl Default for NTMS_DRIVEINFORMATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_DRIVEINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NTMS_DRIVESTATE_BEING_CLEANED: NtmsDriveState = NtmsDriveState(6i32);
 pub const NTMS_DRIVESTATE_DISMOUNTABLE: NtmsDriveState = NtmsDriveState(7i32);
 pub const NTMS_DRIVESTATE_DISMOUNTED: NtmsDriveState = NtmsDriveState(0i32);
@@ -6975,9 +6606,6 @@ impl Default for NTMS_DRIVETYPEINFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_DRIVETYPEINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_DRIVETYPEINFORMATIONW {
@@ -6990,9 +6618,6 @@ impl Default for NTMS_DRIVETYPEINFORMATIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_DRIVETYPEINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_DRIVE_TYPE: NtmsObjectsTypes = NtmsObjectsTypes(6i32);
 pub const NTMS_EJECT_ASK_USER: NtmsEjectOperation = NtmsEjectOperation(5i32);
@@ -7017,9 +6642,6 @@ impl Default for NTMS_FILESYSTEM_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_FILESYSTEM_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7051,9 +6673,6 @@ impl Default for NTMS_I1_LIBRARYINFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_I1_LIBRARYINFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_I1_LIBREQUESTINFORMATIONA {
@@ -7075,9 +6694,6 @@ impl Default for NTMS_I1_LIBREQUESTINFORMATIONA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_I1_LIBREQUESTINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7101,9 +6717,6 @@ impl Default for NTMS_I1_LIBREQUESTINFORMATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_I1_LIBREQUESTINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NTMS_I1_MESSAGE_LENGTH: u32 = 127u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7123,9 +6736,6 @@ impl Default for NTMS_I1_OBJECTINFORMATIONA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_I1_OBJECTINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7151,9 +6761,6 @@ impl Default for NTMS_I1_OBJECTINFORMATIONA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_I1_OBJECTINFORMATIONA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NTMS_I1_OBJECTINFORMATIONW {
@@ -7172,9 +6779,6 @@ impl Default for NTMS_I1_OBJECTINFORMATIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_I1_OBJECTINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7200,9 +6804,6 @@ impl Default for NTMS_I1_OBJECTINFORMATIONW_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_I1_OBJECTINFORMATIONW_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_I1_OPREQUESTINFORMATIONA {
@@ -7222,9 +6823,6 @@ impl Default for NTMS_I1_OPREQUESTINFORMATIONA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_I1_OPREQUESTINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7246,9 +6844,6 @@ impl Default for NTMS_I1_OPREQUESTINFORMATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_I1_OPREQUESTINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_I1_PARTITIONINFORMATIONA {
@@ -7268,9 +6863,6 @@ impl Default for NTMS_I1_PARTITIONINFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_I1_PARTITIONINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_I1_PARTITIONINFORMATIONW {
@@ -7289,9 +6881,6 @@ impl Default for NTMS_I1_PARTITIONINFORMATIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_I1_PARTITIONINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7313,9 +6902,6 @@ impl Default for NTMS_I1_PMIDINFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_I1_PMIDINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_I1_PMIDINFORMATIONW {
@@ -7336,9 +6922,6 @@ impl Default for NTMS_I1_PMIDINFORMATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_I1_PMIDINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NTMS_IEDOOR: NtmsObjectsTypes = NtmsObjectsTypes(7i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7352,9 +6935,6 @@ impl Default for NTMS_IEDOORINFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_IEDOORINFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_IEPORT: NtmsObjectsTypes = NtmsObjectsTypes(8i32);
 #[repr(C)]
@@ -7370,9 +6950,6 @@ impl Default for NTMS_IEPORTINFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_IEPORTINFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_INITIALIZING: NtmsOperationalState = NtmsOperationalState(10i32);
 pub const NTMS_INJECT_RETRACT: NtmsInjectOperation = NtmsInjectOperation(2i32);
@@ -7424,9 +7001,6 @@ impl Default for NTMS_LIBRARYINFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_LIBRARYINFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NTMS_LIBRARYTYPE_OFFLINE: NtmsLibraryType = NtmsLibraryType(1i32);
 pub const NTMS_LIBRARYTYPE_ONLINE: NtmsLibraryType = NtmsLibraryType(2i32);
 pub const NTMS_LIBRARYTYPE_STANDALONE: NtmsLibraryType = NtmsLibraryType(3i32);
@@ -7459,9 +7033,6 @@ impl Default for NTMS_LIBREQUESTINFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_LIBREQUESTINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_LIBREQUESTINFORMATIONW {
@@ -7487,9 +7058,6 @@ impl Default for NTMS_LIBREQUESTINFORMATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_LIBREQUESTINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_LMIDINFORMATION {
@@ -7500,9 +7068,6 @@ impl Default for NTMS_LMIDINFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_LMIDINFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_LM_CANCELLED: NtmsLmState = NtmsLmState(7i32);
 pub const NTMS_LM_CLASSIFY: NtmsLmOperation = NtmsLmOperation(19i32);
@@ -7560,9 +7125,6 @@ impl Default for NTMS_MEDIAPOOLINFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_MEDIAPOOLINFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NTMS_MEDIARW_READONLY: NtmsReadWriteCharacteristics = NtmsReadWriteCharacteristics(3i32);
 pub const NTMS_MEDIARW_REWRITABLE: NtmsReadWriteCharacteristics = NtmsReadWriteCharacteristics(1i32);
 pub const NTMS_MEDIARW_UNKNOWN: NtmsReadWriteCharacteristics = NtmsReadWriteCharacteristics(0i32);
@@ -7587,9 +7149,6 @@ impl Default for NTMS_MEDIATYPEINFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_MEDIATYPEINFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NTMS_MEDIA_POOL: NtmsObjectsTypes = NtmsObjectsTypes(12i32);
 pub const NTMS_MEDIA_TYPE: NtmsObjectsTypes = NtmsObjectsTypes(13i32);
 pub const NTMS_MESSAGE_LENGTH: u32 = 256u32;
@@ -7609,9 +7168,6 @@ impl Default for NTMS_MOUNT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_MOUNT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NTMS_MOUNT_NOWAIT: NtmsMountOptions = NtmsMountOptions(32i32);
 pub const NTMS_MOUNT_READ: NtmsMountOptions = NtmsMountOptions(1i32);
 pub const NTMS_MOUNT_SPECIFIC_DRIVE: NtmsMountOptions = NtmsMountOptions(16i32);
@@ -7627,9 +7183,6 @@ impl Default for NTMS_NOTIFICATIONINFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_NOTIFICATIONINFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_NOT_PRESENT: NtmsOperationalState = NtmsOperationalState(21i32);
 pub const NTMS_NUMBER_OF_OBJECT_TYPES: NtmsObjectsTypes = NtmsObjectsTypes(19i32);
@@ -7652,9 +7205,6 @@ impl Default for NTMS_OBJECTINFORMATIONA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_OBJECTINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7681,9 +7231,6 @@ impl Default for NTMS_OBJECTINFORMATIONA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_OBJECTINFORMATIONA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NTMS_OBJECTINFORMATIONW {
@@ -7702,9 +7249,6 @@ impl Default for NTMS_OBJECTINFORMATIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_OBJECTINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7730,9 +7274,6 @@ impl Default for NTMS_OBJECTINFORMATIONW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_OBJECTINFORMATIONW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_OBJECTNAME_LENGTH: u32 = 64u32;
 pub const NTMS_OBJ_DELETE: NtmsNotificationOperations = NtmsNotificationOperations(3i32);
@@ -7773,9 +7314,6 @@ impl Default for NTMS_OPREQUESTINFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_OPREQUESTINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_OPREQUESTINFORMATIONW {
@@ -7795,9 +7333,6 @@ impl Default for NTMS_OPREQUESTINFORMATIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_OPREQUESTINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_OPREQ_CLEANER: NtmsOpreqCommand = NtmsOpreqCommand(2i32);
 pub const NTMS_OPREQ_DEVICESERVICE: NtmsOpreqCommand = NtmsOpreqCommand(3i32);
@@ -7832,9 +7367,6 @@ impl Default for NTMS_PARTITIONINFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_PARTITIONINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_PARTITIONINFORMATIONW {
@@ -7854,9 +7386,6 @@ impl Default for NTMS_PARTITIONINFORMATIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_PARTITIONINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_PARTSTATE_ALLOCATED: NtmsPartitionState = NtmsPartitionState(5i32);
 pub const NTMS_PARTSTATE_AVAILABLE: NtmsPartitionState = NtmsPartitionState(4i32);
@@ -7892,9 +7421,6 @@ impl Default for NTMS_PMIDINFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTMS_PMIDINFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTMS_PMIDINFORMATIONW {
@@ -7917,9 +7443,6 @@ impl Default for NTMS_PMIDINFORMATIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_PMIDINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_POOLHIERARCHY_LENGTH: u32 = 512u32;
 pub const NTMS_POOLPOLICY_KEEPOFFLINEIMPORT: NtmsMediaPoolPolicy = NtmsMediaPoolPolicy(2i32);
@@ -7964,9 +7487,6 @@ impl Default for NTMS_STORAGESLOTINFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTMS_STORAGESLOTINFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTMS_UIDEST_ADD: NtmsUIOperations = NtmsUIOperations(1i32);
 pub const NTMS_UIDEST_DELETE: NtmsUIOperations = NtmsUIOperations(2i32);
@@ -8121,9 +7641,6 @@ impl Default for OFSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OFSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OF_CANCEL: LZOPENFILE_STYLE = LZOPENFILE_STYLE(2048u16);
 pub const OF_CREATE: LZOPENFILE_STYLE = LZOPENFILE_STYLE(4096u16);
 pub const OF_DELETE: LZOPENFILE_STYLE = LZOPENFILE_STYLE(512u16);
@@ -8213,9 +7730,6 @@ impl Default for REPARSE_GUID_DATA_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPARSE_GUID_DATA_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPARSE_GUID_DATA_BUFFER_0 {
@@ -8225,9 +7739,6 @@ impl Default for REPARSE_GUID_DATA_BUFFER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REPARSE_GUID_DATA_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REPLACEFILE_IGNORE_ACL_ERRORS: REPLACE_FILE_FLAGS = REPLACE_FILE_FLAGS(4u32);
 pub const REPLACEFILE_IGNORE_MERGE_ERRORS: REPLACE_FILE_FLAGS = REPLACE_FILE_FLAGS(2u32);
@@ -8297,9 +7808,6 @@ impl Default for SERVER_ALIAS_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_ALIAS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVER_CERTIFICATE_INFO_0 {
@@ -8322,9 +7830,6 @@ impl Default for SERVER_CERTIFICATE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVER_CERTIFICATE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SERVER_CERTIFICATE_TYPE(pub i32);
@@ -8339,9 +7844,6 @@ impl Default for SESSION_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SESSION_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8358,9 +7860,6 @@ impl Default for SESSION_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SESSION_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SESSION_INFO_10 {
@@ -8373,9 +7872,6 @@ impl Default for SESSION_INFO_10 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SESSION_INFO_10 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8393,9 +7889,6 @@ impl Default for SESSION_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SESSION_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SESSION_INFO_502 {
@@ -8412,9 +7905,6 @@ impl Default for SESSION_INFO_502 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SESSION_INFO_502 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8438,9 +7928,6 @@ impl Default for SHARE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHARE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SHARE_INFO_1 {
@@ -8453,9 +7940,6 @@ impl Default for SHARE_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHARE_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SHARE_INFO_1004 {
@@ -8465,9 +7949,6 @@ impl Default for SHARE_INFO_1004 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHARE_INFO_1004 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8479,9 +7960,6 @@ impl Default for SHARE_INFO_1005 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHARE_INFO_1005 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SHARE_INFO_1006 {
@@ -8491,9 +7969,6 @@ impl Default for SHARE_INFO_1006 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHARE_INFO_1006 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -8508,10 +7983,6 @@ impl Default for SHARE_INFO_1501 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SHARE_INFO_1501 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SHARE_INFO_1503 {
@@ -8521,9 +7992,6 @@ impl Default for SHARE_INFO_1503 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHARE_INFO_1503 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8542,9 +8010,6 @@ impl Default for SHARE_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHARE_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SHARE_INFO_501 {
@@ -8557,9 +8022,6 @@ impl Default for SHARE_INFO_501 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHARE_INFO_501 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -8582,10 +8044,6 @@ impl Default for SHARE_INFO_502 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SHARE_INFO_502 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8607,10 +8065,6 @@ impl Default for SHARE_INFO_503 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SHARE_INFO_503 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8713,9 +8167,6 @@ impl Default for STAT_SERVER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STAT_SERVER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STAT_WORKSTATION_0 {
@@ -8764,9 +8215,6 @@ impl Default for STAT_WORKSTATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STAT_WORKSTATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8842,9 +8290,6 @@ impl Default for TAPE_ERASE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TAPE_ERASE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TAPE_ERASE_LONG: ERASE_TAPE_TYPE = ERASE_TAPE_TYPE(1u32);
 pub const TAPE_ERASE_SHORT: ERASE_TAPE_TYPE = ERASE_TAPE_TYPE(0u32);
 pub const TAPE_FILEMARKS: TAPEMARK_TYPE = TAPEMARK_TYPE(1u32);
@@ -8861,9 +8306,6 @@ impl Default for TAPE_GET_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TAPE_GET_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8891,9 +8333,6 @@ impl Default for TAPE_PREPARE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TAPE_PREPARE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TAPE_REWIND: TAPE_POSITION_METHOD = TAPE_POSITION_METHOD(0u32);
 pub const TAPE_SELECT_PARTITIONS: CREATE_TAPE_PARTITION_METHOD = CREATE_TAPE_PARTITION_METHOD(1u32);
 pub const TAPE_SETMARKS: TAPEMARK_TYPE = TAPEMARK_TYPE(0u32);
@@ -8909,9 +8348,6 @@ impl Default for TAPE_SET_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TAPE_SET_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TAPE_SHORT_FILEMARKS: TAPEMARK_TYPE = TAPEMARK_TYPE(2u32);
 pub const TAPE_SPACE_END_OF_DATA: TAPE_POSITION_METHOD = TAPE_POSITION_METHOD(4u32);
@@ -8934,9 +8370,6 @@ impl Default for TAPE_WRITE_MARKS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TAPE_WRITE_MARKS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRANSACTIONMANAGER_OBJECT_PATH: windows_core::PCWSTR = windows_core::w!("\\TransactionManager\\");
 pub const TRANSACTION_DO_NOT_PROMOTE: u32 = 1u32;
@@ -8962,9 +8395,6 @@ impl Default for TRANSACTION_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSACTION_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSACTION_NOTIFICATION_MARSHAL_ARGUMENT {
@@ -8975,9 +8405,6 @@ impl Default for TRANSACTION_NOTIFICATION_MARSHAL_ARGUMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSACTION_NOTIFICATION_MARSHAL_ARGUMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8992,9 +8419,6 @@ impl Default for TRANSACTION_NOTIFICATION_PROPAGATE_ARGUMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSACTION_NOTIFICATION_PROPAGATE_ARGUMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSACTION_NOTIFICATION_RECOVERY_ARGUMENT {
@@ -9006,9 +8430,6 @@ impl Default for TRANSACTION_NOTIFICATION_RECOVERY_ARGUMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSACTION_NOTIFICATION_RECOVERY_ARGUMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSACTION_NOTIFICATION_SAVEPOINT_ARGUMENT {
@@ -9018,9 +8439,6 @@ impl Default for TRANSACTION_NOTIFICATION_SAVEPOINT_ARGUMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSACTION_NOTIFICATION_SAVEPOINT_ARGUMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9032,9 +8450,6 @@ impl Default for TRANSACTION_NOTIFICATION_TM_ONLINE_ARGUMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSACTION_NOTIFICATION_TM_ONLINE_ARGUMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRANSACTION_NOTIFICATION_TM_ONLINE_FLAG_IS_CLUSTERED: u32 = 1u32;
 pub const TRANSACTION_NOTIFY_COMMIT: u32 = 4u32;
@@ -9085,9 +8500,6 @@ impl Default for TXF_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TXF_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct TXF_ID_0 {
@@ -9098,9 +8510,6 @@ impl Default for TXF_ID_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXF_ID_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -9118,9 +8527,6 @@ impl Default for TXF_LOG_RECORD_AFFECTED_FILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TXF_LOG_RECORD_AFFECTED_FILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct TXF_LOG_RECORD_BASE {
@@ -9132,9 +8538,6 @@ impl Default for TXF_LOG_RECORD_BASE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXF_LOG_RECORD_BASE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TXF_LOG_RECORD_GENERIC_TYPE_ABORT: u32 = 2u32;
 pub const TXF_LOG_RECORD_GENERIC_TYPE_COMMIT: u32 = 1u32;
@@ -9157,9 +8560,6 @@ impl Default for TXF_LOG_RECORD_TRUNCATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXF_LOG_RECORD_TRUNCATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9186,9 +8586,6 @@ impl Default for TXF_LOG_RECORD_WRITE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXF_LOG_RECORD_WRITE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TransactionOutcomeAborted: TRANSACTION_OUTCOME = TRANSACTION_OUTCOME(3i32);
 pub const TransactionOutcomeCommitted: TRANSACTION_OUTCOME = TRANSACTION_OUTCOME(2i32);
@@ -9340,9 +8737,6 @@ impl Default for VOLUME_ALLOCATE_BC_STREAM_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VOLUME_ALLOCATE_BC_STREAM_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_ALLOCATE_BC_STREAM_OUTPUT {
@@ -9353,9 +8747,6 @@ impl Default for VOLUME_ALLOCATE_BC_STREAM_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUME_ALLOCATE_BC_STREAM_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9369,9 +8760,6 @@ impl Default for VOLUME_ALLOCATION_HINT_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VOLUME_ALLOCATION_HINT_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_ALLOCATION_HINT_OUTPUT {
@@ -9381,9 +8769,6 @@ impl Default for VOLUME_ALLOCATION_HINT_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUME_ALLOCATION_HINT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9397,9 +8782,6 @@ impl Default for VOLUME_CRITICAL_IO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VOLUME_CRITICAL_IO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_FAILOVER_SET {
@@ -9410,9 +8792,6 @@ impl Default for VOLUME_FAILOVER_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUME_FAILOVER_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9429,9 +8808,6 @@ impl Default for VOLUME_GET_BC_PROPERTIES_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VOLUME_GET_BC_PROPERTIES_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_GET_BC_PROPERTIES_OUTPUT {
@@ -9447,9 +8823,6 @@ impl Default for VOLUME_GET_BC_PROPERTIES_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VOLUME_GET_BC_PROPERTIES_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_LOGICAL_OFFSET {
@@ -9459,9 +8832,6 @@ impl Default for VOLUME_LOGICAL_OFFSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUME_LOGICAL_OFFSET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VOLUME_NAME_DOS: GETFINALPATHNAMEBYHANDLE_FLAGS = GETFINALPATHNAMEBYHANDLE_FLAGS(0u32);
 pub const VOLUME_NAME_GUID: GETFINALPATHNAMEBYHANDLE_FLAGS = GETFINALPATHNAMEBYHANDLE_FLAGS(1u32);
@@ -9478,9 +8848,6 @@ impl Default for VOLUME_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VOLUME_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_PHYSICAL_OFFSET {
@@ -9491,9 +8858,6 @@ impl Default for VOLUME_PHYSICAL_OFFSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUME_PHYSICAL_OFFSET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9506,9 +8870,6 @@ impl Default for VOLUME_PHYSICAL_OFFSETS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VOLUME_PHYSICAL_OFFSETS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_READ_PLEX_INPUT {
@@ -9520,9 +8881,6 @@ impl Default for VOLUME_READ_PLEX_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUME_READ_PLEX_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9538,9 +8896,6 @@ impl Default for VOLUME_SET_GPT_ATTRIBUTES_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VOLUME_SET_GPT_ATTRIBUTES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_SHRINK_INFO {
@@ -9550,9 +8905,6 @@ impl Default for VOLUME_SHRINK_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUME_SHRINK_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VOS_DOS: VS_FIXEDFILEINFO_FILE_OS = VS_FIXEDFILEINFO_FILE_OS(65536u32);
 pub const VOS_DOS_WINDOWS16: VS_FIXEDFILEINFO_FILE_OS = VS_FIXEDFILEINFO_FILE_OS(65537u32);
@@ -9600,9 +8952,6 @@ impl Default for VS_FIXEDFILEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VS_FIXEDFILEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9671,9 +9020,6 @@ impl Default for WIM_ENTRY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIM_ENTRY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIM_EXTERNAL_FILE_INFO {
@@ -9685,9 +9031,6 @@ impl Default for WIM_EXTERNAL_FILE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIM_EXTERNAL_FILE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIM_EXTERNAL_FILE_INFO_FLAG_NOT_ACTIVE: u32 = 1u32;
 pub const WIM_EXTERNAL_FILE_INFO_FLAG_SUSPENDED: u32 = 2u32;
@@ -9706,9 +9049,6 @@ impl Default for WIN32_FILE_ATTRIBUTE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIN32_FILE_ATTRIBUTE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9729,9 +9069,6 @@ impl Default for WIN32_FIND_DATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIN32_FIND_DATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIN32_FIND_DATAW {
@@ -9751,9 +9088,6 @@ impl Default for WIN32_FIND_DATAW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIN32_FIND_DATAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIN32_FIND_STREAM_DATA {
@@ -9764,9 +9098,6 @@ impl Default for WIN32_FIND_STREAM_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIN32_FIND_STREAM_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9782,9 +9113,6 @@ impl Default for WIN32_STREAM_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIN32_STREAM_ID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WINEFS_SETUSERKEY_SET_CAPABILITIES: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9799,9 +9127,6 @@ impl Default for WOF_FILE_COMPRESSION_INFO_V0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WOF_FILE_COMPRESSION_INFO_V0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WOF_FILE_COMPRESSION_INFO_V1 {
@@ -9812,9 +9137,6 @@ impl Default for WOF_FILE_COMPRESSION_INFO_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WOF_FILE_COMPRESSION_INFO_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WOF_PROVIDER_FILE: u32 = 2u32;
 pub const WOF_PROVIDER_WIM: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
@@ -6959,9 +6959,6 @@ impl Default for IMMP_MPV_STORE_DRIVER_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMMP_MPV_STORE_DRIVER_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[cfg(feature = "Win32_System_Com")]
 windows_core::imp::define_interface!(IMultisession, IMultisession_Vtbl, 0x27354150_7f64_5b0f_8f00_5d77afbe261e);
 #[cfg(feature = "Win32_System_Com")]
@@ -9032,9 +9029,6 @@ impl Default for SPropAttrArray {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPropAttrArray {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SZ_PROGID_SMTPCAT: windows_core::PCSTR = windows_core::s!("Smtp.Cat");
 pub const tagIMMPID_CPV_STRUCT: windows_core::GUID = windows_core::GUID::from_u128(0xa2a76b2a_e52d_11d1_aa64_00c04fa35b82);
 #[repr(C)]
@@ -9048,9 +9042,6 @@ impl Default for tagIMMPID_GUIDLIST_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for tagIMMPID_GUIDLIST_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const tagIMMPID_MPV_STRUCT: windows_core::GUID = windows_core::GUID::from_u128(0xcbe69706_c9bd_11d1_9ff2_00c04fa37348);
 pub const tagIMMPID_MP_STRUCT: windows_core::GUID = windows_core::GUID::from_u128(0x13384cf0_b3c4_11d1_aa92_00aa006bc80b);

--- a/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/mod.rs
@@ -84,9 +84,6 @@ impl Default for CI_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CI_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CI_STATE_ANNEALING_MERGE: u32 = 8u32;
 pub const CI_STATE_BATTERY_POLICY: u32 = 262144u32;
 pub const CI_STATE_BATTERY_POWER: u32 = 2048u32;
@@ -124,10 +121,6 @@ impl Default for DBID {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -141,10 +134,6 @@ impl Default for DBID_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBID_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -157,10 +146,6 @@ impl Default for DBID_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBID_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -176,10 +161,6 @@ impl Default for DBID {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -193,10 +174,6 @@ impl Default for DBID_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBID_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -209,10 +186,6 @@ impl Default for DBID_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBID_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -270,9 +243,6 @@ impl Default for FILTERREGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTERREGION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILTER_E_ACCESS: windows_core::HRESULT = windows_core::HRESULT(0x80041703_u32 as _);
 pub const FILTER_E_EMBEDDING_UNAVAILABLE: windows_core::HRESULT = windows_core::HRESULT(0x80041707_u32 as _);
 pub const FILTER_E_END_OF_CHUNKS: windows_core::HRESULT = windows_core::HRESULT(0x80041700_u32 as _);
@@ -298,10 +268,6 @@ impl Default for FULLPROPSPEC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl windows_core::TypeKind for FULLPROPSPEC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GENERATE_METHOD_EXACT: u32 = 0u32;
 pub const GENERATE_METHOD_INFLECT: u32 = 2u32;
@@ -521,10 +487,6 @@ impl Default for STAT_CHUNK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl windows_core::TypeKind for STAT_CHUNK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STAT_COALESCE_COMP_ALL_NOISE: u32 = 8192u32;
 pub const STAT_CONTENT_OUT_OF_DATE: u32 = 32u32;

--- a/crates/libs/windows/src/Windows/Win32/Storage/InstallableFileSystems/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/InstallableFileSystems/mod.rs
@@ -197,9 +197,6 @@ impl Default for FILTER_AGGREGATE_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTER_AGGREGATE_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILTER_AGGREGATE_BASIC_INFORMATION_0 {
@@ -211,9 +208,6 @@ impl Default for FILTER_AGGREGATE_BASIC_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTER_AGGREGATE_BASIC_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
@@ -224,9 +218,6 @@ impl Default for FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILTER_AGGREGATE_BASIC_INFORMATION_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -243,9 +234,6 @@ impl Default for FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTER_AGGREGATE_BASIC_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct FILTER_AGGREGATE_STANDARD_INFORMATION {
@@ -258,9 +246,6 @@ impl Default for FILTER_AGGREGATE_STANDARD_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTER_AGGREGATE_STANDARD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
@@ -271,9 +256,6 @@ impl Default for FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILTER_AGGREGATE_STANDARD_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -288,9 +270,6 @@ impl Default for FILTER_AGGREGATE_STANDARD_INFORMATION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILTER_AGGREGATE_STANDARD_INFORMATION_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -308,9 +287,6 @@ impl Default for FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTER_AGGREGATE_STANDARD_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILTER_FULL_INFORMATION {
@@ -324,9 +300,6 @@ impl Default for FILTER_FULL_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILTER_FULL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -342,9 +315,6 @@ impl Default for FILTER_MESSAGE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTER_MESSAGE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILTER_NAME_MAX_CHARS: u32 = 255u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -357,9 +327,6 @@ impl Default for FILTER_REPLY_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILTER_REPLY_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILTER_VOLUME_BASIC_INFORMATION {
@@ -370,9 +337,6 @@ impl Default for FILTER_VOLUME_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILTER_VOLUME_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -391,9 +355,6 @@ impl Default for FILTER_VOLUME_STANDARD_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILTER_VOLUME_STANDARD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLTFL_AGGREGATE_INFO_IS_LEGACYFILTER: u32 = 2u32;
 pub const FLTFL_AGGREGATE_INFO_IS_MINIFILTER: u32 = 1u32;
@@ -496,9 +457,6 @@ impl Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INSTANCE_AGGREGATE_STANDARD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
@@ -509,9 +467,6 @@ impl Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -529,9 +484,6 @@ impl Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -554,9 +506,6 @@ impl Default for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INSTANCE_AGGREGATE_STANDARD_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INSTANCE_BASIC_INFORMATION {
@@ -568,9 +517,6 @@ impl Default for INSTANCE_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INSTANCE_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -590,9 +536,6 @@ impl Default for INSTANCE_FULL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INSTANCE_FULL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct INSTANCE_INFORMATION_CLASS(pub i32);
@@ -610,9 +553,6 @@ impl Default for INSTANCE_PARTIAL_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INSTANCE_PARTIAL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const InstanceAggregateStandardInformation: INSTANCE_INFORMATION_CLASS = INSTANCE_INFORMATION_CLASS(3i32);
 pub const InstanceBasicInformation: INSTANCE_INFORMATION_CLASS = INSTANCE_INFORMATION_CLASS(0i32);

--- a/crates/libs/windows/src/Windows/Win32/Storage/IscsiDisc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IscsiDisc/mod.rs
@@ -603,9 +603,6 @@ impl Default for ATA_PASS_THROUGH_DIRECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATA_PASS_THROUGH_DIRECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -629,10 +626,6 @@ impl Default for ATA_PASS_THROUGH_DIRECT32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ATA_PASS_THROUGH_DIRECT32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ATA_PASS_THROUGH_EX {
@@ -653,9 +646,6 @@ impl Default for ATA_PASS_THROUGH_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATA_PASS_THROUGH_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -680,10 +670,6 @@ impl Default for ATA_PASS_THROUGH_EX32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ATA_PASS_THROUGH_EX32 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DD_SCSI_DEVICE_NAME: windows_core::PCSTR = windows_core::s!("\\Device\\ScsiPort");
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -701,9 +687,6 @@ impl Default for DSM_NOTIFICATION_REQUEST_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSM_NOTIFICATION_REQUEST_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DUMP_DRIVER {
@@ -715,9 +698,6 @@ impl Default for DUMP_DRIVER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DUMP_DRIVER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -731,9 +711,6 @@ impl Default for DUMP_DRIVER_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DUMP_DRIVER_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DUMP_DRIVER_NAME_LENGTH: u32 = 15u32;
 pub const DUMP_EX_FLAG_DRIVER_FULL_PATH_SUPPORT: u32 = 8u32;
@@ -758,9 +735,6 @@ impl Default for DUMP_POINTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DUMP_POINTERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -787,9 +761,6 @@ impl Default for DUMP_POINTERS_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DUMP_POINTERS_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DUMP_POINTERS_VERSION {
@@ -800,9 +771,6 @@ impl Default for DUMP_POINTERS_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DUMP_POINTERS_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DUMP_POINTERS_VERSION_1: u32 = 1u32;
 pub const DUMP_POINTERS_VERSION_2: u32 = 2u32;
@@ -827,9 +795,6 @@ impl Default for FIRMWARE_REQUEST_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FIRMWARE_REQUEST_BLOCK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FIRMWARE_REQUEST_BLOCK_STRUCTURE_VERSION: u32 = 1u32;
 pub const FIRMWARE_REQUEST_FLAG_CONTROLLER: u32 = 1u32;
@@ -872,9 +837,6 @@ impl Default for HYBRID_DEMOTE_BY_SIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HYBRID_DEMOTE_BY_SIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HYBRID_DIRTY_THRESHOLDS {
@@ -887,9 +849,6 @@ impl Default for HYBRID_DIRTY_THRESHOLDS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HYBRID_DIRTY_THRESHOLDS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HYBRID_FUNCTION_DEMOTE_BY_SIZE: u32 = 19u32;
 pub const HYBRID_FUNCTION_DISABLE_CACHING_MEDIUM: u32 = 16u32;
@@ -915,9 +874,6 @@ impl Default for HYBRID_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HYBRID_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HYBRID_INFORMATION_0 {
@@ -927,9 +883,6 @@ impl Default for HYBRID_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HYBRID_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -948,9 +901,6 @@ impl Default for HYBRID_INFORMATION_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HYBRID_INFORMATION_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HYBRID_INFORMATION_1_0 {
@@ -963,9 +913,6 @@ impl Default for HYBRID_INFORMATION_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HYBRID_INFORMATION_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -981,9 +928,6 @@ impl Default for HYBRID_REQUEST_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HYBRID_REQUEST_BLOCK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HYBRID_REQUEST_BLOCK_STRUCTURE_VERSION: u32 = 1u32;
 pub const HYBRID_REQUEST_INFO_STRUCTURE_VERSION: u32 = 1u32;
@@ -1007,9 +951,6 @@ impl Default for IDE_IO_CONTROL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IDE_IO_CONTROL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ID_FQDN: windows_core::PCSTR = windows_core::s!("2");
 pub const ID_IPV4_ADDR: windows_core::PCSTR = windows_core::s!("1");
 pub const ID_IPV6_ADDR: windows_core::PCSTR = windows_core::s!("5");
@@ -1025,9 +966,6 @@ impl Default for IKE_AUTHENTICATION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IKE_AUTHENTICATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IKE_AUTHENTICATION_INFORMATION_0 {
@@ -1037,9 +975,6 @@ impl Default for IKE_AUTHENTICATION_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKE_AUTHENTICATION_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1058,9 +993,6 @@ impl Default for IKE_AUTHENTICATION_PRESHARED_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IKE_AUTHENTICATION_PRESHARED_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IKE_AUTHENTICATION_PRESHARED_KEY_METHOD: IKE_AUTHENTICATION_METHOD = IKE_AUTHENTICATION_METHOD(1i32);
 pub const IOCTL_ATA_MINIPORT: u32 = 315444u32;
@@ -1112,9 +1044,6 @@ impl Default for IO_SCSI_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_SCSI_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ISCSI_AUTH_TYPES(pub i32);
@@ -1134,9 +1063,6 @@ impl Default for ISCSI_CONNECTION_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_CONNECTION_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ISCSI_CONNECTION_INFOW {
@@ -1151,9 +1077,6 @@ impl Default for ISCSI_CONNECTION_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ISCSI_CONNECTION_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1172,9 +1095,6 @@ impl Default for ISCSI_CONNECTION_INFO_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ISCSI_CONNECTION_INFO_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Ioctl")]
@@ -1195,10 +1115,6 @@ impl Default for ISCSI_DEVICE_ON_SESSIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Ioctl")]
-impl windows_core::TypeKind for ISCSI_DEVICE_ON_SESSIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Ioctl")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1217,10 +1133,6 @@ impl Default for ISCSI_DEVICE_ON_SESSIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Ioctl")]
-impl windows_core::TypeKind for ISCSI_DEVICE_ON_SESSIONW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1254,9 +1166,6 @@ impl Default for ISCSI_LOGIN_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ISCSI_LOGIN_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ISCSI_LOGIN_OPTIONS_AUTH_TYPE: windows_core::PCSTR = windows_core::s!("0x00000080");
 pub const ISCSI_LOGIN_OPTIONS_DATA_DIGEST: windows_core::PCSTR = windows_core::s!("0x00000002");
@@ -1293,9 +1202,6 @@ impl Default for ISCSI_SESSION_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_SESSION_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ISCSI_SESSION_INFOW {
@@ -1312,9 +1218,6 @@ impl Default for ISCSI_SESSION_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ISCSI_SESSION_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1338,9 +1241,6 @@ impl Default for ISCSI_SESSION_INFO_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_SESSION_INFO_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ISCSI_TARGET_FLAG_HIDE_STATIC_TARGET: u32 = 2u32;
 pub const ISCSI_TARGET_FLAG_MERGE_TARGET_INFORMATION: u32 = 4u32;
 #[repr(C)]
@@ -1360,9 +1260,6 @@ impl Default for ISCSI_TARGET_MAPPINGA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_TARGET_MAPPINGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ISCSI_TARGET_MAPPINGW {
@@ -1380,9 +1277,6 @@ impl Default for ISCSI_TARGET_MAPPINGW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_TARGET_MAPPINGW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ISCSI_TARGET_PORTALA {
@@ -1394,9 +1288,6 @@ impl Default for ISCSI_TARGET_PORTALA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ISCSI_TARGET_PORTALA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1410,9 +1301,6 @@ impl Default for ISCSI_TARGET_PORTALW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_TARGET_PORTALW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ISCSI_TARGET_PORTAL_GROUPA {
@@ -1424,9 +1312,6 @@ impl Default for ISCSI_TARGET_PORTAL_GROUPA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_TARGET_PORTAL_GROUPA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ISCSI_TARGET_PORTAL_GROUPW {
@@ -1437,9 +1322,6 @@ impl Default for ISCSI_TARGET_PORTAL_GROUPW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ISCSI_TARGET_PORTAL_GROUPW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1455,9 +1337,6 @@ impl Default for ISCSI_TARGET_PORTAL_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_TARGET_PORTAL_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ISCSI_TARGET_PORTAL_INFOW {
@@ -1471,9 +1350,6 @@ impl Default for ISCSI_TARGET_PORTAL_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ISCSI_TARGET_PORTAL_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1491,9 +1367,6 @@ impl Default for ISCSI_TARGET_PORTAL_INFO_EXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_TARGET_PORTAL_INFO_EXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ISCSI_TARGET_PORTAL_INFO_EXW {
@@ -1510,9 +1383,6 @@ impl Default for ISCSI_TARGET_PORTAL_INFO_EXW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_TARGET_PORTAL_INFO_EXW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ISCSI_TCP_PROTOCOL_TYPE: TARGETPROTOCOLTYPE = TARGETPROTOCOLTYPE(0i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1525,9 +1395,6 @@ impl Default for ISCSI_UNIQUE_SESSION_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ISCSI_UNIQUE_SESSION_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ISCSI_VERSION_INFO {
@@ -1539,9 +1406,6 @@ impl Default for ISCSI_VERSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ISCSI_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const InitiatorName: TARGET_INFORMATION_CLASS = TARGET_INFORMATION_CLASS(5i32);
 pub const LoginOptions: TARGET_INFORMATION_CLASS = TARGET_INFORMATION_CLASS(7i32);
@@ -1580,9 +1444,6 @@ impl Default for MPIO_PASS_THROUGH_PATH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPIO_PASS_THROUGH_PATH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1599,10 +1460,6 @@ impl Default for MPIO_PASS_THROUGH_PATH32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MPIO_PASS_THROUGH_PATH32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1621,10 +1478,6 @@ impl Default for MPIO_PASS_THROUGH_PATH32_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MPIO_PASS_THROUGH_PATH32_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MPIO_PASS_THROUGH_PATH_DIRECT {
@@ -1639,9 +1492,6 @@ impl Default for MPIO_PASS_THROUGH_PATH_DIRECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPIO_PASS_THROUGH_PATH_DIRECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1660,10 +1510,6 @@ impl Default for MPIO_PASS_THROUGH_PATH_DIRECT32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MPIO_PASS_THROUGH_PATH_DIRECT32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1681,10 +1527,6 @@ impl Default for MPIO_PASS_THROUGH_PATH_DIRECT32_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MPIO_PASS_THROUGH_PATH_DIRECT32_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MPIO_PASS_THROUGH_PATH_DIRECT_EX {
@@ -1699,9 +1541,6 @@ impl Default for MPIO_PASS_THROUGH_PATH_DIRECT_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MPIO_PASS_THROUGH_PATH_DIRECT_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1718,9 +1557,6 @@ impl Default for MPIO_PASS_THROUGH_PATH_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MPIO_PASS_THROUGH_PATH_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MP_DEVICE_DATA_SET_RANGE {
@@ -1731,9 +1567,6 @@ impl Default for MP_DEVICE_DATA_SET_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MP_DEVICE_DATA_SET_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1782,9 +1615,6 @@ impl Default for NTSCSI_UNICODE_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTSCSI_UNICODE_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVCACHE_HINT_PAYLOAD {
@@ -1807,9 +1637,6 @@ impl Default for NVCACHE_HINT_PAYLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVCACHE_HINT_PAYLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVCACHE_PRIORITY_LEVEL_DESCRIPTOR {
@@ -1825,9 +1652,6 @@ impl Default for NVCACHE_PRIORITY_LEVEL_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVCACHE_PRIORITY_LEVEL_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1846,9 +1670,6 @@ impl Default for NVCACHE_REQUEST_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVCACHE_REQUEST_BLOCK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1879,9 +1700,6 @@ impl Default for NV_FEATURE_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NV_FEATURE_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NV_SEP_CACHE_PARAMETER {
@@ -1897,9 +1715,6 @@ impl Default for NV_SEP_CACHE_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NV_SEP_CACHE_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NV_SEP_CACHE_PARAMETER_0 {
@@ -1911,9 +1726,6 @@ impl Default for NV_SEP_CACHE_PARAMETER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NV_SEP_CACHE_PARAMETER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NV_SEP_CACHE_PARAMETER_0_0 {
@@ -1923,9 +1735,6 @@ impl Default for NV_SEP_CACHE_PARAMETER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NV_SEP_CACHE_PARAMETER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NV_SEP_CACHE_PARAMETER_VERSION: u32 = 1u32;
 pub const NV_SEP_CACHE_PARAMETER_VERSION_1: u32 = 1u32;
@@ -1958,9 +1767,6 @@ impl Default for PERSISTENT_ISCSI_LOGIN_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERSISTENT_ISCSI_LOGIN_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERSISTENT_ISCSI_LOGIN_INFOW {
@@ -1978,9 +1784,6 @@ impl Default for PERSISTENT_ISCSI_LOGIN_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERSISTENT_ISCSI_LOGIN_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PersistentTargetMappings: TARGET_INFORMATION_CLASS = TARGET_INFORMATION_CLASS(4i32);
 pub const PortalGroups: TARGET_INFORMATION_CLASS = TARGET_INFORMATION_CLASS(3i32);
 pub const ProtocolType: TARGET_INFORMATION_CLASS = TARGET_INFORMATION_CLASS(0i32);
@@ -1994,9 +1797,6 @@ impl Default for SCSI_ADAPTER_BUS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCSI_ADAPTER_BUS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2012,9 +1812,6 @@ impl Default for SCSI_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCSI_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCSI_BUS_DATA {
@@ -2026,9 +1823,6 @@ impl Default for SCSI_BUS_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCSI_BUS_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2046,9 +1840,6 @@ impl Default for SCSI_INQUIRY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCSI_INQUIRY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCSI_IOCTL_DATA_BIDIRECTIONAL: u32 = 3u32;
 pub const SCSI_IOCTL_DATA_IN: u32 = 1u32;
 pub const SCSI_IOCTL_DATA_OUT: u32 = 0u32;
@@ -2063,9 +1854,6 @@ impl Default for SCSI_LUN_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCSI_LUN_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2088,9 +1876,6 @@ impl Default for SCSI_PASS_THROUGH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCSI_PASS_THROUGH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -2115,10 +1900,6 @@ impl Default for SCSI_PASS_THROUGH32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SCSI_PASS_THROUGH32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -2147,10 +1928,6 @@ impl Default for SCSI_PASS_THROUGH32_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SCSI_PASS_THROUGH32_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCSI_PASS_THROUGH_DIRECT {
@@ -2172,9 +1949,6 @@ impl Default for SCSI_PASS_THROUGH_DIRECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCSI_PASS_THROUGH_DIRECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -2199,10 +1973,6 @@ impl Default for SCSI_PASS_THROUGH_DIRECT32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SCSI_PASS_THROUGH_DIRECT32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -2231,10 +2001,6 @@ impl Default for SCSI_PASS_THROUGH_DIRECT32_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SCSI_PASS_THROUGH_DIRECT32_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCSI_PASS_THROUGH_DIRECT_EX {
@@ -2259,9 +2025,6 @@ impl Default for SCSI_PASS_THROUGH_DIRECT_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCSI_PASS_THROUGH_DIRECT_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2288,9 +2051,6 @@ impl Default for SCSI_PASS_THROUGH_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCSI_PASS_THROUGH_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SRB_IO_CONTROL {
@@ -2305,9 +2065,6 @@ impl Default for SRB_IO_CONTROL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SRB_IO_CONTROL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2325,9 +2082,6 @@ impl Default for STORAGE_DIAGNOSTIC_MP_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DIAGNOSTIC_MP_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_DIAGNOSTIC_STATUS_BUFFER_TOO_SMALL: u32 = 1u32;
 pub const STORAGE_DIAGNOSTIC_STATUS_INVALID_PARAMETER: u32 = 3u32;
@@ -2348,9 +2102,6 @@ impl Default for STORAGE_ENDURANCE_DATA_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_ENDURANCE_DATA_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_ENDURANCE_INFO {
@@ -2366,9 +2117,6 @@ impl Default for STORAGE_ENDURANCE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_ENDURANCE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_ENDURANCE_INFO_0 {
@@ -2378,9 +2126,6 @@ impl Default for STORAGE_ENDURANCE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_ENDURANCE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2394,9 +2139,6 @@ impl Default for STORAGE_FIRMWARE_ACTIVATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_FIRMWARE_ACTIVATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_FIRMWARE_ACTIVATE_STRUCTURE_VERSION: u32 = 1u32;
 #[repr(C)]
@@ -2412,9 +2154,6 @@ impl Default for STORAGE_FIRMWARE_DOWNLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_FIRMWARE_DOWNLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_FIRMWARE_DOWNLOAD_STRUCTURE_VERSION: u32 = 1u32;
 pub const STORAGE_FIRMWARE_DOWNLOAD_STRUCTURE_VERSION_V2: u32 = 2u32;
@@ -2435,9 +2174,6 @@ impl Default for STORAGE_FIRMWARE_DOWNLOAD_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_FIRMWARE_DOWNLOAD_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct STORAGE_FIRMWARE_INFO {
@@ -2454,9 +2190,6 @@ impl Default for STORAGE_FIRMWARE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_FIRMWARE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_FIRMWARE_INFO_INVALID_SLOT: u32 = 255u32;
 pub const STORAGE_FIRMWARE_INFO_STRUCTURE_VERSION: u32 = 1u32;
@@ -2481,9 +2214,6 @@ impl Default for STORAGE_FIRMWARE_INFO_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_FIRMWARE_INFO_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct STORAGE_FIRMWARE_SLOT_INFO {
@@ -2497,9 +2227,6 @@ impl Default for STORAGE_FIRMWARE_SLOT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_FIRMWARE_SLOT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_FIRMWARE_SLOT_INFO_0 {
@@ -2510,9 +2237,6 @@ impl Default for STORAGE_FIRMWARE_SLOT_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_FIRMWARE_SLOT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2526,9 +2250,6 @@ impl Default for STORAGE_FIRMWARE_SLOT_INFO_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_FIRMWARE_SLOT_INFO_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_FIRMWARE_SLOT_INFO_V2_REVISION_LENGTH: u32 = 16u32;
 pub const ScsiRawInterfaceGuid: windows_core::GUID = windows_core::GUID::from_u128(0x53f56309_b6bf_11d0_94f2_00a0c91efb8b);

--- a/crates/libs/windows/src/Windows/Win32/Storage/Jet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Jet/mod.rs
@@ -1300,9 +1300,6 @@ impl Default for JET_BKINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_BKINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_BKINFO_0 {
@@ -1313,9 +1310,6 @@ impl Default for JET_BKINFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_BKINFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1334,9 +1328,6 @@ impl Default for JET_BKLOGTIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_BKLOGTIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_BKLOGTIME_0 {
@@ -1348,9 +1339,6 @@ impl Default for JET_BKLOGTIME_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_BKLOGTIME_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_BKLOGTIME_0_0 {
@@ -1360,9 +1348,6 @@ impl Default for JET_BKLOGTIME_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_BKLOGTIME_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1375,9 +1360,6 @@ impl Default for JET_BKLOGTIME_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_BKLOGTIME_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_BKLOGTIME_1_0 {
@@ -1387,9 +1369,6 @@ impl Default for JET_BKLOGTIME_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_BKLOGTIME_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 pub type JET_CALLBACK = Option<unsafe extern "system" fn(sesid: JET_SESID, dbid: u32, tableid: super::StructuredStorage::JET_TABLEID, cbtyp: u32, pvarg1: *mut core::ffi::c_void, pvarg2: *mut core::ffi::c_void, pvcontext: *const core::ffi::c_void, ulunused: super::StructuredStorage::JET_API_PTR) -> i32>;
@@ -1413,9 +1392,6 @@ impl Default for JET_COLUMNBASE_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_COLUMNBASE_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_COLUMNBASE_W {
@@ -1436,9 +1412,6 @@ impl Default for JET_COLUMNBASE_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_COLUMNBASE_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_COLUMNCREATE_A {
@@ -1457,9 +1430,6 @@ impl Default for JET_COLUMNCREATE_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_COLUMNCREATE_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1480,9 +1450,6 @@ impl Default for JET_COLUMNCREATE_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_COLUMNCREATE_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_COLUMNDEF {
@@ -1500,9 +1467,6 @@ impl Default for JET_COLUMNDEF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_COLUMNDEF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -1532,10 +1496,6 @@ impl Default for JET_COLUMNLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_COLUMNLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -1550,10 +1510,6 @@ impl Default for JET_COMMIT_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for JET_COMMIT_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -1568,10 +1524,6 @@ impl Default for JET_COMMIT_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for JET_COMMIT_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_CONDITIONALCOLUMN_A {
@@ -1583,9 +1535,6 @@ impl Default for JET_CONDITIONALCOLUMN_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_CONDITIONALCOLUMN_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1599,9 +1548,6 @@ impl Default for JET_CONDITIONALCOLUMN_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_CONDITIONALCOLUMN_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct JET_CONVERT_A {
@@ -1612,9 +1558,6 @@ impl Default for JET_CONVERT_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_CONVERT_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1627,9 +1570,6 @@ impl Default for JET_CONVERT_A_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_CONVERT_A_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_CONVERT_A_0_0 {
@@ -1639,9 +1579,6 @@ impl Default for JET_CONVERT_A_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_CONVERT_A_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1654,9 +1591,6 @@ impl Default for JET_CONVERT_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_CONVERT_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_CONVERT_W_0 {
@@ -1668,9 +1602,6 @@ impl Default for JET_CONVERT_W_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_CONVERT_W_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_CONVERT_W_0_0 {
@@ -1680,9 +1611,6 @@ impl Default for JET_CONVERT_W_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_CONVERT_W_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JET_ColInfoGrbitMinimalInfo: u32 = 1073741824u32;
 pub const JET_ColInfoGrbitNonDerivedColumnsOnly: u32 = 2147483648u32;
@@ -1716,9 +1644,6 @@ impl Default for JET_DBINFOMISC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_DBINFOMISC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1765,9 +1690,6 @@ impl Default for JET_DBINFOMISC2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_DBINFOMISC2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct JET_DBINFOMISC3 {
@@ -1813,9 +1735,6 @@ impl Default for JET_DBINFOMISC3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_DBINFOMISC3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1865,9 +1784,6 @@ impl Default for JET_DBINFOMISC4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_DBINFOMISC4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct JET_DBINFOUPGRADE {
@@ -1884,9 +1800,6 @@ impl Default for JET_DBINFOUPGRADE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_DBINFOUPGRADE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_DBINFOUPGRADE_0 {
@@ -1898,9 +1811,6 @@ impl Default for JET_DBINFOUPGRADE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_DBINFOUPGRADE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_DBINFOUPGRADE_0_0 {
@@ -1910,9 +1820,6 @@ impl Default for JET_DBINFOUPGRADE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_DBINFOUPGRADE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JET_DbInfoCollate: u32 = 5u32;
 pub const JET_DbInfoConnect: u32 = 1u32;
@@ -1946,9 +1853,6 @@ impl Default for JET_ENUMCOLUMN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_ENUMCOLUMN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_ENUMCOLUMN_0 {
@@ -1959,9 +1863,6 @@ impl Default for JET_ENUMCOLUMN_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_ENUMCOLUMN_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1974,9 +1875,6 @@ impl Default for JET_ENUMCOLUMN_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_ENUMCOLUMN_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_ENUMCOLUMN_0_1 {
@@ -1987,9 +1885,6 @@ impl Default for JET_ENUMCOLUMN_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_ENUMCOLUMN_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2003,9 +1898,6 @@ impl Default for JET_ENUMCOLUMNID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_ENUMCOLUMNID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_ENUMCOLUMNVALUE {
@@ -2018,9 +1910,6 @@ impl Default for JET_ENUMCOLUMNVALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_ENUMCOLUMNVALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2039,9 +1928,6 @@ impl Default for JET_ERRINFOBASIC_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_ERRINFOBASIC_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JET_EventLoggingDisable: u32 = 0u32;
 pub const JET_EventLoggingLevelHigh: u32 = 75u32;
@@ -2077,9 +1963,6 @@ impl Default for JET_INDEXCREATE2_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEXCREATE2_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_INDEXCREATE2_A_0 {
@@ -2091,9 +1974,6 @@ impl Default for JET_INDEXCREATE2_A_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEXCREATE2_A_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_INDEXCREATE2_A_1 {
@@ -2104,9 +1984,6 @@ impl Default for JET_INDEXCREATE2_A_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_INDEXCREATE2_A_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2130,9 +2007,6 @@ impl Default for JET_INDEXCREATE2_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEXCREATE2_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_INDEXCREATE2_W_0 {
@@ -2144,9 +2018,6 @@ impl Default for JET_INDEXCREATE2_W_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEXCREATE2_W_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_INDEXCREATE2_W_1 {
@@ -2157,9 +2028,6 @@ impl Default for JET_INDEXCREATE2_W_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_INDEXCREATE2_W_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2183,9 +2051,6 @@ impl Default for JET_INDEXCREATE3_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEXCREATE3_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_INDEXCREATE3_A_0 {
@@ -2196,9 +2061,6 @@ impl Default for JET_INDEXCREATE3_A_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_INDEXCREATE3_A_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2222,9 +2084,6 @@ impl Default for JET_INDEXCREATE3_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEXCREATE3_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_INDEXCREATE3_W_0 {
@@ -2235,9 +2094,6 @@ impl Default for JET_INDEXCREATE3_W_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_INDEXCREATE3_W_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2260,9 +2116,6 @@ impl Default for JET_INDEXCREATE_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEXCREATE_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_INDEXCREATE_A_0 {
@@ -2274,9 +2127,6 @@ impl Default for JET_INDEXCREATE_A_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEXCREATE_A_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_INDEXCREATE_A_1 {
@@ -2287,9 +2137,6 @@ impl Default for JET_INDEXCREATE_A_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_INDEXCREATE_A_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2312,9 +2159,6 @@ impl Default for JET_INDEXCREATE_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEXCREATE_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_INDEXCREATE_W_0 {
@@ -2326,9 +2170,6 @@ impl Default for JET_INDEXCREATE_W_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEXCREATE_W_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_INDEXCREATE_W_1 {
@@ -2339,9 +2180,6 @@ impl Default for JET_INDEXCREATE_W_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_INDEXCREATE_W_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -2356,10 +2194,6 @@ impl Default for JET_INDEXID {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for JET_INDEXID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2372,10 +2206,6 @@ impl Default for JET_INDEXID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for JET_INDEXID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -2407,10 +2237,6 @@ impl Default for JET_INDEXLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_INDEXLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2424,10 +2250,6 @@ impl Default for JET_INDEXRANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_INDEXRANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2443,9 +2265,6 @@ impl Default for JET_INDEX_COLUMN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_INDEX_COLUMN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_INDEX_RANGE {
@@ -2458,9 +2277,6 @@ impl Default for JET_INDEX_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_INDEX_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2499,10 +2315,6 @@ impl Default for JET_INSTANCE_INFO_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_INSTANCE_INFO_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2519,10 +2331,6 @@ impl Default for JET_INSTANCE_INFO_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_INSTANCE_INFO_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JET_IOPriorityLow: u32 = 1u32;
 pub const JET_IOPriorityNormal: u32 = 0u32;
@@ -2542,9 +2350,6 @@ impl Default for JET_LGPOS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_LGPOS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_LOGINFO_A {
@@ -2558,9 +2363,6 @@ impl Default for JET_LOGINFO_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_LOGINFO_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_LOGINFO_W {
@@ -2573,9 +2375,6 @@ impl Default for JET_LOGINFO_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_LOGINFO_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2594,9 +2393,6 @@ impl Default for JET_LOGTIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_LOGTIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JET_LOGTIME_0 {
@@ -2608,9 +2404,6 @@ impl Default for JET_LOGTIME_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_LOGTIME_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_LOGTIME_0_0 {
@@ -2620,9 +2413,6 @@ impl Default for JET_LOGTIME_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_LOGTIME_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2635,9 +2425,6 @@ impl Default for JET_LOGTIME_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_LOGTIME_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_LOGTIME_1_0 {
@@ -2647,9 +2434,6 @@ impl Default for JET_LOGTIME_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_LOGTIME_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2685,10 +2469,6 @@ impl Default for JET_OBJECTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for JET_OBJECTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2707,10 +2487,6 @@ impl Default for JET_OBJECTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for JET_OBJECTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -2735,10 +2511,6 @@ impl Default for JET_OBJECTLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_OBJECTLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2758,10 +2530,6 @@ impl Default for JET_OPENTEMPORARYTABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_OPENTEMPORARYTABLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -2783,10 +2551,6 @@ impl Default for JET_OPENTEMPORARYTABLE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_OPENTEMPORARYTABLE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_OPERATIONCONTEXT {
@@ -2800,9 +2564,6 @@ impl Default for JET_OPERATIONCONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_OPERATIONCONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2838,10 +2599,6 @@ impl Default for JET_RECORDLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_RECORDLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_RECPOS {
@@ -2855,9 +2612,6 @@ impl Default for JET_RECPOS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_RECPOS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -2875,10 +2629,6 @@ impl Default for JET_RECPOS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for JET_RECPOS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2895,10 +2645,6 @@ impl Default for JET_RECPOS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for JET_RECPOS2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
@@ -2919,10 +2665,6 @@ impl Default for JET_RECSIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for JET_RECSIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2941,10 +2683,6 @@ impl Default for JET_RECSIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for JET_RECSIZE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
@@ -2968,10 +2706,6 @@ impl Default for JET_RECSIZE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for JET_RECSIZE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2993,10 +2727,6 @@ impl Default for JET_RECSIZE2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for JET_RECSIZE2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3013,9 +2743,6 @@ impl Default for JET_RETINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_RETINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3035,9 +2762,6 @@ impl Default for JET_RETRIEVECOLUMN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_RETRIEVECOLUMN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct JET_RSTINFO_A {
@@ -3052,9 +2776,6 @@ impl Default for JET_RSTINFO_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_RSTINFO_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3071,9 +2792,6 @@ impl Default for JET_RSTINFO_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_RSTINFO_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_RSTMAP_A {
@@ -3085,9 +2803,6 @@ impl Default for JET_RSTMAP_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_RSTMAP_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_RSTMAP_W {
@@ -3098,9 +2813,6 @@ impl Default for JET_RSTMAP_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_RSTMAP_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -3138,9 +2850,6 @@ impl Default for JET_SETCOLUMN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_SETCOLUMN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_SETINFO {
@@ -3152,9 +2861,6 @@ impl Default for JET_SETINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_SETINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -3171,10 +2877,6 @@ impl Default for JET_SETSYSPARAM_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_SETSYSPARAM_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3190,10 +2892,6 @@ impl Default for JET_SETSYSPARAM_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_SETSYSPARAM_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct JET_SIGNATURE {
@@ -3206,9 +2904,6 @@ impl Default for JET_SIGNATURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_SIGNATURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_SNPROG {
@@ -3220,9 +2915,6 @@ impl Default for JET_SNPROG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_SNPROG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3240,9 +2932,6 @@ impl Default for JET_SPACEHINTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_SPACEHINTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -3269,10 +2958,6 @@ impl Default for JET_TABLECREATE2_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_TABLECREATE2_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3297,10 +2982,6 @@ impl Default for JET_TABLECREATE2_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_TABLECREATE2_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -3330,10 +3011,6 @@ impl Default for JET_TABLECREATE3_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_TABLECREATE3_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3361,10 +3038,6 @@ impl Default for JET_TABLECREATE3_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_TABLECREATE3_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -3394,10 +3067,6 @@ impl Default for JET_TABLECREATE4_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_TABLECREATE4_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3426,10 +3095,6 @@ impl Default for JET_TABLECREATE4_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_TABLECREATE4_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3452,10 +3117,6 @@ impl Default for JET_TABLECREATE_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_TABLECREATE_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
@@ -3480,10 +3141,6 @@ impl Default for JET_TABLECREATE_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_StructuredStorage")]
-impl windows_core::TypeKind for JET_TABLECREATE_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_THREADSTATS {
@@ -3500,9 +3157,6 @@ impl Default for JET_THREADSTATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_THREADSTATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(target_arch = "x86")]
@@ -3525,10 +3179,6 @@ impl Default for JET_THREADSTATS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for JET_THREADSTATS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3550,10 +3200,6 @@ impl Default for JET_THREADSTATS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for JET_THREADSTATS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_TUPLELIMITS {
@@ -3568,9 +3214,6 @@ impl Default for JET_TUPLELIMITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_TUPLELIMITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_UNICODEINDEX {
@@ -3582,9 +3225,6 @@ impl Default for JET_UNICODEINDEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_UNICODEINDEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_UNICODEINDEX2 {
@@ -3595,9 +3235,6 @@ impl Default for JET_UNICODEINDEX2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_UNICODEINDEX2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3612,9 +3249,6 @@ impl Default for JET_USERDEFINEDDEFAULT_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JET_USERDEFINEDDEFAULT_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JET_USERDEFINEDDEFAULT_W {
@@ -3627,9 +3261,6 @@ impl Default for JET_USERDEFINEDDEFAULT_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JET_USERDEFINEDDEFAULT_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JET_VERSION: u32 = 1280u32;
 pub const JET_bitAbortSnapshot: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/Storage/Nvme/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Nvme/mod.rs
@@ -8,9 +8,6 @@ impl Default for ACTIVE_LATENCY_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTIVE_LATENCY_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union ACTIVE_LATENCY_CONFIGURATION_0 {
@@ -22,9 +19,6 @@ impl Default for ACTIVE_LATENCY_CONFIGURATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTIVE_LATENCY_CONFIGURATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct ACTIVE_LATENCY_CONFIGURATION_0_0 {
@@ -34,9 +28,6 @@ impl Default for ACTIVE_LATENCY_CONFIGURATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTIVE_LATENCY_CONFIGURATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -51,9 +42,6 @@ impl Default for BUCKET_COUNTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BUCKET_COUNTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DEBUG_BIT_FIELD {
@@ -64,9 +52,6 @@ impl Default for DEBUG_BIT_FIELD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_BIT_FIELD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DSSD_POWER_STATE_DESCRIPTOR {
@@ -76,9 +61,6 @@ impl Default for DSSD_POWER_STATE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DSSD_POWER_STATE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -101,9 +83,6 @@ impl Default for FIRMWARE_ACTIVATION_HISTORY_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FIRMWARE_ACTIVATION_HISTORY_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FIRMWARE_ACTIVATION_HISTORY_ENTRY_VERSION_1: u32 = 1u32;
 pub const GUID_MFND_CHILD_CONTROLLER_EVENT_LOG_PAGE: windows_core::GUID = windows_core::GUID::from_u128(0x98bcce18_a5f0_bf35_a544_d97f259d669c);
@@ -138,9 +117,6 @@ impl Default for LATENCY_MONITOR_FEATURE_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LATENCY_MONITOR_FEATURE_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union LATENCY_MONITOR_FEATURE_STATUS_0 {
@@ -152,9 +128,6 @@ impl Default for LATENCY_MONITOR_FEATURE_STATUS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LATENCY_MONITOR_FEATURE_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LATENCY_MONITOR_FEATURE_STATUS_0_0 {
@@ -164,9 +137,6 @@ impl Default for LATENCY_MONITOR_FEATURE_STATUS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LATENCY_MONITOR_FEATURE_STATUS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -189,9 +159,6 @@ impl Default for LATENCY_STAMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LATENCY_STAMP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct LATENCY_STAMP_UNITS {
@@ -201,9 +168,6 @@ impl Default for LATENCY_STAMP_UNITS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LATENCY_STAMP_UNITS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -225,9 +189,6 @@ impl Default for MEASURED_LATENCY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEASURED_LATENCY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -257,9 +218,6 @@ impl Default for NVME_ACTIVE_NAMESPACE_ID_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_ACTIVE_NAMESPACE_ID_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -302,9 +260,6 @@ impl Default for NVME_ADMIN_COMPLETION_QUEUE_BASE_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_ADMIN_COMPLETION_QUEUE_BASE_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_ADMIN_COMPLETION_QUEUE_BASE_ADDRESS_0 {
@@ -314,9 +269,6 @@ impl Default for NVME_ADMIN_COMPLETION_QUEUE_BASE_ADDRESS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_ADMIN_COMPLETION_QUEUE_BASE_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -329,9 +281,6 @@ impl Default for NVME_ADMIN_QUEUE_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_ADMIN_QUEUE_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_ADMIN_QUEUE_ATTRIBUTES_0 {
@@ -341,9 +290,6 @@ impl Default for NVME_ADMIN_QUEUE_ATTRIBUTES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_ADMIN_QUEUE_ATTRIBUTES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -356,9 +302,6 @@ impl Default for NVME_ADMIN_SUBMISSION_QUEUE_BASE_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_ADMIN_SUBMISSION_QUEUE_BASE_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_ADMIN_SUBMISSION_QUEUE_BASE_ADDRESS_0 {
@@ -368,9 +311,6 @@ impl Default for NVME_ADMIN_SUBMISSION_QUEUE_BASE_ADDRESS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_ADMIN_SUBMISSION_QUEUE_BASE_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -433,9 +373,6 @@ impl Default for NVME_AUTO_POWER_STATE_TRANSITION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_AUTO_POWER_STATE_TRANSITION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NVME_CC_SHN_ABRUPT_SHUTDOWN: NVME_CC_SHN_SHUTDOWN_NOTIFICATIONS = NVME_CC_SHN_SHUTDOWN_NOTIFICATIONS(2i32);
 pub const NVME_CC_SHN_NORMAL_SHUTDOWN: NVME_CC_SHN_SHUTDOWN_NOTIFICATIONS = NVME_CC_SHN_SHUTDOWN_NOTIFICATIONS(1i32);
 pub const NVME_CC_SHN_NO_NOTIFICATION: NVME_CC_SHN_SHUTDOWN_NOTIFICATIONS = NVME_CC_SHN_SHUTDOWN_NOTIFICATIONS(0i32);
@@ -453,9 +390,6 @@ impl Default for NVME_CDW0_FEATURE_ENABLE_IEEE1667_SILO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW0_FEATURE_ENABLE_IEEE1667_SILO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW0_FEATURE_ENABLE_IEEE1667_SILO_0 {
@@ -465,9 +399,6 @@ impl Default for NVME_CDW0_FEATURE_ENABLE_IEEE1667_SILO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW0_FEATURE_ENABLE_IEEE1667_SILO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -480,9 +411,6 @@ impl Default for NVME_CDW0_FEATURE_ERROR_INJECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW0_FEATURE_ERROR_INJECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW0_FEATURE_ERROR_INJECTION_0 {
@@ -492,9 +420,6 @@ impl Default for NVME_CDW0_FEATURE_ERROR_INJECTION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW0_FEATURE_ERROR_INJECTION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -507,9 +432,6 @@ impl Default for NVME_CDW0_FEATURE_READONLY_WRITETHROUGH_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW0_FEATURE_READONLY_WRITETHROUGH_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW0_FEATURE_READONLY_WRITETHROUGH_MODE_0 {
@@ -520,9 +442,6 @@ impl Default for NVME_CDW0_FEATURE_READONLY_WRITETHROUGH_MODE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW0_FEATURE_READONLY_WRITETHROUGH_MODE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW0_RESERVATION_PERSISTENCE {
@@ -532,9 +451,6 @@ impl Default for NVME_CDW0_RESERVATION_PERSISTENCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW0_RESERVATION_PERSISTENCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -547,9 +463,6 @@ impl Default for NVME_CDW10_ABORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_ABORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_ABORT_0 {
@@ -559,9 +472,6 @@ impl Default for NVME_CDW10_ABORT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_ABORT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -574,9 +484,6 @@ impl Default for NVME_CDW10_CREATE_IO_QUEUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_CREATE_IO_QUEUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_CREATE_IO_QUEUE_0 {
@@ -586,9 +493,6 @@ impl Default for NVME_CDW10_CREATE_IO_QUEUE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_CREATE_IO_QUEUE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -601,9 +505,6 @@ impl Default for NVME_CDW10_DATASET_MANAGEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_DATASET_MANAGEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_DATASET_MANAGEMENT_0 {
@@ -613,9 +514,6 @@ impl Default for NVME_CDW10_DATASET_MANAGEMENT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_DATASET_MANAGEMENT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -627,9 +525,6 @@ impl Default for NVME_CDW10_DIRECTIVE_RECEIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_DIRECTIVE_RECEIVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_DIRECTIVE_SEND {
@@ -639,9 +534,6 @@ impl Default for NVME_CDW10_DIRECTIVE_SEND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_DIRECTIVE_SEND {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -654,9 +546,6 @@ impl Default for NVME_CDW10_FIRMWARE_ACTIVATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_FIRMWARE_ACTIVATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_FIRMWARE_ACTIVATE_0 {
@@ -667,9 +556,6 @@ impl Default for NVME_CDW10_FIRMWARE_ACTIVATE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_FIRMWARE_ACTIVATE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_FIRMWARE_DOWNLOAD {
@@ -679,9 +565,6 @@ impl Default for NVME_CDW10_FIRMWARE_DOWNLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_FIRMWARE_DOWNLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -694,9 +577,6 @@ impl Default for NVME_CDW10_FORMAT_NVM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_FORMAT_NVM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_FORMAT_NVM_0 {
@@ -706,9 +586,6 @@ impl Default for NVME_CDW10_FORMAT_NVM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_FORMAT_NVM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -721,9 +598,6 @@ impl Default for NVME_CDW10_GET_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_GET_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_GET_FEATURES_0 {
@@ -733,9 +607,6 @@ impl Default for NVME_CDW10_GET_FEATURES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_GET_FEATURES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -748,9 +619,6 @@ impl Default for NVME_CDW10_GET_LOG_PAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_GET_LOG_PAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_GET_LOG_PAGE_0 {
@@ -760,9 +628,6 @@ impl Default for NVME_CDW10_GET_LOG_PAGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_GET_LOG_PAGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -775,9 +640,6 @@ impl Default for NVME_CDW10_GET_LOG_PAGE_V13 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_GET_LOG_PAGE_V13 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_GET_LOG_PAGE_V13_0 {
@@ -787,9 +649,6 @@ impl Default for NVME_CDW10_GET_LOG_PAGE_V13_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_GET_LOG_PAGE_V13_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -802,9 +661,6 @@ impl Default for NVME_CDW10_IDENTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_IDENTIFY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_IDENTIFY_0 {
@@ -814,9 +670,6 @@ impl Default for NVME_CDW10_IDENTIFY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_IDENTIFY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -829,9 +682,6 @@ impl Default for NVME_CDW10_RESERVATION_ACQUIRE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_RESERVATION_ACQUIRE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_RESERVATION_ACQUIRE_0 {
@@ -841,9 +691,6 @@ impl Default for NVME_CDW10_RESERVATION_ACQUIRE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_RESERVATION_ACQUIRE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -856,9 +703,6 @@ impl Default for NVME_CDW10_RESERVATION_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_RESERVATION_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_RESERVATION_REGISTER_0 {
@@ -868,9 +712,6 @@ impl Default for NVME_CDW10_RESERVATION_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_RESERVATION_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -883,9 +724,6 @@ impl Default for NVME_CDW10_RESERVATION_RELEASE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_RESERVATION_RELEASE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_RESERVATION_RELEASE_0 {
@@ -895,9 +733,6 @@ impl Default for NVME_CDW10_RESERVATION_RELEASE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_RESERVATION_RELEASE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -910,9 +745,6 @@ impl Default for NVME_CDW10_RESERVATION_REPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_RESERVATION_REPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_RESERVATION_REPORT_0 {
@@ -922,9 +754,6 @@ impl Default for NVME_CDW10_RESERVATION_REPORT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_RESERVATION_REPORT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -937,9 +766,6 @@ impl Default for NVME_CDW10_SANITIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_SANITIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_SANITIZE_0 {
@@ -949,9 +775,6 @@ impl Default for NVME_CDW10_SANITIZE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_SANITIZE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -964,9 +787,6 @@ impl Default for NVME_CDW10_SECURITY_SEND_RECEIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_SECURITY_SEND_RECEIVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_SECURITY_SEND_RECEIVE_0 {
@@ -976,9 +796,6 @@ impl Default for NVME_CDW10_SECURITY_SEND_RECEIVE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_SECURITY_SEND_RECEIVE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -991,9 +808,6 @@ impl Default for NVME_CDW10_SET_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_SET_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_SET_FEATURES_0 {
@@ -1003,9 +817,6 @@ impl Default for NVME_CDW10_SET_FEATURES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_SET_FEATURES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1017,9 +828,6 @@ impl Default for NVME_CDW10_ZONE_APPEND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_ZONE_APPEND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_ZONE_MANAGEMENT_RECEIVE {
@@ -1030,9 +838,6 @@ impl Default for NVME_CDW10_ZONE_MANAGEMENT_RECEIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW10_ZONE_MANAGEMENT_RECEIVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW10_ZONE_MANAGEMENT_SEND {
@@ -1042,9 +847,6 @@ impl Default for NVME_CDW10_ZONE_MANAGEMENT_SEND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW10_ZONE_MANAGEMENT_SEND {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1057,9 +859,6 @@ impl Default for NVME_CDW11_CREATE_IO_CQ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_CREATE_IO_CQ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_CREATE_IO_CQ_0 {
@@ -1069,9 +868,6 @@ impl Default for NVME_CDW11_CREATE_IO_CQ_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_CREATE_IO_CQ_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1084,9 +880,6 @@ impl Default for NVME_CDW11_CREATE_IO_SQ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_CREATE_IO_SQ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_CREATE_IO_SQ_0 {
@@ -1096,9 +889,6 @@ impl Default for NVME_CDW11_CREATE_IO_SQ_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_CREATE_IO_SQ_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1111,9 +901,6 @@ impl Default for NVME_CDW11_DATASET_MANAGEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_DATASET_MANAGEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_DATASET_MANAGEMENT_0 {
@@ -1123,9 +910,6 @@ impl Default for NVME_CDW11_DATASET_MANAGEMENT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_DATASET_MANAGEMENT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1138,9 +922,6 @@ impl Default for NVME_CDW11_DIRECTIVE_RECEIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_DIRECTIVE_RECEIVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_DIRECTIVE_RECEIVE_0 {
@@ -1150,9 +931,6 @@ impl Default for NVME_CDW11_DIRECTIVE_RECEIVE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_DIRECTIVE_RECEIVE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1165,9 +943,6 @@ impl Default for NVME_CDW11_DIRECTIVE_SEND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_DIRECTIVE_SEND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_DIRECTIVE_SEND_0 {
@@ -1177,9 +952,6 @@ impl Default for NVME_CDW11_DIRECTIVE_SEND_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_DIRECTIVE_SEND_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1212,9 +984,6 @@ impl Default for NVME_CDW11_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_CDW11_FEATURE_ARBITRATION {
@@ -1226,9 +995,6 @@ impl Default for NVME_CDW11_FEATURE_ARBITRATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_ARBITRATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_ARBITRATION_0 {
@@ -1238,9 +1004,6 @@ impl Default for NVME_CDW11_FEATURE_ARBITRATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_ARBITRATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1253,9 +1016,6 @@ impl Default for NVME_CDW11_FEATURE_ASYNC_EVENT_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_ASYNC_EVENT_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_ASYNC_EVENT_CONFIG_0 {
@@ -1265,9 +1025,6 @@ impl Default for NVME_CDW11_FEATURE_ASYNC_EVENT_CONFIG_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_ASYNC_EVENT_CONFIG_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1280,9 +1037,6 @@ impl Default for NVME_CDW11_FEATURE_AUTO_POWER_STATE_TRANSITION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_AUTO_POWER_STATE_TRANSITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_AUTO_POWER_STATE_TRANSITION_0 {
@@ -1292,9 +1046,6 @@ impl Default for NVME_CDW11_FEATURE_AUTO_POWER_STATE_TRANSITION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_AUTO_POWER_STATE_TRANSITION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1307,9 +1058,6 @@ impl Default for NVME_CDW11_FEATURE_CLEAR_FW_UPDATE_HISTORY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_CLEAR_FW_UPDATE_HISTORY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_CLEAR_FW_UPDATE_HISTORY_0 {
@@ -1319,9 +1067,6 @@ impl Default for NVME_CDW11_FEATURE_CLEAR_FW_UPDATE_HISTORY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_CLEAR_FW_UPDATE_HISTORY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1334,9 +1079,6 @@ impl Default for NVME_CDW11_FEATURE_CLEAR_PCIE_CORRECTABLE_ERROR_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_CLEAR_PCIE_CORRECTABLE_ERROR_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_CLEAR_PCIE_CORRECTABLE_ERROR_COUNTERS_0 {
@@ -1346,9 +1088,6 @@ impl Default for NVME_CDW11_FEATURE_CLEAR_PCIE_CORRECTABLE_ERROR_COUNTERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_CLEAR_PCIE_CORRECTABLE_ERROR_COUNTERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1361,9 +1100,6 @@ impl Default for NVME_CDW11_FEATURE_ENABLE_IEEE1667_SILO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_ENABLE_IEEE1667_SILO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_ENABLE_IEEE1667_SILO_0 {
@@ -1373,9 +1109,6 @@ impl Default for NVME_CDW11_FEATURE_ENABLE_IEEE1667_SILO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_ENABLE_IEEE1667_SILO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1388,9 +1121,6 @@ impl Default for NVME_CDW11_FEATURE_ERROR_RECOVERY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_ERROR_RECOVERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_ERROR_RECOVERY_0 {
@@ -1400,9 +1130,6 @@ impl Default for NVME_CDW11_FEATURE_ERROR_RECOVERY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_ERROR_RECOVERY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1415,9 +1142,6 @@ impl Default for NVME_CDW11_FEATURE_GET_HOST_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_GET_HOST_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_GET_HOST_METADATA_0 {
@@ -1428,9 +1152,6 @@ impl Default for NVME_CDW11_FEATURE_GET_HOST_METADATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_GET_HOST_METADATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_HOST_IDENTIFIER {
@@ -1440,9 +1161,6 @@ impl Default for NVME_CDW11_FEATURE_HOST_IDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_HOST_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1455,9 +1173,6 @@ impl Default for NVME_CDW11_FEATURE_HOST_MEMORY_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_HOST_MEMORY_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_HOST_MEMORY_BUFFER_0 {
@@ -1467,9 +1182,6 @@ impl Default for NVME_CDW11_FEATURE_HOST_MEMORY_BUFFER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_HOST_MEMORY_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1482,9 +1194,6 @@ impl Default for NVME_CDW11_FEATURE_INTERRUPT_COALESCING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_INTERRUPT_COALESCING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_INTERRUPT_COALESCING_0 {
@@ -1494,9 +1203,6 @@ impl Default for NVME_CDW11_FEATURE_INTERRUPT_COALESCING_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_INTERRUPT_COALESCING_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1509,9 +1215,6 @@ impl Default for NVME_CDW11_FEATURE_INTERRUPT_VECTOR_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_INTERRUPT_VECTOR_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_INTERRUPT_VECTOR_CONFIG_0 {
@@ -1521,9 +1224,6 @@ impl Default for NVME_CDW11_FEATURE_INTERRUPT_VECTOR_CONFIG_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_INTERRUPT_VECTOR_CONFIG_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1536,9 +1236,6 @@ impl Default for NVME_CDW11_FEATURE_IO_COMMAND_SET_PROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_IO_COMMAND_SET_PROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_IO_COMMAND_SET_PROFILE_0 {
@@ -1548,9 +1245,6 @@ impl Default for NVME_CDW11_FEATURE_IO_COMMAND_SET_PROFILE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_IO_COMMAND_SET_PROFILE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1563,9 +1257,6 @@ impl Default for NVME_CDW11_FEATURE_LBA_RANGE_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_LBA_RANGE_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_LBA_RANGE_TYPE_0 {
@@ -1575,9 +1266,6 @@ impl Default for NVME_CDW11_FEATURE_LBA_RANGE_TYPE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_LBA_RANGE_TYPE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1590,9 +1278,6 @@ impl Default for NVME_CDW11_FEATURE_NON_OPERATIONAL_POWER_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_NON_OPERATIONAL_POWER_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_NON_OPERATIONAL_POWER_STATE_0 {
@@ -1602,9 +1287,6 @@ impl Default for NVME_CDW11_FEATURE_NON_OPERATIONAL_POWER_STATE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_NON_OPERATIONAL_POWER_STATE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1617,9 +1299,6 @@ impl Default for NVME_CDW11_FEATURE_NUMBER_OF_QUEUES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_NUMBER_OF_QUEUES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_NUMBER_OF_QUEUES_0 {
@@ -1629,9 +1308,6 @@ impl Default for NVME_CDW11_FEATURE_NUMBER_OF_QUEUES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_NUMBER_OF_QUEUES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1644,9 +1320,6 @@ impl Default for NVME_CDW11_FEATURE_POWER_MANAGEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_POWER_MANAGEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_POWER_MANAGEMENT_0 {
@@ -1656,9 +1329,6 @@ impl Default for NVME_CDW11_FEATURE_POWER_MANAGEMENT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_POWER_MANAGEMENT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1671,9 +1341,6 @@ impl Default for NVME_CDW11_FEATURE_READONLY_WRITETHROUGH_MODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_READONLY_WRITETHROUGH_MODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_READONLY_WRITETHROUGH_MODE_0 {
@@ -1683,9 +1350,6 @@ impl Default for NVME_CDW11_FEATURE_READONLY_WRITETHROUGH_MODE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_READONLY_WRITETHROUGH_MODE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1697,9 +1361,6 @@ impl Default for NVME_CDW11_FEATURE_RESERVATION_NOTIFICATION_MASK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_RESERVATION_NOTIFICATION_MASK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_RESERVATION_PERSISTENCE {
@@ -1709,9 +1370,6 @@ impl Default for NVME_CDW11_FEATURE_RESERVATION_PERSISTENCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_RESERVATION_PERSISTENCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1724,9 +1382,6 @@ impl Default for NVME_CDW11_FEATURE_SET_HOST_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_SET_HOST_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_SET_HOST_METADATA_0 {
@@ -1736,9 +1391,6 @@ impl Default for NVME_CDW11_FEATURE_SET_HOST_METADATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_SET_HOST_METADATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1751,9 +1403,6 @@ impl Default for NVME_CDW11_FEATURE_SUPPORTED_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_SUPPORTED_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_SUPPORTED_CAPABILITY_0 {
@@ -1763,9 +1412,6 @@ impl Default for NVME_CDW11_FEATURE_SUPPORTED_CAPABILITY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_SUPPORTED_CAPABILITY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1778,9 +1424,6 @@ impl Default for NVME_CDW11_FEATURE_TEMPERATURE_THRESHOLD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_TEMPERATURE_THRESHOLD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_TEMPERATURE_THRESHOLD_0 {
@@ -1790,9 +1433,6 @@ impl Default for NVME_CDW11_FEATURE_TEMPERATURE_THRESHOLD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_TEMPERATURE_THRESHOLD_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1805,9 +1445,6 @@ impl Default for NVME_CDW11_FEATURE_VOLATILE_WRITE_CACHE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_VOLATILE_WRITE_CACHE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_VOLATILE_WRITE_CACHE_0 {
@@ -1817,9 +1454,6 @@ impl Default for NVME_CDW11_FEATURE_VOLATILE_WRITE_CACHE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_VOLATILE_WRITE_CACHE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1832,9 +1466,6 @@ impl Default for NVME_CDW11_FEATURE_WRITE_ATOMICITY_NORMAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_WRITE_ATOMICITY_NORMAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FEATURE_WRITE_ATOMICITY_NORMAL_0 {
@@ -1845,9 +1476,6 @@ impl Default for NVME_CDW11_FEATURE_WRITE_ATOMICITY_NORMAL_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_FEATURE_WRITE_ATOMICITY_NORMAL_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_FIRMWARE_DOWNLOAD {
@@ -1857,9 +1485,6 @@ impl Default for NVME_CDW11_FIRMWARE_DOWNLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_FIRMWARE_DOWNLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1872,9 +1497,6 @@ impl Default for NVME_CDW11_GET_LOG_PAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_GET_LOG_PAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_GET_LOG_PAGE_0 {
@@ -1884,9 +1506,6 @@ impl Default for NVME_CDW11_GET_LOG_PAGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_GET_LOG_PAGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1900,9 +1519,6 @@ impl Default for NVME_CDW11_IDENTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_IDENTIFY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_IDENTIFY_0 {
@@ -1914,9 +1530,6 @@ impl Default for NVME_CDW11_IDENTIFY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_IDENTIFY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_IDENTIFY_1 {
@@ -1926,9 +1539,6 @@ impl Default for NVME_CDW11_IDENTIFY_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_IDENTIFY_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1941,9 +1551,6 @@ impl Default for NVME_CDW11_RESERVATION_REPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_RESERVATION_REPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_RESERVATION_REPORT_0 {
@@ -1953,9 +1560,6 @@ impl Default for NVME_CDW11_RESERVATION_REPORT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_RESERVATION_REPORT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1968,9 +1572,6 @@ impl Default for NVME_CDW11_SANITIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_SANITIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_SANITIZE_0 {
@@ -1980,9 +1581,6 @@ impl Default for NVME_CDW11_SANITIZE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_SANITIZE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1994,9 +1592,6 @@ impl Default for NVME_CDW11_SECURITY_RECEIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW11_SECURITY_RECEIVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW11_SECURITY_SEND {
@@ -2006,9 +1601,6 @@ impl Default for NVME_CDW11_SECURITY_SEND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW11_SECURITY_SEND {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2021,9 +1613,6 @@ impl Default for NVME_CDW12_DIRECTIVE_RECEIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW12_DIRECTIVE_RECEIVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_CDW12_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCES {
@@ -2035,9 +1624,6 @@ impl Default for NVME_CDW12_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW12_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW12_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCES_0 {
@@ -2047,9 +1633,6 @@ impl Default for NVME_CDW12_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW12_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2062,9 +1645,6 @@ impl Default for NVME_CDW12_DIRECTIVE_SEND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW12_DIRECTIVE_SEND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_CDW12_DIRECTIVE_SEND_IDENTIFY_ENABLE_DIRECTIVE {
@@ -2076,9 +1656,6 @@ impl Default for NVME_CDW12_DIRECTIVE_SEND_IDENTIFY_ENABLE_DIRECTIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW12_DIRECTIVE_SEND_IDENTIFY_ENABLE_DIRECTIVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW12_DIRECTIVE_SEND_IDENTIFY_ENABLE_DIRECTIVE_0 {
@@ -2088,9 +1665,6 @@ impl Default for NVME_CDW12_DIRECTIVE_SEND_IDENTIFY_ENABLE_DIRECTIVE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW12_DIRECTIVE_SEND_IDENTIFY_ENABLE_DIRECTIVE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2103,9 +1677,6 @@ impl Default for NVME_CDW12_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW12_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_CDW12_FEATURE_HOST_MEMORY_BUFFER {
@@ -2117,9 +1688,6 @@ impl Default for NVME_CDW12_FEATURE_HOST_MEMORY_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW12_FEATURE_HOST_MEMORY_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW12_FEATURE_HOST_MEMORY_BUFFER_0 {
@@ -2130,9 +1698,6 @@ impl Default for NVME_CDW12_FEATURE_HOST_MEMORY_BUFFER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW12_FEATURE_HOST_MEMORY_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW12_GET_LOG_PAGE {
@@ -2142,9 +1707,6 @@ impl Default for NVME_CDW12_GET_LOG_PAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW12_GET_LOG_PAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2157,9 +1719,6 @@ impl Default for NVME_CDW12_READ_WRITE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW12_READ_WRITE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW12_READ_WRITE_0 {
@@ -2169,9 +1728,6 @@ impl Default for NVME_CDW12_READ_WRITE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW12_READ_WRITE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2184,9 +1740,6 @@ impl Default for NVME_CDW12_ZONE_APPEND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW12_ZONE_APPEND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW12_ZONE_APPEND_0 {
@@ -2196,9 +1749,6 @@ impl Default for NVME_CDW12_ZONE_APPEND_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW12_ZONE_APPEND_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2211,9 +1761,6 @@ impl Default for NVME_CDW13_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW13_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_CDW13_FEATURE_HOST_MEMORY_BUFFER {
@@ -2225,9 +1772,6 @@ impl Default for NVME_CDW13_FEATURE_HOST_MEMORY_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW13_FEATURE_HOST_MEMORY_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW13_FEATURE_HOST_MEMORY_BUFFER_0 {
@@ -2237,9 +1781,6 @@ impl Default for NVME_CDW13_FEATURE_HOST_MEMORY_BUFFER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW13_FEATURE_HOST_MEMORY_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2251,9 +1792,6 @@ impl Default for NVME_CDW13_GET_LOG_PAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW13_GET_LOG_PAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_CDW13_READ_WRITE {
@@ -2264,9 +1802,6 @@ impl Default for NVME_CDW13_READ_WRITE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW13_READ_WRITE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2280,9 +1815,6 @@ impl Default for NVME_CDW13_READ_WRITE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW13_READ_WRITE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW13_READ_WRITE_0_0 {
@@ -2292,9 +1824,6 @@ impl Default for NVME_CDW13_READ_WRITE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW13_READ_WRITE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2307,9 +1836,6 @@ impl Default for NVME_CDW13_ZONE_MANAGEMENT_RECEIVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW13_ZONE_MANAGEMENT_RECEIVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW13_ZONE_MANAGEMENT_RECEIVE_0 {
@@ -2319,9 +1845,6 @@ impl Default for NVME_CDW13_ZONE_MANAGEMENT_RECEIVE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW13_ZONE_MANAGEMENT_RECEIVE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2334,9 +1857,6 @@ impl Default for NVME_CDW13_ZONE_MANAGEMENT_SEND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW13_ZONE_MANAGEMENT_SEND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW13_ZONE_MANAGEMENT_SEND_0 {
@@ -2346,9 +1866,6 @@ impl Default for NVME_CDW13_ZONE_MANAGEMENT_SEND_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW13_ZONE_MANAGEMENT_SEND_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2361,9 +1878,6 @@ impl Default for NVME_CDW14_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW14_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_CDW14_FEATURE_HOST_MEMORY_BUFFER {
@@ -2375,9 +1889,6 @@ impl Default for NVME_CDW14_FEATURE_HOST_MEMORY_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW14_FEATURE_HOST_MEMORY_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW14_FEATURE_HOST_MEMORY_BUFFER_0 {
@@ -2387,9 +1898,6 @@ impl Default for NVME_CDW14_FEATURE_HOST_MEMORY_BUFFER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW14_FEATURE_HOST_MEMORY_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2402,9 +1910,6 @@ impl Default for NVME_CDW14_GET_LOG_PAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW14_GET_LOG_PAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW14_GET_LOG_PAGE_0 {
@@ -2414,9 +1919,6 @@ impl Default for NVME_CDW14_GET_LOG_PAGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW14_GET_LOG_PAGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2429,9 +1931,6 @@ impl Default for NVME_CDW15_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW15_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_CDW15_FEATURE_HOST_MEMORY_BUFFER {
@@ -2443,9 +1942,6 @@ impl Default for NVME_CDW15_FEATURE_HOST_MEMORY_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW15_FEATURE_HOST_MEMORY_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW15_FEATURE_HOST_MEMORY_BUFFER_0 {
@@ -2455,9 +1951,6 @@ impl Default for NVME_CDW15_FEATURE_HOST_MEMORY_BUFFER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW15_FEATURE_HOST_MEMORY_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2470,9 +1963,6 @@ impl Default for NVME_CDW15_READ_WRITE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW15_READ_WRITE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW15_READ_WRITE_0 {
@@ -2482,9 +1972,6 @@ impl Default for NVME_CDW15_READ_WRITE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CDW15_READ_WRITE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2497,9 +1984,6 @@ impl Default for NVME_CDW15_ZONE_APPEND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW15_ZONE_APPEND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CDW15_ZONE_APPEND_0 {
@@ -2510,9 +1994,6 @@ impl Default for NVME_CDW15_ZONE_APPEND_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CDW15_ZONE_APPEND_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CHANGED_NAMESPACE_LIST_LOG {
@@ -2522,9 +2003,6 @@ impl Default for NVME_CHANGED_NAMESPACE_LIST_LOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CHANGED_NAMESPACE_LIST_LOG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2537,9 +2015,6 @@ impl Default for NVME_CHANGED_ZONE_LIST_LOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CHANGED_ZONE_LIST_LOG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2566,9 +2041,6 @@ impl Default for NVME_COMMAND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2604,9 +2076,6 @@ impl Default for NVME_COMMAND_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_2 {
@@ -2621,9 +2090,6 @@ impl Default for NVME_COMMAND_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2640,9 +2106,6 @@ impl Default for NVME_COMMAND_0_6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_7 {
@@ -2657,9 +2120,6 @@ impl Default for NVME_COMMAND_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2676,9 +2136,6 @@ impl Default for NVME_COMMAND_0_8 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_8 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_14 {
@@ -2693,9 +2150,6 @@ impl Default for NVME_COMMAND_0_14 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_14 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2712,9 +2166,6 @@ impl Default for NVME_COMMAND_0_15 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_15 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_12 {
@@ -2729,9 +2180,6 @@ impl Default for NVME_COMMAND_0_12 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_12 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2748,9 +2196,6 @@ impl Default for NVME_COMMAND_0_11 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_11 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_13 {
@@ -2765,9 +2210,6 @@ impl Default for NVME_COMMAND_0_13 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_13 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2784,9 +2226,6 @@ impl Default for NVME_COMMAND_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_3 {
@@ -2801,9 +2240,6 @@ impl Default for NVME_COMMAND_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2820,9 +2256,6 @@ impl Default for NVME_COMMAND_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_COMMAND_0_5_0 {
@@ -2833,9 +2266,6 @@ impl Default for NVME_COMMAND_0_5_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_5_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2852,9 +2282,6 @@ impl Default for NVME_COMMAND_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_17 {
@@ -2869,9 +2296,6 @@ impl Default for NVME_COMMAND_0_17 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_17 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2888,9 +2312,6 @@ impl Default for NVME_COMMAND_0_18 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_18 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_19 {
@@ -2905,9 +2326,6 @@ impl Default for NVME_COMMAND_0_19 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_19 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2924,9 +2342,6 @@ impl Default for NVME_COMMAND_0_20 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_20 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_21 {
@@ -2941,9 +2356,6 @@ impl Default for NVME_COMMAND_0_21 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_21 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2960,9 +2372,6 @@ impl Default for NVME_COMMAND_0_16 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_16 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_10 {
@@ -2977,9 +2386,6 @@ impl Default for NVME_COMMAND_0_10 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_10 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2996,9 +2402,6 @@ impl Default for NVME_COMMAND_0_9 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_4 {
@@ -3014,9 +2417,6 @@ impl Default for NVME_COMMAND_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_24 {
@@ -3030,9 +2430,6 @@ impl Default for NVME_COMMAND_0_24 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_0_24 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3048,9 +2445,6 @@ impl Default for NVME_COMMAND_0_23 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_23 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_COMMAND_0_22 {
@@ -3065,9 +2459,6 @@ impl Default for NVME_COMMAND_0_22 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_0_22 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_COMMAND_DWORD0 {
@@ -3079,9 +2470,6 @@ impl Default for NVME_COMMAND_DWORD0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_DWORD0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_COMMAND_DWORD0_0 {
@@ -3091,9 +2479,6 @@ impl Default for NVME_COMMAND_DWORD0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_DWORD0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3106,9 +2491,6 @@ impl Default for NVME_COMMAND_EFFECTS_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_EFFECTS_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_COMMAND_EFFECTS_DATA_0 {
@@ -3118,9 +2500,6 @@ impl Default for NVME_COMMAND_EFFECTS_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_EFFECTS_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3133,9 +2512,6 @@ impl Default for NVME_COMMAND_EFFECTS_LOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMMAND_EFFECTS_LOG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3160,9 +2536,6 @@ impl Default for NVME_COMMAND_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_COMMAND_STATUS_0 {
@@ -3173,9 +2546,6 @@ impl Default for NVME_COMMAND_STATUS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMMAND_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_COMPLETION_DW0_ASYNC_EVENT_REQUEST {
@@ -3185,9 +2555,6 @@ impl Default for NVME_COMPLETION_DW0_ASYNC_EVENT_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMPLETION_DW0_ASYNC_EVENT_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3200,9 +2567,6 @@ impl Default for NVME_COMPLETION_DW0_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCE
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMPLETION_DW0_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_COMPLETION_DW0_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCES_0 {
@@ -3212,9 +2576,6 @@ impl Default for NVME_COMPLETION_DW0_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCE
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMPLETION_DW0_DIRECTIVE_RECEIVE_STREAMS_ALLOCATE_RESOURCES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3229,9 +2590,6 @@ impl Default for NVME_COMPLETION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMPLETION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_COMPLETION_ENTRY_0 {
@@ -3242,9 +2600,6 @@ impl Default for NVME_COMPLETION_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMPLETION_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3257,9 +2612,6 @@ impl Default for NVME_COMPLETION_ENTRY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMPLETION_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_COMPLETION_ENTRY_1 {
@@ -3270,9 +2622,6 @@ impl Default for NVME_COMPLETION_ENTRY_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMPLETION_ENTRY_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3285,9 +2634,6 @@ impl Default for NVME_COMPLETION_ENTRY_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMPLETION_ENTRY_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_COMPLETION_QUEUE_HEAD_DOORBELL {
@@ -3299,9 +2645,6 @@ impl Default for NVME_COMPLETION_QUEUE_HEAD_DOORBELL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_COMPLETION_QUEUE_HEAD_DOORBELL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_COMPLETION_QUEUE_HEAD_DOORBELL_0 {
@@ -3311,9 +2654,6 @@ impl Default for NVME_COMPLETION_QUEUE_HEAD_DOORBELL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_COMPLETION_QUEUE_HEAD_DOORBELL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3326,9 +2666,6 @@ impl Default for NVME_CONTEXT_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CONTEXT_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CONTEXT_ATTRIBUTES_0 {
@@ -3338,9 +2675,6 @@ impl Default for NVME_CONTEXT_ATTRIBUTES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CONTEXT_ATTRIBUTES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3353,9 +2687,6 @@ impl Default for NVME_CONTROLLER_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CONTROLLER_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CONTROLLER_CAPABILITIES_0 {
@@ -3365,9 +2696,6 @@ impl Default for NVME_CONTROLLER_CAPABILITIES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CONTROLLER_CAPABILITIES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3380,9 +2708,6 @@ impl Default for NVME_CONTROLLER_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CONTROLLER_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CONTROLLER_CONFIGURATION_0 {
@@ -3392,9 +2717,6 @@ impl Default for NVME_CONTROLLER_CONFIGURATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CONTROLLER_CONFIGURATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3407,9 +2729,6 @@ impl Default for NVME_CONTROLLER_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CONTROLLER_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_CONTROLLER_MEMORY_BUFFER_LOCATION {
@@ -3421,9 +2740,6 @@ impl Default for NVME_CONTROLLER_MEMORY_BUFFER_LOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CONTROLLER_MEMORY_BUFFER_LOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CONTROLLER_MEMORY_BUFFER_LOCATION_0 {
@@ -3433,9 +2749,6 @@ impl Default for NVME_CONTROLLER_MEMORY_BUFFER_LOCATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CONTROLLER_MEMORY_BUFFER_LOCATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3448,9 +2761,6 @@ impl Default for NVME_CONTROLLER_MEMORY_BUFFER_SIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CONTROLLER_MEMORY_BUFFER_SIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CONTROLLER_MEMORY_BUFFER_SIZE_0 {
@@ -3460,9 +2770,6 @@ impl Default for NVME_CONTROLLER_MEMORY_BUFFER_SIZE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CONTROLLER_MEMORY_BUFFER_SIZE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_CONTROLLER_METADATA_CHIPSET_DRIVER_NAME: NVME_CONTROLLER_METADATA_ELEMENT_TYPES = NVME_CONTROLLER_METADATA_ELEMENT_TYPES(8i32);
 pub const NVME_CONTROLLER_METADATA_CHIPSET_DRIVER_VERSION: NVME_CONTROLLER_METADATA_ELEMENT_TYPES = NVME_CONTROLLER_METADATA_ELEMENT_TYPES(9i32);
@@ -3508,9 +2815,6 @@ impl Default for NVME_CONTROLLER_REGISTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CONTROLLER_REGISTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_CONTROLLER_STATUS {
@@ -3522,9 +2826,6 @@ impl Default for NVME_CONTROLLER_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_CONTROLLER_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_CONTROLLER_STATUS_0 {
@@ -3534,9 +2835,6 @@ impl Default for NVME_CONTROLLER_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_CONTROLLER_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_CSS_ADMIN_COMMAND_SET_ONLY: NVME_CSS_COMMAND_SETS = NVME_CSS_COMMAND_SETS(7i32);
 pub const NVME_CSS_ALL_SUPPORTED_IO_COMMAND_SET: NVME_CSS_COMMAND_SETS = NVME_CSS_COMMAND_SETS(6i32);
@@ -3563,9 +2861,6 @@ impl Default for NVME_DEVICE_SELF_TEST_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_DEVICE_SELF_TEST_LOG_1 {
@@ -3576,9 +2871,6 @@ impl Default for NVME_DEVICE_SELF_TEST_LOG_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_LOG_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_DEVICE_SELF_TEST_LOG_0 {
@@ -3588,9 +2880,6 @@ impl Default for NVME_DEVICE_SELF_TEST_LOG_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_LOG_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3611,9 +2900,6 @@ impl Default for NVME_DEVICE_SELF_TEST_RESULT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_RESULT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
@@ -3623,9 +2909,6 @@ impl Default for NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_RESULT_DATA_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3637,9 +2920,6 @@ impl Default for NVME_DEVICE_SELF_TEST_RESULT_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_RESULT_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_DEVICE_SELF_TEST_RESULT_DATA_1 {
@@ -3649,9 +2929,6 @@ impl Default for NVME_DEVICE_SELF_TEST_RESULT_DATA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_DEVICE_SELF_TEST_RESULT_DATA_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3664,9 +2941,6 @@ impl Default for NVME_DIRECTIVE_IDENTIFY_RETURN_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_DIRECTIVE_IDENTIFY_RETURN_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_DIRECTIVE_IDENTIFY_RETURN_PARAMETERS_DESCRIPTOR {
@@ -3677,9 +2951,6 @@ impl Default for NVME_DIRECTIVE_IDENTIFY_RETURN_PARAMETERS_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_DIRECTIVE_IDENTIFY_RETURN_PARAMETERS_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3711,9 +2982,6 @@ impl Default for NVME_DIRECTIVE_STREAMS_GET_STATUS_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_DIRECTIVE_STREAMS_GET_STATUS_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_DIRECTIVE_STREAMS_RETURN_PARAMETERS {
@@ -3731,9 +2999,6 @@ impl Default for NVME_DIRECTIVE_STREAMS_RETURN_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_DIRECTIVE_STREAMS_RETURN_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3758,9 +3023,6 @@ impl Default for NVME_ENDURANCE_GROUP_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_ENDURANCE_GROUP_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_ERROR_INFO_LOG {
@@ -3781,9 +3043,6 @@ impl Default for NVME_ERROR_INFO_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_ERROR_INFO_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_ERROR_INFO_LOG_0 {
@@ -3793,9 +3052,6 @@ impl Default for NVME_ERROR_INFO_LOG_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_ERROR_INFO_LOG_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3810,9 +3066,6 @@ impl Default for NVME_ERROR_INJECTION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_ERROR_INJECTION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_ERROR_INJECTION_ENTRY_0 {
@@ -3824,9 +3077,6 @@ impl Default for NVME_ERROR_INJECTION_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_ERROR_INJECTION_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_ERROR_INJECTION_ENTRY_0_0 {
@@ -3836,9 +3086,6 @@ impl Default for NVME_ERROR_INJECTION_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_ERROR_INJECTION_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3868,9 +3115,6 @@ impl Default for NVME_EXTENDED_REPORT_ZONE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_EXTENDED_REPORT_ZONE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NVME_FEATURES(pub i32);
@@ -3897,9 +3141,6 @@ impl Default for NVME_FEATURE_HOST_IDENTIFIER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_FEATURE_HOST_IDENTIFIER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NVME_FEATURE_HOST_MEMORY_BUFFER: NVME_FEATURES = NVME_FEATURES(13i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3912,9 +3153,6 @@ impl Default for NVME_FEATURE_HOST_METADATA_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_FEATURE_HOST_METADATA_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_FEATURE_INTERRUPT_COALESCING: NVME_FEATURES = NVME_FEATURES(8i32);
 pub const NVME_FEATURE_INTERRUPT_VECTOR_CONFIG: NVME_FEATURES = NVME_FEATURES(9i32);
@@ -3968,9 +3206,6 @@ impl Default for NVME_FIRMWARE_SLOT_INFO_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_FIRMWARE_SLOT_INFO_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_FIRMWARE_SLOT_INFO_LOG_0 {
@@ -3980,9 +3215,6 @@ impl Default for NVME_FIRMWARE_SLOT_INFO_LOG_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_FIRMWARE_SLOT_INFO_LOG_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4026,9 +3258,6 @@ impl Default for NVME_HEALTH_INFO_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_HEALTH_INFO_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_HEALTH_INFO_LOG_0 {
@@ -4040,9 +3269,6 @@ impl Default for NVME_HEALTH_INFO_LOG_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_HEALTH_INFO_LOG_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_HEALTH_INFO_LOG_0_0 {
@@ -4052,9 +3278,6 @@ impl Default for NVME_HEALTH_INFO_LOG_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_HEALTH_INFO_LOG_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_HOST_IDENTIFIER_SIZE: u32 = 8u32;
 #[repr(C)]
@@ -4068,9 +3291,6 @@ impl Default for NVME_HOST_MEMORY_BUFFER_DESCRIPTOR_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_HOST_MEMORY_BUFFER_DESCRIPTOR_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_HOST_METADATA_ADD_ENTRY_MULTIPLE: NVME_HOST_METADATA_ELEMENT_ACTIONS = NVME_HOST_METADATA_ELEMENT_ACTIONS(2i32);
 pub const NVME_HOST_METADATA_ADD_REPLACE_ENTRY: NVME_HOST_METADATA_ELEMENT_ACTIONS = NVME_HOST_METADATA_ELEMENT_ACTIONS(0i32);
@@ -4088,9 +3308,6 @@ impl Default for NVME_HOST_METADATA_ELEMENT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_HOST_METADATA_ELEMENT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4221,9 +3438,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_12 {
@@ -4233,9 +3447,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_12 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_12 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4247,9 +3458,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_8 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_8 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_7 {
@@ -4259,9 +3467,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4273,9 +3478,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_14 {
@@ -4285,9 +3487,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_14 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_14 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4299,9 +3498,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_17 {
@@ -4311,9 +3507,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_17 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_17 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4325,9 +3518,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_16 {
@@ -4337,9 +3527,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_16 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_16 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4351,9 +3538,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_10 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_10 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_6 {
@@ -4363,9 +3547,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4377,9 +3558,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_19 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_19 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_20 {
@@ -4389,9 +3567,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_20 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_20 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4403,9 +3578,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_1 {
@@ -4415,9 +3587,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4429,9 +3598,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_15 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_15 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_9 {
@@ -4441,9 +3607,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_9 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_9 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4455,9 +3618,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_11 {
@@ -4467,9 +3627,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_11 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_11 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4481,9 +3638,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_21 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_21 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_CONTROLLER_DATA_13 {
@@ -4493,9 +3647,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_13 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_13 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4507,9 +3658,6 @@ impl Default for NVME_IDENTIFY_CONTROLLER_DATA_18 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_CONTROLLER_DATA_18 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_IO_COMMAND_SET {
@@ -4519,9 +3667,6 @@ impl Default for NVME_IDENTIFY_IO_COMMAND_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_IO_COMMAND_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4572,9 +3717,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_NAMESPACE_DATA_7 {
@@ -4584,9 +3726,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4598,9 +3737,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_NAMESPACE_DATA_4 {
@@ -4610,9 +3746,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4624,9 +3757,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_NAMESPACE_DATA_6 {
@@ -4636,9 +3766,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4650,9 +3777,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_NAMESPACE_DATA_5 {
@@ -4662,9 +3786,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4676,9 +3797,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_8 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_8 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_NAMESPACE_DATA_0 {
@@ -4688,9 +3806,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4704,9 +3819,6 @@ impl Default for NVME_IDENTIFY_NAMESPACE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_NAMESPACE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4723,9 +3835,6 @@ impl Default for NVME_IDENTIFY_NVM_SPECIFIC_CONTROLLER_IO_COMMAND_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_NVM_SPECIFIC_CONTROLLER_IO_COMMAND_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4746,9 +3855,6 @@ impl Default for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1 {
@@ -4758,9 +3864,6 @@ impl Default for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4772,9 +3875,6 @@ impl Default for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_IDENTIFY_SPECIFIC_NAMESPACE_IO_COMMAND_SET_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_IDENTIFY_ZNS_SPECIFIC_CONTROLLER_IO_COMMAND_SET {
@@ -4785,9 +3885,6 @@ impl Default for NVME_IDENTIFY_ZNS_SPECIFIC_CONTROLLER_IO_COMMAND_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_IDENTIFY_ZNS_SPECIFIC_CONTROLLER_IO_COMMAND_SET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_IO_COMMAND_SET_COMBINATION_REJECTED: NVME_STATUS_COMMAND_SPECIFIC_CODES = NVME_STATUS_COMMAND_SPECIFIC_CODES(43i32);
 pub const NVME_IO_COMMAND_SET_INVALID: NVME_STATUS_COMMAND_SPECIFIC_CODES = NVME_STATUS_COMMAND_SPECIFIC_CODES(44i32);
@@ -4804,9 +3901,6 @@ impl Default for NVME_LBA_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_LBA_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_LBA_FORMAT_0 {
@@ -4819,9 +3913,6 @@ impl Default for NVME_LBA_FORMAT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_LBA_FORMAT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_LBA_RANGE {
@@ -4833,9 +3924,6 @@ impl Default for NVME_LBA_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_LBA_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4853,9 +3941,6 @@ impl Default for NVME_LBA_RANGET_TYPE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_LBA_RANGET_TYPE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_LBA_RANGET_TYPE_ENTRY_0 {
@@ -4865,9 +3950,6 @@ impl Default for NVME_LBA_RANGET_TYPE_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_LBA_RANGET_TYPE_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4888,9 +3970,6 @@ impl Default for NVME_LBA_ZONE_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_LBA_ZONE_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4973,9 +4052,6 @@ impl Default for NVME_NVM_SUBSYSTEM_RESET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_NVM_SUBSYSTEM_RESET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG {
@@ -4998,9 +4074,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union NVME_OCP_DEVICE_CAPABILITIES_LOG_3 {
@@ -5012,9 +4085,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_3_0 {
@@ -5024,9 +4094,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_3_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5039,9 +4106,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
@@ -5051,9 +4115,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_5_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5066,9 +4127,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0 {
@@ -5078,9 +4136,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5093,9 +4148,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0 {
@@ -5105,9 +4157,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5120,9 +4169,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_4_0 {
@@ -5132,9 +4178,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_4_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_4_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5147,9 +4190,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
@@ -5159,9 +4199,6 @@ impl Default for NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_CAPABILITIES_LOG_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_OCP_DEVICE_CAPABILITIES_LOG_VERSION_1: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -5188,9 +4225,6 @@ impl Default for NVME_OCP_DEVICE_ERROR_RECOVERY_LOG_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_ERROR_RECOVERY_LOG_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NVME_OCP_DEVICE_ERROR_RECOVERY_LOG_VERSION_2: u32 = 2u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5207,9 +4241,6 @@ impl Default for NVME_OCP_DEVICE_FIRMWARE_ACTIVATION_HISTORY_LOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_FIRMWARE_ACTIVATION_HISTORY_LOG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_OCP_DEVICE_FIRMWARE_ACTIVATION_HISTORY_LOG_VERSION_1: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -5257,9 +4288,6 @@ impl Default for NVME_OCP_DEVICE_LATENCY_MONITOR_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_LATENCY_MONITOR_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_OCP_DEVICE_LATENCY_MONITOR_LOG_0 {
@@ -5271,9 +4299,6 @@ impl Default for NVME_OCP_DEVICE_LATENCY_MONITOR_LOG_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_LATENCY_MONITOR_LOG_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_OCP_DEVICE_LATENCY_MONITOR_LOG_0_0 {
@@ -5283,9 +4308,6 @@ impl Default for NVME_OCP_DEVICE_LATENCY_MONITOR_LOG_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_LATENCY_MONITOR_LOG_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_OCP_DEVICE_LATENCY_MONITOR_LOG_VERSION_1: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -5328,9 +4350,6 @@ impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1 {
@@ -5341,9 +4360,6 @@ impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5356,9 +4372,6 @@ impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_2 {
@@ -5369,9 +4382,6 @@ impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5384,9 +4394,6 @@ impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
@@ -5397,9 +4404,6 @@ impl Default for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_SMART_INFORMATION_LOG_V3_3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_OCP_DEVICE_SMART_INFORMATION_LOG_VERSION_3: u32 = 3u32;
 #[repr(C, packed(1))]
@@ -5432,9 +4436,6 @@ impl Default for NVME_OCP_DEVICE_TCG_CONFIGURATION_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_TCG_CONFIGURATION_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_OCP_DEVICE_TCG_CONFIGURATION_LOG_0 {
@@ -5446,9 +4447,6 @@ impl Default for NVME_OCP_DEVICE_TCG_CONFIGURATION_LOG_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_TCG_CONFIGURATION_LOG_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_OCP_DEVICE_TCG_CONFIGURATION_LOG_0_0 {
@@ -5458,9 +4456,6 @@ impl Default for NVME_OCP_DEVICE_TCG_CONFIGURATION_LOG_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_TCG_CONFIGURATION_LOG_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_OCP_DEVICE_TCG_CONFIGURATION_LOG_VERSION_1: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -5479,9 +4474,6 @@ impl Default for NVME_OCP_DEVICE_TCG_HISTORY_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_OCP_DEVICE_TCG_HISTORY_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NVME_OCP_DEVICE_TCG_HISTORY_LOG_VERSION_1: u32 = 1u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5497,9 +4489,6 @@ impl Default for NVME_OCP_DEVICE_UNSUPPORTED_REQUIREMENTS_LOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_OCP_DEVICE_UNSUPPORTED_REQUIREMENTS_LOG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_OCP_DEVICE_UNSUPPORTED_REQUIREMENTS_LOG_VERSION_1: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -5519,9 +4508,6 @@ impl Default for NVME_PERSISTENT_EVENT_LOG_EVENT_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_PERSISTENT_EVENT_LOG_EVENT_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5551,9 +4537,6 @@ impl Default for NVME_PERSISTENT_EVENT_LOG_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_PERSISTENT_EVENT_LOG_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_PERSISTENT_EVENT_TYPE_CHANGE_NAMESPACE: NVME_PERSISTENT_EVENT_LOG_EVENT_TYPES = NVME_PERSISTENT_EVENT_LOG_EVENT_TYPES(6i32);
 pub const NVME_PERSISTENT_EVENT_TYPE_FIRMWARE_COMMIT: NVME_PERSISTENT_EVENT_LOG_EVENT_TYPES = NVME_PERSISTENT_EVENT_LOG_EVENT_TYPES(2i32);
@@ -5600,9 +4583,6 @@ impl Default for NVME_POWER_STATE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_POWER_STATE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NVME_PROTECTION_INFORMATION_NOT_ENABLED: NVME_PROTECTION_INFORMATION_TYPES = NVME_PROTECTION_INFORMATION_TYPES(0i32);
 pub const NVME_PROTECTION_INFORMATION_TYPE1: NVME_PROTECTION_INFORMATION_TYPES = NVME_PROTECTION_INFORMATION_TYPES(1i32);
 pub const NVME_PROTECTION_INFORMATION_TYPE2: NVME_PROTECTION_INFORMATION_TYPES = NVME_PROTECTION_INFORMATION_TYPES(2i32);
@@ -5621,9 +4601,6 @@ impl Default for NVME_PRP_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_PRP_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_PRP_ENTRY_0 {
@@ -5633,9 +4610,6 @@ impl Default for NVME_PRP_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_PRP_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5651,9 +4625,6 @@ impl Default for NVME_REGISTERED_CONTROLLER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_REGISTERED_CONTROLLER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_REGISTERED_CONTROLLER_DATA_0 {
@@ -5663,9 +4634,6 @@ impl Default for NVME_REGISTERED_CONTROLLER_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_REGISTERED_CONTROLLER_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5682,9 +4650,6 @@ impl Default for NVME_REGISTERED_CONTROLLER_EXTENDED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_REGISTERED_CONTROLLER_EXTENDED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_REGISTERED_CONTROLLER_EXTENDED_DATA_0 {
@@ -5694,9 +4659,6 @@ impl Default for NVME_REGISTERED_CONTROLLER_EXTENDED_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_REGISTERED_CONTROLLER_EXTENDED_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5709,9 +4671,6 @@ impl Default for NVME_REPORT_ZONE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_REPORT_ZONE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5730,9 +4689,6 @@ impl Default for NVME_RESERVATION_ACQUIRE_DATA_STRUCTURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_RESERVATION_ACQUIRE_DATA_STRUCTURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_RESERVATION_NOTIFICATION_LOG {
@@ -5747,9 +4703,6 @@ impl Default for NVME_RESERVATION_NOTIFICATION_LOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_RESERVATION_NOTIFICATION_LOG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5775,9 +4728,6 @@ impl Default for NVME_RESERVATION_REGISTER_DATA_STRUCTURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_RESERVATION_REGISTER_DATA_STRUCTURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NVME_RESERVATION_REGISTER_PTPL_STATE_CHANGES(pub i32);
@@ -5800,9 +4750,6 @@ impl Default for NVME_RESERVATION_RELEASE_DATA_STRUCTURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_RESERVATION_RELEASE_DATA_STRUCTURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_RESERVATION_REPORT_STATUS_DATA_STRUCTURE {
@@ -5813,9 +4760,6 @@ impl Default for NVME_RESERVATION_REPORT_STATUS_DATA_STRUCTURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_RESERVATION_REPORT_STATUS_DATA_STRUCTURE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5828,9 +4772,6 @@ impl Default for NVME_RESERVATION_REPORT_STATUS_EXTENDED_DATA_STRUCTURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_RESERVATION_REPORT_STATUS_EXTENDED_DATA_STRUCTURE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5846,9 +4787,6 @@ impl Default for NVME_RESERVATION_REPORT_STATUS_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_RESERVATION_REPORT_STATUS_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5886,9 +4824,6 @@ impl Default for NVME_SANITIZE_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_SANITIZE_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_SANITIZE_STATUS_LOG {
@@ -5908,9 +4843,6 @@ impl Default for NVME_SANITIZE_STATUS_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_SANITIZE_STATUS_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_SCSI_NAME_STRING {
@@ -5923,9 +4855,6 @@ impl Default for NVME_SCSI_NAME_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_SCSI_NAME_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_SECURE_ERASE_CRYPTOGRAPHIC: NVME_SECURE_ERASE_SETTINGS = NVME_SECURE_ERASE_SETTINGS(2i32);
 pub const NVME_SECURE_ERASE_NONE: NVME_SECURE_ERASE_SETTINGS = NVME_SECURE_ERASE_SETTINGS(0i32);
@@ -5949,9 +4878,6 @@ impl Default for NVME_SET_ATTRIBUTES_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_SET_ATTRIBUTES_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_STATE_ZSC: ZONE_STATE = ZONE_STATE(4i32);
 pub const NVME_STATE_ZSE: ZONE_STATE = ZONE_STATE(1i32);
@@ -6086,9 +5012,6 @@ impl Default for NVME_SUBMISSION_QUEUE_TAIL_DOORBELL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_SUBMISSION_QUEUE_TAIL_DOORBELL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_SUBMISSION_QUEUE_TAIL_DOORBELL_0 {
@@ -6098,9 +5021,6 @@ impl Default for NVME_SUBMISSION_QUEUE_TAIL_DOORBELL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_SUBMISSION_QUEUE_TAIL_DOORBELL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6122,9 +5042,6 @@ impl Default for NVME_TELEMETRY_CONTROLLER_INITIATED_LOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_TELEMETRY_CONTROLLER_INITIATED_LOG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_TELEMETRY_DATA_BLOCK_SIZE: u32 = 512u32;
 #[repr(C)]
@@ -6149,9 +5066,6 @@ impl Default for NVME_TELEMETRY_HOST_INITIATED_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_TELEMETRY_HOST_INITIATED_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NVME_TEMPERATURE_OVER_THRESHOLD: NVME_TEMPERATURE_THRESHOLD_TYPES = NVME_TEMPERATURE_THRESHOLD_TYPES(0i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6171,9 +5085,6 @@ impl Default for NVME_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_VERSION_0 {
@@ -6184,9 +5095,6 @@ impl Default for NVME_VERSION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_VERSION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct NVME_WCS_DEVICE_CAPABILITIES {
@@ -6196,9 +5104,6 @@ impl Default for NVME_WCS_DEVICE_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_WCS_DEVICE_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6211,9 +5116,6 @@ impl Default for NVME_WCS_DEVICE_CAPABILITIES_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_WCS_DEVICE_CAPABILITIES_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_WCS_DEVICE_CAPABILITIES_0_0 {
@@ -6223,9 +5125,6 @@ impl Default for NVME_WCS_DEVICE_CAPABILITIES_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_WCS_DEVICE_CAPABILITIES_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -6248,9 +5147,6 @@ impl Default for NVME_WCS_DEVICE_ERROR_RECOVERY_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_WCS_DEVICE_ERROR_RECOVERY_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NVME_WCS_DEVICE_ERROR_RECOVERY_LOG_VERSION_1: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6268,9 +5164,6 @@ impl Default for NVME_WCS_DEVICE_RESET_ACTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_WCS_DEVICE_RESET_ACTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NVME_WCS_DEVICE_RESET_ACTION_0 {
@@ -6282,9 +5175,6 @@ impl Default for NVME_WCS_DEVICE_RESET_ACTION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_WCS_DEVICE_RESET_ACTION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_WCS_DEVICE_RESET_ACTION_0_0 {
@@ -6294,9 +5184,6 @@ impl Default for NVME_WCS_DEVICE_RESET_ACTION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_WCS_DEVICE_RESET_ACTION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -6309,9 +5196,6 @@ impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -6350,9 +5234,6 @@ impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1 {
@@ -6363,9 +5244,6 @@ impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6378,9 +5256,6 @@ impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_2 {
@@ -6391,9 +5266,6 @@ impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6406,9 +5278,6 @@ impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
@@ -6419,9 +5288,6 @@ impl Default for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_V2_3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVME_WCS_DEVICE_SMART_ATTRIBUTES_LOG_VERSION_2: u32 = 2u32;
 #[repr(C)]
@@ -6441,9 +5307,6 @@ impl Default for NVME_ZONE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_ZONE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_ZONE_DESCRIPTOR_0 {
@@ -6453,9 +5316,6 @@ impl Default for NVME_ZONE_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_ZONE_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6467,9 +5327,6 @@ impl Default for NVME_ZONE_DESCRIPTOR_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_ZONE_DESCRIPTOR_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_ZONE_DESCRIPTOR_2 {
@@ -6479,9 +5336,6 @@ impl Default for NVME_ZONE_DESCRIPTOR_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_ZONE_DESCRIPTOR_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6493,9 +5347,6 @@ impl Default for NVME_ZONE_DESCRIPTOR_EXTENSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVME_ZONE_DESCRIPTOR_EXTENSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVME_ZONE_EXTENDED_REPORT_ZONE_DESC {
@@ -6506,9 +5357,6 @@ impl Default for NVME_ZONE_EXTENDED_REPORT_ZONE_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVME_ZONE_EXTENDED_REPORT_ZONE_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6546,9 +5394,6 @@ impl Default for NVM_RESERVATION_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NVM_RESERVATION_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NVM_RESERVATION_CAPABILITIES_0 {
@@ -6558,9 +5403,6 @@ impl Default for NVM_RESERVATION_CAPABILITIES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVM_RESERVATION_CAPABILITIES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6573,9 +5415,6 @@ impl Default for NVM_SET_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NVM_SET_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVMeDeviceRecovery1Max: NVME_WCS_DEVICE_RECOVERY_ACTION1 = NVME_WCS_DEVICE_RECOVERY_ACTION1(15i32);
 pub const NVMeDeviceRecovery2Max: NVME_WCS_DEVICE_RECOVERY_ACTION2 = NVME_WCS_DEVICE_RECOVERY_ACTION2(15i32);
@@ -6601,9 +5440,6 @@ impl Default for TCG_ACTIVATE_METHOD_SPECIFIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCG_ACTIVATE_METHOD_SPECIFIC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct TCG_ASSIGN_METHOD_SPECIFIC {
@@ -6613,9 +5449,6 @@ impl Default for TCG_ASSIGN_METHOD_SPECIFIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCG_ASSIGN_METHOD_SPECIFIC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -6628,9 +5461,6 @@ impl Default for TCG_AUTH_METHOD_SPECIFIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCG_AUTH_METHOD_SPECIFIC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCG_BLOCKSID_METHOD_SPECIFIC {
@@ -6640,9 +5470,6 @@ impl Default for TCG_BLOCKSID_METHOD_SPECIFIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCG_BLOCKSID_METHOD_SPECIFIC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -6665,9 +5492,6 @@ impl Default for TCG_HISTORY_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCG_HISTORY_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TCG_HISTORY_ENTRY_VERSION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6679,9 +5503,6 @@ impl Default for TCG_REACTIVATE_METHOD_SPECIFIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCG_REACTIVATE_METHOD_SPECIFIC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UNSUPPORTED_REQUIREMENT {
@@ -6691,9 +5512,6 @@ impl Default for UNSUPPORTED_REQUIREMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UNSUPPORTED_REQUIREMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Storage/OperationRecorder/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/OperationRecorder/mod.rs
@@ -21,9 +21,6 @@ impl Default for OPERATION_END_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPERATION_END_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct OPERATION_END_PARAMETERS_FLAGS(pub u32);
@@ -107,8 +104,5 @@ impl Default for OPERATION_START_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPERATION_START_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPERATION_START_TRACE_CURRENT_THREAD: OPERATION_START_FLAGS = OPERATION_START_FLAGS(1u32);

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
@@ -500,9 +500,6 @@ impl Default for APPX_ENCRYPTED_EXEMPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APPX_ENCRYPTED_EXEMPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct APPX_ENCRYPTED_PACKAGE_OPTIONS(pub i32);
@@ -557,10 +554,6 @@ impl Default for APPX_ENCRYPTED_PACKAGE_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for APPX_ENCRYPTED_PACKAGE_SETTINGS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Debug, PartialEq)]
@@ -575,10 +568,6 @@ impl Default for APPX_ENCRYPTED_PACKAGE_SETTINGS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for APPX_ENCRYPTED_PACKAGE_SETTINGS2 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -600,9 +589,6 @@ impl Default for APPX_KEY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APPX_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -678,10 +664,6 @@ impl Default for APPX_PACKAGE_SETTINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for APPX_PACKAGE_SETTINGS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Debug, PartialEq)]
@@ -696,10 +678,6 @@ impl Default for APPX_PACKAGE_WRITER_PAYLOAD_STREAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for APPX_PACKAGE_WRITER_PAYLOAD_STREAM {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6859,10 +6837,6 @@ impl Default for PACKAGE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for PACKAGE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -6881,10 +6855,6 @@ impl Default for PACKAGE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for PACKAGE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -6902,10 +6872,6 @@ impl Default for PACKAGE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for PACKAGE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -6922,10 +6888,6 @@ impl Default for PACKAGE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for PACKAGE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PACKAGE_INFORMATION_BASIC: u32 = 0u32;
 pub const PACKAGE_INFORMATION_FULL: u32 = 256u32;
@@ -6960,9 +6922,6 @@ impl Default for PACKAGE_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PACKAGE_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub union PACKAGE_VERSION_0 {
@@ -6973,9 +6932,6 @@ impl Default for PACKAGE_VERSION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PACKAGE_VERSION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6989,9 +6945,6 @@ impl Default for PACKAGE_VERSION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PACKAGE_VERSION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PACKAGE_VERSION_MAX_LENGTH: u32 = 23u32;
 pub const PACKAGE_VERSION_MIN_LENGTH: u32 = 7u32;
@@ -7092,7 +7045,4 @@ impl Default for _PACKAGE_INFO_REFERENCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _PACKAGE_INFO_REFERENCE {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
@@ -151,9 +151,6 @@ impl Default for PRJ_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRJ_CALLBACK_DATA {
@@ -174,9 +171,6 @@ impl Default for PRJ_CALLBACK_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_CALLBACK_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PRJ_CALLBACK_DATA_FLAGS(pub i32);
@@ -194,9 +188,6 @@ impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
@@ -208,9 +199,6 @@ impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
@@ -221,9 +209,6 @@ impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
@@ -233,9 +218,6 @@ impl Default for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRJ_COMPLETE_COMMAND_EXTENDED_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -271,9 +253,6 @@ impl Default for PRJ_EXTENDED_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_EXTENDED_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PRJ_EXTENDED_INFO_0 {
@@ -284,9 +263,6 @@ impl Default for PRJ_EXTENDED_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_EXTENDED_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRJ_EXTENDED_INFO_0_0 {
@@ -296,9 +272,6 @@ impl Default for PRJ_EXTENDED_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRJ_EXTENDED_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -319,9 +292,6 @@ impl Default for PRJ_FILE_BASIC_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRJ_FILE_BASIC_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -408,9 +378,6 @@ impl Default for PRJ_NOTIFICATION_MAPPING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_NOTIFICATION_MAPPING {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PRJ_NOTIFICATION_NEW_FILE_CREATED: PRJ_NOTIFICATION = PRJ_NOTIFICATION(4i32);
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -424,9 +391,6 @@ impl Default for PRJ_NOTIFICATION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_NOTIFICATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRJ_NOTIFICATION_PARAMETERS_2 {
@@ -436,9 +400,6 @@ impl Default for PRJ_NOTIFICATION_PARAMETERS_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRJ_NOTIFICATION_PARAMETERS_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -450,9 +411,6 @@ impl Default for PRJ_NOTIFICATION_PARAMETERS_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_NOTIFICATION_PARAMETERS_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRJ_NOTIFICATION_PARAMETERS_0 {
@@ -462,9 +420,6 @@ impl Default for PRJ_NOTIFICATION_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRJ_NOTIFICATION_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRJ_NOTIFICATION_PRE_DELETE: PRJ_NOTIFICATION = PRJ_NOTIFICATION(16i32);
 pub const PRJ_NOTIFICATION_PRE_RENAME: PRJ_NOTIFICATION = PRJ_NOTIFICATION(32i32);
@@ -539,9 +494,6 @@ impl Default for PRJ_PLACEHOLDER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_PLACEHOLDER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRJ_PLACEHOLDER_INFO_0 {
@@ -552,9 +504,6 @@ impl Default for PRJ_PLACEHOLDER_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRJ_PLACEHOLDER_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -567,9 +516,6 @@ impl Default for PRJ_PLACEHOLDER_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_PLACEHOLDER_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRJ_PLACEHOLDER_INFO_2 {
@@ -581,9 +527,6 @@ impl Default for PRJ_PLACEHOLDER_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRJ_PLACEHOLDER_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRJ_PLACEHOLDER_VERSION_INFO {
@@ -594,9 +537,6 @@ impl Default for PRJ_PLACEHOLDER_VERSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRJ_PLACEHOLDER_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PRJ_QUERY_FILE_NAME_CB = Option<unsafe extern "system" fn(callbackdata: *const PRJ_CALLBACK_DATA) -> windows_core::HRESULT>;
 #[repr(transparent)]
@@ -648,9 +588,6 @@ impl Default for PRJ_STARTVIRTUALIZING_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRJ_STARTVIRTUALIZING_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PRJ_START_DIRECTORY_ENUMERATION_CB = Option<unsafe extern "system" fn(callbackdata: *const PRJ_CALLBACK_DATA, enumerationid: *const windows_core::GUID) -> windows_core::HRESULT>;
 pub const PRJ_UPDATE_ALLOW_DIRTY_DATA: PRJ_UPDATE_TYPES = PRJ_UPDATE_TYPES(2i32);
@@ -748,7 +685,4 @@ impl Default for PRJ_VIRTUALIZATION_INSTANCE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRJ_VIRTUALIZATION_INSTANCE_INFO {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
@@ -213,9 +213,6 @@ impl Default for APPLY_SNAPSHOT_VHDSET_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APPLY_SNAPSHOT_VHDSET_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union APPLY_SNAPSHOT_VHDSET_PARAMETERS_0 {
@@ -225,9 +222,6 @@ impl Default for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -239,9 +233,6 @@ impl Default for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APPLY_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -307,9 +298,6 @@ impl Default for ATTACH_VIRTUAL_DISK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATTACH_VIRTUAL_DISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ATTACH_VIRTUAL_DISK_PARAMETERS_0 {
@@ -321,9 +309,6 @@ impl Default for ATTACH_VIRTUAL_DISK_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ATTACH_VIRTUAL_DISK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ATTACH_VIRTUAL_DISK_PARAMETERS_0_0 {
@@ -333,9 +318,6 @@ impl Default for ATTACH_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATTACH_VIRTUAL_DISK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -347,9 +329,6 @@ impl Default for ATTACH_VIRTUAL_DISK_PARAMETERS_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ATTACH_VIRTUAL_DISK_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -407,9 +386,6 @@ impl Default for COMPACT_VIRTUAL_DISK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMPACT_VIRTUAL_DISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union COMPACT_VIRTUAL_DISK_PARAMETERS_0 {
@@ -420,9 +396,6 @@ impl Default for COMPACT_VIRTUAL_DISK_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMPACT_VIRTUAL_DISK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COMPACT_VIRTUAL_DISK_PARAMETERS_0_0 {
@@ -432,9 +405,6 @@ impl Default for COMPACT_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COMPACT_VIRTUAL_DISK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -500,9 +470,6 @@ impl Default for CREATE_VIRTUAL_DISK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREATE_VIRTUAL_DISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CREATE_VIRTUAL_DISK_PARAMETERS_0 {
@@ -515,9 +482,6 @@ impl Default for CREATE_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_VIRTUAL_DISK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -533,9 +497,6 @@ impl Default for CREATE_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_VIRTUAL_DISK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -556,9 +517,6 @@ impl Default for CREATE_VIRTUAL_DISK_PARAMETERS_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_VIRTUAL_DISK_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -581,9 +539,6 @@ impl Default for CREATE_VIRTUAL_DISK_PARAMETERS_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_VIRTUAL_DISK_PARAMETERS_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -608,9 +563,6 @@ impl Default for CREATE_VIRTUAL_DISK_PARAMETERS_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_VIRTUAL_DISK_PARAMETERS_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CREATE_VIRTUAL_DISK_PARAMETERS_DEFAULT_BLOCK_SIZE: u32 = 0u32;
 pub const CREATE_VIRTUAL_DISK_PARAMETERS_DEFAULT_SECTOR_SIZE: u32 = 0u32;
@@ -671,9 +623,6 @@ impl Default for DELETE_SNAPSHOT_VHDSET_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DELETE_SNAPSHOT_VHDSET_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DELETE_SNAPSHOT_VHDSET_PARAMETERS_0 {
@@ -684,9 +633,6 @@ impl Default for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DELETE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
@@ -696,9 +642,6 @@ impl Default for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DELETE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -842,9 +785,6 @@ impl Default for EXPAND_VIRTUAL_DISK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXPAND_VIRTUAL_DISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EXPAND_VIRTUAL_DISK_PARAMETERS_0 {
@@ -855,9 +795,6 @@ impl Default for EXPAND_VIRTUAL_DISK_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXPAND_VIRTUAL_DISK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXPAND_VIRTUAL_DISK_PARAMETERS_0_0 {
@@ -867,9 +804,6 @@ impl Default for EXPAND_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXPAND_VIRTUAL_DISK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -925,9 +859,6 @@ impl Default for FORK_VIRTUAL_DISK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FORK_VIRTUAL_DISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FORK_VIRTUAL_DISK_PARAMETERS_0 {
@@ -938,9 +869,6 @@ impl Default for FORK_VIRTUAL_DISK_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FORK_VIRTUAL_DISK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FORK_VIRTUAL_DISK_PARAMETERS_0_0 {
@@ -950,9 +878,6 @@ impl Default for FORK_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FORK_VIRTUAL_DISK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1009,9 +934,6 @@ impl Default for GET_VIRTUAL_DISK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union GET_VIRTUAL_DISK_INFO_0 {
@@ -1036,9 +958,6 @@ impl Default for GET_VIRTUAL_DISK_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_VIRTUAL_DISK_INFO_0_3 {
@@ -1051,9 +970,6 @@ impl Default for GET_VIRTUAL_DISK_INFO_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_VIRTUAL_DISK_INFO_0_1 {
@@ -1064,9 +980,6 @@ impl Default for GET_VIRTUAL_DISK_INFO_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1080,9 +993,6 @@ impl Default for GET_VIRTUAL_DISK_INFO_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_VIRTUAL_DISK_INFO_0_0 {
@@ -1095,9 +1005,6 @@ impl Default for GET_VIRTUAL_DISK_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GET_VIRTUAL_DISK_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GET_VIRTUAL_DISK_INFO_CHANGE_TRACKING_STATE: GET_VIRTUAL_DISK_INFO_VERSION = GET_VIRTUAL_DISK_INFO_VERSION(15i32);
 pub const GET_VIRTUAL_DISK_INFO_FRAGMENTATION: GET_VIRTUAL_DISK_INFO_VERSION = GET_VIRTUAL_DISK_INFO_VERSION(12i32);
@@ -1167,9 +1074,6 @@ impl Default for MERGE_VIRTUAL_DISK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MERGE_VIRTUAL_DISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MERGE_VIRTUAL_DISK_PARAMETERS_0 {
@@ -1181,9 +1085,6 @@ impl Default for MERGE_VIRTUAL_DISK_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MERGE_VIRTUAL_DISK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MERGE_VIRTUAL_DISK_PARAMETERS_0_0 {
@@ -1193,9 +1094,6 @@ impl Default for MERGE_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MERGE_VIRTUAL_DISK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1207,9 +1105,6 @@ impl Default for MERGE_VIRTUAL_DISK_PARAMETERS_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MERGE_VIRTUAL_DISK_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1269,9 +1164,6 @@ impl Default for MIRROR_VIRTUAL_DISK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIRROR_VIRTUAL_DISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MIRROR_VIRTUAL_DISK_PARAMETERS_0 {
@@ -1282,9 +1174,6 @@ impl Default for MIRROR_VIRTUAL_DISK_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIRROR_VIRTUAL_DISK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIRROR_VIRTUAL_DISK_PARAMETERS_0_0 {
@@ -1294,9 +1183,6 @@ impl Default for MIRROR_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIRROR_VIRTUAL_DISK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1353,9 +1239,6 @@ impl Default for MODIFY_VHDSET_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MODIFY_VHDSET_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MODIFY_VHDSET_PARAMETERS_0 {
@@ -1368,9 +1251,6 @@ impl Default for MODIFY_VHDSET_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MODIFY_VHDSET_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MODIFY_VHDSET_PARAMETERS_0_0 {
@@ -1381,9 +1261,6 @@ impl Default for MODIFY_VHDSET_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MODIFY_VHDSET_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MODIFY_VHDSET_REMOVE_SNAPSHOT: MODIFY_VHDSET_VERSION = MODIFY_VHDSET_VERSION(2i32);
 pub const MODIFY_VHDSET_SNAPSHOT_PATH: MODIFY_VHDSET_VERSION = MODIFY_VHDSET_VERSION(1i32);
@@ -1451,9 +1328,6 @@ impl Default for OPEN_VIRTUAL_DISK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPEN_VIRTUAL_DISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union OPEN_VIRTUAL_DISK_PARAMETERS_0 {
@@ -1466,9 +1340,6 @@ impl Default for OPEN_VIRTUAL_DISK_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPEN_VIRTUAL_DISK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OPEN_VIRTUAL_DISK_PARAMETERS_0_0 {
@@ -1478,9 +1349,6 @@ impl Default for OPEN_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPEN_VIRTUAL_DISK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1494,9 +1362,6 @@ impl Default for OPEN_VIRTUAL_DISK_PARAMETERS_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPEN_VIRTUAL_DISK_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OPEN_VIRTUAL_DISK_PARAMETERS_0_2 {
@@ -1509,9 +1374,6 @@ impl Default for OPEN_VIRTUAL_DISK_PARAMETERS_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OPEN_VIRTUAL_DISK_PARAMETERS_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPEN_VIRTUAL_DISK_RW_DEPTH_DEFAULT: u32 = 1u32;
 #[repr(transparent)]
@@ -1570,9 +1432,6 @@ impl Default for QUERY_CHANGES_VIRTUAL_DISK_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUERY_CHANGES_VIRTUAL_DISK_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct RAW_SCSI_VIRTUAL_DISK_FLAG(pub i32);
@@ -1621,9 +1480,6 @@ impl Default for RAW_SCSI_VIRTUAL_DISK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAW_SCSI_VIRTUAL_DISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0 {
@@ -1633,9 +1489,6 @@ impl Default for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1655,9 +1508,6 @@ impl Default for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAW_SCSI_VIRTUAL_DISK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RAW_SCSI_VIRTUAL_DISK_RESPONSE {
@@ -1669,9 +1519,6 @@ impl Default for RAW_SCSI_VIRTUAL_DISK_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAW_SCSI_VIRTUAL_DISK_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RAW_SCSI_VIRTUAL_DISK_RESPONSE_0 {
@@ -1681,9 +1528,6 @@ impl Default for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1696,9 +1540,6 @@ impl Default for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAW_SCSI_VIRTUAL_DISK_RESPONSE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1755,9 +1596,6 @@ impl Default for RESIZE_VIRTUAL_DISK_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESIZE_VIRTUAL_DISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RESIZE_VIRTUAL_DISK_PARAMETERS_0 {
@@ -1768,9 +1606,6 @@ impl Default for RESIZE_VIRTUAL_DISK_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESIZE_VIRTUAL_DISK_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RESIZE_VIRTUAL_DISK_PARAMETERS_0_0 {
@@ -1780,9 +1615,6 @@ impl Default for RESIZE_VIRTUAL_DISK_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESIZE_VIRTUAL_DISK_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1800,9 +1632,6 @@ impl Default for SET_VIRTUAL_DISK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SET_VIRTUAL_DISK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SET_VIRTUAL_DISK_INFO_0 {
@@ -1819,9 +1648,6 @@ impl Default for SET_VIRTUAL_DISK_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SET_VIRTUAL_DISK_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SET_VIRTUAL_DISK_INFO_0_1 {
@@ -1833,9 +1659,6 @@ impl Default for SET_VIRTUAL_DISK_INFO_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SET_VIRTUAL_DISK_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SET_VIRTUAL_DISK_INFO_0_0 {
@@ -1846,9 +1669,6 @@ impl Default for SET_VIRTUAL_DISK_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SET_VIRTUAL_DISK_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SET_VIRTUAL_DISK_INFO_CHANGE_TRACKING_STATE: SET_VIRTUAL_DISK_INFO_VERSION = SET_VIRTUAL_DISK_INFO_VERSION(6i32);
 pub const SET_VIRTUAL_DISK_INFO_IDENTIFIER: SET_VIRTUAL_DISK_INFO_VERSION = SET_VIRTUAL_DISK_INFO_VERSION(2i32);
@@ -1873,9 +1693,6 @@ impl Default for STORAGE_DEPENDENCY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_DEPENDENCY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_DEPENDENCY_INFO_0 {
@@ -1886,9 +1703,6 @@ impl Default for STORAGE_DEPENDENCY_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEPENDENCY_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1901,9 +1715,6 @@ impl Default for STORAGE_DEPENDENCY_INFO_TYPE_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEPENDENCY_INFO_TYPE_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1921,9 +1732,6 @@ impl Default for STORAGE_DEPENDENCY_INFO_TYPE_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEPENDENCY_INFO_TYPE_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1980,9 +1788,6 @@ impl Default for TAKE_SNAPSHOT_VHDSET_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TAKE_SNAPSHOT_VHDSET_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TAKE_SNAPSHOT_VHDSET_PARAMETERS_0 {
@@ -1993,9 +1798,6 @@ impl Default for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TAKE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
@@ -2005,9 +1807,6 @@ impl Default for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TAKE_SNAPSHOT_VHDSET_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2073,9 +1872,6 @@ impl Default for VIRTUAL_DISK_PROGRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_DISK_PROGRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_STORAGE_TYPE {
@@ -2086,9 +1882,6 @@ impl Default for VIRTUAL_STORAGE_TYPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_STORAGE_TYPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VIRTUAL_STORAGE_TYPE_DEVICE_ISO: u32 = 1u32;
 pub const VIRTUAL_STORAGE_TYPE_DEVICE_UNKNOWN: u32 = 0u32;

--- a/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
@@ -11,9 +11,6 @@ impl Default for CHANGE_ATTRIBUTES_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGE_ATTRIBUTES_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CHANGE_ATTRIBUTES_PARAMETERS_0 {
@@ -25,9 +22,6 @@ impl Default for CHANGE_ATTRIBUTES_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGE_ATTRIBUTES_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CHANGE_ATTRIBUTES_PARAMETERS_0_1 {
@@ -38,9 +32,6 @@ impl Default for CHANGE_ATTRIBUTES_PARAMETERS_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGE_ATTRIBUTES_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CHANGE_ATTRIBUTES_PARAMETERS_0_0 {
@@ -50,9 +41,6 @@ impl Default for CHANGE_ATTRIBUTES_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANGE_ATTRIBUTES_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -65,9 +53,6 @@ impl Default for CHANGE_PARTITION_TYPE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGE_PARTITION_TYPE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CHANGE_PARTITION_TYPE_PARAMETERS_0 {
@@ -79,9 +64,6 @@ impl Default for CHANGE_PARTITION_TYPE_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGE_PARTITION_TYPE_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CHANGE_PARTITION_TYPE_PARAMETERS_0_1 {
@@ -92,9 +74,6 @@ impl Default for CHANGE_PARTITION_TYPE_PARAMETERS_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGE_PARTITION_TYPE_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CHANGE_PARTITION_TYPE_PARAMETERS_0_0 {
@@ -104,9 +83,6 @@ impl Default for CHANGE_PARTITION_TYPE_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANGE_PARTITION_TYPE_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLSID_VdsLoader: windows_core::GUID = windows_core::GUID::from_u128(0x9c38ed61_d565_4728_aeee_c80952f0ecde);
 pub const CLSID_VdsService: windows_core::GUID = windows_core::GUID::from_u128(0x7d1933cb_86f6_4a98_8628_01be94c9a575);
@@ -121,9 +97,6 @@ impl Default for CREATE_PARTITION_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREATE_PARTITION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CREATE_PARTITION_PARAMETERS_0 {
@@ -134,9 +107,6 @@ impl Default for CREATE_PARTITION_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_PARTITION_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -151,9 +121,6 @@ impl Default for CREATE_PARTITION_PARAMETERS_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREATE_PARTITION_PARAMETERS_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CREATE_PARTITION_PARAMETERS_0_0 {
@@ -164,9 +131,6 @@ impl Default for CREATE_PARTITION_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_PARTITION_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GPT_PARTITION_NAME_LENGTH: u32 = 36u32;
 windows_core::imp::define_interface!(IEnumVdsObject, IEnumVdsObject_Vtbl, 0x118610b7_8d94_4030_b5b8_500889788e4e);
@@ -5542,9 +5506,6 @@ impl Default for VDS_ADVANCEDDISK_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_ADVANCEDDISK_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VDS_ADVANCEDDISK_PROP_0 {
@@ -5555,9 +5516,6 @@ impl Default for VDS_ADVANCEDDISK_PROP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_ADVANCEDDISK_PROP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VDS_ASYNCOUT_ADDLUNPLEX: VDS_ASYNC_OUTPUT_TYPE = VDS_ASYNC_OUTPUT_TYPE(52i32);
 pub const VDS_ASYNCOUT_ADDPORTAL: VDS_ASYNC_OUTPUT_TYPE = VDS_ASYNC_OUTPUT_TYPE(65i32);
@@ -5606,9 +5564,6 @@ impl Default for VDS_ASYNC_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union VDS_ASYNC_OUTPUT_0 {
     pub cp: VDS_ASYNC_OUTPUT_0_0,
@@ -5630,9 +5585,6 @@ impl Default for VDS_ASYNC_OUTPUT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct VDS_ASYNC_OUTPUT_0_2 {
@@ -5643,9 +5595,6 @@ impl Default for VDS_ASYNC_OUTPUT_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_2 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct VDS_ASYNC_OUTPUT_0_4 {
@@ -5655,9 +5604,6 @@ impl Default for VDS_ASYNC_OUTPUT_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_4 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5670,9 +5616,6 @@ impl Default for VDS_ASYNC_OUTPUT_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct VDS_ASYNC_OUTPUT_0_6 {
@@ -5682,9 +5625,6 @@ impl Default for VDS_ASYNC_OUTPUT_0_6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_6 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -5696,9 +5636,6 @@ impl Default for VDS_ASYNC_OUTPUT_0_5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_5 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct VDS_ASYNC_OUTPUT_0_1 {
@@ -5708,9 +5645,6 @@ impl Default for VDS_ASYNC_OUTPUT_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_1 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -5722,9 +5656,6 @@ impl Default for VDS_ASYNC_OUTPUT_0_7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_7 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_ASYNC_OUTPUT_0_3 {
@@ -5734,9 +5665,6 @@ impl Default for VDS_ASYNC_OUTPUT_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_ASYNC_OUTPUT_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5753,9 +5681,6 @@ impl Default for VDS_CONTROLLER_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_CONTROLLER_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_CONTROLLER_PROP {
@@ -5770,9 +5695,6 @@ impl Default for VDS_CONTROLLER_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_CONTROLLER_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5791,9 +5713,6 @@ impl Default for VDS_CREATE_VDISK_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_CREATE_VDISK_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VDS_CS_FAILED: VDS_CONTROLLER_STATUS = VDS_CONTROLLER_STATUS(5i32);
 pub const VDS_CS_NOT_READY: VDS_CONTROLLER_STATUS = VDS_CONTROLLER_STATUS(2i32);
@@ -5843,9 +5762,6 @@ impl Default for VDS_DISK_EXTENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_DISK_EXTENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VDS_DISK_EXTENT_TYPE(pub i32);
@@ -5864,9 +5780,6 @@ impl Default for VDS_DISK_FREE_EXTENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_DISK_FREE_EXTENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_DISK_NOTIFICATION {
@@ -5877,9 +5790,6 @@ impl Default for VDS_DISK_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_DISK_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5912,9 +5822,6 @@ impl Default for VDS_DISK_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_DISK_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VDS_DISK_PROP_0 {
@@ -5925,9 +5832,6 @@ impl Default for VDS_DISK_PROP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_DISK_PROP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5959,9 +5863,6 @@ impl Default for VDS_DISK_PROP2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_DISK_PROP2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VDS_DISK_PROP2_0 {
@@ -5972,9 +5873,6 @@ impl Default for VDS_DISK_PROP2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_DISK_PROP2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5998,9 +5896,6 @@ impl Default for VDS_DRIVE_EXTENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_DRIVE_EXTENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VDS_DRIVE_FLAG(pub i32);
@@ -6019,9 +5914,6 @@ impl Default for VDS_DRIVE_LETTER_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_DRIVE_LETTER_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_DRIVE_LETTER_PROP {
@@ -6035,9 +5927,6 @@ impl Default for VDS_DRIVE_LETTER_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_DRIVE_LETTER_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_DRIVE_NOTIFICATION {
@@ -6048,9 +5937,6 @@ impl Default for VDS_DRIVE_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_DRIVE_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6069,9 +5955,6 @@ impl Default for VDS_DRIVE_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_DRIVE_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6093,9 +5976,6 @@ impl Default for VDS_DRIVE_PROP2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_DRIVE_PROP2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6482,9 +6362,6 @@ impl Default for VDS_FILE_SYSTEM_FORMAT_SUPPORT_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_FILE_SYSTEM_FORMAT_SUPPORT_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_FILE_SYSTEM_NOTIFICATION {
@@ -6496,9 +6373,6 @@ impl Default for VDS_FILE_SYSTEM_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_FILE_SYSTEM_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6515,9 +6389,6 @@ impl Default for VDS_FILE_SYSTEM_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_FILE_SYSTEM_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6539,9 +6410,6 @@ impl Default for VDS_FILE_SYSTEM_TYPE_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_FILE_SYSTEM_TYPE_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6598,9 +6466,6 @@ impl Default for VDS_HBAPORT_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_HBAPORT_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VDS_HBAPORT_SPEED_FLAG(pub i32);
@@ -6639,9 +6504,6 @@ impl Default for VDS_HINTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_HINTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6682,9 +6544,6 @@ impl Default for VDS_HINTS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_HINTS2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VDS_HINT_ALLOCATEHOTSPARE: i32 = 512i32;
 pub const VDS_HINT_BUSTYPE: i32 = 1024i32;
@@ -6782,9 +6641,6 @@ impl Default for VDS_INPUT_DISK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_INPUT_DISK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_INTERCONNECT {
@@ -6798,9 +6654,6 @@ impl Default for VDS_INTERCONNECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_INTERCONNECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6823,9 +6676,6 @@ impl Default for VDS_IPADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_IPADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6853,9 +6703,6 @@ impl Default for VDS_ISCSI_INITIATOR_ADAPTER_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_ISCSI_INITIATOR_ADAPTER_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_ISCSI_INITIATOR_PORTAL_PROP {
@@ -6867,9 +6714,6 @@ impl Default for VDS_ISCSI_INITIATOR_PORTAL_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_ISCSI_INITIATOR_PORTAL_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6884,9 +6728,6 @@ impl Default for VDS_ISCSI_IPSEC_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_ISCSI_IPSEC_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6905,9 +6746,6 @@ impl Default for VDS_ISCSI_PORTALGROUP_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_ISCSI_PORTALGROUP_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_ISCSI_PORTAL_PROP {
@@ -6919,9 +6757,6 @@ impl Default for VDS_ISCSI_PORTAL_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_ISCSI_PORTAL_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6937,9 +6772,6 @@ impl Default for VDS_ISCSI_SHARED_SECRET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_ISCSI_SHARED_SECRET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_ISCSI_TARGET_PROP {
@@ -6952,9 +6784,6 @@ impl Default for VDS_ISCSI_TARGET_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_ISCSI_TARGET_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VDS_ITF_FIBRE_CHANNEL: VDS_INTERCONNECT_FLAG = VDS_INTERCONNECT_FLAG(2i32);
 pub const VDS_ITF_ISCSI: VDS_INTERCONNECT_FLAG = VDS_INTERCONNECT_FLAG(4i32);
@@ -7071,9 +6900,6 @@ impl Default for VDS_LUN_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_LUN_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_LUN_NOTIFICATION {
@@ -7084,9 +6910,6 @@ impl Default for VDS_LUN_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_LUN_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7108,9 +6931,6 @@ impl Default for VDS_LUN_PLEX_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_LUN_PLEX_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7138,9 +6958,6 @@ impl Default for VDS_LUN_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_LUN_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VDS_LUN_RESERVE_MODE(pub i32);
@@ -7163,9 +6980,6 @@ impl Default for VDS_MOUNT_POINT_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_MOUNT_POINT_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VDS_MPS_FAILED: VDS_PATH_STATUS = VDS_PATH_STATUS(5i32);
 pub const VDS_MPS_ONLINE: VDS_PATH_STATUS = VDS_PATH_STATUS(1i32);
@@ -7250,9 +7064,6 @@ impl Default for VDS_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VDS_NOTIFICATION_0 {
@@ -7277,9 +7088,6 @@ impl Default for VDS_NOTIFICATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_NOTIFICATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7341,9 +7149,6 @@ impl Default for VDS_PACK_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_PACK_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_PACK_PROP {
@@ -7356,9 +7161,6 @@ impl Default for VDS_PACK_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PACK_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7381,9 +7183,6 @@ impl Default for VDS_PARTITION_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_PARTITION_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VDS_PARTITION_INFORMATION_EX_0 {
@@ -7394,9 +7193,6 @@ impl Default for VDS_PARTITION_INFORMATION_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PARTITION_INFORMATION_EX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7411,9 +7207,6 @@ impl Default for VDS_PARTITION_INFO_GPT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_PARTITION_INFO_GPT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_PARTITION_INFO_MBR {
@@ -7427,9 +7220,6 @@ impl Default for VDS_PARTITION_INFO_MBR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_PARTITION_INFO_MBR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_PARTITION_NOTIFICATION {
@@ -7441,9 +7231,6 @@ impl Default for VDS_PARTITION_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PARTITION_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7460,9 +7247,6 @@ impl Default for VDS_PARTITION_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_PARTITION_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VDS_PARTITION_PROP_0 {
@@ -7473,9 +7257,6 @@ impl Default for VDS_PARTITION_PROP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PARTITION_PROP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7494,9 +7275,6 @@ impl Default for VDS_PATH_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_PATH_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct VDS_PATH_INFO {
@@ -7512,9 +7290,6 @@ impl Default for VDS_PATH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_PATH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VDS_PATH_INFO_0 {
@@ -7525,9 +7300,6 @@ impl Default for VDS_PATH_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PATH_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7540,9 +7312,6 @@ impl Default for VDS_PATH_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_PATH_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VDS_PATH_INFO_2 {
@@ -7553,9 +7322,6 @@ impl Default for VDS_PATH_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PATH_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7568,9 +7334,6 @@ impl Default for VDS_PATH_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PATH_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7637,9 +7400,6 @@ impl Default for VDS_POOL_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_POOL_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VDS_POOL_ATTRIB_ACCS_BDW_WT_HINT: i32 = 16777216i32;
 pub const VDS_POOL_ATTRIB_ACCS_DIR_HINT: i32 = 2097152i32;
 pub const VDS_POOL_ATTRIB_ACCS_LTNCY_HINT: i32 = 8388608i32;
@@ -7679,9 +7439,6 @@ impl Default for VDS_POOL_CUSTOM_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_POOL_CUSTOM_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_PORTAL_GROUP_NOTIFICATION {
@@ -7692,9 +7449,6 @@ impl Default for VDS_PORTAL_GROUP_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PORTAL_GROUP_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7707,9 +7461,6 @@ impl Default for VDS_PORTAL_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_PORTAL_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_PORT_NOTIFICATION {
@@ -7720,9 +7471,6 @@ impl Default for VDS_PORT_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PORT_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7736,9 +7484,6 @@ impl Default for VDS_PORT_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PORT_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7765,9 +7510,6 @@ impl Default for VDS_PROVIDER_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_PROVIDER_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7818,9 +7560,6 @@ impl Default for VDS_REPARSE_POINT_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_REPARSE_POINT_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VDS_RT_RAID0: VDS_RAID_TYPE = VDS_RAID_TYPE(10i32);
 pub const VDS_RT_RAID01: VDS_RAID_TYPE = VDS_RAID_TYPE(17i32);
 pub const VDS_RT_RAID03: VDS_RAID_TYPE = VDS_RAID_TYPE(18i32);
@@ -7857,9 +7596,6 @@ impl Default for VDS_SERVICE_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_SERVICE_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_SERVICE_PROP {
@@ -7870,9 +7606,6 @@ impl Default for VDS_SERVICE_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_SERVICE_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VDS_SF_CONSISTENCY_CHECK_CAPABLE: VDS_SUB_SYSTEM_FLAG = VDS_SUB_SYSTEM_FLAG(16777216i32);
 pub const VDS_SF_DRIVE_EXTENT_CAPABLE: VDS_SUB_SYSTEM_FLAG = VDS_SUB_SYSTEM_FLAG(8i32);
@@ -7948,9 +7681,6 @@ impl Default for VDS_STORAGE_DEVICE_ID_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_STORAGE_DEVICE_ID_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_STORAGE_IDENTIFIER {
@@ -7963,9 +7693,6 @@ impl Default for VDS_STORAGE_IDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_STORAGE_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7985,9 +7712,6 @@ impl Default for VDS_STORAGE_POOL_DRIVE_EXTENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_STORAGE_POOL_DRIVE_EXTENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_STORAGE_POOL_PROP {
@@ -8005,9 +7729,6 @@ impl Default for VDS_STORAGE_POOL_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_STORAGE_POOL_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8029,9 +7750,6 @@ impl Default for VDS_SUB_SYSTEM_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_SUB_SYSTEM_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_SUB_SYSTEM_PROP {
@@ -8051,9 +7769,6 @@ impl Default for VDS_SUB_SYSTEM_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_SUB_SYSTEM_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8076,9 +7791,6 @@ impl Default for VDS_SUB_SYSTEM_PROP2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_SUB_SYSTEM_PROP2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8142,9 +7854,6 @@ impl Default for VDS_TARGET_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_TARGET_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VDS_TRANSITION_STATE(pub i32);
@@ -8174,10 +7883,6 @@ impl Default for VDS_VDISK_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_Vhd")]
-impl windows_core::TypeKind for VDS_VDISK_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8227,9 +7932,6 @@ impl Default for VDS_VOLUME_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_VOLUME_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_VOLUME_PLEX_PROP {
@@ -8246,9 +7948,6 @@ impl Default for VDS_VOLUME_PLEX_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_VOLUME_PLEX_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8274,9 +7973,6 @@ impl Default for VDS_VOLUME_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VDS_VOLUME_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VDS_VOLUME_PROP2 {
@@ -8296,9 +7992,6 @@ impl Default for VDS_VOLUME_PROP2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_VOLUME_PROP2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8352,9 +8045,6 @@ impl Default for VDS_WWN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDS_WWN {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VER_VDS_LUN_INFORMATION: u32 = 1u32;
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
@@ -2654,9 +2654,6 @@ impl Default for VSS_DIFF_AREA_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VSS_DIFF_AREA_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VSS_DIFF_VOLUME_PROP {
@@ -2669,9 +2666,6 @@ impl Default for VSS_DIFF_VOLUME_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VSS_DIFF_VOLUME_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VSS_E_ASRERROR_CRITICAL_DISKS_TOO_SMALL: windows_core::HRESULT = windows_core::HRESULT(0x80042408_u32 as _);
 pub const VSS_E_ASRERROR_CRITICAL_DISK_CANNOT_BE_EXCLUDED: windows_core::HRESULT = windows_core::HRESULT(0x80042415_u32 as _);
@@ -2783,9 +2777,6 @@ impl Default for VSS_MGMT_OBJECT_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VSS_MGMT_OBJECT_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VSS_MGMT_OBJECT_TYPE(pub i32);
@@ -2801,9 +2792,6 @@ impl Default for VSS_MGMT_OBJECT_UNION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VSS_MGMT_OBJECT_UNION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VSS_MGMT_OBJECT_UNKNOWN: VSS_MGMT_OBJECT_TYPE = VSS_MGMT_OBJECT_TYPE(0i32);
 pub const VSS_MGMT_OBJECT_VOLUME: VSS_MGMT_OBJECT_TYPE = VSS_MGMT_OBJECT_TYPE(1i32);
 pub const VSS_OBJECT_NONE: VSS_OBJECT_TYPE = VSS_OBJECT_TYPE(1i32);
@@ -2817,9 +2805,6 @@ impl Default for VSS_OBJECT_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VSS_OBJECT_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VSS_OBJECT_PROVIDER: VSS_OBJECT_TYPE = VSS_OBJECT_TYPE(4i32);
 pub const VSS_OBJECT_SNAPSHOT: VSS_OBJECT_TYPE = VSS_OBJECT_TYPE(3i32);
@@ -2838,9 +2823,6 @@ impl Default for VSS_OBJECT_UNION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VSS_OBJECT_UNION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VSS_OBJECT_UNKNOWN: VSS_OBJECT_TYPE = VSS_OBJECT_TYPE(0i32);
 pub const VSS_ONLUNSTATECHANGE_DO_MASK_LUNS: VSS_HARDWARE_OPTIONS = VSS_HARDWARE_OPTIONS(2048i32);
@@ -2889,9 +2871,6 @@ impl Default for VSS_PROVIDER_PROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VSS_PROVIDER_PROP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2989,9 +2968,6 @@ impl Default for VSS_SNAPSHOT_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VSS_SNAPSHOT_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VSS_SNAPSHOT_PROPERTY_ID(pub i32);
@@ -3081,9 +3057,6 @@ impl Default for VSS_VOLUME_PROP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VSS_VOLUME_PROP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VSS_VOLUME_PROTECTION_INFO {
@@ -3098,9 +3071,6 @@ impl Default for VSS_VOLUME_PROTECTION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VSS_VOLUME_PROTECTION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/mod.rs
@@ -330,9 +330,6 @@ impl Default for PrintDocumentPackageStatus {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PrintDocumentPackageStatus {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PrintDocumentPackageTarget: windows_core::GUID = windows_core::GUID::from_u128(0x4842669e_9947_46ea_8ba2_d8cce432c2ca);
 pub const PrintDocumentPackageTargetFactory: windows_core::GUID = windows_core::GUID::from_u128(0x348ef17d_6c81_4982_92b4_ee188a43867a);
 pub const XPS_JOB_CANCELLED: XPS_JOB_COMPLETION = XPS_JOB_COMPLETION(2i32);
@@ -356,7 +353,4 @@ impl Default for XPS_JOB_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XPS_JOB_STATUS {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
@@ -126,9 +126,6 @@ impl Default for DOCINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOCINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DOCINFOW {
@@ -143,9 +140,6 @@ impl Default for DOCINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOCINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRAWPATRECT {
@@ -158,9 +152,6 @@ impl Default for DRAWPATRECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRAWPATRECT {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IXpsDocumentPackageTarget, IXpsDocumentPackageTarget_Vtbl, 0x3b0b6d38_53ad_41da_b212_d37637a6714e);
 windows_core::imp::interface_hierarchy!(IXpsDocumentPackageTarget, windows_core::IUnknown);
@@ -10756,9 +10747,6 @@ impl Default for PSFEATURE_CUSTPAPER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSFEATURE_CUSTPAPER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSFEATURE_OUTPUT {
@@ -10769,9 +10757,6 @@ impl Default for PSFEATURE_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSFEATURE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10784,9 +10769,6 @@ impl Default for PSINJECTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSINJECTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PSINJECT_BEGINDEFAULTS: PSINJECT_POINT = PSINJECT_POINT(12u16);
 pub const PSINJECT_BEGINPAGESETUP: PSINJECT_POINT = PSINJECT_POINT(101u16);
@@ -10867,9 +10849,6 @@ impl Default for XPS_COLOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XPS_COLOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union XPS_COLOR_0 {
@@ -10882,9 +10861,6 @@ impl Default for XPS_COLOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XPS_COLOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XPS_COLOR_0_2 {
@@ -10895,9 +10871,6 @@ impl Default for XPS_COLOR_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XPS_COLOR_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10912,9 +10885,6 @@ impl Default for XPS_COLOR_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XPS_COLOR_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XPS_COLOR_0_1 {
@@ -10927,9 +10897,6 @@ impl Default for XPS_COLOR_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XPS_COLOR_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10952,9 +10919,6 @@ impl Default for XPS_DASH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XPS_DASH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11079,9 +11043,6 @@ impl Default for XPS_GLYPH_INDEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XPS_GLYPH_INDEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XPS_GLYPH_MAPPING {
@@ -11094,9 +11055,6 @@ impl Default for XPS_GLYPH_MAPPING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XPS_GLYPH_MAPPING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11139,9 +11097,6 @@ impl Default for XPS_MATRIX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XPS_MATRIX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct XPS_OBJECT_TYPE(pub i32);
@@ -11166,9 +11121,6 @@ impl Default for XPS_POINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XPS_POINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XPS_RECT {
@@ -11181,9 +11133,6 @@ impl Default for XPS_RECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XPS_RECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11299,9 +11248,6 @@ impl Default for XPS_SIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XPS_SIZE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
@@ -367,10 +367,6 @@ impl Default for ADRENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for ADRENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -383,10 +379,6 @@ impl Default for ADRLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for ADRLIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -417,10 +409,6 @@ impl Default for ADRPARM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for ADRPARM {
-    type TypeKind = windows_core::CopyType;
-}
 pub type CALLERRELEASE = Option<unsafe extern "system" fn(ulcallerdata: u32, lptbldata: Option<ITableData>, lpvue: Option<IMAPITable>)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -434,9 +422,6 @@ impl Default for DTBLBUTTON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DTBLBUTTON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DTBLCHECKBOX {
@@ -448,9 +433,6 @@ impl Default for DTBLCHECKBOX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DTBLCHECKBOX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -466,9 +448,6 @@ impl Default for DTBLCOMBOBOX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DTBLCOMBOBOX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DTBLDDLBX {
@@ -481,9 +460,6 @@ impl Default for DTBLDDLBX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DTBLDDLBX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -498,9 +474,6 @@ impl Default for DTBLEDIT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DTBLEDIT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DTBLGROUPBOX {
@@ -512,9 +485,6 @@ impl Default for DTBLGROUPBOX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DTBLGROUPBOX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DTBLLABEL {
@@ -525,9 +495,6 @@ impl Default for DTBLLABEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DTBLLABEL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -541,9 +508,6 @@ impl Default for DTBLLBX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DTBLLBX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DTBLMVDDLBX {
@@ -555,9 +519,6 @@ impl Default for DTBLMVDDLBX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DTBLMVDDLBX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DTBLMVLISTBOX {
@@ -568,9 +529,6 @@ impl Default for DTBLMVLISTBOX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DTBLMVLISTBOX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -585,9 +543,6 @@ impl Default for DTBLPAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DTBLPAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DTBLRADIOBUTTON {
@@ -601,9 +556,6 @@ impl Default for DTBLRADIOBUTTON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DTBLRADIOBUTTON {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -620,9 +572,6 @@ impl Default for DTCTL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DTCTL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -646,9 +595,6 @@ impl Default for DTCTL_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DTCTL_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DTPAGE {
@@ -662,9 +608,6 @@ impl Default for DTPAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DTPAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DTPAGE_0 {
@@ -676,9 +619,6 @@ impl Default for DTPAGE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DTPAGE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENTRYID {
@@ -689,9 +629,6 @@ impl Default for ENTRYID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENTRYID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -707,9 +644,6 @@ impl Default for ERROR_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ERROR_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXTENDED_NOTIFICATION {
@@ -721,9 +655,6 @@ impl Default for EXTENDED_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXTENDED_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const E_IMAPI_BURN_VERIFICATION_FAILED: windows_core::HRESULT = windows_core::HRESULT(0xC0AA0007_u32 as _);
 pub const E_IMAPI_DF2DATA_CLIENT_NAME_IS_NOT_VALID: windows_core::HRESULT = windows_core::HRESULT(0xC0AA0408_u32 as _);
@@ -821,9 +752,6 @@ impl Default for FLATENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLATENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FLATENTRYLIST {
@@ -835,9 +763,6 @@ impl Default for FLATENTRYLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLATENTRYLIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -851,9 +776,6 @@ impl Default for FLATMTSIDLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLATMTSIDLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FlagList {
@@ -864,9 +786,6 @@ impl Default for FlagList {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FlagList {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3287,9 +3206,6 @@ impl Default for MAPIERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MAPIERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MAPINAMEID {
@@ -3302,9 +3218,6 @@ impl Default for MAPINAMEID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MAPINAMEID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MAPINAMEID_0 {
@@ -3316,9 +3229,6 @@ impl Default for MAPINAMEID_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MAPINAMEID_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MAPIUID {
@@ -3328,9 +3238,6 @@ impl Default for MAPIUID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MAPIUID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MAPI_COMPOUND: u32 = 128u32;
 pub const MAPI_DIM: u32 = 1u32;
@@ -3362,9 +3269,6 @@ impl Default for MTSID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MTSID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MV_FLAG: u32 = 4096u32;
 pub const MV_INSTANCE: u32 = 8192u32;
 #[repr(C)]
@@ -3383,9 +3287,6 @@ impl Default for NEWMAIL_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NEWMAIL_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -3399,10 +3300,6 @@ impl Default for NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3421,10 +3318,6 @@ impl Default for NOTIFICATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for NOTIFICATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NOTIFKEY {
@@ -3435,9 +3328,6 @@ impl Default for NOTIFKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NOTIFKEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3457,9 +3347,6 @@ impl Default for OBJECT_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OBJECT_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPENSTREAMONFILE: windows_core::PCSTR = windows_core::s!("OpenStreamOnFile");
 pub type PFNIDLE = Option<unsafe extern "system" fn(param0: *mut core::ffi::c_void) -> super::super::Foundation::BOOL>;
@@ -3483,10 +3370,6 @@ impl Default for SAndRestriction {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SAndRestriction {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SAppTimeArray {
@@ -3497,9 +3380,6 @@ impl Default for SAppTimeArray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SAppTimeArray {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3512,9 +3392,6 @@ impl Default for SBinary {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SBinary {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SBinaryArray {
@@ -3525,9 +3402,6 @@ impl Default for SBinaryArray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SBinaryArray {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3540,9 +3414,6 @@ impl Default for SBitMaskRestriction {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SBitMaskRestriction {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3558,10 +3429,6 @@ impl Default for SCommentRestriction {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SCommentRestriction {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SComparePropsRestriction {
@@ -3573,9 +3440,6 @@ impl Default for SComparePropsRestriction {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SComparePropsRestriction {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3591,10 +3455,6 @@ impl Default for SContentRestriction {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SContentRestriction {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3608,10 +3468,6 @@ impl Default for SCurrencyArray {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SCurrencyArray {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SDateTimeArray {
@@ -3623,9 +3479,6 @@ impl Default for SDateTimeArray {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SDateTimeArray {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SDoubleArray {
@@ -3636,9 +3489,6 @@ impl Default for SDoubleArray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SDoubleArray {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_UI_ALLOWED: u32 = 16u32;
 pub const SERVICE_UI_ALWAYS: u32 = 2u32;
@@ -3654,9 +3504,6 @@ impl Default for SExistRestriction {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SExistRestriction {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SGuidArray {
@@ -3667,9 +3514,6 @@ impl Default for SGuidArray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SGuidArray {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3682,9 +3526,6 @@ impl Default for SLPSTRArray {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SLPSTRArray {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SLargeIntegerArray {
@@ -3696,9 +3537,6 @@ impl Default for SLargeIntegerArray {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SLargeIntegerArray {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SLongArray {
@@ -3709,9 +3547,6 @@ impl Default for SLongArray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SLongArray {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3726,10 +3561,6 @@ impl Default for SNotRestriction {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SNotRestriction {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3743,10 +3574,6 @@ impl Default for SOrRestriction {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SOrRestriction {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPropProblem {
@@ -3759,9 +3586,6 @@ impl Default for SPropProblem {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPropProblem {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPropProblemArray {
@@ -3773,9 +3597,6 @@ impl Default for SPropProblemArray {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SPropProblemArray {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SPropTagArray {
@@ -3786,9 +3607,6 @@ impl Default for SPropTagArray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SPropTagArray {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3804,10 +3622,6 @@ impl Default for SPropValue {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SPropValue {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3822,10 +3636,6 @@ impl Default for SPropertyRestriction {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SPropertyRestriction {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SRealArray {
@@ -3836,9 +3646,6 @@ impl Default for SRealArray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SRealArray {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3852,10 +3659,6 @@ impl Default for SRestriction {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SRestriction {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3879,10 +3682,6 @@ impl Default for SRestriction_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SRestriction_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3897,10 +3696,6 @@ impl Default for SRow {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SRow {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3914,10 +3709,6 @@ impl Default for SRowSet {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SRowSet {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SShortArray {
@@ -3928,9 +3719,6 @@ impl Default for SShortArray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SShortArray {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3944,9 +3732,6 @@ impl Default for SSizeRestriction {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SSizeRestriction {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SSortOrder {
@@ -3957,9 +3742,6 @@ impl Default for SSortOrder {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SSortOrder {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3974,9 +3756,6 @@ impl Default for SSortOrderSet {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SSortOrderSet {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3989,10 +3768,6 @@ impl Default for SSubRestriction {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSubRestriction {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -4009,10 +3784,6 @@ impl Default for STATUS_OBJECT_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for STATUS_OBJECT_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SWStringArray {
@@ -4023,9 +3794,6 @@ impl Default for SWStringArray {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SWStringArray {
-    type TypeKind = windows_core::CopyType;
 }
 pub const S_IMAPI_BOTHADJUSTED: windows_core::HRESULT = windows_core::HRESULT(0xAA0006_u32 as _);
 pub const S_IMAPI_COMMAND_HAS_SENSE_DATA: windows_core::HRESULT = windows_core::HRESULT(0xAA0200_u32 as _);
@@ -4051,10 +3819,6 @@ impl Default for TABLE_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for TABLE_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TABLE_RELOAD: u32 = 9u32;
 pub const TABLE_RESTRICT_DONE: u32 = 7u32;
@@ -4084,9 +3848,6 @@ impl Default for WABEXTDISPLAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WABEXTDISPLAY {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct WABIMPORTPARAM {
@@ -4100,9 +3861,6 @@ impl Default for WABIMPORTPARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WABIMPORTPARAM {
-    type TypeKind = windows_core::CloneType;
 }
 pub const WABOBJECT_LDAPURL_RETURN_MAILUSER: u32 = 1u32;
 pub const WABOBJECT_ME_NEW: u32 = 1u32;
@@ -4128,9 +3886,6 @@ impl Default for WAB_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WAB_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WAB_PROFILE_CONTENTS: u32 = 2097152u32;
 pub const WAB_USE_OE_SENDMAIL: u32 = 1u32;
@@ -4174,10 +3929,6 @@ impl Default for __UPV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for __UPV {
-    type TypeKind = windows_core::CopyType;
 }
 pub const cchProfileNameMax: u32 = 64u32;
 pub const cchProfilePassMax: u32 = 64u32;

--- a/crates/libs/windows/src/Windows/Win32/System/Antimalware/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Antimalware/mod.rs
@@ -97,9 +97,6 @@ impl Default for AMSI_UAC_REQUEST_AX_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMSI_UAC_REQUEST_AX_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMSI_UAC_REQUEST_COM_INFO {
@@ -112,9 +109,6 @@ impl Default for AMSI_UAC_REQUEST_COM_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMSI_UAC_REQUEST_COM_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -131,9 +125,6 @@ impl Default for AMSI_UAC_REQUEST_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMSI_UAC_REQUEST_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union AMSI_UAC_REQUEST_CONTEXT_0 {
@@ -148,9 +139,6 @@ impl Default for AMSI_UAC_REQUEST_CONTEXT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMSI_UAC_REQUEST_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMSI_UAC_REQUEST_EXE_INFO {
@@ -163,9 +151,6 @@ impl Default for AMSI_UAC_REQUEST_EXE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMSI_UAC_REQUEST_EXE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -187,9 +172,6 @@ impl Default for AMSI_UAC_REQUEST_MSI_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AMSI_UAC_REQUEST_MSI_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AMSI_UAC_REQUEST_PACKAGED_APP_INFO {
@@ -203,9 +185,6 @@ impl Default for AMSI_UAC_REQUEST_PACKAGED_APP_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AMSI_UAC_REQUEST_PACKAGED_APP_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
@@ -2701,9 +2701,6 @@ impl Default for ACTCTXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTCTXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTCTXW {
@@ -2721,9 +2718,6 @@ impl Default for ACTCTXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTCTXW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2763,10 +2757,6 @@ impl Default for ACTCTX_SECTION_KEYED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_WindowsProgramming")]
-impl windows_core::TypeKind for ACTCTX_SECTION_KEYED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTIVATION_CONTEXT_ASSEMBLY_DETAILED_INFORMATION {
@@ -2795,9 +2785,6 @@ impl Default for ACTIVATION_CONTEXT_ASSEMBLY_DETAILED_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTIVATION_CONTEXT_ASSEMBLY_DETAILED_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTIVATION_CONTEXT_COMPATIBILITY_INFORMATION {
@@ -2808,9 +2795,6 @@ impl Default for ACTIVATION_CONTEXT_COMPATIBILITY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTIVATION_CONTEXT_COMPATIBILITY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2833,9 +2817,6 @@ impl Default for ACTIVATION_CONTEXT_DETAILED_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTIVATION_CONTEXT_DETAILED_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTIVATION_CONTEXT_QUERY_INDEX {
@@ -2846,9 +2827,6 @@ impl Default for ACTIVATION_CONTEXT_QUERY_INDEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTIVATION_CONTEXT_QUERY_INDEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2861,9 +2839,6 @@ impl Default for ACTIVATION_CONTEXT_RUN_LEVEL_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTIVATION_CONTEXT_RUN_LEVEL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2979,9 +2954,6 @@ impl Default for ASSEMBLY_FILE_DETAILED_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ASSEMBLY_FILE_DETAILED_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ASSEMBLY_INFO {
@@ -2995,9 +2967,6 @@ impl Default for ASSEMBLY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ASSEMBLY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CANOF_PARSE_DISPLAY_NAME: CREATE_ASM_NAME_OBJ_FLAGS = CREATE_ASM_NAME_OBJ_FLAGS(1i32);
 pub const CANOF_SET_DEFAULT_VALUES: CREATE_ASM_NAME_OBJ_FLAGS = CREATE_ASM_NAME_OBJ_FLAGS(2i32);
@@ -3015,9 +2984,6 @@ impl Default for COMPATIBILITY_CONTEXT_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMPATIBILITY_CONTEXT_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CREATE_ASM_NAME_OBJ_FLAGS(pub i32);
@@ -3034,9 +3000,6 @@ impl Default for DELTA_HASH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DELTA_HASH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security_Cryptography")]
@@ -3056,10 +3019,6 @@ impl Default for DELTA_HEADER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for DELTA_HEADER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DELTA_INPUT {
@@ -3072,9 +3031,6 @@ impl Default for DELTA_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DELTA_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DELTA_INPUT_0 {
@@ -3085,9 +3041,6 @@ impl Default for DELTA_INPUT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DELTA_INPUT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DELTA_MAX_HASH_SIZE: u32 = 32u32;
 #[repr(C)]
@@ -3100,9 +3053,6 @@ impl Default for DELTA_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DELTA_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ERROR_PATCH_BIGGER_THAN_COMPRESSED: u32 = 3222155525u32;
 pub const ERROR_PATCH_CORRUPT: u32 = 3222159618u32;
@@ -3298,9 +3248,6 @@ impl Default for FUSION_INSTALL_REFERENCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FUSION_INSTALL_REFERENCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FUSION_REFCOUNT_FILEPATH_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xb02f9d65_fb77_4f7a_afa5_b391309f11c9);
 pub const FUSION_REFCOUNT_OPAQUE_STRING_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x2ec93463_b0c3_45e1_8364_327e96aea856);
@@ -8703,9 +8650,6 @@ impl Default for MSIFILEHASHINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSIFILEHASHINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct MSIHANDLE(pub u32);
@@ -8772,9 +8716,6 @@ impl Default for MSIPATCHSEQUENCEINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSIPATCHSEQUENCEINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MSIPATCHSEQUENCEINFOW {
@@ -8787,9 +8728,6 @@ impl Default for MSIPATCHSEQUENCEINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSIPATCHSEQUENCEINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8891,9 +8829,6 @@ impl Default for PATCH_IGNORE_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PATCH_IGNORE_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PATCH_INTERLEAVE_MAP {
@@ -8904,9 +8839,6 @@ impl Default for PATCH_INTERLEAVE_MAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PATCH_INTERLEAVE_MAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8919,9 +8851,6 @@ impl Default for PATCH_INTERLEAVE_MAP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PATCH_INTERLEAVE_MAP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8938,9 +8867,6 @@ impl Default for PATCH_OLD_FILE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PATCH_OLD_FILE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PATCH_OLD_FILE_INFO_0 {
@@ -8952,9 +8878,6 @@ impl Default for PATCH_OLD_FILE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PATCH_OLD_FILE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8971,9 +8894,6 @@ impl Default for PATCH_OLD_FILE_INFO_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PATCH_OLD_FILE_INFO_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PATCH_OLD_FILE_INFO_H {
@@ -8989,9 +8909,6 @@ impl Default for PATCH_OLD_FILE_INFO_H {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PATCH_OLD_FILE_INFO_H {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PATCH_OLD_FILE_INFO_W {
@@ -9006,9 +8923,6 @@ impl Default for PATCH_OLD_FILE_INFO_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PATCH_OLD_FILE_INFO_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9027,9 +8941,6 @@ impl Default for PATCH_OPTION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PATCH_OPTION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PATCH_OPTION_FAIL_IF_BIGGER: u32 = 1048576u32;
 pub const PATCH_OPTION_FAIL_IF_SAME_FILE: u32 = 524288u32;
@@ -9059,9 +8970,6 @@ impl Default for PATCH_RETAIN_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PATCH_RETAIN_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PATCH_SYMBOL_NO_FAILURES: u32 = 2u32;
 pub const PATCH_SYMBOL_NO_IMAGEHLP: u32 = 1u32;
@@ -9099,9 +9007,6 @@ impl Default for PMSIHANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PMSIHANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PMSvc: windows_core::GUID = windows_core::GUID::from_u128(0xb9e511fc_e364_497a_a121_b7b3612cedce);
 #[repr(transparent)]
@@ -9157,9 +9062,6 @@ impl Default for PM_APPTASKTYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PM_APPTASKTYPE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PM_APP_FILTER_ALL: PM_ENUM_APP_FILTER = PM_ENUM_APP_FILTER(0i32);
 pub const PM_APP_FILTER_ALL_INCLUDE_MODERN: PM_ENUM_APP_FILTER = PM_ENUM_APP_FILTER(6i32);
 pub const PM_APP_FILTER_FRAMEWORK: PM_ENUM_APP_FILTER = PM_ENUM_APP_FILTER(7i32);
@@ -9186,9 +9088,6 @@ impl Default for PM_BSATASKID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PM_BSATASKID {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PM_BWTASKID {
@@ -9199,9 +9098,6 @@ impl Default for PM_BWTASKID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PM_BWTASKID {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9250,9 +9146,6 @@ impl Default for PM_ENUM_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PM_ENUM_FILTER {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union PM_ENUM_FILTER_0 {
     pub Dummy: i32,
@@ -9283,9 +9176,6 @@ impl Default for PM_ENUM_FILTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PM_ENUM_FILTER_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PM_ENUM_TASK_FILTER(pub i32);
@@ -9302,9 +9192,6 @@ impl Default for PM_EXTENSIONCONSUMER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PM_EXTENSIONCONSUMER {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -9324,9 +9211,6 @@ impl Default for PM_INSTALLINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PM_INSTALLINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PM_INVOCATIONINFO {
@@ -9337,9 +9221,6 @@ impl Default for PM_INVOCATIONINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PM_INVOCATIONINFO {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9375,9 +9256,6 @@ impl Default for PM_STARTAPPBLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PM_STARTAPPBLOB {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PM_STARTTILEBLOB {
@@ -9399,9 +9277,6 @@ impl Default for PM_STARTTILEBLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PM_STARTTILEBLOB {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9479,9 +9354,6 @@ impl Default for PM_UPDATEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PM_UPDATEINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PM_UPDATEINFO_LEGACY {
@@ -9497,9 +9369,6 @@ impl Default for PM_UPDATEINFO_LEGACY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PM_UPDATEINFO_LEGACY {
-    type TypeKind = windows_core::CloneType;
-}
 pub type PPATCH_PROGRESS_CALLBACK = Option<unsafe extern "system" fn(callbackcontext: *mut core::ffi::c_void, currentposition: u32, maximumposition: u32) -> super::super::Foundation::BOOL>;
 pub type PPATCH_SYMLOAD_CALLBACK = Option<unsafe extern "system" fn(whichfile: u32, symbolfilename: windows_core::PCSTR, symtype: u32, symbolfilechecksum: u32, symbolfiletimedate: u32, imagefilechecksum: u32, imagefiletimedate: u32, callbackcontext: *mut core::ffi::c_void) -> super::super::Foundation::BOOL>;
 #[repr(C)]
@@ -9512,9 +9381,6 @@ impl Default for PROTECTED_FILE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROTECTED_FILE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationVerifier/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationVerifier/mod.rs
@@ -15,9 +15,6 @@ impl Default for AVRF_BACKTRACE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AVRF_BACKTRACE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AVRF_ENUM_RESOURCES_FLAGS_DONT_RESOLVE_TRACES: VERIFIER_ENUM_RESOURCE_FLAGS = VERIFIER_ENUM_RESOURCE_FLAGS(2u32);
 pub const AVRF_ENUM_RESOURCES_FLAGS_SUSPEND: VERIFIER_ENUM_RESOURCE_FLAGS = VERIFIER_ENUM_RESOURCE_FLAGS(1u32);
 pub type AVRF_HANDLEOPERATION_ENUMERATE_CALLBACK = Option<unsafe extern "system" fn(handleoperation: *mut AVRF_HANDLE_OPERATION, enumerationcontext: *mut core::ffi::c_void, enumerationlevel: *mut u32) -> u32>;
@@ -35,9 +32,6 @@ impl Default for AVRF_HANDLE_OPERATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVRF_HANDLE_OPERATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub type AVRF_HEAPALLOCATION_ENUMERATE_CALLBACK = Option<unsafe extern "system" fn(heapallocation: *mut AVRF_HEAP_ALLOCATION, enumerationcontext: *mut core::ffi::c_void, enumerationlevel: *mut u32) -> u32>;
 #[repr(C)]
@@ -57,9 +51,6 @@ impl Default for AVRF_HEAP_ALLOCATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AVRF_HEAP_ALLOCATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AVRF_MAX_TRACES: u32 = 32u32;
 pub type AVRF_RESOURCE_ENUMERATE_CALLBACK = Option<unsafe extern "system" fn(resourcedescription: *mut core::ffi::c_void, enumerationcontext: *mut core::ffi::c_void, enumerationlevel: *mut u32) -> u32>;

--- a/crates/libs/windows/src/Windows/Win32/System/ClrHosting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ClrHosting/mod.rs
@@ -228,9 +228,6 @@ impl Default for AssemblyBindInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AssemblyBindInfo {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BucketParamLength: u32 = 255u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -246,9 +243,6 @@ impl Default for BucketParameters {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BucketParameters {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BucketParamsCount: u32 = 10u32;
 pub type CLRCreateInstanceFnPtr = Option<unsafe extern "system" fn(clsid: *const windows_core::GUID, riid: *const windows_core::GUID, ppinterface: *mut *mut core::ffi::c_void) -> windows_core::HRESULT>;
@@ -276,9 +270,6 @@ impl Default for CLR_DEBUGGING_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLR_DEBUGGING_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLR_MAJOR_VERSION: u32 = 4u32;
 pub const CLR_MINOR_VERSION: u32 = 0u32;
@@ -315,9 +306,6 @@ impl Default for COR_GC_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COR_GC_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct COR_GC_STAT_TYPES(pub i32);
@@ -332,9 +320,6 @@ impl Default for COR_GC_THREAD_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COR_GC_THREAD_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -356,9 +341,6 @@ impl Default for CustomDumpItem {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CustomDumpItem {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CustomDumpItem_0 {
@@ -368,9 +350,6 @@ impl Default for CustomDumpItem_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CustomDumpItem_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEPRECATED_CLR_API_MESG: windows_core::PCSTR = windows_core::s!("This API has been deprecated. Refer to https://go.microsoft.com/fwlink/?LinkId=143720 for more details.");
 pub const DUMP_FLAVOR_CriticalCLRState: ECustomDumpFlavor = ECustomDumpFlavor(1i32);
@@ -5860,9 +5839,6 @@ impl Default for MDAInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MDAInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct METAHOST_CONFIG_FLAGS(pub i32);
@@ -5895,9 +5871,6 @@ impl Default for ModuleBindInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ModuleBindInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPR_AppDomainRudeUnload: EClrOperation = EClrOperation(4i32);
 pub const OPR_AppDomainUnload: EClrOperation = EClrOperation(3i32);
@@ -5963,10 +5936,6 @@ impl Default for StackOverflowInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for StackOverflowInfo {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/mod.rs
@@ -36,9 +36,6 @@ impl Default for CALLFRAMEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CALLFRAMEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CALLFRAMEPARAMINFO {
@@ -51,9 +48,6 @@ impl Default for CALLFRAMEPARAMINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CALLFRAMEPARAMINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -83,9 +77,6 @@ impl Default for CALLFRAME_MARSHALCONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CALLFRAME_MARSHALCONTEXT {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Events/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Events/mod.rs
@@ -17,9 +17,6 @@ impl Default for COMEVENTSYSCHANGEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMEVENTSYSCHANGEINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct EOC_ChangeType(pub i32);

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
@@ -921,9 +921,6 @@ impl Default for BSTRBLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BSTRBLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CABOOL {
@@ -934,9 +931,6 @@ impl Default for CABOOL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CABOOL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -949,9 +943,6 @@ impl Default for CABSTR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CABSTR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CABSTRBLOB {
@@ -962,9 +953,6 @@ impl Default for CABSTRBLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CABSTRBLOB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -977,9 +965,6 @@ impl Default for CAC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CAC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CACLIPDATA {
@@ -990,9 +975,6 @@ impl Default for CACLIPDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CACLIPDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1005,9 +987,6 @@ impl Default for CACLSID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CACLSID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CACY {
@@ -1018,9 +997,6 @@ impl Default for CACY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CACY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1033,9 +1009,6 @@ impl Default for CADATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CADATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CADBL {
@@ -1046,9 +1019,6 @@ impl Default for CADBL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CADBL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1061,9 +1031,6 @@ impl Default for CAFILETIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CAFILETIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CAFLT {
@@ -1074,9 +1041,6 @@ impl Default for CAFLT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CAFLT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1089,9 +1053,6 @@ impl Default for CAH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CAH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CAI {
@@ -1102,9 +1063,6 @@ impl Default for CAI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CAI {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1117,9 +1075,6 @@ impl Default for CAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CALPSTR {
@@ -1131,9 +1086,6 @@ impl Default for CALPSTR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CALPSTR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CALPWSTR {
@@ -1144,9 +1096,6 @@ impl Default for CALPWSTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CALPWSTR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
@@ -1161,10 +1110,6 @@ impl Default for CAPROPVARIANT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for CAPROPVARIANT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CASCODE {
@@ -1175,9 +1120,6 @@ impl Default for CASCODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CASCODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1190,9 +1132,6 @@ impl Default for CAUB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CAUB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CAUH {
@@ -1203,9 +1142,6 @@ impl Default for CAUH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CAUH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1218,9 +1154,6 @@ impl Default for CAUI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CAUI {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CAUL {
@@ -1231,9 +1164,6 @@ impl Default for CAUL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CAUL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CCH_MAX_PROPSTG_NAME: u32 = 31u32;
 #[repr(C)]
@@ -1247,9 +1177,6 @@ impl Default for CLIPDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLIPDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CWCSTORAGENAME: u32 = 32u32;
 windows_core::imp::define_interface!(IDirectWriterLock, IDirectWriterLock_Vtbl, 0x0e6d4d92_6738_11cf_9608_00aa00680db4);
@@ -2593,9 +2520,6 @@ impl Default for OLESTREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OLESTREAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OLESTREAMVTBL {
@@ -2606,9 +2530,6 @@ impl Default for OLESTREAMVTBL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OLESTREAMVTBL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PIDDI_THUMBNAIL: i32 = 2i32;
 pub const PIDDSI_BYTECOUNT: u32 = 4u32;
@@ -2695,10 +2616,6 @@ impl Default for PROPBAG2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for PROPBAG2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PROPSETFLAG_ANSI: u32 = 2u32;
 pub const PROPSETFLAG_CASE_SENSITIVE: u32 = 8u32;
 pub const PROPSETFLAG_DEFAULT: u32 = 0u32;
@@ -2717,9 +2634,6 @@ impl Default for PROPSPEC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROPSPEC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROPSPEC_0 {
@@ -2730,9 +2644,6 @@ impl Default for PROPSPEC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROPSPEC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2747,10 +2658,6 @@ impl Default for PROPVARIANT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for PROPVARIANT {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
@@ -2769,10 +2676,6 @@ impl Default for PROPVARIANT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for PROPVARIANT_0 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
@@ -2794,10 +2697,6 @@ impl Default for PROPVARIANT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for PROPVARIANT_0_0 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
@@ -2887,10 +2786,6 @@ impl Default for PROPVARIANT_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for PROPVARIANT_0_0_0 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3002,9 +2897,6 @@ impl Default for RemSNB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RemSNB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERIALIZEDPROPERTYVALUE {
@@ -3015,9 +2907,6 @@ impl Default for SERIALIZEDPROPERTYVALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERIALIZEDPROPERTYVALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3035,9 +2924,6 @@ impl Default for STATPROPSETSTG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STATPROPSETSTG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3051,10 +2937,6 @@ impl Default for STATPROPSTG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for STATPROPSTG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3084,9 +2966,6 @@ impl Default for STGOPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STGOPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STGOPTIONS_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -3098,7 +2977,4 @@ impl Default for VERSIONEDSTREAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VERSIONEDSTREAM {
-    type TypeKind = windows_core::CloneType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/mod.rs
@@ -859,9 +859,6 @@ impl Default for CODEBASEHOLD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CODEBASEHOLD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct CONFIRMSAFETY {
@@ -873,9 +870,6 @@ impl Default for CONFIRMSAFETY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONFIRMSAFETY {
-    type TypeKind = windows_core::CloneType;
 }
 pub const CONFIRMSAFETYACTION_LOADOBJECT: u32 = 1u32;
 #[repr(C)]
@@ -890,9 +884,6 @@ impl Default for DATAINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DATAINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const E_PENDING: windows_core::HRESULT = windows_core::HRESULT(0x8000000A_u32 as _);
 pub const FEATURE_ADDON_MANAGEMENT: INTERNETFEATURELIST = INTERNETFEATURELIST(13i32);
@@ -958,9 +949,6 @@ impl Default for HIT_LOGGING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HIT_LOGGING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IBindCallbackRedirect, IBindCallbackRedirect_Vtbl, 0x11c81bc2_121e_4ed5_b9c4_b430bd54f2c0);
 windows_core::imp::interface_hierarchy!(IBindCallbackRedirect, windows_core::IUnknown);
@@ -3667,9 +3655,6 @@ impl Default for PROTOCOLDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROTOCOLDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PROTOCOLFILTERDATA {
@@ -3684,9 +3669,6 @@ impl Default for PROTOCOLFILTERDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROTOCOLFILTERDATA {
-    type TypeKind = windows_core::CloneType;
-}
 pub const PROTOCOLFLAG_NO_PICS_CHECK: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3698,9 +3680,6 @@ impl Default for PROTOCOL_ARGUMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROTOCOL_ARGUMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3767,9 +3746,6 @@ impl Default for REMSECURITY_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REMSECURITY_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct RemBINDINFO {
@@ -3792,9 +3768,6 @@ impl Default for RemBINDINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RemBINDINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RemFORMATETC {
@@ -3808,9 +3781,6 @@ impl Default for RemFORMATETC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RemFORMATETC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECURITY_IE_STATE_GREEN: u32 = 0u32;
 pub const SECURITY_IE_STATE_RED: u32 = 1u32;
@@ -3844,9 +3814,6 @@ impl Default for SOFTDISTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOFTDISTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SOFTDIST_ADSTATE_AVAILABLE: u32 = 1u32;
 pub const SOFTDIST_ADSTATE_DOWNLOADED: u32 = 2u32;
 pub const SOFTDIST_ADSTATE_INSTALLED: u32 = 3u32;
@@ -3872,9 +3839,6 @@ impl Default for StartParam {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for StartParam {
-    type TypeKind = windows_core::CloneType;
 }
 pub const TRUSTEDDOWNLOADPROP: MONIKERPROPERTY = MONIKERPROPERTY(3i32);
 pub const UAS_EXACTLEGACY: u32 = 4096u32;
@@ -4147,7 +4111,4 @@ impl Default for ZONEATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ZONEATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -880,9 +880,6 @@ impl Default for AUTHENTICATEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHENTICATEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ApplicationType(pub i32);
@@ -1405,10 +1402,6 @@ impl Default for BINDINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
-impl windows_core::TypeKind for BINDINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BINDINFOF(pub i32);
@@ -1433,10 +1426,6 @@ impl Default for BINDPTR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for BINDPTR {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BIND_FLAGS(pub i32);
@@ -1455,9 +1444,6 @@ impl Default for BIND_OPTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BIND_OPTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BIND_OPTS2 {
@@ -1472,9 +1458,6 @@ impl Default for BIND_OPTS2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BIND_OPTS2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BIND_OPTS3 {
@@ -1485,9 +1468,6 @@ impl Default for BIND_OPTS3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BIND_OPTS3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1500,9 +1480,6 @@ impl Default for BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BYTE_BLOB {
@@ -1514,9 +1491,6 @@ impl Default for BYTE_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BYTE_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BYTE_SIZEDARR {
@@ -1527,9 +1501,6 @@ impl Default for BYTE_SIZEDARR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BYTE_SIZEDARR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1553,9 +1524,6 @@ impl Default for CATEGORYINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CATEGORYINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CC_CDECL: CALLCONV = CALLCONV(1i32);
 pub const CC_FASTCALL: CALLCONV = CALLCONV(0i32);
@@ -1651,9 +1619,6 @@ impl Default for COAUTHIDENTITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COAUTHIDENTITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COAUTHINFO {
@@ -1669,9 +1634,6 @@ impl Default for COAUTHINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COAUTHINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1774,9 +1736,6 @@ impl Default for CONNECTDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONNECTDATA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COSERVERINFO {
@@ -1789,9 +1748,6 @@ impl Default for COSERVERINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COSERVERINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COWAIT_ALERTABLE: COWAIT_FLAGS = COWAIT_FLAGS(2i32);
 pub const COWAIT_DEFAULT: COWAIT_FLAGS = COWAIT_FLAGS(0i32);
@@ -1920,9 +1876,6 @@ impl Default for CSPLATFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSPLATFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1935,10 +1888,6 @@ impl Default for CUSTDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for CUSTDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -1957,10 +1906,6 @@ impl Default for CUSTDATAITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for CUSTDATAITEM {
-    type TypeKind = windows_core::CloneType;
 }
 pub const CWMO_DEFAULT: CWMO_FLAGS = CWMO_FLAGS(0i32);
 pub const CWMO_DISPATCH_CALLS: CWMO_FLAGS = CWMO_FLAGS(1i32);
@@ -2013,9 +1958,6 @@ impl Default for CY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CY_0 {
@@ -2026,9 +1968,6 @@ impl Default for CY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2042,9 +1981,6 @@ impl Default for ComCallData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ComCallData {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ContextProperty {
@@ -2056,9 +1992,6 @@ impl Default for ContextProperty {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ContextProperty {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2141,10 +2074,6 @@ impl Default for DISPPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DISPPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DMUS_ERRBASE: u32 = 4096u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2170,9 +2099,6 @@ impl Default for DVTARGETDEVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVTARGETDEVICE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWORD_BLOB {
@@ -2184,9 +2110,6 @@ impl Default for DWORD_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DWORD_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DWORD_SIZEDARR {
@@ -2197,9 +2120,6 @@ impl Default for DWORD_SIZEDARR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DWORD_SIZEDARR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -2214,10 +2134,6 @@ impl Default for ELEMDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for ELEMDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy)]
@@ -2230,10 +2146,6 @@ impl Default for ELEMDESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for ELEMDESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EOAC_ACCESS_CONTROL: EOLE_AUTHENTICATION_CAPABILITIES = EOLE_AUTHENTICATION_CAPABILITIES(4i32);
 pub const EOAC_ANY_AUTHORITY: EOLE_AUTHENTICATION_CAPABILITIES = EOLE_AUTHENTICATION_CAPABILITIES(128i32);
@@ -2272,9 +2184,6 @@ impl Default for EXCEPINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXCEPINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct EXTCONN(pub i32);
@@ -2305,9 +2214,6 @@ impl Default for FLAGGED_BYTE_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLAGGED_BYTE_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FLAGGED_WORD_BLOB {
@@ -2319,9 +2225,6 @@ impl Default for FLAGGED_WORD_BLOB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLAGGED_WORD_BLOB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
@@ -2342,10 +2245,6 @@ impl Default for FLAG_STGMEDIUM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
-impl windows_core::TypeKind for FLAG_STGMEDIUM {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FORMATETC {
@@ -2359,9 +2258,6 @@ impl Default for FORMATETC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FORMATETC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -2385,10 +2281,6 @@ impl Default for FUNCDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for FUNCDESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2428,10 +2320,6 @@ impl Default for GDI_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl windows_core::TypeKind for GDI_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 #[derive(Clone, Copy)]
@@ -2445,10 +2333,6 @@ impl Default for GDI_OBJECT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl windows_core::TypeKind for GDI_OBJECT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2475,9 +2359,6 @@ impl Default for HYPER_SIZEDARR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HYPER_SIZEDARR {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IActivationFilter, IActivationFilter_Vtbl, 0x00000017_0000_0000_c000_000000000046);
 windows_core::imp::interface_hierarchy!(IActivationFilter, windows_core::IUnknown);
@@ -4293,9 +4174,6 @@ impl Default for IDLDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IDLDESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6466,9 +6344,6 @@ impl Default for INTERFACEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERFACEINFO {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10674,9 +10549,6 @@ impl Default for MULTI_QI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MULTI_QI {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MachineGlobalObjectTableRegistrationToken(pub *mut core::ffi::c_void);
@@ -10718,9 +10590,6 @@ impl Default for QUERYCONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUERYCONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10819,9 +10688,6 @@ impl Default for RPCOLEMESSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPCOLEMESSAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct RPCOPT_PROPERTIES(pub i32);
@@ -10861,9 +10727,6 @@ impl Default for RemSTGMEDIUM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RemSTGMEDIUM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SAFEARRAY {
@@ -10879,9 +10742,6 @@ impl Default for SAFEARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SAFEARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SAFEARRAYBOUND {
@@ -10892,9 +10752,6 @@ impl Default for SAFEARRAYBOUND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SAFEARRAYBOUND {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10910,9 +10767,6 @@ impl Default for SChannelHookCallInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SChannelHookCallInfo {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SD_ACCESSPERMISSIONS: COMSD = COMSD(1i32);
 pub const SD_ACCESSRESTRICTIONS: COMSD = COMSD(3i32);
@@ -10939,9 +10793,6 @@ impl Default for SOLE_AUTHENTICATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOLE_AUTHENTICATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOLE_AUTHENTICATION_LIST {
@@ -10952,9 +10803,6 @@ impl Default for SOLE_AUTHENTICATION_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOLE_AUTHENTICATION_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10969,9 +10817,6 @@ impl Default for SOLE_AUTHENTICATION_SERVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOLE_AUTHENTICATION_SERVICE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct STATDATA {
@@ -10984,9 +10829,6 @@ impl Default for STATDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STATDATA {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11013,9 +10855,6 @@ impl Default for STATSTG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STATSTG {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11113,10 +10952,6 @@ impl Default for STGMEDIUM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
-impl windows_core::TypeKind for STGMEDIUM {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub union STGMEDIUM_0 {
@@ -11139,10 +10974,6 @@ impl Default for STGMEDIUM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
-impl windows_core::TypeKind for STGMEDIUM_0 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const STGM_CONVERT: STGM = STGM(131072u32);
 pub const STGM_CREATE: STGM = STGM(4096u32);
@@ -11203,9 +11034,6 @@ impl Default for StorageLayout {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for StorageLayout {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct THDTYPE(pub i32);
@@ -11234,9 +11062,6 @@ impl Default for TLIBATTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TLIBATTR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11278,10 +11103,6 @@ impl Default for TYPEATTR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for TYPEATTR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy)]
@@ -11294,10 +11115,6 @@ impl Default for TYPEDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for TYPEDESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -11312,10 +11129,6 @@ impl Default for TYPEDESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for TYPEDESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11427,10 +11240,6 @@ impl Default for VARDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for VARDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy)]
@@ -11443,10 +11252,6 @@ impl Default for VARDESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for VARDESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11482,9 +11287,6 @@ impl Default for WORD_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WORD_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WORD_SIZEDARR {
@@ -11496,9 +11298,6 @@ impl Default for WORD_SIZEDARR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WORD_SIZEDARR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct uCLSSPEC {
@@ -11509,9 +11308,6 @@ impl Default for uCLSSPEC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for uCLSSPEC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -11529,9 +11325,6 @@ impl Default for uCLSSPEC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for uCLSSPEC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct uCLSSPEC_0_0 {
@@ -11543,9 +11336,6 @@ impl Default for uCLSSPEC_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for uCLSSPEC_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct uCLSSPEC_0_1 {
@@ -11556,9 +11346,6 @@ impl Default for uCLSSPEC_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for uCLSSPEC_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -11579,10 +11366,6 @@ impl Default for userFLAG_STGMEDIUM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl windows_core::TypeKind for userFLAG_STGMEDIUM {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 pub struct userSTGMEDIUM {
@@ -11601,10 +11384,6 @@ impl Default for userSTGMEDIUM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl windows_core::TypeKind for userSTGMEDIUM {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
 #[derive(Clone, Copy)]
@@ -11617,10 +11396,6 @@ impl Default for userSTGMEDIUM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl windows_core::TypeKind for userSTGMEDIUM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
@@ -11639,8 +11414,4 @@ impl Default for userSTGMEDIUM_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_SystemServices"))]
-impl windows_core::TypeKind for userSTGMEDIUM_0_0 {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/ComponentServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ComponentServices/mod.rs
@@ -70,9 +70,6 @@ impl Default for APPDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APPDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct APPSTATISTICS {
@@ -85,9 +82,6 @@ impl Default for APPSTATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APPSTATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const APPTYPE_LIBRARY: COMPLUS_APPTYPE = COMPLUS_APPTYPE(0i32);
 pub const APPTYPE_SERVER: COMPLUS_APPTYPE = COMPLUS_APPTYPE(1i32);
@@ -117,9 +111,6 @@ impl Default for ApplicationProcessRecycleInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ApplicationProcessRecycleInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ApplicationProcessStatistics {
@@ -136,9 +127,6 @@ impl Default for ApplicationProcessStatistics {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ApplicationProcessStatistics {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -158,9 +146,6 @@ impl Default for ApplicationProcessSummary {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ApplicationProcessSummary {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ApplicationSummary {
@@ -176,9 +161,6 @@ impl Default for ApplicationSummary {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ApplicationSummary {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -201,9 +183,6 @@ impl Default for CLSIDDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLSIDDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CLSIDDATA2 {
@@ -225,9 +204,6 @@ impl Default for CLSIDDATA2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLSIDDATA2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COMAdmin32BitComponent: COMAdminComponentType = COMAdminComponentType(1i32);
 pub const COMAdmin64BitComponent: COMAdminComponentType = COMAdminComponentType(2i32);
@@ -530,9 +506,6 @@ impl Default for COMSVCSEVENTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMSVCSEVENTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CRMClerk: windows_core::GUID = windows_core::GUID::from_u128(0xecabb0bd_7f19_11d2_978e_0000f8757e2a);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -634,9 +607,6 @@ impl Default for ComponentHangMonitorInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ComponentHangMonitorInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ComponentStatistics {
@@ -659,9 +629,6 @@ impl Default for ComponentStatistics {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ComponentStatistics {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ComponentSummary {
@@ -676,9 +643,6 @@ impl Default for ComponentSummary {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ComponentSummary {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
 windows_core::imp::define_interface!(ContextInfo, ContextInfo_Vtbl, 0x19a5a02c_0ac8_11d2_b286_00c04f8ef934);
@@ -900,10 +864,6 @@ impl Default for CrmLogRecordRead {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for CrmLogRecordRead {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CrmTransactionState(pub i32);
@@ -941,9 +901,6 @@ impl Default for HANG_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HANG_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
 windows_core::imp::define_interface!(IAppDomainHelper, IAppDomainHelper_Vtbl, 0xc7b67079_8255_42c6_9ec0_6994a3548780);
@@ -10496,9 +10453,6 @@ impl Default for RECYCLE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RECYCLE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/Console/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Console/mod.rs
@@ -570,9 +570,6 @@ impl Default for CHAR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHAR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CHAR_INFO_0 {
@@ -583,9 +580,6 @@ impl Default for CHAR_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHAR_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COMMON_LVB_GRID_HORIZONTAL: CONSOLE_CHARACTER_ATTRIBUTES = CONSOLE_CHARACTER_ATTRIBUTES(1024u16);
 pub const COMMON_LVB_GRID_LVERTICAL: CONSOLE_CHARACTER_ATTRIBUTES = CONSOLE_CHARACTER_ATTRIBUTES(2048u16);
@@ -611,9 +605,6 @@ impl Default for CONSOLEENDTASK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONSOLEENDTASK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONSOLESETFOREGROUND {
@@ -624,9 +615,6 @@ impl Default for CONSOLESETFOREGROUND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONSOLESETFOREGROUND {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -640,9 +628,6 @@ impl Default for CONSOLEWINDOWOWNER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONSOLEWINDOWOWNER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONSOLE_CARET_INFO {
@@ -653,9 +638,6 @@ impl Default for CONSOLE_CARET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONSOLE_CARET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -704,9 +686,6 @@ impl Default for CONSOLE_CURSOR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONSOLE_CURSOR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONSOLE_FONT_INFO {
@@ -717,9 +696,6 @@ impl Default for CONSOLE_FONT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONSOLE_FONT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -736,9 +712,6 @@ impl Default for CONSOLE_FONT_INFOEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONSOLE_FONT_INFOEX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CONSOLE_FULLSCREEN: u32 = 1u32;
 pub const CONSOLE_FULLSCREEN_HARDWARE: u32 = 2u32;
 pub const CONSOLE_FULLSCREEN_MODE: u32 = 1u32;
@@ -754,9 +727,6 @@ impl Default for CONSOLE_HISTORY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONSOLE_HISTORY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -808,9 +778,6 @@ impl Default for CONSOLE_PROCESS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONSOLE_PROCESS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONSOLE_READCONSOLE_CONTROL {
@@ -823,9 +790,6 @@ impl Default for CONSOLE_READCONSOLE_CONTROL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONSOLE_READCONSOLE_CONTROL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -840,9 +804,6 @@ impl Default for CONSOLE_SCREEN_BUFFER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONSOLE_SCREEN_BUFFER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -862,9 +823,6 @@ impl Default for CONSOLE_SCREEN_BUFFER_INFOEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONSOLE_SCREEN_BUFFER_INFOEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONSOLE_SELECTION_INFO {
@@ -876,9 +834,6 @@ impl Default for CONSOLE_SELECTION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONSOLE_SELECTION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONSOLE_SELECTION_IN_PROGRESS: u32 = 1u32;
 pub const CONSOLE_SELECTION_NOT_EMPTY: u32 = 2u32;
@@ -894,9 +849,6 @@ impl Default for COORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CTRL_BREAK_EVENT: u32 = 1u32;
 pub const CTRL_CLOSE_EVENT: u32 = 2u32;
@@ -935,9 +887,6 @@ impl Default for FOCUS_EVENT_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FOCUS_EVENT_RECORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FOREGROUND_BLUE: CONSOLE_CHARACTER_ATTRIBUTES = CONSOLE_CHARACTER_ATTRIBUTES(1u16);
 pub const FOREGROUND_GREEN: CONSOLE_CHARACTER_ATTRIBUTES = CONSOLE_CHARACTER_ATTRIBUTES(2u16);
@@ -979,9 +928,6 @@ impl Default for INPUT_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INPUT_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INPUT_RECORD_0 {
@@ -995,9 +941,6 @@ impl Default for INPUT_RECORD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INPUT_RECORD_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KEY_EVENT: u32 = 1u32;
 #[repr(C)]
@@ -1015,9 +958,6 @@ impl Default for KEY_EVENT_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KEY_EVENT_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KEY_EVENT_RECORD_0 {
@@ -1028,9 +968,6 @@ impl Default for KEY_EVENT_RECORD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEY_EVENT_RECORD_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LEFT_ALT_PRESSED: u32 = 2u32;
 pub const LEFT_CTRL_PRESSED: u32 = 8u32;
@@ -1045,9 +982,6 @@ impl Default for MENU_EVENT_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MENU_EVENT_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MOUSE_EVENT: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1061,9 +995,6 @@ impl Default for MOUSE_EVENT_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MOUSE_EVENT_RECORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MOUSE_HWHEELED: u32 = 8u32;
 pub const MOUSE_MOVED: u32 = 1u32;
@@ -1099,9 +1030,6 @@ impl Default for SMALL_RECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SMALL_RECT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STD_ERROR_HANDLE: STD_HANDLE = STD_HANDLE(4294967284u32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1118,7 +1046,4 @@ impl Default for WINDOW_BUFFER_SIZE_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINDOW_BUFFER_SIZE_RECORD {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
@@ -119,9 +119,6 @@ impl Default for CONTACT_AGGREGATION_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONTACT_AGGREGATION_BLOB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CONTACT_AGGREGATION_COLLECTION_OPTIONS(pub i32);

--- a/crates/libs/windows/src/Windows/Win32/System/CorrelationVector/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/CorrelationVector/mod.rs
@@ -29,9 +29,6 @@ impl Default for CORRELATION_VECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CORRELATION_VECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RTL_CORRELATION_VECTOR_STRING_LENGTH: u32 = 129u32;
 pub const RTL_CORRELATION_VECTOR_V1_LENGTH: u32 = 64u32;
 pub const RTL_CORRELATION_VECTOR_V1_PREFIX_LENGTH: u32 = 16u32;

--- a/crates/libs/windows/src/Windows/Win32/System/DataExchange/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DataExchange/mod.rs
@@ -473,10 +473,6 @@ impl Default for CONVCONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for CONVCONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -503,10 +499,6 @@ impl Default for CONVINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for CONVINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -559,9 +551,6 @@ impl Default for COPYDATASTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COPYDATASTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CP_WINANSI: i32 = 1004i32;
 pub const CP_WINNEUTRAL: i32 = 1200i32;
 pub const CP_WINUNICODE: i32 = 1200i32;
@@ -575,9 +564,6 @@ impl Default for DDEACK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDEACK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDEADVISE {
@@ -588,9 +574,6 @@ impl Default for DDEADVISE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDEADVISE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -604,9 +587,6 @@ impl Default for DDEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDELN {
@@ -617,9 +597,6 @@ impl Default for DDELN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDELN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -634,9 +611,6 @@ impl Default for DDEML_MSG_HOOK_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDEML_MSG_HOOK_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDEPOKE {
@@ -649,9 +623,6 @@ impl Default for DDEPOKE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DDEPOKE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DDEUP {
@@ -663,9 +634,6 @@ impl Default for DDEUP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DDEUP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -852,9 +820,6 @@ impl Default for HSZPAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSZPAIR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MAX_MONITORS: u32 = 4u32;
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -870,10 +835,6 @@ impl Default for METAFILEPICT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for METAFILEPICT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MF_CALLBACKS: DDE_INITIALIZE_COMMAND = DDE_INITIALIZE_COMMAND(134217728u32);
 pub const MF_CONV: DDE_INITIALIZE_COMMAND = DDE_INITIALIZE_COMMAND(1073741824u32);
@@ -913,10 +874,6 @@ impl Default for MONCBSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for MONCBSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONCONVSTRUCT {
@@ -934,9 +891,6 @@ impl Default for MONCONVSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONCONVSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONERRSTRUCT {
@@ -949,9 +903,6 @@ impl Default for MONERRSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MONERRSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -968,9 +919,6 @@ impl Default for MONHSZSTRUCTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONHSZSTRUCTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONHSZSTRUCTW {
@@ -985,9 +933,6 @@ impl Default for MONHSZSTRUCTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MONHSZSTRUCTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1010,9 +955,6 @@ impl Default for MONLINKSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONLINKSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONMSGSTRUCT {
@@ -1029,9 +971,6 @@ impl Default for MONMSGSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MONMSGSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSGF_DDEMGR: u32 = 32769u32;
 pub type PFNCALLBACK = Option<unsafe extern "system" fn(wtype: u32, wfmt: u32, hconv: HCONV, hsz1: HSZ, hsz2: HSZ, hdata: HDDEDATA, dwdata1: usize, dwdata2: usize) -> HDDEDATA>;

--- a/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/mod.rs
@@ -3316,9 +3316,6 @@ impl Default for PXE_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PXE_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PXE_ADDRESS_0 {
@@ -3329,9 +3326,6 @@ impl Default for PXE_ADDRESS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PXE_ADDRESS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PXE_ADDR_BROADCAST: u32 = 1u32;
 pub const PXE_ADDR_USE_ADDR: u32 = 4u32;
@@ -3360,9 +3354,6 @@ impl Default for PXE_DHCPV6_MESSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PXE_DHCPV6_MESSAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct PXE_DHCPV6_MESSAGE_HEADER {
@@ -3373,9 +3364,6 @@ impl Default for PXE_DHCPV6_MESSAGE_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PXE_DHCPV6_MESSAGE_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3390,9 +3378,6 @@ impl Default for PXE_DHCPV6_NESTED_RELAY_MESSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PXE_DHCPV6_NESTED_RELAY_MESSAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct PXE_DHCPV6_OPTION {
@@ -3404,9 +3389,6 @@ impl Default for PXE_DHCPV6_OPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PXE_DHCPV6_OPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PXE_DHCPV6_RELAY_HOP_COUNT_LIMIT: u32 = 32u32;
 #[repr(C, packed(1))]
@@ -3422,9 +3404,6 @@ impl Default for PXE_DHCPV6_RELAY_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PXE_DHCPV6_RELAY_MESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PXE_DHCPV6_SERVER_PORT: u32 = 547u32;
 pub const PXE_DHCP_CLIENT_PORT: u32 = 68u32;
@@ -3456,9 +3435,6 @@ impl Default for PXE_DHCP_MESSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PXE_DHCP_MESSAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union PXE_DHCP_MESSAGE_0 {
@@ -3469,9 +3445,6 @@ impl Default for PXE_DHCP_MESSAGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PXE_DHCP_MESSAGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -3484,9 +3457,6 @@ impl Default for PXE_DHCP_OPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PXE_DHCP_OPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PXE_DHCP_SERVER_PORT: u32 = 67u32;
 pub const PXE_DHCP_SERVER_SIZE: u32 = 64u32;
@@ -3506,9 +3476,6 @@ impl Default for PXE_PROVIDER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PXE_PROVIDER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PXE_PROV_ATTR_FILTER: u32 = 0u32;
 pub const PXE_PROV_ATTR_FILTER_IPV6: u32 = 1u32;
@@ -3538,9 +3505,6 @@ impl Default for TRANSPORTCLIENT_SESSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSPORTCLIENT_SESSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3685,9 +3649,6 @@ impl Default for WDS_CLI_CRED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WDS_CLI_CRED {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WDS_CLI_FIRMWARE_BIOS: WDS_CLI_FIRMWARE_TYPE = WDS_CLI_FIRMWARE_TYPE(1i32);
 pub const WDS_CLI_FIRMWARE_EFI: WDS_CLI_FIRMWARE_TYPE = WDS_CLI_FIRMWARE_TYPE(2i32);
 #[repr(transparent)]
@@ -3762,9 +3723,6 @@ impl Default for WDS_TRANSPORTCLIENT_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WDS_TRANSPORTCLIENT_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WDS_TRANSPORTCLIENT_CURRENT_API_VERSION: u32 = 1u32;
 pub const WDS_TRANSPORTCLIENT_MAX_CALLBACKS: TRANSPORTCLIENT_CALLBACK_ID = TRANSPORTCLIENT_CALLBACK_ID(6i32);
 pub const WDS_TRANSPORTCLIENT_NO_AUTH: WDS_TRANSPORTCLIENT_REQUEST_AUTH_LEVEL = WDS_TRANSPORTCLIENT_REQUEST_AUTH_LEVEL(2u32);
@@ -3790,9 +3748,6 @@ impl Default for WDS_TRANSPORTCLIENT_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WDS_TRANSPORTCLIENT_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3826,10 +3781,6 @@ impl Default for WDS_TRANSPORTPROVIDER_INIT_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for WDS_TRANSPORTPROVIDER_INIT_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WDS_TRANSPORTPROVIDER_MAX_CALLBACKS: TRANSPORTPROVIDER_CALLBACK_ID = TRANSPORTPROVIDER_CALLBACK_ID(12i32);
 pub const WDS_TRANSPORTPROVIDER_OPEN_CONTENT: TRANSPORTPROVIDER_CALLBACK_ID = TRANSPORTPROVIDER_CALLBACK_ID(2i32);
 pub const WDS_TRANSPORTPROVIDER_READ_CONTENT: TRANSPORTPROVIDER_CALLBACK_ID = TRANSPORTPROVIDER_CALLBACK_ID(5i32);
@@ -3844,9 +3795,6 @@ impl Default for WDS_TRANSPORTPROVIDER_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WDS_TRANSPORTPROVIDER_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WDS_TRANSPORTPROVIDER_SHUTDOWN: TRANSPORTPROVIDER_CALLBACK_ID = TRANSPORTPROVIDER_CALLBACK_ID(8i32);
 pub const WDS_TRANSPORTPROVIDER_USER_ACCESS_CHECK: TRANSPORTPROVIDER_CALLBACK_ID = TRANSPORTPROVIDER_CALLBACK_ID(3i32);

--- a/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/mod.rs
@@ -2992,6 +2992,3 @@ impl Default for __ReferenceRemainingTypes__ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for __ReferenceRemainingTypes__ {
-    type TypeKind = windows_core::CopyType;
-}

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ClrProfiling/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ClrProfiling/mod.rs
@@ -10,9 +10,6 @@ impl Default for COR_DEBUG_IL_TO_NATIVE_MAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COR_DEBUG_IL_TO_NATIVE_MAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COR_IL_MAP {
@@ -24,9 +21,6 @@ impl Default for COR_IL_MAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COR_IL_MAP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COR_PRF_ALL: COR_PRF_MONITOR = COR_PRF_MONITOR(-1879048193i32);
 pub const COR_PRF_ALLOWABLE_AFTER_ATTACH: COR_PRF_MONITOR = COR_PRF_MONITOR(268763902i32);
@@ -48,10 +42,6 @@ impl Default for COR_PRF_ASSEMBLY_REFERENCE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_WinRT_Metadata")]
-impl windows_core::TypeKind for COR_PRF_ASSEMBLY_REFERENCE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COR_PRF_CACHED_FUNCTION_FOUND: COR_PRF_JIT_CACHE = COR_PRF_JIT_CACHE(0i32);
 pub const COR_PRF_CACHED_FUNCTION_NOT_FOUND: COR_PRF_JIT_CACHE = COR_PRF_JIT_CACHE(1i32);
@@ -77,9 +67,6 @@ impl Default for COR_PRF_CODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COR_PRF_CODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COR_PRF_CORE_CLR: COR_PRF_RUNTIME_TYPE = COR_PRF_RUNTIME_TYPE(2i32);
 pub const COR_PRF_DESKTOP_CLR: COR_PRF_RUNTIME_TYPE = COR_PRF_RUNTIME_TYPE(1i32);
@@ -126,9 +113,6 @@ impl Default for COR_PRF_EVENTPIPE_PARAM_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COR_PRF_EVENTPIPE_PARAM_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct COR_PRF_EVENTPIPE_PARAM_TYPE(pub i32);
@@ -144,9 +128,6 @@ impl Default for COR_PRF_EVENTPIPE_PROVIDER_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COR_PRF_EVENTPIPE_PROVIDER_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COR_PRF_EVENTPIPE_SBYTE: COR_PRF_EVENTPIPE_PARAM_TYPE = COR_PRF_EVENTPIPE_PARAM_TYPE(5i32);
 pub const COR_PRF_EVENTPIPE_SINGLE: COR_PRF_EVENTPIPE_PARAM_TYPE = COR_PRF_EVENTPIPE_PARAM_TYPE(13i32);
@@ -168,9 +149,6 @@ impl Default for COR_PRF_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COR_PRF_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COR_PRF_EX_CLAUSE_INFO {
@@ -183,9 +161,6 @@ impl Default for COR_PRF_EX_CLAUSE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COR_PRF_EX_CLAUSE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COR_PRF_FIELD_APP_DOMAIN_STATIC: COR_PRF_STATIC_TYPE = COR_PRF_STATIC_TYPE(1i32);
 pub const COR_PRF_FIELD_CONTEXT_STATIC: COR_PRF_STATIC_TYPE = COR_PRF_STATIC_TYPE(4i32);
@@ -204,9 +179,6 @@ impl Default for COR_PRF_FILTER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COR_PRF_FILTER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const COR_PRF_FINALIZER_CRITICAL: COR_PRF_FINALIZER_FLAGS = COR_PRF_FINALIZER_FLAGS(1i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -222,9 +194,6 @@ impl Default for COR_PRF_FUNCTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COR_PRF_FUNCTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COR_PRF_FUNCTION_ARGUMENT_INFO {
@@ -237,9 +206,6 @@ impl Default for COR_PRF_FUNCTION_ARGUMENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COR_PRF_FUNCTION_ARGUMENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COR_PRF_FUNCTION_ARGUMENT_RANGE {
@@ -250,9 +216,6 @@ impl Default for COR_PRF_FUNCTION_ARGUMENT_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COR_PRF_FUNCTION_ARGUMENT_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -269,9 +232,6 @@ impl Default for COR_PRF_GC_GENERATION_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COR_PRF_GC_GENERATION_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COR_PRF_GC_GEN_0: COR_PRF_GC_GENERATION = COR_PRF_GC_GENERATION(0i32);
 pub const COR_PRF_GC_GEN_1: COR_PRF_GC_GENERATION = COR_PRF_GC_GENERATION(1i32);
@@ -334,9 +294,6 @@ impl Default for COR_PRF_METHOD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COR_PRF_METHOD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct COR_PRF_MISC(pub i32);
@@ -386,9 +343,6 @@ impl Default for COR_PRF_NONGC_HEAP_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COR_PRF_NONGC_HEAP_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COR_PRF_REJIT_BLOCK_INLINING: COR_PRF_REJIT_FLAGS = COR_PRF_REJIT_FLAGS(1i32);
 #[repr(transparent)]
@@ -447,9 +401,6 @@ impl Default for FunctionIDOrClientID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FunctionIDOrClientID {
-    type TypeKind = windows_core::CopyType;
 }
 pub type FunctionLeave = Option<unsafe extern "system" fn(funcid: usize)>;
 pub type FunctionLeave2 = Option<unsafe extern "system" fn(funcid: usize, clientdata: usize, func: usize, retvalrange: *mut COR_PRF_FUNCTION_ARGUMENT_RANGE)>;

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/ActiveScript/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/ActiveScript/mod.rs
@@ -200,9 +200,6 @@ impl Default for DebugStackFrameDescriptor {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DebugStackFrameDescriptor {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct DebugStackFrameDescriptor64 {
@@ -216,9 +213,6 @@ impl Default for DebugStackFrameDescriptor64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DebugStackFrameDescriptor64 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DefaultDebugSessionProvider: windows_core::GUID = windows_core::GUID::from_u128(0x834128a2_51f4_11d0_8f20_00805f2cd064);
 #[repr(transparent)]
@@ -9301,9 +9295,6 @@ impl Default for JS_NATIVE_FRAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JS_NATIVE_FRAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct JS_PROPERTY_ATTRIBUTES(pub i32);
@@ -9334,9 +9325,6 @@ impl Default for JsDebugPropertyInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JsDebugPropertyInfo {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9446,9 +9434,6 @@ impl Default for PROFILER_HEAP_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROFILER_HEAP_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROFILER_HEAP_OBJECT_0 {
@@ -9459,9 +9444,6 @@ impl Default for PROFILER_HEAP_OBJECT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROFILER_HEAP_OBJECT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9524,9 +9506,6 @@ impl Default for PROFILER_HEAP_OBJECT_OPTIONAL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROFILER_HEAP_OBJECT_OPTIONAL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROFILER_HEAP_OBJECT_OPTIONAL_INFO_0 {
@@ -9548,9 +9527,6 @@ impl Default for PROFILER_HEAP_OBJECT_OPTIONAL_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROFILER_HEAP_OBJECT_OPTIONAL_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROFILER_HEAP_OBJECT_OPTIONAL_INFO_ELEMENT_ATTRIBUTES_SIZE: PROFILER_HEAP_OBJECT_OPTIONAL_INFO_TYPE = PROFILER_HEAP_OBJECT_OPTIONAL_INFO_TYPE(7i32);
 pub const PROFILER_HEAP_OBJECT_OPTIONAL_INFO_ELEMENT_TEXT_CHILDREN_SIZE: PROFILER_HEAP_OBJECT_OPTIONAL_INFO_TYPE = PROFILER_HEAP_OBJECT_OPTIONAL_INFO_TYPE(8i32);
@@ -9585,9 +9561,6 @@ impl Default for PROFILER_HEAP_OBJECT_RELATIONSHIP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROFILER_HEAP_OBJECT_RELATIONSHIP {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union PROFILER_HEAP_OBJECT_RELATIONSHIP_0 {
     pub numberValue: f64,
@@ -9606,9 +9579,6 @@ impl Default for PROFILER_HEAP_OBJECT_RELATIONSHIP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROFILER_HEAP_OBJECT_RELATIONSHIP_0 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9666,9 +9636,6 @@ impl Default for PROFILER_HEAP_OBJECT_RELATIONSHIP_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROFILER_HEAP_OBJECT_RELATIONSHIP_LIST {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROFILER_HEAP_OBJECT_SCOPE_LIST {
@@ -9680,9 +9647,6 @@ impl Default for PROFILER_HEAP_OBJECT_SCOPE_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROFILER_HEAP_OBJECT_SCOPE_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROFILER_HEAP_SUMMARY {
@@ -9693,9 +9657,6 @@ impl Default for PROFILER_HEAP_SUMMARY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROFILER_HEAP_SUMMARY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9717,9 +9678,6 @@ impl Default for PROFILER_PROPERTY_TYPE_SUBSTRING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROFILER_PROPERTY_TYPE_SUBSTRING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9919,9 +9877,6 @@ impl Default for TEXT_DOCUMENT_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TEXT_DOCUMENT_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TEXT_DOC_ATTR_READONLY: u32 = 1u32;
 pub const TEXT_DOC_ATTR_TYPE_PRIMARY: u32 = 2u32;

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/Extensions/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/Extensions/mod.rs
@@ -55,9 +55,6 @@ impl Default for ArrayDimension {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ArrayDimension {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BUSDATA {
@@ -73,9 +70,6 @@ impl Default for BUSDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BUSDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CANNOT_ALLOCATE_MEMORY: u32 = 9u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -89,9 +83,6 @@ impl Default for CKCL_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CKCL_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CKCL_LISTHEAD {
@@ -102,9 +93,6 @@ impl Default for CKCL_LISTHEAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CKCL_LISTHEAD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLSID_DebugFailureAnalysisBasic: windows_core::GUID = windows_core::GUID::from_u128(0xb74eed7f_1c7d_4c1b_959f_b96dd9175aa4);
 pub const CLSID_DebugFailureAnalysisKernel: windows_core::GUID = windows_core::GUID::from_u128(0xee433078_64af_4c33_ab2f_ecad7f2a002d);
@@ -126,9 +114,6 @@ impl Default for CPU_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CPU_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CPU_INFO_v1 {
@@ -143,9 +128,6 @@ impl Default for CPU_INFO_v1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CPU_INFO_v1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CPU_INFO_v2 {
@@ -159,9 +141,6 @@ impl Default for CPU_INFO_v2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CPU_INFO_v2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CROSS_PLATFORM_MAXIMUM_PROCESSORS: u32 = 2048u32;
 pub const CURRENT_KD_SECONDARY_VERSION: u32 = 2u32;
@@ -188,10 +167,6 @@ impl Default for DBGKD_DEBUG_DATA_HEADER32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DBGKD_DEBUG_DATA_HEADER32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -205,10 +180,6 @@ impl Default for DBGKD_DEBUG_DATA_HEADER64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DBGKD_DEBUG_DATA_HEADER64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -233,9 +204,6 @@ impl Default for DBGKD_GET_VERSION32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DBGKD_GET_VERSION32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DBGKD_GET_VERSION64 {
@@ -258,9 +226,6 @@ impl Default for DBGKD_GET_VERSION64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DBGKD_GET_VERSION64 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DBGKD_MAJOR_BIG: DBGKD_MAJOR_TYPES = DBGKD_MAJOR_TYPES(2i32);
 pub const DBGKD_MAJOR_CE: DBGKD_MAJOR_TYPES = DBGKD_MAJOR_TYPES(10i32);
@@ -341,9 +306,6 @@ impl Default for DBG_THREAD_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DBG_THREAD_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_ADDSYNTHMOD_DEFAULT: u32 = 0u32;
 pub const DEBUG_ADDSYNTHMOD_ZEROBASE: u32 = 1u32;
 pub const DEBUG_ADDSYNTHSYM_DEFAULT: u32 = 0u32;
@@ -370,9 +332,6 @@ impl Default for DEBUG_ANALYSIS_PROCESSOR_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_ANALYSIS_PROCESSOR_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_ANY_ID: u32 = 4294967295u32;
 pub const DEBUG_ASMOPT_DEFAULT: u32 = 0u32;
@@ -420,9 +379,6 @@ impl Default for DEBUG_BREAKPOINT_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_BREAKPOINT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_BREAKPOINT_TIME: u32 = 2u32;
 pub const DEBUG_BREAK_EXECUTE: u32 = 4u32;
 pub const DEBUG_BREAK_IO: u32 = 8u32;
@@ -441,9 +397,6 @@ impl Default for DEBUG_CACHED_SYMBOL_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_CACHED_SYMBOL_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_CDS_ALL: u32 = 4294967295u32;
 pub const DEBUG_CDS_DATA: u32 = 2u32;
@@ -498,9 +451,6 @@ impl Default for DEBUG_CLIENT_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_CLIENT_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_CLIENT_KD: u32 = 5u32;
 pub const DEBUG_CLIENT_NTKD: u32 = 3u32;
 pub const DEBUG_CLIENT_NTSD: u32 = 2u32;
@@ -531,9 +481,6 @@ impl Default for DEBUG_CPU_MICROCODE_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_CPU_MICROCODE_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_CPU_SPEED_INFO {
@@ -547,9 +494,6 @@ impl Default for DEBUG_CPU_SPEED_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_CPU_SPEED_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_CREATE_PROCESS_OPTIONS {
@@ -562,9 +506,6 @@ impl Default for DEBUG_CREATE_PROCESS_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_CREATE_PROCESS_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_CSS_ALL: u32 = 4294967295u32;
 pub const DEBUG_CSS_COLLAPSE_CHILDREN: u32 = 64u32;
@@ -723,9 +664,6 @@ impl Default for DEBUG_DECODE_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_DECODE_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_DEVICE_OBJECT_INFO {
@@ -742,9 +680,6 @@ impl Default for DEBUG_DEVICE_OBJECT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_DEVICE_OBJECT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_DISASM_EFFECTIVE_ADDRESS: u32 = 1u32;
 pub const DEBUG_DISASM_MATCHING_SYMBOLS: u32 = 2u32;
@@ -766,9 +701,6 @@ impl Default for DEBUG_DRIVER_OBJECT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_DRIVER_OBJECT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_DRIVER_OBJECT_INFO_0 {
@@ -780,9 +712,6 @@ impl Default for DEBUG_DRIVER_OBJECT_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_DRIVER_OBJECT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_DUMP_ACTIVE: u32 = 1030u32;
 pub const DEBUG_DUMP_DEFAULT: u32 = 1025u32;
@@ -850,9 +779,6 @@ impl Default for DEBUG_EVENT_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_EVENT_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_EVENT_CREATE_PROCESS: u32 = 16u32;
 pub const DEBUG_EVENT_CREATE_THREAD: u32 = 4u32;
 pub const DEBUG_EVENT_EXCEPTION: u32 = 2u32;
@@ -877,9 +803,6 @@ impl Default for DEBUG_EXCEPTION_FILTER_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_EXCEPTION_FILTER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_EXECUTE_DEFAULT: u32 = 0u32;
 pub const DEBUG_EXECUTE_ECHO: u32 = 1u32;
@@ -1796,9 +1719,6 @@ impl Default for DEBUG_GET_TEXT_COMPLETIONS_IN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_GET_TEXT_COMPLETIONS_IN {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_GET_TEXT_COMPLETIONS_IS_DOT_COMMAND: u32 = 1u32;
 pub const DEBUG_GET_TEXT_COMPLETIONS_IS_EXTENSION_COMMAND: u32 = 2u32;
 pub const DEBUG_GET_TEXT_COMPLETIONS_IS_SYMBOL: u32 = 4u32;
@@ -1818,9 +1738,6 @@ impl Default for DEBUG_GET_TEXT_COMPLETIONS_OUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_GET_TEXT_COMPLETIONS_OUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_GSEL_ALLOW_HIGHER: u32 = 4u32;
 pub const DEBUG_GSEL_ALLOW_LOWER: u32 = 2u32;
@@ -1842,9 +1759,6 @@ impl Default for DEBUG_HANDLE_DATA_BASIC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_HANDLE_DATA_BASIC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_HANDLE_DATA_TYPE_ALL_HANDLE_OPERATIONS: u32 = 10u32;
 pub const DEBUG_HANDLE_DATA_TYPE_BASIC: u32 = 0u32;
@@ -1889,9 +1803,6 @@ impl Default for DEBUG_IRP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_IRP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_IRP_STACK_INFO {
@@ -1906,9 +1817,6 @@ impl Default for DEBUG_IRP_STACK_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_IRP_STACK_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_KERNEL_ACTIVE_DUMP: u32 = 1030u32;
 pub const DEBUG_KERNEL_CONNECTION: u32 = 0u32;
@@ -1934,9 +1842,6 @@ impl Default for DEBUG_LAST_EVENT_INFO_BREAKPOINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_LAST_EVENT_INFO_BREAKPOINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_LAST_EVENT_INFO_EXCEPTION {
@@ -1948,9 +1853,6 @@ impl Default for DEBUG_LAST_EVENT_INFO_EXCEPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_LAST_EVENT_INFO_EXCEPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_LAST_EVENT_INFO_EXIT_PROCESS {
@@ -1960,9 +1862,6 @@ impl Default for DEBUG_LAST_EVENT_INFO_EXIT_PROCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_LAST_EVENT_INFO_EXIT_PROCESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1974,9 +1873,6 @@ impl Default for DEBUG_LAST_EVENT_INFO_EXIT_THREAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_LAST_EVENT_INFO_EXIT_THREAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_LAST_EVENT_INFO_LOAD_MODULE {
@@ -1986,9 +1882,6 @@ impl Default for DEBUG_LAST_EVENT_INFO_LOAD_MODULE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_LAST_EVENT_INFO_LOAD_MODULE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2002,9 +1895,6 @@ impl Default for DEBUG_LAST_EVENT_INFO_SERVICE_EXCEPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_LAST_EVENT_INFO_SERVICE_EXCEPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_LAST_EVENT_INFO_SYSTEM_ERROR {
@@ -2016,9 +1906,6 @@ impl Default for DEBUG_LAST_EVENT_INFO_SYSTEM_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_LAST_EVENT_INFO_SYSTEM_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_LAST_EVENT_INFO_UNLOAD_MODULE {
@@ -2028,9 +1915,6 @@ impl Default for DEBUG_LAST_EVENT_INFO_UNLOAD_MODULE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_LAST_EVENT_INFO_UNLOAD_MODULE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_LEVEL_ASSEMBLY: u32 = 1u32;
 pub const DEBUG_LEVEL_SOURCE: u32 = 0u32;
@@ -2063,9 +1947,6 @@ impl Default for DEBUG_MODULE_AND_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_MODULE_AND_ID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_MODULE_EXE_MODULE: u32 = 4u32;
 pub const DEBUG_MODULE_EXPLICIT: u32 = 8u32;
 pub const DEBUG_MODULE_LOADED: u32 = 0u32;
@@ -2090,9 +1971,6 @@ impl Default for DEBUG_MODULE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_MODULE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_MODULE_SECONDARY: u32 = 16u32;
 pub const DEBUG_MODULE_SYM_BAD_CHECKSUM: u32 = 65536u32;
 pub const DEBUG_MODULE_SYNTHETIC: u32 = 32u32;
@@ -2112,9 +1990,6 @@ impl Default for DEBUG_OFFSET_REGION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_OFFSET_REGION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_OFFSINFO_VIRTUAL_SOURCE: u32 = 1u32;
 pub const DEBUG_OUTCBF_COMBINED_EXPLICIT_FLUSH: u32 = 1u32;
@@ -2205,9 +2080,6 @@ impl Default for DEBUG_PNP_TRIAGE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_PNP_TRIAGE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_POOLTAG_DESCRIPTION {
@@ -2221,9 +2093,6 @@ impl Default for DEBUG_POOLTAG_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_POOLTAG_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2244,9 +2113,6 @@ impl Default for DEBUG_POOL_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_POOL_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEBUG_POOL_DATA_0 {
@@ -2258,9 +2124,6 @@ impl Default for DEBUG_POOL_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_POOL_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_POOL_DATA_0_0 {
@@ -2270,9 +2133,6 @@ impl Default for DEBUG_POOL_DATA_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_POOL_DATA_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2292,9 +2152,6 @@ impl Default for DEBUG_PROCESSOR_IDENTIFICATION_ALL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_PROCESSOR_IDENTIFICATION_ALL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_PROCESSOR_IDENTIFICATION_ALPHA {
@@ -2305,9 +2162,6 @@ impl Default for DEBUG_PROCESSOR_IDENTIFICATION_ALPHA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_PROCESSOR_IDENTIFICATION_ALPHA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2322,9 +2176,6 @@ impl Default for DEBUG_PROCESSOR_IDENTIFICATION_AMD64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_PROCESSOR_IDENTIFICATION_AMD64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_PROCESSOR_IDENTIFICATION_ARM {
@@ -2337,9 +2188,6 @@ impl Default for DEBUG_PROCESSOR_IDENTIFICATION_ARM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_PROCESSOR_IDENTIFICATION_ARM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_PROCESSOR_IDENTIFICATION_ARM64 {
@@ -2351,9 +2199,6 @@ impl Default for DEBUG_PROCESSOR_IDENTIFICATION_ARM64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_PROCESSOR_IDENTIFICATION_ARM64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2369,9 +2214,6 @@ impl Default for DEBUG_PROCESSOR_IDENTIFICATION_IA64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_PROCESSOR_IDENTIFICATION_IA64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_PROCESSOR_IDENTIFICATION_X86 {
@@ -2384,9 +2226,6 @@ impl Default for DEBUG_PROCESSOR_IDENTIFICATION_X86 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_PROCESSOR_IDENTIFICATION_X86 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_PROCESS_DETACH_ON_EXIT: u32 = 1u32;
 pub const DEBUG_PROCESS_ONLY_THIS_PROCESS: u32 = 2u32;
@@ -2414,9 +2253,6 @@ impl Default for DEBUG_READ_USER_MINIDUMP_STREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_READ_USER_MINIDUMP_STREAM {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_REGISTERS_ALL: u32 = 7u32;
 pub const DEBUG_REGISTERS_DEFAULT: u32 = 0u32;
 pub const DEBUG_REGISTERS_FLOAT: u32 = 4u32;
@@ -2437,9 +2273,6 @@ impl Default for DEBUG_REGISTER_DESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_REGISTER_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_REGISTER_SUB_REGISTER: u32 = 1u32;
 pub const DEBUG_REGSRC_DEBUGGEE: u32 = 0u32;
@@ -2528,9 +2361,6 @@ impl Default for DEBUG_SMBIOS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_SMBIOS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_SOURCE_IS_STATEMENT: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2545,9 +2375,6 @@ impl Default for DEBUG_SPECIFIC_FILTER_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_SPECIFIC_FILTER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_SRCFILE_SYMBOL_CHECKSUMINFO: u32 = 2u32;
 pub const DEBUG_SRCFILE_SYMBOL_TOKEN: u32 = 0u32;
@@ -2573,9 +2400,6 @@ impl Default for DEBUG_STACK_FRAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_STACK_FRAME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_STACK_FRAME_ADDRESSES: u32 = 8u32;
 pub const DEBUG_STACK_FRAME_ADDRESSES_RA_ONLY: u32 = 256u32;
 pub const DEBUG_STACK_FRAME_ARCH: u32 = 16384u32;
@@ -2598,9 +2422,6 @@ impl Default for DEBUG_STACK_FRAME_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_STACK_FRAME_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_STACK_FRAME_MEMORY_USAGE: u32 = 512u32;
 pub const DEBUG_STACK_FRAME_NUMBERS: u32 = 64u32;
@@ -2653,9 +2474,6 @@ impl Default for DEBUG_SYMBOL_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_SYMBOL_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEBUG_SYMBOL_EXPANDED: u32 = 16u32;
 pub const DEBUG_SYMBOL_EXPANSION_LEVEL_MASK: u32 = 15u32;
 pub const DEBUG_SYMBOL_IS_ARGUMENT: u32 = 256u32;
@@ -2676,9 +2494,6 @@ impl Default for DEBUG_SYMBOL_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_SYMBOL_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_SYMBOL_READ_ONLY: u32 = 32u32;
 #[repr(C)]
@@ -2701,9 +2516,6 @@ impl Default for DEBUG_SYMBOL_SOURCE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_SYMBOL_SOURCE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_SYMENT_IS_CODE: u32 = 1u32;
 pub const DEBUG_SYMENT_IS_DATA: u32 = 2u32;
@@ -2754,9 +2566,6 @@ impl Default for DEBUG_THREAD_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_THREAD_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_TRIAGE_FOLLOWUP_INFO {
@@ -2768,9 +2577,6 @@ impl Default for DEBUG_TRIAGE_FOLLOWUP_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_TRIAGE_FOLLOWUP_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2785,9 +2591,6 @@ impl Default for DEBUG_TRIAGE_FOLLOWUP_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_TRIAGE_FOLLOWUP_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2808,9 +2611,6 @@ impl Default for DEBUG_TYPED_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_TYPED_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_TYPED_DATA_IS_IN_MEMORY: u32 = 1u32;
 pub const DEBUG_TYPED_DATA_PHYSICAL_CACHED: u32 = 4u32;
@@ -2841,9 +2641,6 @@ impl Default for DEBUG_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEBUG_VALUE_0 {
@@ -2871,9 +2668,6 @@ impl Default for DEBUG_VALUE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_VALUE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_VALUE_0_0 {
@@ -2884,9 +2678,6 @@ impl Default for DEBUG_VALUE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_VALUE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2899,9 +2690,6 @@ impl Default for DEBUG_VALUE_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUG_VALUE_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEBUG_VALUE_0_1 {
@@ -2912,9 +2700,6 @@ impl Default for DEBUG_VALUE_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEBUG_VALUE_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_VALUE_FLOAT128: u32 = 9u32;
 pub const DEBUG_VALUE_FLOAT32: u32 = 5u32;
@@ -3022,9 +2807,6 @@ impl Default for EXTSTACKTRACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXTSTACKTRACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXTSTACKTRACE32 {
@@ -3038,9 +2820,6 @@ impl Default for EXTSTACKTRACE32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXTSTACKTRACE32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXTSTACKTRACE64 {
@@ -3053,9 +2832,6 @@ impl Default for EXTSTACKTRACE64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXTSTACKTRACE64 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type EXTS_JOB_PROCESS_CALLBACK = Option<unsafe extern "system" fn(job: u64, process: u64, context: *mut core::ffi::c_void) -> super::super::super::super::Foundation::BOOLEAN>;
 pub type EXTS_TABLE_ENTRY_CALLBACK = Option<unsafe extern "system" fn(entry: u64, context: *mut core::ffi::c_void) -> super::super::super::super::Foundation::BOOLEAN>;
@@ -3076,9 +2852,6 @@ impl Default for EXT_API_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXT_API_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EXT_API_VERSION_NUMBER: u32 = 5u32;
 pub const EXT_API_VERSION_NUMBER32: u32 = 5u32;
 pub const EXT_API_VERSION_NUMBER64: u32 = 6u32;
@@ -3095,9 +2868,6 @@ impl Default for EXT_CAB_XML_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXT_CAB_XML_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXT_CAB_XML_DATA_0 {
@@ -3112,9 +2882,6 @@ impl Default for EXT_CAB_XML_DATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXT_CAB_XML_DATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type EXT_DECODE_ERROR = Option<unsafe extern "system" fn(pdecodeerror: *mut DEBUG_DECODE_ERROR)>;
 #[repr(C)]
@@ -3138,9 +2905,6 @@ impl Default for EXT_FIND_FILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXT_FIND_FILE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EXT_FIND_FILE_ALLOW_GIVEN_PATH: u32 = 1u32;
 pub type EXT_GET_DEBUG_FAILURE_ANALYSIS = Option<unsafe extern "system" fn(client: Option<IDebugClient4>, flags: u32, classid: windows_core::GUID, ppanalysis: *mut Option<IDebugFailureAnalysis2>) -> windows_core::HRESULT>;
 pub type EXT_GET_ENVIRONMENT_VARIABLE = Option<unsafe extern "system" fn(peb: u64, variable: windows_core::PCSTR, buffer: windows_core::PCSTR, buffersize: u32) -> windows_core::HRESULT>;
@@ -3158,9 +2922,6 @@ impl Default for EXT_MATCH_PATTERN_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXT_MATCH_PATTERN_A {
-    type TypeKind = windows_core::CopyType;
 }
 pub type EXT_RELOAD_TRIAGER = Option<unsafe extern "system" fn(client: Option<IDebugClient4>) -> windows_core::HRESULT>;
 pub type EXT_TARGET_INFO = Option<unsafe extern "system" fn(client: Option<IDebugClient4>, ptargetinfo: *mut TARGET_DEBUG_INFO) -> windows_core::HRESULT>;
@@ -3219,9 +2980,6 @@ impl Default for EXT_TYPED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXT_TYPED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub type EXT_XML_DATA = Option<unsafe extern "system" fn(client: Option<IDebugClient4>, pxmpdata: *mut EXT_CAB_XML_DATA) -> windows_core::HRESULT>;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3269,9 +3027,6 @@ impl Default for FA_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FA_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FA_ENTRY_TYPE(pub i32);
@@ -3303,9 +3058,6 @@ impl Default for FIELD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FIELD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FIELD_INFO_0 {
@@ -3317,9 +3069,6 @@ impl Default for FIELD_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FIELD_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FIELD_INFO_1 {
@@ -3330,9 +3079,6 @@ impl Default for FIELD_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FIELD_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FormatBSTRString: PreferredFormat = PreferredFormat(8i32);
 pub const FormatEnumNameOnly: PreferredFormat = PreferredFormat(12i32);
@@ -3362,9 +3108,6 @@ impl Default for GET_CONTEXT_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_CONTEXT_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_CURRENT_PROCESS_ADDRESS {
@@ -3377,9 +3120,6 @@ impl Default for GET_CURRENT_PROCESS_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_CURRENT_PROCESS_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_CURRENT_THREAD_ADDRESS {
@@ -3390,9 +3130,6 @@ impl Default for GET_CURRENT_THREAD_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GET_CURRENT_THREAD_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3405,9 +3142,6 @@ impl Default for GET_EXPRESSION_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GET_EXPRESSION_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3422,9 +3156,6 @@ impl Default for GET_INPUT_LINE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_INPUT_LINE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_PEB_ADDRESS {
@@ -3435,9 +3166,6 @@ impl Default for GET_PEB_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GET_PEB_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3451,9 +3179,6 @@ impl Default for GET_SET_SYMPATH {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_SET_SYMPATH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_TEB_ADDRESS {
@@ -3463,9 +3188,6 @@ impl Default for GET_TEB_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GET_TEB_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(ICodeAddressConcept, ICodeAddressConcept_Vtbl, 0xc7371568_5c78_4a00_a4ab_6ef8823184cb);
 windows_core::imp::interface_hierarchy!(ICodeAddressConcept, windows_core::IUnknown);
@@ -44925,9 +44647,6 @@ impl Default for INLINE_FRAME_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INLINE_FRAME_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INLINE_FRAME_CONTEXT_0 {
@@ -44939,9 +44658,6 @@ impl Default for INLINE_FRAME_CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INLINE_FRAME_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INSUFFICIENT_SPACE_TO_COPY: u32 = 10u32;
 #[repr(C)]
@@ -44956,9 +44672,6 @@ impl Default for IOSPACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOSPACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IOSPACE32 {
@@ -44971,9 +44684,6 @@ impl Default for IOSPACE32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOSPACE32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IOSPACE64 {
@@ -44985,9 +44695,6 @@ impl Default for IOSPACE64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IOSPACE64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -45004,9 +44711,6 @@ impl Default for IOSPACE_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOSPACE_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IOSPACE_EX32 {
@@ -45022,9 +44726,6 @@ impl Default for IOSPACE_EX32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IOSPACE_EX32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IOSPACE_EX64 {
@@ -45039,9 +44740,6 @@ impl Default for IOSPACE_EX64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IOSPACE_EX64 {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IPreferredRuntimeTypeConcept, IPreferredRuntimeTypeConcept_Vtbl, 0x9d6c1d7b_a76f_4618_8068_5f76bd9a4e8a);
 windows_core::imp::interface_hierarchy!(IPreferredRuntimeTypeConcept, windows_core::IUnknown);
@@ -45250,10 +44948,6 @@ impl Default for KDDEBUGGER_DATA32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KDDEBUGGER_DATA32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -45428,10 +45122,6 @@ impl Default for KDDEBUGGER_DATA64 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for KDDEBUGGER_DATA64 {
-    type TypeKind = windows_core::CopyType;
-}
 pub type KDEXTS_LOCK_CALLBACKROUTINE = Option<unsafe extern "system" fn(plock: *mut KDEXTS_LOCK_INFO, context: *mut core::ffi::c_void) -> windows_core::HRESULT>;
 pub const KDEXTS_LOCK_CALLBACKROUTINE_DEFINED: u32 = 2u32;
 #[repr(C)]
@@ -45453,9 +45143,6 @@ impl Default for KDEXTS_LOCK_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KDEXTS_LOCK_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KDEXTS_PTE_INFO {
@@ -45474,9 +45161,6 @@ impl Default for KDEXTS_PTE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KDEXTS_PTE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub type KDEXT_DUMP_HANDLE_CALLBACK = Option<unsafe extern "system" fn(handleinfo: *const KDEXT_HANDLE_INFORMATION, flags: u32, context: *mut core::ffi::c_void) -> super::super::super::super::Foundation::BOOLEAN>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -45492,9 +45176,6 @@ impl Default for KDEXT_FILELOCK_OWNER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KDEXT_FILELOCK_OWNER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -45512,9 +45193,6 @@ impl Default for KDEXT_HANDLE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KDEXT_HANDLE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KDEXT_PROCESS_FIND_PARAMS {
@@ -45528,9 +45206,6 @@ impl Default for KDEXT_PROCESS_FIND_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KDEXT_PROCESS_FIND_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KDEXT_THREAD_FIND_PARAMS {
@@ -45543,9 +45218,6 @@ impl Default for KDEXT_THREAD_FIND_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KDEXT_THREAD_FIND_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KD_SECONDARY_VERSION_AMD64_CONTEXT: u32 = 2u32;
 pub const KD_SECONDARY_VERSION_AMD64_OBSOLETE_CONTEXT_1: u32 = 0u32;
@@ -45569,9 +45241,6 @@ impl Default for Location {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for Location {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LocationConstant: LocationKind = LocationKind(2i32);
 #[repr(transparent)]
@@ -45619,9 +45288,6 @@ impl Default for OS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OS_INFO_0 {
@@ -45631,9 +45297,6 @@ impl Default for OS_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -45653,9 +45316,6 @@ impl Default for OS_INFO_v1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OS_INFO_v1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union OS_INFO_v1_0 {
@@ -45666,9 +45326,6 @@ impl Default for OS_INFO_v1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OS_INFO_v1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -45681,9 +45338,6 @@ impl Default for OS_INFO_v1_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OS_INFO_v1_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OS_INFO_v1_1 {
@@ -45693,9 +45347,6 @@ impl Default for OS_INFO_v1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OS_INFO_v1_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -45755,9 +45406,6 @@ impl Default for PHYSICAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PHYSICAL_TO_VIRTUAL {
@@ -45769,9 +45417,6 @@ impl Default for PHYSICAL_TO_VIRTUAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PHYSICAL_TO_VIRTUAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -45785,9 +45430,6 @@ impl Default for PHYSICAL_WITH_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PHYSICAL_WITH_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PHYS_FLAG_CACHED: u32 = 1u32;
 pub const PHYS_FLAG_DEFAULT: u32 = 0u32;
@@ -45811,9 +45453,6 @@ impl Default for POINTER_SEARCH_PHYSICAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POINTER_SEARCH_PHYSICAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESSORINFO {
@@ -45824,9 +45463,6 @@ impl Default for PROCESSORINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESSORINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -45844,9 +45480,6 @@ impl Default for PROCESS_COMMIT_USAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_COMMIT_USAGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PROCESS_END: TANALYZE_RETURN = TANALYZE_RETURN(1i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -45860,9 +45493,6 @@ impl Default for PROCESS_NAME_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_NAME_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PSYM_DUMP_FIELD_CALLBACK = Option<unsafe extern "system" fn(pfield: *mut FIELD_INFO, usercontext: *mut core::ffi::c_void) -> u32>;
 pub const PTR_SEARCH_NO_SYMBOL_CHECK: u32 = 2147483648u32;
@@ -45935,9 +45565,6 @@ impl Default for READCONTROLSPACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for READCONTROLSPACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct READCONTROLSPACE32 {
@@ -45950,9 +45577,6 @@ impl Default for READCONTROLSPACE32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for READCONTROLSPACE32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -45967,9 +45591,6 @@ impl Default for READCONTROLSPACE64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for READCONTROLSPACE64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct READ_WRITE_MSR {
@@ -45980,9 +45601,6 @@ impl Default for READ_WRITE_MSR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for READ_WRITE_MSR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -46002,9 +45620,6 @@ impl Default for SEARCHMEMORY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEARCHMEMORY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STACK_FRAME_TYPE_IGNORE: u32 = 255u32;
 pub const STACK_FRAME_TYPE_INIT: u32 = 0u32;
@@ -46026,9 +45641,6 @@ impl Default for STACK_SRC_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STACK_SRC_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STACK_SYM_FRAME_INFO {
@@ -46039,9 +45651,6 @@ impl Default for STACK_SYM_FRAME_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STACK_SYM_FRAME_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -46057,9 +45666,6 @@ impl Default for SYMBOL_INFO_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYMBOL_INFO_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SYMBOL_TYPE_INDEX_NOT_FOUND: u32 = 2u32;
 pub const SYMBOL_TYPE_INFO_NOT_FOUND: u32 = 3u32;
@@ -46086,9 +45692,6 @@ impl Default for SYM_DUMP_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYM_DUMP_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SYM_DUMP_PARAM_0 {
@@ -46099,9 +45702,6 @@ impl Default for SYM_DUMP_PARAM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYM_DUMP_PARAM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -46132,9 +45732,6 @@ impl Default for ScriptDebugEventInformation {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ScriptDebugEventInformation {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ScriptDebugEventInformation_0 {
@@ -46146,9 +45743,6 @@ impl Default for ScriptDebugEventInformation_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ScriptDebugEventInformation_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ScriptDebugEventInformation_0_1 {
@@ -46159,9 +45753,6 @@ impl Default for ScriptDebugEventInformation_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ScriptDebugEventInformation_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ScriptDebugEventInformation_0_0 {
@@ -46171,9 +45762,6 @@ impl Default for ScriptDebugEventInformation_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ScriptDebugEventInformation_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ScriptDebugException: ScriptDebugEvent = ScriptDebugEvent(2i32);
 pub const ScriptDebugExecuting: ScriptDebugState = ScriptDebugState(2i32);
@@ -46189,9 +45777,6 @@ impl Default for ScriptDebugPosition {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ScriptDebugPosition {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -46247,9 +45832,6 @@ impl Default for TARGET_DEBUG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TARGET_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct TARGET_DEBUG_INFO_v1 {
@@ -46272,9 +45854,6 @@ impl Default for TARGET_DEBUG_INFO_v1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TARGET_DEBUG_INFO_v1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct TARGET_DEBUG_INFO_v2 {
@@ -46293,9 +45872,6 @@ impl Default for TARGET_DEBUG_INFO_v2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TARGET_DEBUG_INFO_v2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSLATE_VIRTUAL_TO_PHYSICAL {
@@ -46306,9 +45882,6 @@ impl Default for TRANSLATE_VIRTUAL_TO_PHYSICAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSLATE_VIRTUAL_TO_PHYSICAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRIAGE_FOLLOWUP_DEFAULT: u32 = 2u32;
 pub const TRIAGE_FOLLOWUP_FAIL: u32 = 0u32;
@@ -46342,9 +45915,6 @@ impl Default for VIRTUAL_TO_PHYSICAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_TO_PHYSICAL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VarArgsCStyle: VarArgsKind = VarArgsKind(1i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -46365,9 +45935,6 @@ impl Default for WDBGEXTS_CLR_DATA_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WDBGEXTS_CLR_DATA_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WDBGEXTS_DISASSEMBLE_BUFFER {
@@ -46386,9 +45953,6 @@ impl Default for WDBGEXTS_DISASSEMBLE_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WDBGEXTS_DISASSEMBLE_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WDBGEXTS_MODULE_IN_RANGE {
@@ -46402,9 +45966,6 @@ impl Default for WDBGEXTS_MODULE_IN_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WDBGEXTS_MODULE_IN_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WDBGEXTS_QUERY_INTERFACE {
@@ -46415,9 +45976,6 @@ impl Default for WDBGEXTS_QUERY_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WDBGEXTS_QUERY_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -46437,9 +45995,6 @@ impl Default for WDBGEXTS_THREAD_OS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WDBGEXTS_THREAD_OS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -46464,10 +46019,6 @@ impl Default for WINDBG_EXTENSION_APIS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for WINDBG_EXTENSION_APIS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -46490,10 +46041,6 @@ impl Default for WINDBG_EXTENSION_APIS32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for WINDBG_EXTENSION_APIS32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -46518,10 +46065,6 @@ impl Default for WINDBG_EXTENSION_APIS64 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for WINDBG_EXTENSION_APIS64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINDBG_OLDKD_EXTENSION_APIS {
@@ -46541,9 +46084,6 @@ impl Default for WINDBG_OLDKD_EXTENSION_APIS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINDBG_OLDKD_EXTENSION_APIS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINDBG_OLD_EXTENSION_APIS {
@@ -46558,9 +46098,6 @@ impl Default for WINDBG_OLD_EXTENSION_APIS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINDBG_OLD_EXTENSION_APIS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIN_95: OS_TYPE = OS_TYPE(0i32);
 pub const WIN_98: OS_TYPE = OS_TYPE(1i32);
@@ -46588,9 +46125,6 @@ impl Default for XML_DRIVER_NODE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XML_DRIVER_NODE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const _EXTSAPI_VER_: u32 = 10u32;
 pub type fnDebugFailureAnalysisCreateInstance = Option<unsafe extern "system" fn(client: Option<IDebugClient>, args: windows_core::PCWSTR, flags: u32, rclsid: *const windows_core::GUID, riid: *const windows_core::GUID, ppv: *mut *mut core::ffi::c_void) -> windows_core::HRESULT>;

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
@@ -2232,10 +2232,6 @@ impl Default for ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ADDRESS64 {
@@ -2247,9 +2243,6 @@ impl Default for ADDRESS64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADDRESS64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2265,9 +2258,6 @@ impl Default for AER_BRIDGE_DESCRIPTOR_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AER_BRIDGE_DESCRIPTOR_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct AER_BRIDGE_DESCRIPTOR_FLAGS_0 {
@@ -2277,9 +2267,6 @@ impl Default for AER_BRIDGE_DESCRIPTOR_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AER_BRIDGE_DESCRIPTOR_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2292,9 +2279,6 @@ impl Default for AER_ENDPOINT_DESCRIPTOR_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AER_ENDPOINT_DESCRIPTOR_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct AER_ENDPOINT_DESCRIPTOR_FLAGS_0 {
@@ -2304,9 +2288,6 @@ impl Default for AER_ENDPOINT_DESCRIPTOR_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AER_ENDPOINT_DESCRIPTOR_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -2319,9 +2300,6 @@ impl Default for AER_ROOTPORT_DESCRIPTOR_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AER_ROOTPORT_DESCRIPTOR_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct AER_ROOTPORT_DESCRIPTOR_FLAGS_0 {
@@ -2331,9 +2309,6 @@ impl Default for AER_ROOTPORT_DESCRIPTOR_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AER_ROOTPORT_DESCRIPTOR_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AGP_GART_CORRUPTION: BUGCHECK_ERROR = BUGCHECK_ERROR(261u32);
 pub const AGP_ILLEGALLY_REPROGRAMMED: BUGCHECK_ERROR = BUGCHECK_ERROR(262u32);
@@ -2354,10 +2329,6 @@ impl Default for APC_CALLBACK_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for APC_CALLBACK_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const APC_INDEX_MISMATCH: BUGCHECK_ERROR = BUGCHECK_ERROR(1u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2371,9 +2342,6 @@ impl Default for API_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for API_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const API_VERSION_NUMBER: u32 = 12u32;
 pub const APP_TAGGING_INITIALIZATION_FAILED: BUGCHECK_ERROR = BUGCHECK_ERROR(266u32);
@@ -2400,10 +2368,6 @@ impl Default for ARM64_NT_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ARM64_NT_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -2416,10 +2380,6 @@ impl Default for ARM64_NT_CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ARM64_NT_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86", target_arch = "x86_64"))]
@@ -2463,10 +2423,6 @@ impl Default for ARM64_NT_CONTEXT_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ARM64_NT_CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ARM64_NT_NEON128 {
@@ -2481,9 +2437,6 @@ impl Default for ARM64_NT_NEON128 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ARM64_NT_NEON128 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ARM64_NT_NEON128_0 {
@@ -2494,9 +2447,6 @@ impl Default for ARM64_NT_NEON128_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ARM64_NT_NEON128_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ASSIGN_DRIVE_LETTERS_FAILED: BUGCHECK_ERROR = BUGCHECK_ERROR(114u32);
 pub const ATDISK_DRIVER_INTERNAL: BUGCHECK_ERROR = BUGCHECK_ERROR(66u32);
@@ -2659,11 +2609,6 @@ impl Default for CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -2721,10 +2666,6 @@ impl Default for CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -2737,10 +2678,6 @@ impl Default for CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -2771,10 +2708,6 @@ impl Default for CONTEXT_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "aarch64")]
 #[derive(Clone, Copy)]
@@ -2798,10 +2731,6 @@ impl Default for CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "aarch64")]
-impl windows_core::TypeKind for CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "aarch64")]
 #[derive(Clone, Copy)]
@@ -2814,10 +2743,6 @@ impl Default for CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "aarch64")]
-impl windows_core::TypeKind for CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "aarch64")]
@@ -2860,10 +2785,6 @@ impl Default for CONTEXT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "aarch64")]
-impl windows_core::TypeKind for CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONTEXT_ALL_AMD64: CONTEXT_FLAGS = CONTEXT_FLAGS(1048607u32);
 pub const CONTEXT_ALL_ARM: CONTEXT_FLAGS = CONTEXT_FLAGS(2097167u32);
@@ -2971,9 +2892,6 @@ impl Default for CPU_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CPU_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct CPU_INFORMATION_1 {
@@ -2983,9 +2901,6 @@ impl Default for CPU_INFORMATION_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CPU_INFORMATION_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2999,9 +2914,6 @@ impl Default for CPU_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CPU_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRASHDUMP_WATCHDOG_TIMEOUT: BUGCHECK_ERROR = BUGCHECK_ERROR(486u32);
 pub const CREATE_DELETE_LOCK_NOT_LOCKED: BUGCHECK_ERROR = BUGCHECK_ERROR(20u32);
@@ -3027,10 +2939,6 @@ impl Default for CREATE_PROCESS_DEBUG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Threading")]
-impl windows_core::TypeKind for CREATE_PROCESS_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CREATE_THREAD_DEBUG_EVENT: DEBUG_EVENT_CODE = DEBUG_EVENT_CODE(2u32);
 #[repr(C)]
 #[cfg(feature = "Win32_System_Threading")]
@@ -3045,10 +2953,6 @@ impl Default for CREATE_THREAD_DEBUG_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Threading")]
-impl windows_core::TypeKind for CREATE_THREAD_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CRITICAL_INITIALIZATION_FAILURE: BUGCHECK_ERROR = BUGCHECK_ERROR(317u32);
 pub const CRITICAL_OBJECT_TERMINATION: BUGCHECK_ERROR = BUGCHECK_ERROR(244u32);
@@ -3073,9 +2977,6 @@ impl Default for DBGHELP_DATA_REPORT_STRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DBGHELP_DATA_REPORT_STRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DBGPROP_ATTRIB_ACCESS_FINAL: DBGPROP_ATTRIB_FLAGS = DBGPROP_ATTRIB_FLAGS(32768i32);
 pub const DBGPROP_ATTRIB_ACCESS_PRIVATE: DBGPROP_ATTRIB_FLAGS = DBGPROP_ATTRIB_FLAGS(8192i32);
@@ -3201,10 +3102,6 @@ impl Default for DEBUG_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Threading")]
-impl windows_core::TypeKind for DEBUG_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Threading")]
 #[derive(Clone, Copy)]
@@ -3224,10 +3121,6 @@ impl Default for DEBUG_EVENT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Threading")]
-impl windows_core::TypeKind for DEBUG_EVENT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3267,11 +3160,6 @@ impl Default for DISPATCHER_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "aarch64")]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -3296,11 +3184,6 @@ impl Default for DISPATCHER_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "aarch64")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for DISPATCHER_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DMA_COMMON_BUFFER_VECTOR_ERROR: BUGCHECK_ERROR = BUGCHECK_ERROR(476u32);
 pub const DMP_CONTEXT_RECORD_SIZE_32: u32 = 1200u32;
@@ -3355,9 +3238,6 @@ impl Default for DUMP_FILE_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DUMP_FILE_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DUMP_FILE_ATTRIBUTES_0 {
@@ -3367,9 +3247,6 @@ impl Default for DUMP_FILE_ATTRIBUTES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DUMP_FILE_ATTRIBUTES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3418,9 +3295,6 @@ impl Default for DUMP_HEADER32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DUMP_HEADER32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DUMP_HEADER32_0 {
@@ -3431,9 +3305,6 @@ impl Default for DUMP_HEADER32_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DUMP_HEADER32_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3480,9 +3351,6 @@ impl Default for DUMP_HEADER64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DUMP_HEADER64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DUMP_HEADER64_0 {
@@ -3493,9 +3361,6 @@ impl Default for DUMP_HEADER64_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DUMP_HEADER64_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DUMP_SUMMARY_VALID_CURRENT_USER_VA: u32 = 2u32;
 pub const DUMP_SUMMARY_VALID_KERNEL_VA: u32 = 1u32;
@@ -3527,9 +3392,6 @@ impl Default for DebugPropertyInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DebugPropertyInfo {
-    type TypeKind = windows_core::CloneType;
 }
 pub const EFS_FATAL_ERROR: BUGCHECK_ERROR = BUGCHECK_ERROR(471u32);
 pub const ELAM_DRIVER_DETECTED_FATAL_ERROR: BUGCHECK_ERROR = BUGCHECK_ERROR(376u32);
@@ -3564,9 +3426,6 @@ impl Default for EXCEPTION_DEBUG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXCEPTION_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EXCEPTION_EXECUTE_HANDLER: i32 = 1i32;
 pub const EXCEPTION_ON_INVALID_STACK: BUGCHECK_ERROR = BUGCHECK_ERROR(426u32);
 #[repr(C)]
@@ -3581,10 +3440,6 @@ impl Default for EXCEPTION_POINTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for EXCEPTION_POINTERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3601,9 +3456,6 @@ impl Default for EXCEPTION_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXCEPTION_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXCEPTION_RECORD32 {
@@ -3618,9 +3470,6 @@ impl Default for EXCEPTION_RECORD32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXCEPTION_RECORD32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3638,9 +3487,6 @@ impl Default for EXCEPTION_RECORD64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXCEPTION_RECORD64 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EXCEPTION_SCOPE_INVALID: BUGCHECK_ERROR = BUGCHECK_ERROR(333u32);
 pub const EXFAT_FILE_SYSTEM: BUGCHECK_ERROR = BUGCHECK_ERROR(300u32);
 pub const EXIT_PROCESS_DEBUG_EVENT: DEBUG_EVENT_CODE = DEBUG_EVENT_CODE(5u32);
@@ -3654,9 +3500,6 @@ impl Default for EXIT_PROCESS_DEBUG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXIT_PROCESS_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EXIT_THREAD_DEBUG_EVENT: DEBUG_EVENT_CODE = DEBUG_EVENT_CODE(4u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3667,9 +3510,6 @@ impl Default for EXIT_THREAD_DEBUG_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXIT_THREAD_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EXRESOURCE_TIMEOUT_LIVEDUMP: BUGCHECK_ERROR = BUGCHECK_ERROR(460u32);
 pub const EXT_OUTPUT_VER: u32 = 1u32;
@@ -3709,10 +3549,6 @@ impl Default for ExtendedDebugPropertyInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for ExtendedDebugPropertyInfo {
-    type TypeKind = windows_core::CloneType;
 }
 pub const FACILITY_AAF: FACILITY_CODE = FACILITY_CODE(18u32);
 pub const FACILITY_ACCELERATOR: FACILITY_CODE = FACILITY_CODE(1536u32);
@@ -3937,9 +3773,6 @@ impl Default for FPO_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FPO_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FP_EMULATION_ERROR: BUGCHECK_ERROR = BUGCHECK_ERROR(166u32);
 pub const FSRTL_EXTRA_CREATE_PARAMETER_VIOLATION: BUGCHECK_ERROR = BUGCHECK_ERROR(268u32);
@@ -4442,9 +4275,6 @@ impl Default for IMAGEHLP_CBA_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGEHLP_CBA_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_CBA_EVENTW {
@@ -4457,9 +4287,6 @@ impl Default for IMAGEHLP_CBA_EVENTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_CBA_EVENTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4476,9 +4303,6 @@ impl Default for IMAGEHLP_CBA_READ_MEMORY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_CBA_READ_MEMORY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -4498,10 +4322,6 @@ impl Default for IMAGEHLP_DEFERRED_SYMBOL_LOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGEHLP_DEFERRED_SYMBOL_LOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_DEFERRED_SYMBOL_LOAD64 {
@@ -4518,9 +4338,6 @@ impl Default for IMAGEHLP_DEFERRED_SYMBOL_LOAD64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_DEFERRED_SYMBOL_LOAD64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4539,9 +4356,6 @@ impl Default for IMAGEHLP_DEFERRED_SYMBOL_LOADW64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGEHLP_DEFERRED_SYMBOL_LOADW64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4557,10 +4371,6 @@ impl Default for IMAGEHLP_DUPLICATE_SYMBOL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGEHLP_DUPLICATE_SYMBOL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_DUPLICATE_SYMBOL64 {
@@ -4573,9 +4383,6 @@ impl Default for IMAGEHLP_DUPLICATE_SYMBOL64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_DUPLICATE_SYMBOL64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4611,9 +4418,6 @@ impl Default for IMAGEHLP_GET_TYPE_INFO_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGEHLP_GET_TYPE_INFO_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGEHLP_GET_TYPE_INFO_UNCACHED: IMAGEHLP_GET_TYPE_INFO_FLAGS = IMAGEHLP_GET_TYPE_INFO_FLAGS(1u32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4629,9 +4433,6 @@ impl Default for IMAGEHLP_JIT_SYMBOLMAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_JIT_SYMBOLMAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -4649,10 +4450,6 @@ impl Default for IMAGEHLP_LINE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGEHLP_LINE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_LINE64 {
@@ -4666,9 +4463,6 @@ impl Default for IMAGEHLP_LINE64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_LINE64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -4686,10 +4480,6 @@ impl Default for IMAGEHLP_LINEW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGEHLP_LINEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_LINEW64 {
@@ -4703,9 +4493,6 @@ impl Default for IMAGEHLP_LINEW64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_LINEW64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -4727,10 +4514,6 @@ impl Default for IMAGEHLP_MODULE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGEHLP_MODULE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4766,9 +4549,6 @@ impl Default for IMAGEHLP_MODULE64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGEHLP_MODULE64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_MODULE64_EX {
@@ -4779,9 +4559,6 @@ impl Default for IMAGEHLP_MODULE64_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_MODULE64_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -4803,10 +4580,6 @@ impl Default for IMAGEHLP_MODULEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGEHLP_MODULEW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4842,9 +4615,6 @@ impl Default for IMAGEHLP_MODULEW64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGEHLP_MODULEW64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_MODULEW64_EX {
@@ -4855,9 +4625,6 @@ impl Default for IMAGEHLP_MODULEW64_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_MODULEW64_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGEHLP_MODULE_REGION_ADDITIONAL: u32 = 4u32;
 pub const IMAGEHLP_MODULE_REGION_ALL: u32 = 255u32;
@@ -4893,9 +4660,6 @@ impl Default for IMAGEHLP_STACK_FRAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGEHLP_STACK_FRAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct IMAGEHLP_STATUS_REASON(pub i32);
@@ -4916,10 +4680,6 @@ impl Default for IMAGEHLP_SYMBOL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGEHLP_SYMBOL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_SYMBOL64 {
@@ -4935,9 +4695,6 @@ impl Default for IMAGEHLP_SYMBOL64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGEHLP_SYMBOL64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_SYMBOL64_PACKAGE {
@@ -4948,9 +4705,6 @@ impl Default for IMAGEHLP_SYMBOL64_PACKAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_SYMBOL64_PACKAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -4969,10 +4723,6 @@ impl Default for IMAGEHLP_SYMBOLW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGEHLP_SYMBOLW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_SYMBOLW64 {
@@ -4988,9 +4738,6 @@ impl Default for IMAGEHLP_SYMBOLW64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGEHLP_SYMBOLW64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_SYMBOLW64_PACKAGE {
@@ -5001,9 +4748,6 @@ impl Default for IMAGEHLP_SYMBOLW64_PACKAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_SYMBOLW64_PACKAGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -5017,10 +4761,6 @@ impl Default for IMAGEHLP_SYMBOLW_PACKAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGEHLP_SYMBOLW_PACKAGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGEHLP_SYMBOL_FUNCTION: u32 = 2048u32;
 pub const IMAGEHLP_SYMBOL_INFO_CONSTANT: u32 = 256u32;
@@ -5044,10 +4784,6 @@ impl Default for IMAGEHLP_SYMBOL_PACKAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGEHLP_SYMBOL_PACKAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGEHLP_SYMBOL_SRC {
@@ -5059,9 +4795,6 @@ impl Default for IMAGEHLP_SYMBOL_SRC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGEHLP_SYMBOL_SRC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGEHLP_SYMBOL_THUNK: u32 = 8192u32;
 #[repr(transparent)]
@@ -5080,9 +4813,6 @@ impl Default for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0 {
@@ -5094,9 +4824,6 @@ impl Default for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0_0 {
@@ -5106,9 +4833,6 @@ impl Default for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5126,9 +4850,6 @@ impl Default for IMAGE_COFF_SYMBOLS_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_COFF_SYMBOLS_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5151,9 +4872,6 @@ impl Default for IMAGE_COR20_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_COR20_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_COR20_HEADER_0 {
@@ -5165,9 +4883,6 @@ impl Default for IMAGE_COR20_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_COR20_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_DATA_DIRECTORY {
@@ -5178,9 +4893,6 @@ impl Default for IMAGE_DATA_DIRECTORY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_DATA_DIRECTORY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5198,9 +4910,6 @@ impl Default for IMAGE_DEBUG_DIRECTORY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_DEBUG_DIRECTORY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -5245,11 +4954,6 @@ impl Default for IMAGE_DEBUG_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for IMAGE_DEBUG_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5437,10 +5141,6 @@ impl Default for IMAGE_FILE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl windows_core::TypeKind for IMAGE_FILE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_FILE_LARGE_ADDRESS_AWARE: IMAGE_FILE_CHARACTERISTICS = IMAGE_FILE_CHARACTERISTICS(32u16);
 pub const IMAGE_FILE_LARGE_ADDRESS_AWARE2: IMAGE_FILE_CHARACTERISTICS2 = IMAGE_FILE_CHARACTERISTICS2(32u32);
 pub const IMAGE_FILE_LINE_NUMS_STRIPPED: IMAGE_FILE_CHARACTERISTICS = IMAGE_FILE_CHARACTERISTICS(4u16);
@@ -5469,9 +5169,6 @@ impl Default for IMAGE_FUNCTION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_FUNCTION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_FUNCTION_ENTRY64 {
@@ -5484,9 +5181,6 @@ impl Default for IMAGE_FUNCTION_ENTRY64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_FUNCTION_ENTRY64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub union IMAGE_FUNCTION_ENTRY64_0 {
@@ -5497,9 +5191,6 @@ impl Default for IMAGE_FUNCTION_ENTRY64_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_FUNCTION_ENTRY64_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5513,9 +5204,6 @@ impl Default for IMAGE_LOAD_CONFIG_CODE_INTEGRITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_LOAD_CONFIG_CODE_INTEGRITY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5575,9 +5263,6 @@ impl Default for IMAGE_LOAD_CONFIG_DIRECTORY32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_LOAD_CONFIG_DIRECTORY32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_LOAD_CONFIG_DIRECTORY64 {
@@ -5636,9 +5321,6 @@ impl Default for IMAGE_LOAD_CONFIG_DIRECTORY64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_LOAD_CONFIG_DIRECTORY64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_SystemInformation")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5653,10 +5335,6 @@ impl Default for IMAGE_NT_HEADERS32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl windows_core::TypeKind for IMAGE_NT_HEADERS32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_SystemInformation")]
 #[derive(Clone, Copy)]
@@ -5670,10 +5348,6 @@ impl Default for IMAGE_NT_HEADERS64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl windows_core::TypeKind for IMAGE_NT_HEADERS64 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_NT_OPTIONAL_HDR32_MAGIC: IMAGE_OPTIONAL_HEADER_MAGIC = IMAGE_OPTIONAL_HEADER_MAGIC(267u16);
 pub const IMAGE_NT_OPTIONAL_HDR64_MAGIC: IMAGE_OPTIONAL_HEADER_MAGIC = IMAGE_OPTIONAL_HEADER_MAGIC(523u16);
@@ -5718,9 +5392,6 @@ impl Default for IMAGE_OPTIONAL_HEADER32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_OPTIONAL_HEADER32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_OPTIONAL_HEADER64 {
@@ -5760,9 +5431,6 @@ impl Default for IMAGE_OPTIONAL_HEADER64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_OPTIONAL_HEADER64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct IMAGE_OPTIONAL_HEADER_MAGIC(pub u16);
@@ -5778,10 +5446,6 @@ impl Default for IMAGE_ROM_HEADERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl windows_core::TypeKind for IMAGE_ROM_HEADERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_ROM_OPTIONAL_HDR_MAGIC: IMAGE_OPTIONAL_HEADER_MAGIC = IMAGE_OPTIONAL_HEADER_MAGIC(263u16);
 #[repr(C)]
@@ -5806,9 +5470,6 @@ impl Default for IMAGE_ROM_OPTIONAL_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_ROM_OPTIONAL_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IMAGE_RUNTIME_FUNCTION_ENTRY {
@@ -5821,9 +5482,6 @@ impl Default for IMAGE_RUNTIME_FUNCTION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_RUNTIME_FUNCTION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_RUNTIME_FUNCTION_ENTRY_0 {
@@ -5834,9 +5492,6 @@ impl Default for IMAGE_RUNTIME_FUNCTION_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_RUNTIME_FUNCTION_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_SCN_ALIGN_1024BYTES: IMAGE_SECTION_CHARACTERISTICS = IMAGE_SECTION_CHARACTERISTICS(11534336u32);
 pub const IMAGE_SCN_ALIGN_128BYTES: IMAGE_SECTION_CHARACTERISTICS = IMAGE_SECTION_CHARACTERISTICS(8388608u32);
@@ -5932,9 +5587,6 @@ impl Default for IMAGE_SECTION_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_SECTION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_SECTION_HEADER_0 {
@@ -5945,9 +5597,6 @@ impl Default for IMAGE_SECTION_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_SECTION_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6068,9 +5717,6 @@ impl Default for IPMI_OS_SEL_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IPMI_OS_SEL_RECORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPMI_OS_SEL_RECORD_MASK: u32 = 65535u32;
 #[repr(transparent)]
@@ -6210,10 +5856,6 @@ impl Default for KDHELP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for KDHELP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KDHELP64 {
@@ -6239,9 +5881,6 @@ impl Default for KDHELP64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KDHELP64 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KERNEL_APC_PENDING_DURING_EXIT: BUGCHECK_ERROR = BUGCHECK_ERROR(32u32);
 pub const KERNEL_AUTO_BOOST_INVALID_LOCK_RELEASE: BUGCHECK_ERROR = BUGCHECK_ERROR(354u32);
@@ -6273,10 +5912,6 @@ impl Default for KNONVOLATILE_CONTEXT_POINTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for KNONVOLATILE_CONTEXT_POINTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -6290,10 +5925,6 @@ impl Default for KNONVOLATILE_CONTEXT_POINTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for KNONVOLATILE_CONTEXT_POINTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -6306,10 +5937,6 @@ impl Default for KNONVOLATILE_CONTEXT_POINTERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for KNONVOLATILE_CONTEXT_POINTERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -6338,10 +5965,6 @@ impl Default for KNONVOLATILE_CONTEXT_POINTERS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for KNONVOLATILE_CONTEXT_POINTERS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -6354,10 +5977,6 @@ impl Default for KNONVOLATILE_CONTEXT_POINTERS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for KNONVOLATILE_CONTEXT_POINTERS_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -6385,10 +6004,6 @@ impl Default for KNONVOLATILE_CONTEXT_POINTERS_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for KNONVOLATILE_CONTEXT_POINTERS_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "aarch64")]
@@ -6421,10 +6036,6 @@ impl Default for KNONVOLATILE_CONTEXT_POINTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "aarch64")]
-impl windows_core::TypeKind for KNONVOLATILE_CONTEXT_POINTERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KernelMinidumpStatusCallback: MINIDUMP_CALLBACK_TYPE = MINIDUMP_CALLBACK_TYPE(8i32);
 pub const LAST_CHANCE_CALLED_FROM_KMODE: BUGCHECK_ERROR = BUGCHECK_ERROR(21u32);
 #[repr(C)]
@@ -6439,9 +6050,6 @@ impl Default for LDT_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDT_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union LDT_ENTRY_0 {
@@ -6453,9 +6061,6 @@ impl Default for LDT_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LDT_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LDT_ENTRY_0_1 {
@@ -6465,9 +6070,6 @@ impl Default for LDT_ENTRY_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LDT_ENTRY_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6481,9 +6083,6 @@ impl Default for LDT_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LDT_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LIVE_SYSTEM_DUMP: BUGCHECK_ERROR = BUGCHECK_ERROR(353u32);
 pub const LM_SERVER_INTERNAL_ERROR: BUGCHECK_ERROR = BUGCHECK_ERROR(84u32);
@@ -6514,11 +6113,6 @@ impl Default for LOADED_IMAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_System_Kernel", feature = "Win32_System_SystemInformation"))]
-impl windows_core::TypeKind for LOADED_IMAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_System_Kernel", feature = "Win32_System_SystemInformation"))]
@@ -6546,11 +6140,6 @@ impl Default for LOADED_IMAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_System_Kernel", feature = "Win32_System_SystemInformation"))]
-impl windows_core::TypeKind for LOADED_IMAGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LOADER_BLOCK_MISMATCH: BUGCHECK_ERROR = BUGCHECK_ERROR(256u32);
 pub const LOADER_ROLLBACK_DETECTED: BUGCHECK_ERROR = BUGCHECK_ERROR(406u32);
 pub const LOAD_DLL_DEBUG_EVENT: DEBUG_EVENT_CODE = DEBUG_EVENT_CODE(6u32);
@@ -6569,9 +6158,6 @@ impl Default for LOAD_DLL_DEBUG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOAD_DLL_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LOCKED_PAGES_TRACKER_CORRUPTION: BUGCHECK_ERROR = BUGCHECK_ERROR(217u32);
 pub type LPCALL_BACK_USER_INTERRUPT_ROUTINE = Option<unsafe extern "system" fn() -> u32>;
 pub const LPC_INITIALIZATION_FAILED: BUGCHECK_ERROR = BUGCHECK_ERROR(106u32);
@@ -6588,9 +6174,6 @@ impl Default for M128A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for M128A {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MACHINE_CHECK_EXCEPTION: BUGCHECK_ERROR = BUGCHECK_ERROR(156u32);
 pub const MAILSLOT_FILE_SYSTEM: BUGCHECK_ERROR = BUGCHECK_ERROR(82u32);
@@ -6622,11 +6205,6 @@ impl Default for MINIDUMP_CALLBACK_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel", feature = "Win32_System_Memory"))]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel", feature = "Win32_System_Memory"))]
@@ -6642,11 +6220,6 @@ impl Default for MINIDUMP_CALLBACK_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel", feature = "Win32_System_Memory"))]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(all(feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
 #[derive(Clone, Copy)]
@@ -6661,10 +6234,6 @@ impl Default for MINIDUMP_CALLBACK_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
@@ -6689,10 +6258,6 @@ impl Default for MINIDUMP_CALLBACK_INPUT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_INPUT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(feature = "Win32_System_Memory")]
 #[derive(Clone, Copy)]
@@ -6704,10 +6269,6 @@ impl Default for MINIDUMP_CALLBACK_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Memory")]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Memory")]
@@ -6730,10 +6291,6 @@ impl Default for MINIDUMP_CALLBACK_OUTPUT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Memory")]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_OUTPUT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(feature = "Win32_System_Memory")]
 #[derive(Clone, Copy)]
@@ -6746,10 +6303,6 @@ impl Default for MINIDUMP_CALLBACK_OUTPUT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Memory")]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_OUTPUT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Memory")]
@@ -6764,10 +6317,6 @@ impl Default for MINIDUMP_CALLBACK_OUTPUT_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Memory")]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_OUTPUT_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Memory")]
 #[derive(Clone, Copy)]
@@ -6780,10 +6329,6 @@ impl Default for MINIDUMP_CALLBACK_OUTPUT_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Memory")]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_OUTPUT_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Memory")]
@@ -6798,10 +6343,6 @@ impl Default for MINIDUMP_CALLBACK_OUTPUT_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Memory")]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_OUTPUT_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Memory")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6814,10 +6355,6 @@ impl Default for MINIDUMP_CALLBACK_OUTPUT_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Memory")]
-impl windows_core::TypeKind for MINIDUMP_CALLBACK_OUTPUT_0_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel", feature = "Win32_System_Memory"))]
 pub type MINIDUMP_CALLBACK_ROUTINE = Option<unsafe extern "system" fn(callbackparam: *mut core::ffi::c_void, callbackinput: *const MINIDUMP_CALLBACK_INPUT, callbackoutput: *mut MINIDUMP_CALLBACK_OUTPUT) -> super::super::super::Foundation::BOOL>;
@@ -6835,9 +6372,6 @@ impl Default for MINIDUMP_DIRECTORY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_DIRECTORY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_EXCEPTION {
@@ -6853,9 +6387,6 @@ impl Default for MINIDUMP_EXCEPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_EXCEPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -6873,11 +6404,6 @@ impl Default for MINIDUMP_EXCEPTION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for MINIDUMP_EXCEPTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -6894,11 +6420,6 @@ impl Default for MINIDUMP_EXCEPTION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for MINIDUMP_EXCEPTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_EXCEPTION_INFORMATION64 {
@@ -6911,9 +6432,6 @@ impl Default for MINIDUMP_EXCEPTION_INFORMATION64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_EXCEPTION_INFORMATION64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -6928,9 +6446,6 @@ impl Default for MINIDUMP_EXCEPTION_STREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_EXCEPTION_STREAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
@@ -6944,9 +6459,6 @@ impl Default for MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -6963,9 +6475,6 @@ impl Default for MINIDUMP_FUNCTION_TABLE_STREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_FUNCTION_TABLE_STREAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_HANDLE_DATA_STREAM {
@@ -6978,9 +6487,6 @@ impl Default for MINIDUMP_HANDLE_DATA_STREAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_HANDLE_DATA_STREAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -6997,9 +6503,6 @@ impl Default for MINIDUMP_HANDLE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_HANDLE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -7019,9 +6522,6 @@ impl Default for MINIDUMP_HANDLE_DESCRIPTOR_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_HANDLE_DESCRIPTOR_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_HANDLE_OBJECT_INFORMATION {
@@ -7033,9 +6533,6 @@ impl Default for MINIDUMP_HANDLE_OBJECT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_HANDLE_OBJECT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7053,9 +6550,6 @@ impl Default for MINIDUMP_HANDLE_OPERATION_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_HANDLE_OPERATION_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_HEADER {
@@ -7072,9 +6566,6 @@ impl Default for MINIDUMP_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MINIDUMP_HEADER_0 {
@@ -7086,9 +6577,6 @@ impl Default for MINIDUMP_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_INCLUDE_MODULE_CALLBACK {
@@ -7099,9 +6587,6 @@ impl Default for MINIDUMP_INCLUDE_MODULE_CALLBACK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_INCLUDE_MODULE_CALLBACK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_INCLUDE_THREAD_CALLBACK {
@@ -7111,9 +6596,6 @@ impl Default for MINIDUMP_INCLUDE_THREAD_CALLBACK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_INCLUDE_THREAD_CALLBACK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -7128,9 +6610,6 @@ impl Default for MINIDUMP_IO_CALLBACK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_IO_CALLBACK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_LOCATION_DESCRIPTOR {
@@ -7142,9 +6621,6 @@ impl Default for MINIDUMP_LOCATION_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_LOCATION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_LOCATION_DESCRIPTOR64 {
@@ -7155,9 +6631,6 @@ impl Default for MINIDUMP_LOCATION_DESCRIPTOR64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_LOCATION_DESCRIPTOR64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -7171,9 +6644,6 @@ impl Default for MINIDUMP_MEMORY64_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_MEMORY64_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_MEMORY_DESCRIPTOR {
@@ -7185,9 +6655,6 @@ impl Default for MINIDUMP_MEMORY_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_MEMORY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_MEMORY_DESCRIPTOR64 {
@@ -7198,9 +6665,6 @@ impl Default for MINIDUMP_MEMORY_DESCRIPTOR64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_MEMORY_DESCRIPTOR64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(feature = "Win32_System_Memory")]
@@ -7222,10 +6686,6 @@ impl Default for MINIDUMP_MEMORY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Memory")]
-impl windows_core::TypeKind for MINIDUMP_MEMORY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_MEMORY_INFO_LIST {
@@ -7238,9 +6698,6 @@ impl Default for MINIDUMP_MEMORY_INFO_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_MEMORY_INFO_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_MEMORY_LIST {
@@ -7251,9 +6708,6 @@ impl Default for MINIDUMP_MEMORY_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_MEMORY_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MINIDUMP_MISC1_PROCESSOR_POWER_INFO: u32 = 4u32;
 pub const MINIDUMP_MISC1_PROCESS_ID: MINIDUMP_MISC_INFO_FLAGS = MINIDUMP_MISC_INFO_FLAGS(1u32);
@@ -7279,9 +6733,6 @@ impl Default for MINIDUMP_MISC_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_MISC_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_MISC_INFO_2 {
@@ -7301,9 +6752,6 @@ impl Default for MINIDUMP_MISC_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_MISC_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(feature = "Win32_System_Time")]
@@ -7331,10 +6779,6 @@ impl Default for MINIDUMP_MISC_INFO_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for MINIDUMP_MISC_INFO_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(feature = "Win32_System_Time")]
@@ -7364,10 +6808,6 @@ impl Default for MINIDUMP_MISC_INFO_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for MINIDUMP_MISC_INFO_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(feature = "Win32_System_Time")]
@@ -7399,10 +6839,6 @@ impl Default for MINIDUMP_MISC_INFO_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for MINIDUMP_MISC_INFO_5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7461,10 +6897,6 @@ impl Default for MINIDUMP_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for MINIDUMP_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
@@ -7486,10 +6918,6 @@ impl Default for MINIDUMP_MODULE_CALLBACK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for MINIDUMP_MODULE_CALLBACK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
@@ -7502,10 +6930,6 @@ impl Default for MINIDUMP_MODULE_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for MINIDUMP_MODULE_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MINIDUMP_PROCESS_VM_COUNTERS: u32 = 1u32;
 #[repr(C, packed(4))]
@@ -7527,9 +6951,6 @@ impl Default for MINIDUMP_PROCESS_VM_COUNTERS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_PROCESS_VM_COUNTERS_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -7561,9 +6982,6 @@ impl Default for MINIDUMP_PROCESS_VM_COUNTERS_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_PROCESS_VM_COUNTERS_2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MINIDUMP_PROCESS_VM_COUNTERS_EX: u32 = 4u32;
 pub const MINIDUMP_PROCESS_VM_COUNTERS_EX2: u32 = 8u32;
 pub const MINIDUMP_PROCESS_VM_COUNTERS_JOB: u32 = 16u32;
@@ -7579,9 +6997,6 @@ impl Default for MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7599,9 +7014,6 @@ impl Default for MINIDUMP_STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_STRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MINIDUMP_SYSMEMINFO1_BASICPERF: u32 = 2u32;
 pub const MINIDUMP_SYSMEMINFO1_FILECACHE_TRANSITIONREPURPOSECOUNT_FLAGS: u32 = 1u32;
@@ -7626,9 +7038,6 @@ impl Default for MINIDUMP_SYSTEM_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_SYSTEM_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {
@@ -7641,9 +7050,6 @@ impl Default for MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -7662,9 +7068,6 @@ impl Default for MINIDUMP_SYSTEM_FILECACHE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_SYSTEM_FILECACHE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(feature = "Win32_System_SystemInformation")]
@@ -7688,10 +7091,6 @@ impl Default for MINIDUMP_SYSTEM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl windows_core::TypeKind for MINIDUMP_SYSTEM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_SystemInformation")]
 #[derive(Clone, Copy)]
@@ -7704,10 +7103,6 @@ impl Default for MINIDUMP_SYSTEM_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl windows_core::TypeKind for MINIDUMP_SYSTEM_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_SystemInformation")]
@@ -7722,10 +7117,6 @@ impl Default for MINIDUMP_SYSTEM_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl windows_core::TypeKind for MINIDUMP_SYSTEM_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_SystemInformation")]
 #[derive(Clone, Copy)]
@@ -7739,10 +7130,6 @@ impl Default for MINIDUMP_SYSTEM_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl windows_core::TypeKind for MINIDUMP_SYSTEM_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_SystemInformation")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7755,10 +7142,6 @@ impl Default for MINIDUMP_SYSTEM_INFO_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl windows_core::TypeKind for MINIDUMP_SYSTEM_INFO_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -7774,9 +7157,6 @@ impl Default for MINIDUMP_SYSTEM_MEMORY_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_SYSTEM_MEMORY_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -7865,9 +7245,6 @@ impl Default for MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_THREAD {
@@ -7883,9 +7260,6 @@ impl Default for MINIDUMP_THREAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_THREAD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86", target_arch = "x86_64"))]
@@ -7905,11 +7279,6 @@ impl Default for MINIDUMP_THREAD_CALLBACK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for MINIDUMP_THREAD_CALLBACK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(target_arch = "aarch64")]
@@ -7930,11 +7299,6 @@ impl Default for MINIDUMP_THREAD_CALLBACK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "aarch64")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for MINIDUMP_THREAD_CALLBACK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -7953,9 +7317,6 @@ impl Default for MINIDUMP_THREAD_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_THREAD_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -7976,11 +7337,6 @@ impl Default for MINIDUMP_THREAD_EX_CALLBACK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for MINIDUMP_THREAD_EX_CALLBACK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(target_arch = "aarch64")]
@@ -8004,11 +7360,6 @@ impl Default for MINIDUMP_THREAD_EX_CALLBACK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "aarch64")]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for MINIDUMP_THREAD_EX_CALLBACK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_THREAD_EX_LIST {
@@ -8019,9 +7370,6 @@ impl Default for MINIDUMP_THREAD_EX_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_THREAD_EX_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -8041,9 +7389,6 @@ impl Default for MINIDUMP_THREAD_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_THREAD_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8065,9 +7410,6 @@ impl Default for MINIDUMP_THREAD_INFO_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_THREAD_INFO_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MINIDUMP_THREAD_INFO_WRITING_THREAD: MINIDUMP_THREAD_INFO_DUMP_FLAGS = MINIDUMP_THREAD_INFO_DUMP_FLAGS(2u32);
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -8080,9 +7422,6 @@ impl Default for MINIDUMP_THREAD_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_THREAD_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_THREAD_NAME {
@@ -8094,9 +7433,6 @@ impl Default for MINIDUMP_THREAD_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_THREAD_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_THREAD_NAME_LIST {
@@ -8107,9 +7443,6 @@ impl Default for MINIDUMP_THREAD_NAME_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_THREAD_NAME_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -8123,9 +7456,6 @@ impl Default for MINIDUMP_TOKEN_INFO_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_TOKEN_INFO_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_TOKEN_INFO_LIST {
@@ -8138,9 +7468,6 @@ impl Default for MINIDUMP_TOKEN_INFO_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_TOKEN_INFO_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8192,9 +7519,6 @@ impl Default for MINIDUMP_UNLOADED_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_UNLOADED_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_UNLOADED_MODULE_LIST {
@@ -8207,9 +7531,6 @@ impl Default for MINIDUMP_UNLOADED_MODULE_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_UNLOADED_MODULE_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_USER_RECORD {
@@ -8221,9 +7542,6 @@ impl Default for MINIDUMP_USER_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_USER_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8237,10 +7555,6 @@ impl Default for MINIDUMP_USER_STREAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for MINIDUMP_USER_STREAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -8256,10 +7570,6 @@ impl Default for MINIDUMP_USER_STREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MINIDUMP_USER_STREAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8273,10 +7583,6 @@ impl Default for MINIDUMP_USER_STREAM_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for MINIDUMP_USER_STREAM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -8289,10 +7595,6 @@ impl Default for MINIDUMP_USER_STREAM_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MINIDUMP_USER_STREAM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MINIDUMP_VERSION: u32 = 42899u32;
 #[repr(C, packed(4))]
@@ -8309,9 +7611,6 @@ impl Default for MINIDUMP_VM_POST_READ_CALLBACK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_VM_POST_READ_CALLBACK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_VM_PRE_READ_CALLBACK {
@@ -8324,9 +7623,6 @@ impl Default for MINIDUMP_VM_PRE_READ_CALLBACK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIDUMP_VM_PRE_READ_CALLBACK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
 pub struct MINIDUMP_VM_QUERY_CALLBACK {
@@ -8336,9 +7632,6 @@ impl Default for MINIDUMP_VM_QUERY_CALLBACK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINIDUMP_VM_QUERY_CALLBACK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MISALIGNED_POINTER_PARAMETER: BUGCHECK_ERROR = BUGCHECK_ERROR(502u32);
 pub const MISMATCHED_HAL: BUGCHECK_ERROR = BUGCHECK_ERROR(121u32);
@@ -8357,9 +7650,6 @@ impl Default for MODLOAD_CVMISC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MODLOAD_CVMISC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MODLOAD_DATA {
@@ -8373,9 +7663,6 @@ impl Default for MODLOAD_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MODLOAD_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8391,9 +7678,6 @@ impl Default for MODLOAD_PDBGUID_PDBAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MODLOAD_PDBGUID_PDBAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MODULE_TYPE_INFO {
@@ -8405,9 +7689,6 @@ impl Default for MODULE_TYPE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MODULE_TYPE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8547,9 +7828,6 @@ impl Default for OMAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OMAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct OPEN_THREAD_WAIT_CHAIN_SESSION_FLAGS(pub u32);
@@ -8566,9 +7844,6 @@ impl Default for OUTPUT_DEBUG_STRING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OUTPUT_DEBUG_STRING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PAGE_FAULT_BEYOND_END_OF_ALLOCATION: BUGCHECK_ERROR = BUGCHECK_ERROR(205u32);
 pub const PAGE_FAULT_IN_FREED_SPECIAL_POOL: BUGCHECK_ERROR = BUGCHECK_ERROR(204u32);
@@ -8632,9 +7907,6 @@ impl Default for PHYSICAL_MEMORY_DESCRIPTOR32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_MEMORY_DESCRIPTOR32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PHYSICAL_MEMORY_DESCRIPTOR64 {
@@ -8647,9 +7919,6 @@ impl Default for PHYSICAL_MEMORY_DESCRIPTOR64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_MEMORY_DESCRIPTOR64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PHYSICAL_MEMORY_RUN32 {
@@ -8661,9 +7930,6 @@ impl Default for PHYSICAL_MEMORY_RUN32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_MEMORY_RUN32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PHYSICAL_MEMORY_RUN64 {
@@ -8674,9 +7940,6 @@ impl Default for PHYSICAL_MEMORY_RUN64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PHYSICAL_MEMORY_RUN64 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PIMAGEHLP_STATUS_ROUTINE = Option<unsafe extern "system" fn(reason: IMAGEHLP_STATUS_REASON, imagename: windows_core::PCSTR, dllname: windows_core::PCSTR, va: usize, parameter: usize) -> super::super::super::Foundation::BOOL>;
 pub type PIMAGEHLP_STATUS_ROUTINE32 = Option<unsafe extern "system" fn(reason: IMAGEHLP_STATUS_REASON, imagename: windows_core::PCSTR, dllname: windows_core::PCSTR, va: u32, parameter: usize) -> super::super::super::Foundation::BOOL>;
@@ -8804,9 +8067,6 @@ impl Default for RIP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RIP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct RIP_INFO_TYPE(pub u32);
@@ -8902,9 +8162,6 @@ impl Default for SOURCEFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOURCEFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOURCEFILEW {
@@ -8915,9 +8172,6 @@ impl Default for SOURCEFILEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOURCEFILEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPECIAL_POOL_DETECTED_MEMORY_CORRUPTION: BUGCHECK_ERROR = BUGCHECK_ERROR(193u32);
 pub const SPIN_LOCK_ALREADY_OWNED: BUGCHECK_ERROR = BUGCHECK_ERROR(15u32);
@@ -8942,9 +8196,6 @@ impl Default for SRCCODEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SRCCODEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SRCCODEINFOW {
@@ -8960,9 +8211,6 @@ impl Default for SRCCODEINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SRCCODEINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SSRVACTION_CHECKSUMSTATUS: u32 = 8u32;
 pub const SSRVACTION_EVENT: u32 = 3u32;
@@ -9040,10 +8288,6 @@ impl Default for STACKFRAME {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for STACKFRAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STACKFRAME64 {
@@ -9063,9 +8307,6 @@ impl Default for STACKFRAME64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STACKFRAME64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9088,9 +8329,6 @@ impl Default for STACKFRAME_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STACKFRAME_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_DEVICE_ABNORMALITY_DETECTED: BUGCHECK_ERROR = BUGCHECK_ERROR(320u32);
 pub const STORAGE_MINIPORT_ERROR: BUGCHECK_ERROR = BUGCHECK_ERROR(240u32);
@@ -9123,9 +8361,6 @@ impl Default for SYMBOL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYMBOL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYMBOL_INFOW {
@@ -9149,9 +8384,6 @@ impl Default for SYMBOL_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYMBOL_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9200,9 +8432,6 @@ impl Default for SYMBOL_INFO_PACKAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYMBOL_INFO_PACKAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYMBOL_INFO_PACKAGEW {
@@ -9213,9 +8442,6 @@ impl Default for SYMBOL_INFO_PACKAGEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYMBOL_INFO_PACKAGEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SYMENUM_OPTIONS_DEFAULT: u32 = 1u32;
 pub const SYMENUM_OPTIONS_INLINE: u32 = 2u32;
@@ -9311,9 +8537,6 @@ impl Default for SYMSRV_EXTENDED_OUTPUT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYMSRV_EXTENDED_OUTPUT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYMSRV_INDEX_INFO {
@@ -9333,9 +8556,6 @@ impl Default for SYMSRV_INDEX_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYMSRV_INDEX_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYMSRV_INDEX_INFOW {
@@ -9354,9 +8574,6 @@ impl Default for SYMSRV_INDEX_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYMSRV_INDEX_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SYMSRV_VERSION: u32 = 2u32;
 pub const SYMSTOREOPT_ALT_INDEX: u32 = 16u32;
@@ -9506,9 +8723,6 @@ impl Default for TI_FINDCHILDREN_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TI_FINDCHILDREN_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TI_GET_ADDRESS: IMAGEHLP_SYMBOL_TYPE_INFO = IMAGEHLP_SYMBOL_TYPE_INFO(22i32);
 pub const TI_GET_ADDRESSOFFSET: IMAGEHLP_SYMBOL_TYPE_INFO = IMAGEHLP_SYMBOL_TYPE_INFO(9i32);
 pub const TI_GET_ARRAYINDEXTYPEID: IMAGEHLP_SYMBOL_TYPE_INFO = IMAGEHLP_SYMBOL_TYPE_INFO(6i32);
@@ -9597,9 +8811,6 @@ impl Default for UNLOAD_DLL_DEBUG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UNLOAD_DLL_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const UNMOUNTABLE_BOOT_VOLUME: BUGCHECK_ERROR = BUGCHECK_ERROR(237u32);
 pub const UNSUPPORTED_INSTRUCTION_MODE: BUGCHECK_ERROR = BUGCHECK_ERROR(337u32);
 pub const UNSUPPORTED_PROCESSOR: BUGCHECK_ERROR = BUGCHECK_ERROR(93u32);
@@ -9622,10 +8833,6 @@ impl Default for UNWIND_HISTORY_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for UNWIND_HISTORY_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9639,10 +8846,6 @@ impl Default for UNWIND_HISTORY_TABLE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for UNWIND_HISTORY_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "aarch64")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9655,10 +8858,6 @@ impl Default for UNWIND_HISTORY_TABLE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "aarch64")]
-impl windows_core::TypeKind for UNWIND_HISTORY_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UNWIND_ON_INVALID_STACK: BUGCHECK_ERROR = BUGCHECK_ERROR(427u32);
 pub const UNW_FLAG_CHAININFO: RTL_VIRTUAL_UNWIND_HANDLER_TYPE = RTL_VIRTUAL_UNWIND_HANDLER_TYPE(4u32);
@@ -9716,9 +8915,6 @@ impl Default for WAITCHAIN_NODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAITCHAIN_NODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WAITCHAIN_NODE_INFO_0 {
@@ -9729,9 +8925,6 @@ impl Default for WAITCHAIN_NODE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WAITCHAIN_NODE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9745,9 +8938,6 @@ impl Default for WAITCHAIN_NODE_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WAITCHAIN_NODE_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WAITCHAIN_NODE_INFO_0_1 {
@@ -9760,9 +8950,6 @@ impl Default for WAITCHAIN_NODE_INFO_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WAITCHAIN_NODE_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9805,9 +8992,6 @@ impl Default for WHEA_AER_BRIDGE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_AER_BRIDGE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_AER_ENDPOINT_DESCRIPTOR {
@@ -9827,9 +9011,6 @@ impl Default for WHEA_AER_ENDPOINT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_AER_ENDPOINT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -9851,9 +9032,6 @@ impl Default for WHEA_AER_ROOTPORT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_AER_ROOTPORT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_BAD_PAGE_LIST_LOCATION: u32 = 15u32;
 pub const WHEA_BAD_PAGE_LIST_MAX_SIZE: u32 = 14u32;
@@ -9892,9 +9070,6 @@ impl Default for WHEA_DEVICE_DRIVER_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_DEVICE_DRIVER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WHEA_DISABLE_DUMMY_WRITE: u32 = 6u32;
 pub const WHEA_DISABLE_OFFLINE: u32 = 0u32;
 #[repr(C, packed(1))]
@@ -9912,9 +9087,6 @@ impl Default for WHEA_DRIVER_BUFFER_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_DRIVER_BUFFER_SET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ERROR_SOURCE_CONFIGURATION_DD {
@@ -9926,9 +9098,6 @@ impl Default for WHEA_ERROR_SOURCE_CONFIGURATION_DD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_SOURCE_CONFIGURATION_DD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -9949,9 +9118,6 @@ impl Default for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER_V1 {
@@ -9966,9 +9132,6 @@ impl Default for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_SOURCE_CONFIGURATION_DEVICE_DRIVER_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type WHEA_ERROR_SOURCE_CORRECT_DEVICE_DRIVER = Option<unsafe extern "system" fn(errorsourcedesc: *mut core::ffi::c_void, maximumsectionlength: *mut u32) -> super::super::super::Foundation::NTSTATUS>;
 #[repr(C, packed(1))]
@@ -9991,9 +9154,6 @@ impl Default for WHEA_ERROR_SOURCE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_ERROR_SOURCE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHEA_ERROR_SOURCE_DESCRIPTOR_0 {
@@ -10014,9 +9174,6 @@ impl Default for WHEA_ERROR_SOURCE_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_ERROR_SOURCE_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_ERROR_SOURCE_DESCRIPTOR_TYPE_AERBRIDGE: u32 = 8u32;
 pub const WHEA_ERROR_SOURCE_DESCRIPTOR_TYPE_AERENDPOINT: u32 = 7u32;
@@ -10064,9 +9221,6 @@ impl Default for WHEA_GENERIC_ERROR_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_GENERIC_ERROR_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_GENERIC_ERROR_DESCRIPTOR_V2 {
@@ -10094,9 +9248,6 @@ impl Default for WHEA_GENERIC_ERROR_DESCRIPTOR_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_GENERIC_ERROR_DESCRIPTOR_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WHEA_INTERNAL_ERROR: BUGCHECK_ERROR = BUGCHECK_ERROR(290u32);
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -10110,9 +9261,6 @@ impl Default for WHEA_IPF_CMC_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_IPF_CMC_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_IPF_CPE_DESCRIPTOR {
@@ -10125,9 +9273,6 @@ impl Default for WHEA_IPF_CPE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_IPF_CPE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_IPF_MCA_DESCRIPTOR {
@@ -10139,9 +9284,6 @@ impl Default for WHEA_IPF_MCA_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_IPF_MCA_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_MAX_MC_BANKS: u32 = 32u32;
 pub const WHEA_MEM_PERSISTOFFLINE: u32 = 1u32;
@@ -10162,9 +9304,6 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHEA_NOTIFICATION_DESCRIPTOR_0 {
@@ -10182,9 +9321,6 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
@@ -10199,9 +9335,6 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_7 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -10218,9 +9351,6 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_2 {
@@ -10235,9 +9365,6 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -10254,9 +9381,6 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
@@ -10266,9 +9390,6 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -10285,9 +9406,6 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_NOTIFICATION_DESCRIPTOR_0_5 {
@@ -10302,9 +9420,6 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -10321,9 +9436,6 @@ impl Default for WHEA_NOTIFICATION_DESCRIPTOR_0_6 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_NOTIFICATION_DESCRIPTOR_0_6 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_NOTIFICATION_FLAGS {
@@ -10335,9 +9447,6 @@ impl Default for WHEA_NOTIFICATION_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_NOTIFICATION_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_NOTIFICATION_FLAGS_0 {
@@ -10347,9 +9456,6 @@ impl Default for WHEA_NOTIFICATION_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_NOTIFICATION_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_NOTIFICATION_TYPE_ARMV8_SEA: u32 = 8u32;
 pub const WHEA_NOTIFICATION_TYPE_ARMV8_SEI: u32 = 9u32;
@@ -10374,9 +9480,6 @@ impl Default for WHEA_PCI_SLOT_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCI_SLOT_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WHEA_PCI_SLOT_NUMBER_0 {
@@ -10388,9 +9491,6 @@ impl Default for WHEA_PCI_SLOT_NUMBER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_PCI_SLOT_NUMBER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_PCI_SLOT_NUMBER_0_0 {
@@ -10400,9 +9500,6 @@ impl Default for WHEA_PCI_SLOT_NUMBER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_PCI_SLOT_NUMBER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHEA_PENDING_PAGE_LIST_SZ: u32 = 13u32;
 pub const WHEA_RESTORE_CMCI_ATTEMPTS: u32 = 8u32;
@@ -10427,9 +9524,6 @@ impl Default for WHEA_XPF_CMC_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_CMC_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct WHEA_XPF_MCE_DESCRIPTOR {
@@ -10445,9 +9539,6 @@ impl Default for WHEA_XPF_MCE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_XPF_MCE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -10467,9 +9558,6 @@ impl Default for WHEA_XPF_MC_BANK_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHEA_XPF_MC_BANK_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WHEA_XPF_MC_BANK_STATUSFORMAT_AMD64MCA: u32 = 2u32;
 pub const WHEA_XPF_MC_BANK_STATUSFORMAT_IA32MCA: u32 = 0u32;
 pub const WHEA_XPF_MC_BANK_STATUSFORMAT_Intel64MCA: u32 = 1u32;
@@ -10483,9 +9571,6 @@ impl Default for WHEA_XPF_NMI_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHEA_XPF_NMI_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WIN32K_ATOMIC_CHECK_FAILURE: BUGCHECK_ERROR = BUGCHECK_ERROR(352u32);
 pub const WIN32K_CALLOUT_WATCHDOG_BUGCHECK: BUGCHECK_ERROR = BUGCHECK_ERROR(418u32);
@@ -10546,9 +9631,6 @@ impl Default for WOW64_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WOW64_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WOW64_CONTEXT_ALL: WOW64_CONTEXT_FLAGS = WOW64_CONTEXT_FLAGS(65599u32);
 pub const WOW64_CONTEXT_CONTROL: WOW64_CONTEXT_FLAGS = WOW64_CONTEXT_FLAGS(65537u32);
@@ -10611,9 +9693,6 @@ impl Default for WOW64_DESCRIPTOR_TABLE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WOW64_DESCRIPTOR_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WOW64_FLOATING_SAVE_AREA {
@@ -10632,9 +9711,6 @@ impl Default for WOW64_FLOATING_SAVE_AREA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WOW64_FLOATING_SAVE_AREA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WOW64_LDT_ENTRY {
@@ -10647,9 +9723,6 @@ impl Default for WOW64_LDT_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WOW64_LDT_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WOW64_LDT_ENTRY_0 {
@@ -10661,9 +9734,6 @@ impl Default for WOW64_LDT_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WOW64_LDT_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WOW64_LDT_ENTRY_0_1 {
@@ -10673,9 +9743,6 @@ impl Default for WOW64_LDT_ENTRY_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WOW64_LDT_ENTRY_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10689,9 +9756,6 @@ impl Default for WOW64_LDT_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WOW64_LDT_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WOW64_MAXIMUM_SUPPORTED_EXTENSION: u32 = 512u32;
 pub const WOW64_SIZE_OF_80387_REGISTERS: u32 = 80u32;
@@ -10773,9 +9837,6 @@ impl Default for XPF_MCE_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XPF_MCE_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct XPF_MCE_FLAGS_0 {
@@ -10785,9 +9846,6 @@ impl Default for XPF_MCE_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XPF_MCE_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10800,9 +9858,6 @@ impl Default for XPF_MC_BANK_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XPF_MC_BANK_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XPF_MC_BANK_FLAGS_0 {
@@ -10812,9 +9867,6 @@ impl Default for XPF_MC_BANK_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XPF_MC_BANK_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10827,9 +9879,6 @@ impl Default for XSAVE_AREA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XSAVE_AREA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XSAVE_AREA_HEADER {
@@ -10841,9 +9890,6 @@ impl Default for XSAVE_AREA_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XSAVE_AREA_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -10872,10 +9918,6 @@ impl Default for XSAVE_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for XSAVE_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10903,10 +9945,6 @@ impl Default for XSAVE_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for XSAVE_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct XSTATE_CONFIGURATION {
@@ -10929,9 +9967,6 @@ impl Default for XSTATE_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XSTATE_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union XSTATE_CONFIGURATION_0 {
@@ -10943,9 +9978,6 @@ impl Default for XSTATE_CONFIGURATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XSTATE_CONFIGURATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XSTATE_CONFIGURATION_0_0 {
@@ -10955,9 +9987,6 @@ impl Default for XSTATE_CONFIGURATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XSTATE_CONFIGURATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -10971,9 +10000,6 @@ impl Default for XSTATE_CONFIG_FEATURE_MSC_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XSTATE_CONFIG_FEATURE_MSC_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -10993,10 +10019,6 @@ impl Default for XSTATE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for XSTATE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11013,10 +10035,6 @@ impl Default for XSTATE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for XSTATE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XSTATE_FEATURE {
@@ -11027,9 +10045,6 @@ impl Default for XSTATE_FEATURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XSTATE_FEATURE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ceStreamBucketParameters: MINIDUMP_STREAM_TYPE = MINIDUMP_STREAM_TYPE(32778i32);
 pub const ceStreamDiagnosisList: MINIDUMP_STREAM_TYPE = MINIDUMP_STREAM_TYPE(32780i32);

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -535,9 +535,6 @@ impl Default for CLASSIC_EVENT_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLASSIC_EVENT_ID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLSID_TraceRelogger: windows_core::GUID = windows_core::GUID::from_u128(0x7b40792d_05ff_44c4_9058_f440c71f17d4);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -548,9 +545,6 @@ impl Default for CONTROLTRACE_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONTROLTRACE_HANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CTraceRelogger: windows_core::GUID = windows_core::GUID::from_u128(0x7b40792d_05ff_44c4_9058_f440c71f17d4);
 #[repr(transparent)]
@@ -583,9 +577,6 @@ impl Default for ENABLE_TRACE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENABLE_TRACE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENABLE_TRACE_PARAMETERS_V1 {
@@ -599,9 +590,6 @@ impl Default for ENABLE_TRACE_PARAMETERS_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENABLE_TRACE_PARAMETERS_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENABLE_TRACE_PARAMETERS_VERSION: u32 = 1u32;
 pub const ENABLE_TRACE_PARAMETERS_VERSION_2: u32 = 2u32;
@@ -623,10 +611,6 @@ impl Default for ETW_BUFFER_CALLBACK_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for ETW_BUFFER_CALLBACK_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ETW_BUFFER_CONTEXT {
@@ -637,9 +621,6 @@ impl Default for ETW_BUFFER_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ETW_BUFFER_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -652,9 +633,6 @@ impl Default for ETW_BUFFER_CONTEXT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ETW_BUFFER_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ETW_BUFFER_CONTEXT_0_0 {
@@ -665,9 +643,6 @@ impl Default for ETW_BUFFER_CONTEXT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ETW_BUFFER_CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -684,9 +659,6 @@ impl Default for ETW_BUFFER_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ETW_BUFFER_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ETW_BYTE_TYPE_VALUE: u32 = 4u32;
 pub const ETW_CHAR_TYPE_VALUE: u32 = 11u32;
@@ -722,10 +694,6 @@ impl Default for ETW_OPEN_TRACE_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for ETW_OPEN_TRACE_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ETW_PMC_COUNTER_OWNER {
@@ -738,9 +706,6 @@ impl Default for ETW_PMC_COUNTER_OWNER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ETW_PMC_COUNTER_OWNER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ETW_PMC_COUNTER_OWNERSHIP_STATUS {
@@ -752,9 +717,6 @@ impl Default for ETW_PMC_COUNTER_OWNERSHIP_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ETW_PMC_COUNTER_OWNERSHIP_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -772,9 +734,6 @@ impl Default for ETW_PMC_SESSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ETW_PMC_SESSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ETW_POINTER_TYPE_VALUE: u32 = 105u32;
 #[repr(transparent)]
@@ -812,9 +771,6 @@ impl Default for ETW_TRACE_PARTITION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ETW_TRACE_PARTITION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ETW_TRACE_PARTITION_INFORMATION_V2 {
@@ -827,9 +783,6 @@ impl Default for ETW_TRACE_PARTITION_INFORMATION_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ETW_TRACE_PARTITION_INFORMATION_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ETW_UINT16_TYPE_VALUE: u32 = 6u32;
 pub const ETW_UINT32_TYPE_VALUE: u32 = 8u32;
@@ -868,9 +821,6 @@ impl Default for EVENT_DATA_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_DATA_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_DATA_DESCRIPTOR_0 {
@@ -881,9 +831,6 @@ impl Default for EVENT_DATA_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_DATA_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -896,9 +843,6 @@ impl Default for EVENT_DATA_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_DATA_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_DATA_DESCRIPTOR_TYPE_EVENT_METADATA: u32 = 1u32;
 pub const EVENT_DATA_DESCRIPTOR_TYPE_NONE: u32 = 0u32;
@@ -919,9 +863,6 @@ impl Default for EVENT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_ENABLE_PROPERTY_ENABLE_KEYWORD_0: u32 = 64u32;
 pub const EVENT_ENABLE_PROPERTY_ENABLE_SILOS: u32 = 1024u32;
@@ -945,9 +886,6 @@ impl Default for EVENT_EXTENDED_ITEM_EVENT_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_EVENT_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_EXTENDED_ITEM_INSTANCE {
@@ -960,9 +898,6 @@ impl Default for EVENT_EXTENDED_ITEM_INSTANCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_INSTANCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_EXTENDED_ITEM_PEBS_INDEX {
@@ -972,9 +907,6 @@ impl Default for EVENT_EXTENDED_ITEM_PEBS_INDEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_PEBS_INDEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -986,9 +918,6 @@ impl Default for EVENT_EXTENDED_ITEM_PMC_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_PMC_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_EXTENDED_ITEM_PROCESS_START_KEY {
@@ -999,9 +928,6 @@ impl Default for EVENT_EXTENDED_ITEM_PROCESS_START_KEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_PROCESS_START_KEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID {
@@ -1011,9 +937,6 @@ impl Default for EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1027,9 +950,6 @@ impl Default for EVENT_EXTENDED_ITEM_STACK_KEY32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_STACK_KEY32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_EXTENDED_ITEM_STACK_KEY64 {
@@ -1040,9 +960,6 @@ impl Default for EVENT_EXTENDED_ITEM_STACK_KEY64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_STACK_KEY64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1055,9 +972,6 @@ impl Default for EVENT_EXTENDED_ITEM_STACK_TRACE32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_STACK_TRACE32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_EXTENDED_ITEM_STACK_TRACE64 {
@@ -1069,9 +983,6 @@ impl Default for EVENT_EXTENDED_ITEM_STACK_TRACE64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_STACK_TRACE64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_EXTENDED_ITEM_TS_ID {
@@ -1081,9 +992,6 @@ impl Default for EVENT_EXTENDED_ITEM_TS_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_EXTENDED_ITEM_TS_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1100,9 +1008,6 @@ impl Default for EVENT_FILTER_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_FILTER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_FILTER_EVENT_ID {
@@ -1115,9 +1020,6 @@ impl Default for EVENT_FILTER_EVENT_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_FILTER_EVENT_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1134,9 +1036,6 @@ impl Default for EVENT_FILTER_EVENT_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_FILTER_EVENT_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_FILTER_HEADER {
@@ -1152,9 +1051,6 @@ impl Default for EVENT_FILTER_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_FILTER_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_FILTER_LEVEL_KW {
@@ -1167,9 +1063,6 @@ impl Default for EVENT_FILTER_LEVEL_KW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_FILTER_LEVEL_KW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_FILTER_TYPE_CONTAINER: u32 = 2147516416u32;
 pub const EVENT_FILTER_TYPE_EVENT_ID: u32 = 2147484160u32;
@@ -1206,9 +1099,6 @@ impl Default for EVENT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_HEADER_0 {
@@ -1220,9 +1110,6 @@ impl Default for EVENT_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_HEADER_0_0 {
@@ -1233,9 +1120,6 @@ impl Default for EVENT_HEADER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1251,9 +1135,6 @@ impl Default for EVENT_HEADER_EXTENDED_DATA_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_HEADER_EXTENDED_DATA_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_HEADER_EXTENDED_DATA_ITEM_0 {
@@ -1263,9 +1144,6 @@ impl Default for EVENT_HEADER_EXTENDED_DATA_ITEM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_HEADER_EXTENDED_DATA_ITEM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_HEADER_EXT_TYPE_CONTAINER_ID: u32 = 16u32;
 pub const EVENT_HEADER_EXT_TYPE_CONTROL_GUID: u32 = 14u32;
@@ -1323,9 +1201,6 @@ impl Default for EVENT_INSTANCE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_INSTANCE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_INSTANCE_HEADER_0 {
@@ -1336,9 +1211,6 @@ impl Default for EVENT_INSTANCE_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_INSTANCE_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1351,9 +1223,6 @@ impl Default for EVENT_INSTANCE_HEADER_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_INSTANCE_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_INSTANCE_HEADER_1 {
@@ -1364,9 +1233,6 @@ impl Default for EVENT_INSTANCE_HEADER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_INSTANCE_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1380,9 +1246,6 @@ impl Default for EVENT_INSTANCE_HEADER_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_INSTANCE_HEADER_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_INSTANCE_HEADER_2 {
@@ -1395,9 +1258,6 @@ impl Default for EVENT_INSTANCE_HEADER_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_INSTANCE_HEADER_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_INSTANCE_HEADER_2_0 {
@@ -1408,9 +1268,6 @@ impl Default for EVENT_INSTANCE_HEADER_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_INSTANCE_HEADER_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1423,9 +1280,6 @@ impl Default for EVENT_INSTANCE_HEADER_2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_INSTANCE_HEADER_2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_INSTANCE_INFO {
@@ -1436,9 +1290,6 @@ impl Default for EVENT_INSTANCE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_INSTANCE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_LOGGER_NAME: windows_core::PCWSTR = windows_core::w!("EventLog");
 pub const EVENT_LOGGER_NAMEA: windows_core::PCSTR = windows_core::s!("EventLog");
@@ -1454,9 +1305,6 @@ impl Default for EVENT_MAP_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_MAP_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_MAP_ENTRY_0 {
@@ -1467,9 +1315,6 @@ impl Default for EVENT_MAP_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_MAP_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1485,9 +1330,6 @@ impl Default for EVENT_MAP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_MAP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_MAP_INFO_0 {
@@ -1498,9 +1340,6 @@ impl Default for EVENT_MAP_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_MAP_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_MAX_LEVEL: u32 = 255u32;
 pub const EVENT_MIN_LEVEL: u32 = 0u32;
@@ -1519,9 +1358,6 @@ impl Default for EVENT_PROPERTY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_PROPERTY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_PROPERTY_INFO_0 {
@@ -1533,9 +1369,6 @@ impl Default for EVENT_PROPERTY_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_PROPERTY_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1549,9 +1382,6 @@ impl Default for EVENT_PROPERTY_INFO_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_PROPERTY_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_PROPERTY_INFO_0_0 {
@@ -1563,9 +1393,6 @@ impl Default for EVENT_PROPERTY_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_PROPERTY_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1579,9 +1406,6 @@ impl Default for EVENT_PROPERTY_INFO_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_PROPERTY_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_PROPERTY_INFO_1 {
@@ -1592,9 +1416,6 @@ impl Default for EVENT_PROPERTY_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_PROPERTY_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1607,9 +1428,6 @@ impl Default for EVENT_PROPERTY_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_PROPERTY_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_PROPERTY_INFO_3 {
@@ -1621,9 +1439,6 @@ impl Default for EVENT_PROPERTY_INFO_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_PROPERTY_INFO_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_PROPERTY_INFO_3_0 {
@@ -1633,9 +1448,6 @@ impl Default for EVENT_PROPERTY_INFO_3_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_PROPERTY_INFO_3_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1653,9 +1465,6 @@ impl Default for EVENT_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct EVENT_TRACE {
@@ -1672,9 +1481,6 @@ impl Default for EVENT_TRACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_TRACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_TRACE_0 {
@@ -1685,9 +1491,6 @@ impl Default for EVENT_TRACE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_TRACE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_TRACE_ADDTO_TRIAGE_DUMP: u32 = 2147483648u32;
 pub const EVENT_TRACE_ADD_HEADER_MODE: u32 = 4096u32;
@@ -1793,9 +1596,6 @@ impl Default for EVENT_TRACE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_TRACE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_TRACE_HEADER_0 {
@@ -1806,9 +1606,6 @@ impl Default for EVENT_TRACE_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_TRACE_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1821,9 +1618,6 @@ impl Default for EVENT_TRACE_HEADER_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_TRACE_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_TRACE_HEADER_1 {
@@ -1834,9 +1628,6 @@ impl Default for EVENT_TRACE_HEADER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_TRACE_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1850,9 +1641,6 @@ impl Default for EVENT_TRACE_HEADER_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_TRACE_HEADER_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_TRACE_HEADER_2 {
@@ -1863,9 +1651,6 @@ impl Default for EVENT_TRACE_HEADER_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_TRACE_HEADER_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1879,9 +1664,6 @@ impl Default for EVENT_TRACE_HEADER_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_TRACE_HEADER_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_TRACE_HEADER_3_0 {
@@ -1893,9 +1675,6 @@ impl Default for EVENT_TRACE_HEADER_3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_TRACE_HEADER_3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_TRACE_HEADER_3_1 {
@@ -1906,9 +1685,6 @@ impl Default for EVENT_TRACE_HEADER_3_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_TRACE_HEADER_3_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_TRACE_INDEPENDENT_SESSION_MODE: u32 = 134217728u32;
 #[repr(C)]
@@ -1936,10 +1712,6 @@ impl Default for EVENT_TRACE_LOGFILEA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for EVENT_TRACE_LOGFILEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
 #[derive(Clone, Copy)]
@@ -1953,10 +1725,6 @@ impl Default for EVENT_TRACE_LOGFILEA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for EVENT_TRACE_LOGFILEA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
 #[derive(Clone, Copy)]
@@ -1969,10 +1737,6 @@ impl Default for EVENT_TRACE_LOGFILEA_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for EVENT_TRACE_LOGFILEA_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
@@ -1999,10 +1763,6 @@ impl Default for EVENT_TRACE_LOGFILEW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for EVENT_TRACE_LOGFILEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
 #[derive(Clone, Copy)]
@@ -2016,10 +1776,6 @@ impl Default for EVENT_TRACE_LOGFILEW_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for EVENT_TRACE_LOGFILEW_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
 #[derive(Clone, Copy)]
@@ -2032,10 +1788,6 @@ impl Default for EVENT_TRACE_LOGFILEW_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for EVENT_TRACE_LOGFILEW_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_TRACE_MODE_RESERVED: u32 = 1048576u32;
 pub const EVENT_TRACE_NONSTOPPABLE_MODE: u32 = 64u32;
@@ -2070,9 +1822,6 @@ impl Default for EVENT_TRACE_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_TRACE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_TRACE_PROPERTIES_0 {
@@ -2083,9 +1832,6 @@ impl Default for EVENT_TRACE_PROPERTIES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_TRACE_PROPERTIES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2118,9 +1864,6 @@ impl Default for EVENT_TRACE_PROPERTIES_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_TRACE_PROPERTIES_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EVENT_TRACE_PROPERTIES_V2_0 {
@@ -2131,9 +1874,6 @@ impl Default for EVENT_TRACE_PROPERTIES_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_TRACE_PROPERTIES_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2146,9 +1886,6 @@ impl Default for EVENT_TRACE_PROPERTIES_V2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_TRACE_PROPERTIES_V2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_TRACE_PROPERTIES_V2_1_0 {
@@ -2158,9 +1895,6 @@ impl Default for EVENT_TRACE_PROPERTIES_V2_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_TRACE_PROPERTIES_V2_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2173,9 +1907,6 @@ impl Default for EVENT_TRACE_PROPERTIES_V2_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENT_TRACE_PROPERTIES_V2_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EVENT_TRACE_PROPERTIES_V2_2_0 {
@@ -2185,9 +1916,6 @@ impl Default for EVENT_TRACE_PROPERTIES_V2_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_TRACE_PROPERTIES_V2_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_TRACE_REAL_TIME_MODE: u32 = 256u32;
 pub const EVENT_TRACE_RELOG_MODE: u32 = 65536u32;
@@ -2744,9 +2472,6 @@ impl Default for MOF_FIELD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MOF_FIELD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MaxEventInfo: EVENT_INFO_CLASS = EVENT_INFO_CLASS(4i32);
 pub const MaxTraceSetInfoClass: TRACE_QUERY_INFO_CLASS = TRACE_QUERY_INFO_CLASS(28i32);
 #[repr(C)]
@@ -2759,9 +2484,6 @@ impl Default for OFFSETINSTANCEDATAANDLENGTH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OFFSETINSTANCEDATAANDLENGTH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PAYLOADFIELD_BETWEEN: PAYLOAD_OPERATOR = PAYLOAD_OPERATOR(6i32);
 pub const PAYLOADFIELD_CONTAINS: PAYLOAD_OPERATOR = PAYLOAD_OPERATOR(20i32);
@@ -2789,9 +2511,6 @@ impl Default for PAYLOAD_FILTER_PREDICATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PAYLOAD_FILTER_PREDICATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PAYLOAD_OPERATOR(pub i32);
@@ -2815,9 +2534,6 @@ impl Default for PROCESSTRACE_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSTRACE_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PROCESS_TRACE_MODE_EVENT_RECORD: u32 = 268435456u32;
 pub const PROCESS_TRACE_MODE_RAW_TIMESTAMP: u32 = 4096u32;
 pub const PROCESS_TRACE_MODE_REAL_TIME: u32 = 256u32;
@@ -2836,9 +2552,6 @@ impl Default for PROFILE_SOURCE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROFILE_SOURCE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROPERTY_DATA_DESCRIPTOR {
@@ -2850,9 +2563,6 @@ impl Default for PROPERTY_DATA_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROPERTY_DATA_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2869,9 +2579,6 @@ impl Default for PROVIDER_ENUMERATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROVIDER_ENUMERATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROVIDER_EVENT_INFO {
@@ -2883,9 +2590,6 @@ impl Default for PROVIDER_EVENT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROVIDER_EVENT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2899,9 +2603,6 @@ impl Default for PROVIDER_FIELD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROVIDER_FIELD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROVIDER_FIELD_INFOARRAY {
@@ -2913,9 +2614,6 @@ impl Default for PROVIDER_FIELD_INFOARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROVIDER_FIELD_INFOARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2931,9 +2629,6 @@ impl Default for PROVIDER_FILTER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROVIDER_FILTER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PageFaultGuid: windows_core::GUID = windows_core::GUID::from_u128(0x3d6fa8d3_fe05_11d0_9dda_00c04fd7ba7c);
 pub const PerfInfoGuid: windows_core::GUID = windows_core::GUID::from_u128(0xce1dbfb4_137e_4da6_87b0_3f59aa102cbc);
@@ -2962,9 +2657,6 @@ impl Default for RELOGSTREAM_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RELOGSTREAM_HANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RegistryGuid: windows_core::GUID = windows_core::GUID::from_u128(0xae53722e_c863_11d2_8659_00c04fa321a1);
 pub const SYSTEM_ALPC_KW_GENERAL: u64 = 1u64;
@@ -3092,9 +2784,6 @@ impl Default for TDH_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TDH_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TDH_CONTEXT_MAXIMUM: TDH_CONTEXT_TYPE = TDH_CONTEXT_TYPE(5i32);
 pub const TDH_CONTEXT_PDB_PATH: TDH_CONTEXT_TYPE = TDH_CONTEXT_TYPE(4i32);
@@ -3235,9 +2924,6 @@ impl Default for TRACE_ENABLE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRACE_ENABLE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct TRACE_EVENT_INFO {
@@ -3267,9 +2953,6 @@ impl Default for TRACE_EVENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRACE_EVENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TRACE_EVENT_INFO_0 {
@@ -3280,9 +2963,6 @@ impl Default for TRACE_EVENT_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRACE_EVENT_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3295,9 +2975,6 @@ impl Default for TRACE_EVENT_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRACE_EVENT_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TRACE_EVENT_INFO_2 {
@@ -3309,9 +2986,6 @@ impl Default for TRACE_EVENT_INFO_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRACE_EVENT_INFO_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRACE_EVENT_INFO_2_0 {
@@ -3321,9 +2995,6 @@ impl Default for TRACE_EVENT_INFO_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRACE_EVENT_INFO_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3335,9 +3006,6 @@ impl Default for TRACE_GUID_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRACE_GUID_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3354,9 +3022,6 @@ impl Default for TRACE_GUID_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRACE_GUID_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRACE_GUID_REGISTRATION {
@@ -3367,9 +3032,6 @@ impl Default for TRACE_GUID_REGISTRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRACE_GUID_REGISTRATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRACE_HEADER_FLAG_LOG_WNODE: u32 = 262144u32;
 pub const TRACE_HEADER_FLAG_TRACED_GUID: u32 = 131072u32;
@@ -3416,10 +3078,6 @@ impl Default for TRACE_LOGFILE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
 #[derive(Clone, Copy)]
@@ -3432,10 +3090,6 @@ impl Default for TRACE_LOGFILE_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
@@ -3452,10 +3106,6 @@ impl Default for TRACE_LOGFILE_HEADER_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
 #[derive(Clone, Copy)]
@@ -3468,10 +3118,6 @@ impl Default for TRACE_LOGFILE_HEADER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
@@ -3487,10 +3133,6 @@ impl Default for TRACE_LOGFILE_HEADER_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
@@ -3521,10 +3163,6 @@ impl Default for TRACE_LOGFILE_HEADER32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
 #[derive(Clone, Copy)]
@@ -3537,10 +3175,6 @@ impl Default for TRACE_LOGFILE_HEADER32_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER32_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
@@ -3557,10 +3191,6 @@ impl Default for TRACE_LOGFILE_HEADER32_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER32_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
 #[derive(Clone, Copy)]
@@ -3573,10 +3203,6 @@ impl Default for TRACE_LOGFILE_HEADER32_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER32_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
@@ -3592,10 +3218,6 @@ impl Default for TRACE_LOGFILE_HEADER32_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER32_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
@@ -3626,10 +3248,6 @@ impl Default for TRACE_LOGFILE_HEADER64 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
 #[derive(Clone, Copy)]
@@ -3642,10 +3260,6 @@ impl Default for TRACE_LOGFILE_HEADER64_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER64_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
@@ -3662,10 +3276,6 @@ impl Default for TRACE_LOGFILE_HEADER64_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER64_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
 #[derive(Clone, Copy)]
@@ -3678,10 +3288,6 @@ impl Default for TRACE_LOGFILE_HEADER64_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER64_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Time")]
@@ -3697,10 +3303,6 @@ impl Default for TRACE_LOGFILE_HEADER64_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Time")]
-impl windows_core::TypeKind for TRACE_LOGFILE_HEADER64_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRACE_MESSAGE_COMPONENTID: TRACE_MESSAGE_FLAGS = TRACE_MESSAGE_FLAGS(4u32);
 #[repr(transparent)]
@@ -3759,9 +3361,6 @@ impl Default for TRACE_PERIODIC_CAPTURE_STATE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRACE_PERIODIC_CAPTURE_STATE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRACE_PROFILE_INTERVAL {
@@ -3772,9 +3371,6 @@ impl Default for TRACE_PROFILE_INTERVAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRACE_PROFILE_INTERVAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRACE_PROVIDER_FLAG_LEGACY: u32 = 1u32;
 pub const TRACE_PROVIDER_FLAG_PRE_ENABLE: u32 = 2u32;
@@ -3790,9 +3386,6 @@ impl Default for TRACE_PROVIDER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRACE_PROVIDER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRACE_PROVIDER_INSTANCE_INFO {
@@ -3805,9 +3398,6 @@ impl Default for TRACE_PROVIDER_INSTANCE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRACE_PROVIDER_INSTANCE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3824,9 +3414,6 @@ impl Default for TRACE_STACK_CACHING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRACE_STACK_CACHING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRACE_VERSION_INFO {
@@ -3837,9 +3424,6 @@ impl Default for TRACE_VERSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRACE_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TcpIpGuid: windows_core::GUID = windows_core::GUID::from_u128(0x9a280ac0_c8e0_11d1_84e2_00c04fb998a2);
 pub const ThreadGuid: windows_core::GUID = windows_core::GUID::from_u128(0x3d6fa8d1_fe05_11d0_9dda_00c04fd7ba7c);
@@ -3894,9 +3478,6 @@ impl Default for WMIREGGUIDW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WMIREGGUIDW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WMIREGGUIDW_0 {
@@ -3909,9 +3490,6 @@ impl Default for WMIREGGUIDW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMIREGGUIDW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3927,9 +3505,6 @@ impl Default for WMIREGINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WMIREGINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMIREG_FLAG_EVENT_ONLY_GUID: u32 = 64u32;
 pub const WMIREG_FLAG_EXPENSIVE: u32 = 1u32;
@@ -3971,9 +3546,6 @@ impl Default for WNODE_ALL_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WNODE_ALL_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WNODE_ALL_DATA_0 {
@@ -3985,9 +3557,6 @@ impl Default for WNODE_ALL_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WNODE_ALL_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WNODE_EVENT_ITEM {
@@ -3997,9 +3566,6 @@ impl Default for WNODE_EVENT_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WNODE_EVENT_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4014,9 +3580,6 @@ impl Default for WNODE_EVENT_REFERENCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WNODE_EVENT_REFERENCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WNODE_EVENT_REFERENCE_0 {
@@ -4027,9 +3590,6 @@ impl Default for WNODE_EVENT_REFERENCE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WNODE_EVENT_REFERENCE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WNODE_FLAG_ALL_DATA: u32 = 1u32;
 pub const WNODE_FLAG_ANSI_INSTANCENAMES: u32 = 16384u32;
@@ -4070,9 +3630,6 @@ impl Default for WNODE_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WNODE_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WNODE_HEADER_0 {
@@ -4083,9 +3640,6 @@ impl Default for WNODE_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WNODE_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4098,9 +3652,6 @@ impl Default for WNODE_HEADER_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WNODE_HEADER_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WNODE_HEADER_1 {
@@ -4112,9 +3663,6 @@ impl Default for WNODE_HEADER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WNODE_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4132,9 +3680,6 @@ impl Default for WNODE_METHOD_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WNODE_METHOD_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WNODE_SINGLE_INSTANCE {
@@ -4149,9 +3694,6 @@ impl Default for WNODE_SINGLE_INSTANCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WNODE_SINGLE_INSTANCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4169,9 +3711,6 @@ impl Default for WNODE_SINGLE_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WNODE_SINGLE_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WNODE_TOO_SMALL {
@@ -4182,9 +3721,6 @@ impl Default for WNODE_TOO_SMALL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WNODE_TOO_SMALL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
@@ -101,9 +101,6 @@ impl Default for PSS_ALLOCATOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSS_ALLOCATOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSS_AUXILIARY_PAGES_INFORMATION {
@@ -113,9 +110,6 @@ impl Default for PSS_AUXILIARY_PAGES_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSS_AUXILIARY_PAGES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Memory")]
@@ -132,10 +126,6 @@ impl Default for PSS_AUXILIARY_PAGE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Memory")]
-impl windows_core::TypeKind for PSS_AUXILIARY_PAGE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -258,9 +248,6 @@ impl Default for PSS_HANDLE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PSS_HANDLE_ENTRY_0 {
@@ -276,9 +263,6 @@ impl Default for PSS_HANDLE_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSS_HANDLE_ENTRY_0_3 {
@@ -289,9 +273,6 @@ impl Default for PSS_HANDLE_ENTRY_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -305,9 +286,6 @@ impl Default for PSS_HANDLE_ENTRY_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -325,9 +303,6 @@ impl Default for PSS_HANDLE_ENTRY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSS_HANDLE_ENTRY_0_4 {
@@ -340,9 +315,6 @@ impl Default for PSS_HANDLE_ENTRY_0_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSS_HANDLE_ENTRY_0_5 {
@@ -353,9 +325,6 @@ impl Default for PSS_HANDLE_ENTRY_0_5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_5 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -373,9 +342,6 @@ impl Default for PSS_HANDLE_ENTRY_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSS_HANDLE_ENTRY_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -427,9 +393,6 @@ impl Default for PSS_HANDLE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSS_HANDLE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PSS_HANDLE_NONE: PSS_HANDLE_FLAGS = PSS_HANDLE_FLAGS(0i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -441,9 +404,6 @@ impl Default for PSS_HANDLE_TRACE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSS_HANDLE_TRACE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -475,9 +435,6 @@ impl Default for PSS_PERFORMANCE_COUNTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSS_PERFORMANCE_COUNTERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PSS_PERF_RESOLUTION: u32 = 1000000u32;
 #[repr(transparent)]
@@ -557,9 +514,6 @@ impl Default for PSS_PROCESS_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSS_PROCESS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PSS_QUERY_AUXILIARY_PAGES_INFORMATION: PSS_QUERY_INFORMATION_CLASS = PSS_QUERY_INFORMATION_CLASS(2i32);
 pub const PSS_QUERY_HANDLE_INFORMATION: PSS_QUERY_INFORMATION_CLASS = PSS_QUERY_INFORMATION_CLASS(4i32);
 pub const PSS_QUERY_HANDLE_TRACE_INFORMATION: PSS_QUERY_INFORMATION_CLASS = PSS_QUERY_INFORMATION_CLASS(6i32);
@@ -600,10 +554,6 @@ impl Default for PSS_THREAD_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for PSS_THREAD_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -654,9 +604,6 @@ impl Default for PSS_THREAD_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSS_THREAD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSS_VA_CLONE_INFORMATION {
@@ -666,9 +613,6 @@ impl Default for PSS_VA_CLONE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSS_VA_CLONE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -692,9 +636,6 @@ impl Default for PSS_VA_SPACE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSS_VA_SPACE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSS_VA_SPACE_INFORMATION {
@@ -704,9 +645,6 @@ impl Default for PSS_VA_SPACE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSS_VA_SPACE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PSS_WALK_AUXILIARY_PAGES: PSS_WALK_INFORMATION_CLASS = PSS_WALK_INFORMATION_CLASS(0i32);
 pub const PSS_WALK_HANDLES: PSS_WALK_INFORMATION_CLASS = PSS_WALK_INFORMATION_CLASS(2i32);

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ToolHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ToolHelp/mod.rs
@@ -133,9 +133,6 @@ impl Default for HEAPENTRY32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HEAPENTRY32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HEAPENTRY32_FLAGS(pub u32);
@@ -151,9 +148,6 @@ impl Default for HEAPLIST32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HEAPLIST32 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HF32_DEFAULT: u32 = 1u32;
 pub const HF32_SHARED: u32 = 2u32;
@@ -180,9 +174,6 @@ impl Default for MODULEENTRY32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MODULEENTRY32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MODULEENTRY32W {
@@ -201,9 +192,6 @@ impl Default for MODULEENTRY32W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MODULEENTRY32W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -224,9 +212,6 @@ impl Default for PROCESSENTRY32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSENTRY32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESSENTRY32W {
@@ -245,9 +230,6 @@ impl Default for PROCESSENTRY32W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESSENTRY32W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TH32CS_INHERIT: CREATE_TOOLHELP_SNAPSHOT_FLAGS = CREATE_TOOLHELP_SNAPSHOT_FLAGS(2147483648u32);
 pub const TH32CS_SNAPALL: CREATE_TOOLHELP_SNAPSHOT_FLAGS = CREATE_TOOLHELP_SNAPSHOT_FLAGS(15u32);
@@ -271,7 +253,4 @@ impl Default for THREADENTRY32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for THREADENTRY32 {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/mod.rs
@@ -50,9 +50,6 @@ impl Default for BOID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BOID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLSID_MSDtcTransaction: windows_core::GUID = windows_core::GUID::from_u128(0x39f8d76b_0928_11d1_97df_00c04fb9618a);
 pub const CLSID_MSDtcTransactionManager: windows_core::GUID = windows_core::GUID::from_u128(0x5b18ab61_091d_11d1_97df_00c04fb9618a);
 pub const CLUSTERRESOURCE_APPLICATIONTYPE: APPLICATIONTYPE = APPLICATIONTYPE(1i32);
@@ -3766,9 +3763,6 @@ impl Default for OLE_TM_CONFIG_PARAMS_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OLE_TM_CONFIG_PARAMS_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OLE_TM_CONFIG_PARAMS_V2 {
@@ -3781,9 +3775,6 @@ impl Default for OLE_TM_CONFIG_PARAMS_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OLE_TM_CONFIG_PARAMS_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OLE_TM_CONFIG_VERSION_1: u32 = 1u32;
 pub const OLE_TM_CONFIG_VERSION_2: u32 = 2u32;
@@ -3801,9 +3792,6 @@ impl Default for PROXY_CONFIG_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROXY_CONFIG_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RMNAMESZ: u32 = 32u32;
 pub const TMASYNC: i32 = -2147483648i32;
@@ -3853,9 +3841,6 @@ impl Default for XACTOPT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XACTOPT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct XACTRM(pub i32);
@@ -3880,9 +3865,6 @@ impl Default for XACTSTATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XACTSTATS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XACTSTAT_ABORTED: XACTSTAT = XACTSTAT(512i32);
 pub const XACTSTAT_ABORTING: XACTSTAT = XACTSTAT(256i32);
@@ -3931,9 +3913,6 @@ impl Default for XACTTRANSINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XACTTRANSINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4012,9 +3991,6 @@ impl Default for XID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const XIDDATASIZE: u32 = 128u32;
 pub const dwUSER_MS_SQLSERVER: XACT_DTC_CONSTANTS = XACT_DTC_CONSTANTS(65535i32);
 #[repr(C)]
@@ -4038,7 +4014,4 @@ impl Default for xa_switch_t {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for xa_switch_t {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Environment/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Environment/mod.rs
@@ -268,9 +268,6 @@ impl Default for ENCLAVE_IDENTITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENCLAVE_IDENTITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ENCLAVE_IDENTITY_POLICY_SEAL_EXACT_CODE: ENCLAVE_SEALING_IDENTITY_POLICY = ENCLAVE_SEALING_IDENTITY_POLICY(1i32);
 pub const ENCLAVE_IDENTITY_POLICY_SEAL_INVALID: ENCLAVE_SEALING_IDENTITY_POLICY = ENCLAVE_SEALING_IDENTITY_POLICY(0i32);
 pub const ENCLAVE_IDENTITY_POLICY_SEAL_SAME_AUTHOR: ENCLAVE_SEALING_IDENTITY_POLICY = ENCLAVE_SEALING_IDENTITY_POLICY(5i32);
@@ -290,9 +287,6 @@ impl Default for ENCLAVE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENCLAVE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENCLAVE_REPORT_DATA_LENGTH: u32 = 64u32;
 pub const ENCLAVE_RUNTIME_POLICY_ALLOW_DYNAMIC_DEBUG: u32 = 2u32;
@@ -318,9 +312,6 @@ impl Default for ENCLAVE_VBS_BASIC_KEY_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENCLAVE_VBS_BASIC_KEY_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 pub type VBS_BASIC_ENCLAVE_BASIC_CALL_COMMIT_PAGES = Option<unsafe extern "system" fn(enclaveaddress: *const core::ffi::c_void, numberofbytes: usize, sourceaddress: *const core::ffi::c_void, pageprotection: u32) -> i32>;
 #[cfg(target_arch = "x86")]
@@ -364,9 +355,6 @@ impl Default for VBS_BASIC_ENCLAVE_EXCEPTION_AMD64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBS_BASIC_ENCLAVE_EXCEPTION_AMD64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VBS_BASIC_ENCLAVE_SYSCALL_PAGE {
@@ -389,9 +377,6 @@ impl Default for VBS_BASIC_ENCLAVE_SYSCALL_PAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBS_BASIC_ENCLAVE_SYSCALL_PAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR32 {
@@ -406,9 +391,6 @@ impl Default for VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -425,9 +407,6 @@ impl Default for VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct VBS_ENCLAVE_REPORT {
@@ -440,9 +419,6 @@ impl Default for VBS_ENCLAVE_REPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VBS_ENCLAVE_REPORT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -460,9 +436,6 @@ impl Default for VBS_ENCLAVE_REPORT_MODULE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBS_ENCLAVE_REPORT_MODULE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct VBS_ENCLAVE_REPORT_PKG_HEADER {
@@ -478,9 +451,6 @@ impl Default for VBS_ENCLAVE_REPORT_PKG_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VBS_ENCLAVE_REPORT_PKG_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VBS_ENCLAVE_REPORT_PKG_HEADER_VERSION_CURRENT: u32 = 1u32;
 pub const VBS_ENCLAVE_REPORT_SIGNATURE_SCHEME_SHA256_RSA_PSS_SHA256: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -493,9 +463,6 @@ impl Default for VBS_ENCLAVE_REPORT_VARDATA_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VBS_ENCLAVE_REPORT_VARDATA_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VBS_ENCLAVE_REPORT_VERSION_CURRENT: u32 = 1u32;
 pub const VBS_ENCLAVE_VARDATA_INVALID: u32 = 0u32;

--- a/crates/libs/windows/src/Windows/Win32/System/ErrorReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ErrorReporting/mod.rs
@@ -370,9 +370,6 @@ impl Default for WER_DUMP_CUSTOM_OPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WER_DUMP_CUSTOM_OPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WER_DUMP_CUSTOM_OPTIONS_V2 {
@@ -394,9 +391,6 @@ impl Default for WER_DUMP_CUSTOM_OPTIONS_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WER_DUMP_CUSTOM_OPTIONS_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -423,9 +417,6 @@ impl Default for WER_DUMP_CUSTOM_OPTIONS_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WER_DUMP_CUSTOM_OPTIONS_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WER_DUMP_MASK_START: u32 = 1u32;
 pub const WER_DUMP_NOHEAP_ONQUEUE: u32 = 1u32;
 #[repr(transparent)]
@@ -443,10 +434,6 @@ impl Default for WER_EXCEPTION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for WER_EXCEPTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -585,9 +572,6 @@ impl Default for WER_REPORT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WER_REPORT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WER_REPORT_INFORMATION_V3 {
@@ -606,9 +590,6 @@ impl Default for WER_REPORT_INFORMATION_V3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WER_REPORT_INFORMATION_V3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -631,9 +612,6 @@ impl Default for WER_REPORT_INFORMATION_V4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WER_REPORT_INFORMATION_V4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -658,9 +636,6 @@ impl Default for WER_REPORT_INFORMATION_V5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WER_REPORT_INFORMATION_V5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WER_REPORT_METADATA_V1 {
@@ -674,9 +649,6 @@ impl Default for WER_REPORT_METADATA_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WER_REPORT_METADATA_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -697,9 +669,6 @@ impl Default for WER_REPORT_METADATA_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WER_REPORT_METADATA_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -727,9 +696,6 @@ impl Default for WER_REPORT_METADATA_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WER_REPORT_METADATA_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WER_REPORT_PARAMETER {
@@ -741,9 +707,6 @@ impl Default for WER_REPORT_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WER_REPORT_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WER_REPORT_SIGNATURE {
@@ -754,9 +717,6 @@ impl Default for WER_REPORT_SIGNATURE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WER_REPORT_SIGNATURE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -785,10 +745,6 @@ impl Default for WER_RUNTIME_EXCEPTION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Kernel"))]
-impl windows_core::TypeKind for WER_RUNTIME_EXCEPTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WER_SUBMIT_ADD_REGISTERED_DATA: WER_SUBMIT_FLAGS = WER_SUBMIT_FLAGS(16u32);
 pub const WER_SUBMIT_ARCHIVE_PARAMETERS_ONLY: WER_SUBMIT_FLAGS = WER_SUBMIT_FLAGS(4096u32);

--- a/crates/libs/windows/src/Windows/Win32/System/EventCollector/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventCollector/mod.rs
@@ -127,9 +127,6 @@ impl Default for EC_VARIANT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EC_VARIANT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union EC_VARIANT_0 {
@@ -147,9 +144,6 @@ impl Default for EC_VARIANT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EC_VARIANT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/EventLog/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventLog/mod.rs
@@ -407,9 +407,6 @@ impl Default for EVENTLOGRECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVENTLOGRECORD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EVENTLOG_AUDIT_FAILURE: REPORT_EVENT_TYPE = REPORT_EVENT_TYPE(16u16);
 pub const EVENTLOG_AUDIT_SUCCESS: REPORT_EVENT_TYPE = REPORT_EVENT_TYPE(8u16);
 pub const EVENTLOG_ERROR_TYPE: REPORT_EVENT_TYPE = REPORT_EVENT_TYPE(1u16);
@@ -422,9 +419,6 @@ impl Default for EVENTLOG_FULL_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENTLOG_FULL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENTLOG_INFORMATION_TYPE: REPORT_EVENT_TYPE = REPORT_EVENT_TYPE(4u16);
 pub const EVENTLOG_SEEK_READ: READ_EVENT_LOG_READ_FLAGS = READ_EVENT_LOG_READ_FLAGS(2u32);
@@ -443,9 +437,6 @@ impl Default for EVENTSFORLOGFILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENTSFORLOGFILE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVT_ALL_ACCESS: u32 = 7u32;
 #[repr(transparent)]
@@ -538,9 +529,6 @@ impl Default for EVT_RPC_LOGIN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EVT_RPC_LOGIN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct EVT_RPC_LOGIN_FLAGS(pub u32);
@@ -570,10 +558,6 @@ impl Default for EVT_VARIANT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for EVT_VARIANT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -625,10 +609,6 @@ impl Default for EVT_VARIANT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for EVT_VARIANT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/mod.rs
@@ -379,9 +379,6 @@ impl Default for QOCINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QOCINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SENS: windows_core::GUID = windows_core::GUID::from_u128(0xd597cafe_5b9f_11d1_8dd2_00aa004abd5e);
 pub const SENSGUID_EVENTCLASS_LOGON: windows_core::GUID = windows_core::GUID::from_u128(0xd5978630_5b9f_11d1_8dd2_00aa004abd5e);
 pub const SENSGUID_EVENTCLASS_LOGON2: windows_core::GUID = windows_core::GUID::from_u128(0xd5978650_5b9f_11d1_8dd2_00aa004abd5e);
@@ -405,7 +402,4 @@ impl Default for SENS_QOCINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SENS_QOCINFO {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
@@ -380,9 +380,6 @@ impl Default for GPOBROWSEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GPOBROWSEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GPOTypeDS: GROUP_POLICY_OBJECT_TYPE = GROUP_POLICY_OBJECT_TYPE(2i32);
 pub const GPOTypeLocal: GROUP_POLICY_OBJECT_TYPE = GROUP_POLICY_OBJECT_TYPE(0i32);
 pub const GPOTypeLocalGroup: GROUP_POLICY_OBJECT_TYPE = GROUP_POLICY_OBJECT_TYPE(4i32);
@@ -500,9 +497,6 @@ impl Default for GROUP_POLICY_OBJECTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GROUP_POLICY_OBJECTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GROUP_POLICY_OBJECTW {
@@ -524,9 +518,6 @@ impl Default for GROUP_POLICY_OBJECTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GROUP_POLICY_OBJECTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7868,9 +7859,6 @@ impl Default for INSTALLDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INSTALLDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INSTALLSPEC {
@@ -7884,9 +7872,6 @@ impl Default for INSTALLSPEC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INSTALLSPEC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INSTALLSPEC_0 {
@@ -7898,9 +7883,6 @@ impl Default for INSTALLSPEC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INSTALLSPEC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INSTALLSPEC_1 {
@@ -7911,9 +7893,6 @@ impl Default for INSTALLSPEC_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INSTALLSPEC_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7994,9 +7973,6 @@ impl Default for LOCALMANAGEDAPPLICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOCALMANAGEDAPPLICATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LOCALSTATE_ASSIGNED: u32 = 1u32;
 pub const LOCALSTATE_ORPHANED: u32 = 32u32;
 pub const LOCALSTATE_POLICYREMOVE_ORPHAN: u32 = 8u32;
@@ -8029,9 +8005,6 @@ impl Default for MANAGEDAPPLICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MANAGEDAPPLICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MANAGED_APPS_FROMCATEGORY: u32 = 2u32;
 pub const MANAGED_APPS_INFOLEVEL_DEFAULT: u32 = 65536u32;
@@ -8072,9 +8045,6 @@ impl Default for POLICYSETTINGSTATUSINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POLICYSETTINGSTATUSINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PROGID: INSTALLSPECTYPE = INSTALLSPECTYPE(3i32);
 pub const PT_MANDATORY: u32 = 4u32;
 pub const PT_ROAMING: u32 = 2u32;
@@ -8114,10 +8084,6 @@ impl Default for RSOP_TARGET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Wmi"))]
-impl windows_core::TypeKind for RSOP_TARGET {
-    type TypeKind = windows_core::CloneType;
 }
 pub const RSOP_TEMPNAMESPACE_EXISTS: u32 = 4u32;
 pub const RSOP_USER_ACCESS_DENIED: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/System/HostComputeNetwork/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/HostComputeNetwork/mod.rs
@@ -307,9 +307,6 @@ impl Default for HCN_PORT_RANGE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HCN_PORT_RANGE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HCN_PORT_RANGE_RESERVATION {
@@ -320,9 +317,6 @@ impl Default for HCN_PORT_RANGE_RESERVATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HCN_PORT_RANGE_RESERVATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HcnNotificationFlagsReserved: HCN_NOTIFICATIONS = HCN_NOTIFICATIONS(-268435456i32);
 pub const HcnNotificationGuestNetworkServiceCreate: HCN_NOTIFICATIONS = HCN_NOTIFICATIONS(7i32);

--- a/crates/libs/windows/src/Windows/Win32/System/HostComputeSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/HostComputeSystem/mod.rs
@@ -505,10 +505,6 @@ impl Default for HCS_CREATE_OPTIONS_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for HCS_CREATE_OPTIONS_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HCS_EVENT {
@@ -520,9 +516,6 @@ impl Default for HCS_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HCS_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub type HCS_EVENT_CALLBACK = Option<unsafe extern "system" fn(event: *const HCS_EVENT, context: *const core::ffi::c_void)>;
 #[repr(transparent)]
@@ -674,9 +667,6 @@ impl Default for HCS_PROCESS_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HCS_PROCESS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
@@ -796,9 +796,6 @@ impl Default for DOS_IMAGE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DOS_IMAGE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub type FOUND_IMAGE_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, imageinfo: *const DOS_IMAGE_INFO) -> super::super::Foundation::BOOL>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -810,9 +807,6 @@ impl Default for GPA_MEMORY_CHUNK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GPA_MEMORY_CHUNK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -826,9 +820,6 @@ impl Default for GUEST_OS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GUEST_OS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GUEST_OS_INFO_0 {
@@ -839,9 +830,6 @@ impl Default for GUEST_OS_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GUEST_OS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GUEST_OS_INFO_1 {
@@ -851,9 +839,6 @@ impl Default for GUEST_OS_INFO_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GUEST_OS_INFO_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -997,9 +982,6 @@ impl Default for HDV_PCI_DEVICE_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HDV_PCI_DEVICE_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type HDV_PCI_DEVICE_SET_CONFIGURATION = Option<unsafe extern "system" fn(devicecontext: *const core::ffi::c_void, configurationvaluecount: u32, configurationvalues: *const windows_core::PCWSTR) -> windows_core::HRESULT>;
 pub type HDV_PCI_DEVICE_START = Option<unsafe extern "system" fn(devicecontext: *const core::ffi::c_void) -> windows_core::HRESULT>;
 pub type HDV_PCI_DEVICE_STOP = Option<unsafe extern "system" fn(devicecontext: *const core::ffi::c_void)>;
@@ -1024,9 +1006,6 @@ impl Default for HDV_PCI_PNP_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HDV_PCI_PNP_ID {
-    type TypeKind = windows_core::CopyType;
-}
 pub type HDV_PCI_READ_CONFIG_SPACE = Option<unsafe extern "system" fn(devicecontext: *const core::ffi::c_void, offset: u32, value: *mut u32) -> windows_core::HRESULT>;
 pub type HDV_PCI_READ_INTERCEPTED_MEMORY = Option<unsafe extern "system" fn(devicecontext: *const core::ffi::c_void, barindex: HDV_PCI_BAR_SELECTOR, offset: u64, length: u64, value: *mut u8) -> windows_core::HRESULT>;
 pub type HDV_PCI_WRITE_CONFIG_SPACE = Option<unsafe extern "system" fn(devicecontext: *const core::ffi::c_void, offset: u32, value: u32) -> windows_core::HRESULT>;
@@ -1044,9 +1023,6 @@ impl Default for HVSOCKET_ADDRESS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HVSOCKET_ADDRESS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HVSOCKET_CONNECTED_SUSPEND: u32 = 4u32;
 pub const HVSOCKET_CONNECT_TIMEOUT: u32 = 1u32;
@@ -1081,9 +1057,6 @@ impl Default for MODULE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MODULE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PAGING_MODE(pub i32);
@@ -1116,10 +1089,6 @@ impl Default for SOCKADDR_HV {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for SOCKADDR_HV {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VIRTUAL_PROCESSOR_ARCH(pub i32);
@@ -1138,9 +1107,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_PROCESSOR_REGISTER_0 {
@@ -1151,9 +1117,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1167,9 +1130,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1186,9 +1146,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIRTUAL_PROCESSOR_REGISTER_1_2_0 {
@@ -1200,9 +1157,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_PROCESSOR_REGISTER_1_2_0_0 {
@@ -1213,9 +1167,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1230,9 +1181,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
@@ -1244,9 +1192,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {
@@ -1256,9 +1201,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1270,9 +1212,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1286,9 +1225,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union VIRTUAL_PROCESSOR_REGISTER_1_3_0 {
@@ -1300,9 +1236,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUAL_PROCESSOR_REGISTER_1_3_0_0 {
@@ -1313,9 +1246,6 @@ impl Default for VIRTUAL_PROCESSOR_REGISTER_1_3_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUAL_PROCESSOR_REGISTER_1_3_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1331,9 +1261,6 @@ impl Default for VM_GENCOUNTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VM_GENCOUNTER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VM_GENCOUNTER_SYMBOLIC_LINK_NAME: windows_core::PCWSTR = windows_core::w!("\\VmGenerationCounter");
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1346,9 +1273,6 @@ impl Default for WHV_ACCESS_GPA_CONTROLS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_ACCESS_GPA_CONTROLS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_ACCESS_GPA_CONTROLS_0 {
@@ -1360,9 +1284,6 @@ impl Default for WHV_ACCESS_GPA_CONTROLS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_ACCESS_GPA_CONTROLS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_ADVISE_GPA_RANGE {
@@ -1372,9 +1293,6 @@ impl Default for WHV_ADVISE_GPA_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_ADVISE_GPA_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1390,9 +1308,6 @@ impl Default for WHV_ADVISE_GPA_RANGE_POPULATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_ADVISE_GPA_RANGE_POPULATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS {
@@ -1404,9 +1319,6 @@ impl Default for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS_0 {
@@ -1416,9 +1328,6 @@ impl Default for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_ADVISE_GPA_RANGE_POPULATE_FLAGS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1486,9 +1395,6 @@ impl Default for WHV_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHV_CAPABILITY_CODE(pub i32);
@@ -1503,9 +1409,6 @@ impl Default for WHV_CAPABILITY_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_CAPABILITY_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_CAPABILITY_FEATURES_0 {
@@ -1515,9 +1418,6 @@ impl Default for WHV_CAPABILITY_FEATURES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_CAPABILITY_FEATURES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1533,9 +1433,6 @@ impl Default for WHV_CAPABILITY_PROCESSOR_FREQUENCY_CAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_CAPABILITY_PROCESSOR_FREQUENCY_CAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_CPUID_OUTPUT {
@@ -1548,9 +1445,6 @@ impl Default for WHV_CPUID_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_CPUID_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1601,9 +1495,6 @@ impl Default for WHV_DOORBELL_MATCH_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_DOORBELL_MATCH_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_EMULATOR_CALLBACKS {
@@ -1620,9 +1511,6 @@ impl Default for WHV_EMULATOR_CALLBACKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_EMULATOR_CALLBACKS {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WHV_EMULATOR_GET_VIRTUAL_PROCESSOR_REGISTERS_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, registernames: *const WHV_REGISTER_NAME, registercount: u32, registervalues: *mut WHV_REGISTER_VALUE) -> windows_core::HRESULT>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1636,9 +1524,6 @@ impl Default for WHV_EMULATOR_IO_ACCESS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_EMULATOR_IO_ACCESS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub type WHV_EMULATOR_IO_PORT_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, ioaccess: *mut WHV_EMULATOR_IO_ACCESS_INFO) -> windows_core::HRESULT>;
 #[repr(C)]
@@ -1654,9 +1539,6 @@ impl Default for WHV_EMULATOR_MEMORY_ACCESS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_EMULATOR_MEMORY_ACCESS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WHV_EMULATOR_MEMORY_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, memoryaccess: *mut WHV_EMULATOR_MEMORY_ACCESS_INFO) -> windows_core::HRESULT>;
 pub type WHV_EMULATOR_SET_VIRTUAL_PROCESSOR_REGISTERS_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, registernames: *const WHV_REGISTER_NAME, registercount: u32, registervalues: *const WHV_REGISTER_VALUE) -> windows_core::HRESULT>;
 #[repr(C)]
@@ -1670,9 +1552,6 @@ impl Default for WHV_EMULATOR_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_EMULATOR_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_EMULATOR_STATUS_0 {
@@ -1682,9 +1561,6 @@ impl Default for WHV_EMULATOR_STATUS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_EMULATOR_STATUS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type WHV_EMULATOR_TRANSLATE_GVA_PAGE_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, gva: u64, translateflags: WHV_TRANSLATE_GVA_FLAGS, translationresult: *mut WHV_TRANSLATE_GVA_RESULT_CODE, gpa: *mut u64) -> windows_core::HRESULT>;
 #[repr(transparent)]
@@ -1701,9 +1577,6 @@ impl Default for WHV_EXTENDED_VM_EXITS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_EXTENDED_VM_EXITS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_EXTENDED_VM_EXITS_0 {
@@ -1713,9 +1586,6 @@ impl Default for WHV_EXTENDED_VM_EXITS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_EXTENDED_VM_EXITS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1736,9 +1606,6 @@ impl Default for WHV_HYPERCALL_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_HYPERCALL_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WHV_HYPERCALL_CONTEXT_MAX_XMM_REGISTERS: u32 = 6u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1751,9 +1618,6 @@ impl Default for WHV_INTERNAL_ACTIVITY_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_INTERNAL_ACTIVITY_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_INTERNAL_ACTIVITY_REGISTER_0 {
@@ -1763,9 +1627,6 @@ impl Default for WHV_INTERNAL_ACTIVITY_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_INTERNAL_ACTIVITY_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1778,9 +1639,6 @@ impl Default for WHV_INTERRUPT_CONTROL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_INTERRUPT_CONTROL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1843,9 +1701,6 @@ impl Default for WHV_MEMORY_ACCESS_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_MEMORY_ACCESS_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_MEMORY_ACCESS_INFO {
@@ -1857,9 +1712,6 @@ impl Default for WHV_MEMORY_ACCESS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_MEMORY_ACCESS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_MEMORY_ACCESS_INFO_0 {
@@ -1869,9 +1721,6 @@ impl Default for WHV_MEMORY_ACCESS_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_MEMORY_ACCESS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1886,9 +1735,6 @@ impl Default for WHV_MEMORY_RANGE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_MEMORY_RANGE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1906,9 +1752,6 @@ impl Default for WHV_MSR_ACTION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_MSR_ACTION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHV_NOTIFICATION_PORT_PARAMETERS {
@@ -1921,9 +1764,6 @@ impl Default for WHV_NOTIFICATION_PORT_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_NOTIFICATION_PORT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_NOTIFICATION_PORT_PARAMETERS_0 {
@@ -1935,9 +1775,6 @@ impl Default for WHV_NOTIFICATION_PORT_PARAMETERS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_NOTIFICATION_PORT_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_NOTIFICATION_PORT_PARAMETERS_0_0 {
@@ -1947,9 +1784,6 @@ impl Default for WHV_NOTIFICATION_PORT_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_NOTIFICATION_PORT_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1992,9 +1826,6 @@ impl Default for WHV_PARTITION_MEMORY_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PARTITION_MEMORY_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_PARTITION_PROPERTY {
@@ -2034,9 +1865,6 @@ impl Default for WHV_PARTITION_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PARTITION_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHV_PARTITION_PROPERTY_CODE(pub i32);
@@ -2054,9 +1882,6 @@ impl Default for WHV_PROCESSOR_APIC_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PROCESSOR_APIC_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHV_PROCESSOR_COUNTER_SET(pub i32);
@@ -2072,9 +1897,6 @@ impl Default for WHV_PROCESSOR_EVENT_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PROCESSOR_EVENT_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_PROCESSOR_FEATURES {
@@ -2086,9 +1908,6 @@ impl Default for WHV_PROCESSOR_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PROCESSOR_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_PROCESSOR_FEATURES_0 {
@@ -2098,9 +1917,6 @@ impl Default for WHV_PROCESSOR_FEATURES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_PROCESSOR_FEATURES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2113,9 +1929,6 @@ impl Default for WHV_PROCESSOR_FEATURES1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PROCESSOR_FEATURES1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_PROCESSOR_FEATURES1_0 {
@@ -2125,9 +1938,6 @@ impl Default for WHV_PROCESSOR_FEATURES1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_PROCESSOR_FEATURES1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2141,9 +1951,6 @@ impl Default for WHV_PROCESSOR_FEATURES_BANKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PROCESSOR_FEATURES_BANKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_PROCESSOR_FEATURES_BANKS_0 {
@@ -2154,9 +1961,6 @@ impl Default for WHV_PROCESSOR_FEATURES_BANKS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_PROCESSOR_FEATURES_BANKS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2169,9 +1973,6 @@ impl Default for WHV_PROCESSOR_FEATURES_BANKS_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PROCESSOR_FEATURES_BANKS_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WHV_PROCESSOR_FEATURES_BANKS_COUNT: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2183,9 +1984,6 @@ impl Default for WHV_PROCESSOR_INTERCEPT_COUNTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_PROCESSOR_INTERCEPT_COUNTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2210,9 +2008,6 @@ impl Default for WHV_PROCESSOR_INTERCEPT_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PROCESSOR_INTERCEPT_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_PROCESSOR_PERFMON_FEATURES {
@@ -2224,9 +2019,6 @@ impl Default for WHV_PROCESSOR_PERFMON_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PROCESSOR_PERFMON_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_PROCESSOR_PERFMON_FEATURES_0 {
@@ -2236,9 +2028,6 @@ impl Default for WHV_PROCESSOR_PERFMON_FEATURES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_PROCESSOR_PERFMON_FEATURES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2250,9 +2039,6 @@ impl Default for WHV_PROCESSOR_RUNTIME_COUNTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_PROCESSOR_RUNTIME_COUNTERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2269,9 +2055,6 @@ impl Default for WHV_PROCESSOR_SYNTHETIC_FEATURES_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PROCESSOR_SYNTHETIC_FEATURES_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHV_PROCESSOR_VENDOR(pub i32);
@@ -2286,9 +2069,6 @@ impl Default for WHV_PROCESSOR_XSAVE_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_PROCESSOR_XSAVE_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_PROCESSOR_XSAVE_FEATURES_0 {
@@ -2298,9 +2078,6 @@ impl Default for WHV_PROCESSOR_XSAVE_FEATURES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_PROCESSOR_XSAVE_FEATURES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHV_READ_WRITE_GPA_RANGE_MAX_SIZE: u32 = 16u32;
 #[repr(transparent)]
@@ -2332,9 +2109,6 @@ impl Default for WHV_REGISTER_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_REGISTER_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_RUN_VP_CANCELED_CONTEXT {
@@ -2344,9 +2118,6 @@ impl Default for WHV_RUN_VP_CANCELED_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_RUN_VP_CANCELED_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2363,9 +2134,6 @@ impl Default for WHV_RUN_VP_EXIT_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_RUN_VP_EXIT_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2391,9 +2159,6 @@ impl Default for WHV_RUN_VP_EXIT_CONTEXT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_RUN_VP_EXIT_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHV_RUN_VP_EXIT_REASON(pub i32);
@@ -2408,9 +2173,6 @@ impl Default for WHV_SCHEDULER_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_SCHEDULER_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_SCHEDULER_FEATURES_0 {
@@ -2420,9 +2182,6 @@ impl Default for WHV_SCHEDULER_FEATURES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_SCHEDULER_FEATURES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2437,9 +2196,6 @@ impl Default for WHV_SRIOV_RESOURCE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_SRIOV_RESOURCE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_SYNIC_EVENT_PARAMETERS {
@@ -2452,9 +2208,6 @@ impl Default for WHV_SYNIC_EVENT_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_SYNIC_EVENT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHV_SYNIC_MESSAGE_SIZE: u32 = 256u32;
 #[repr(C)]
@@ -2469,9 +2222,6 @@ impl Default for WHV_SYNIC_SINT_DELIVERABLE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_SYNIC_SINT_DELIVERABLE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_SYNTHETIC_PROCESSOR_FEATURES {
@@ -2483,9 +2233,6 @@ impl Default for WHV_SYNTHETIC_PROCESSOR_FEATURES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_SYNTHETIC_PROCESSOR_FEATURES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_SYNTHETIC_PROCESSOR_FEATURES_0 {
@@ -2495,9 +2242,6 @@ impl Default for WHV_SYNTHETIC_PROCESSOR_FEATURES_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_SYNTHETIC_PROCESSOR_FEATURES_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2511,9 +2255,6 @@ impl Default for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0 {
@@ -2525,9 +2266,6 @@ impl Default for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0_0 {
@@ -2537,9 +2275,6 @@ impl Default for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS_COUNT: u32 = 1u32;
 #[repr(transparent)]
@@ -2589,9 +2324,6 @@ impl Default for WHV_TRANSLATE_GVA_RESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_TRANSLATE_GVA_RESULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHV_TRANSLATE_GVA_RESULT_CODE(pub i32);
@@ -2607,9 +2339,6 @@ impl Default for WHV_TRIGGER_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_TRIGGER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_TRIGGER_PARAMETERS_0 {
@@ -2621,9 +2350,6 @@ impl Default for WHV_TRIGGER_PARAMETERS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_TRIGGER_PARAMETERS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2637,9 +2363,6 @@ impl Default for WHV_TRIGGER_PARAMETERS_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_TRIGGER_PARAMETERS_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2655,9 +2378,6 @@ impl Default for WHV_UINT128 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_UINT128 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_UINT128_0 {
@@ -2668,9 +2388,6 @@ impl Default for WHV_UINT128_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_UINT128_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2684,9 +2401,6 @@ impl Default for WHV_VIRTUAL_PROCESSOR_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_VIRTUAL_PROCESSOR_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_VIRTUAL_PROCESSOR_PROPERTY_0 {
@@ -2697,9 +2411,6 @@ impl Default for WHV_VIRTUAL_PROCESSOR_PROPERTY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_VIRTUAL_PROCESSOR_PROPERTY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2719,9 +2430,6 @@ impl Default for WHV_VPCI_DEVICE_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_VPCI_DEVICE_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_VPCI_DEVICE_NOTIFICATION_0 {
@@ -2731,9 +2439,6 @@ impl Default for WHV_VPCI_DEVICE_NOTIFICATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_VPCI_DEVICE_NOTIFICATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2752,9 +2457,6 @@ impl Default for WHV_VPCI_DEVICE_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_VPCI_DEVICE_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2776,9 +2478,6 @@ impl Default for WHV_VPCI_HARDWARE_IDS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_VPCI_HARDWARE_IDS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_VPCI_INTERRUPT_TARGET {
@@ -2791,9 +2490,6 @@ impl Default for WHV_VPCI_INTERRUPT_TARGET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_VPCI_INTERRUPT_TARGET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2845,9 +2541,6 @@ impl Default for WHV_VPCI_MMIO_MAPPING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_VPCI_MMIO_MAPPING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WHV_VPCI_MMIO_RANGE_FLAGS(pub i32);
@@ -2894,9 +2587,6 @@ impl Default for WHV_VPCI_PROBED_BARS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_VPCI_PROBED_BARS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WHV_VPCI_TYPE0_BAR_COUNT: u32 = 6u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2915,9 +2605,6 @@ impl Default for WHV_VP_EXCEPTION_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_VP_EXCEPTION_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_VP_EXCEPTION_INFO {
@@ -2929,9 +2616,6 @@ impl Default for WHV_VP_EXCEPTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_VP_EXCEPTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_VP_EXCEPTION_INFO_0 {
@@ -2941,9 +2625,6 @@ impl Default for WHV_VP_EXCEPTION_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_VP_EXCEPTION_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2961,9 +2642,6 @@ impl Default for WHV_VP_EXIT_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_VP_EXIT_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_APIC_EOI_CONTEXT {
@@ -2973,9 +2651,6 @@ impl Default for WHV_X64_APIC_EOI_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_APIC_EOI_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2987,9 +2662,6 @@ impl Default for WHV_X64_APIC_INIT_SIPI_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_APIC_INIT_SIPI_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_APIC_SMI_CONTEXT {
@@ -2999,9 +2671,6 @@ impl Default for WHV_X64_APIC_SMI_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_APIC_SMI_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3014,9 +2683,6 @@ impl Default for WHV_X64_APIC_WRITE_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_APIC_WRITE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3038,9 +2704,6 @@ impl Default for WHV_X64_CPUID_ACCESS_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_CPUID_ACCESS_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_CPUID_RESULT {
@@ -3056,9 +2719,6 @@ impl Default for WHV_X64_CPUID_RESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_CPUID_RESULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_CPUID_RESULT2 {
@@ -3073,9 +2733,6 @@ impl Default for WHV_X64_CPUID_RESULT2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_CPUID_RESULT2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3124,9 +2781,6 @@ impl Default for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER_0 {
@@ -3136,9 +2790,6 @@ impl Default for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_DELIVERABILITY_NOTIFICATIONS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3150,9 +2801,6 @@ impl Default for WHV_X64_FP_CONTROL_STATUS_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_FP_CONTROL_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3169,9 +2817,6 @@ impl Default for WHV_X64_FP_CONTROL_STATUS_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_FP_CONTROL_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0 {
@@ -3182,9 +2827,6 @@ impl Default for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3198,9 +2840,6 @@ impl Default for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_FP_CONTROL_STATUS_REGISTER_0_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_X64_FP_REGISTER {
@@ -3211,9 +2850,6 @@ impl Default for WHV_X64_FP_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_FP_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3226,9 +2862,6 @@ impl Default for WHV_X64_FP_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_FP_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_INTERRUPTION_DELIVERABLE_CONTEXT {
@@ -3238,9 +2871,6 @@ impl Default for WHV_X64_INTERRUPTION_DELIVERABLE_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_INTERRUPTION_DELIVERABLE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3253,9 +2883,6 @@ impl Default for WHV_X64_INTERRUPT_STATE_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_INTERRUPT_STATE_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_INTERRUPT_STATE_REGISTER_0 {
@@ -3265,9 +2892,6 @@ impl Default for WHV_X64_INTERRUPT_STATE_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_INTERRUPT_STATE_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3290,9 +2914,6 @@ impl Default for WHV_X64_IO_PORT_ACCESS_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_IO_PORT_ACCESS_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_X64_IO_PORT_ACCESS_INFO {
@@ -3304,9 +2925,6 @@ impl Default for WHV_X64_IO_PORT_ACCESS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_IO_PORT_ACCESS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_IO_PORT_ACCESS_INFO_0 {
@@ -3316,9 +2934,6 @@ impl Default for WHV_X64_IO_PORT_ACCESS_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_IO_PORT_ACCESS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3336,9 +2951,6 @@ impl Default for WHV_X64_MSR_ACCESS_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_MSR_ACCESS_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_X64_MSR_ACCESS_INFO {
@@ -3350,9 +2962,6 @@ impl Default for WHV_X64_MSR_ACCESS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_MSR_ACCESS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_MSR_ACCESS_INFO_0 {
@@ -3362,9 +2971,6 @@ impl Default for WHV_X64_MSR_ACCESS_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_MSR_ACCESS_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3377,9 +2983,6 @@ impl Default for WHV_X64_MSR_EXIT_BITMAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_MSR_EXIT_BITMAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_MSR_EXIT_BITMAP_0 {
@@ -3389,9 +2992,6 @@ impl Default for WHV_X64_MSR_EXIT_BITMAP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_MSR_EXIT_BITMAP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3404,9 +3004,6 @@ impl Default for WHV_X64_PENDING_DEBUG_EXCEPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_PENDING_DEBUG_EXCEPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_PENDING_DEBUG_EXCEPTION_0 {
@@ -3416,9 +3013,6 @@ impl Default for WHV_X64_PENDING_DEBUG_EXCEPTION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_PENDING_DEBUG_EXCEPTION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3434,9 +3028,6 @@ impl Default for WHV_X64_PENDING_EXCEPTION_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_PENDING_EXCEPTION_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_PENDING_EXCEPTION_EVENT_0 {
@@ -3449,9 +3040,6 @@ impl Default for WHV_X64_PENDING_EXCEPTION_EVENT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_PENDING_EXCEPTION_EVENT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_X64_PENDING_EXT_INT_EVENT {
@@ -3462,9 +3050,6 @@ impl Default for WHV_X64_PENDING_EXT_INT_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_PENDING_EXT_INT_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3477,9 +3062,6 @@ impl Default for WHV_X64_PENDING_EXT_INT_EVENT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_PENDING_EXT_INT_EVENT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_X64_PENDING_INTERRUPTION_REGISTER {
@@ -3491,9 +3073,6 @@ impl Default for WHV_X64_PENDING_INTERRUPTION_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_PENDING_INTERRUPTION_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_PENDING_INTERRUPTION_REGISTER_0 {
@@ -3504,9 +3083,6 @@ impl Default for WHV_X64_PENDING_INTERRUPTION_REGISTER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_PENDING_INTERRUPTION_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3525,9 +3101,6 @@ impl Default for WHV_X64_RDTSC_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_RDTSC_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_X64_RDTSC_INFO {
@@ -3539,9 +3112,6 @@ impl Default for WHV_X64_RDTSC_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_RDTSC_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_RDTSC_INFO_0 {
@@ -3551,9 +3121,6 @@ impl Default for WHV_X64_RDTSC_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_RDTSC_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3568,9 +3135,6 @@ impl Default for WHV_X64_SEGMENT_REGISTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_SEGMENT_REGISTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_X64_SEGMENT_REGISTER_0 {
@@ -3582,9 +3146,6 @@ impl Default for WHV_X64_SEGMENT_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_SEGMENT_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_SEGMENT_REGISTER_0_0 {
@@ -3594,9 +3155,6 @@ impl Default for WHV_X64_SEGMENT_REGISTER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_SEGMENT_REGISTER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3609,9 +3167,6 @@ impl Default for WHV_X64_TABLE_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_TABLE_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3628,9 +3183,6 @@ impl Default for WHV_X64_UNSUPPORTED_FEATURE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_UNSUPPORTED_FEATURE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_X64_VP_EXECUTION_STATE {
@@ -3642,9 +3194,6 @@ impl Default for WHV_X64_VP_EXECUTION_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_VP_EXECUTION_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WHV_X64_VP_EXECUTION_STATE_0 {
@@ -3654,9 +3203,6 @@ impl Default for WHV_X64_VP_EXECUTION_STATE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_VP_EXECUTION_STATE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3668,9 +3214,6 @@ impl Default for WHV_X64_XMM_CONTROL_STATUS_REGISTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_XMM_CONTROL_STATUS_REGISTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3684,9 +3227,6 @@ impl Default for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0 {
@@ -3697,9 +3237,6 @@ impl Default for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3712,9 +3249,6 @@ impl Default for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WHV_X64_XMM_CONTROL_STATUS_REGISTER_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WHvAdviseGpaRangeCodePin: WHV_ADVISE_GPA_RANGE_CODE = WHV_ADVISE_GPA_RANGE_CODE(1i32);
 pub const WHvAdviseGpaRangeCodePopulate: WHV_ADVISE_GPA_RANGE_CODE = WHV_ADVISE_GPA_RANGE_CODE(0i32);

--- a/crates/libs/windows/src/Windows/Win32/System/IO/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/IO/mod.rs
@@ -74,9 +74,6 @@ impl Default for IO_STATUS_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_STATUS_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IO_STATUS_BLOCK_0 {
@@ -87,9 +84,6 @@ impl Default for IO_STATUS_BLOCK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_STATUS_BLOCK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type LPOVERLAPPED_COMPLETION_ROUTINE = Option<unsafe extern "system" fn(dwerrorcode: u32, dwnumberofbytestransfered: u32, lpoverlapped: *mut OVERLAPPED)>;
 #[repr(C)]
@@ -105,9 +99,6 @@ impl Default for OVERLAPPED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OVERLAPPED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union OVERLAPPED_0 {
@@ -119,9 +110,6 @@ impl Default for OVERLAPPED_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OVERLAPPED_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OVERLAPPED_0_0 {
@@ -132,9 +120,6 @@ impl Default for OVERLAPPED_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OVERLAPPED_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -148,8 +133,5 @@ impl Default for OVERLAPPED_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OVERLAPPED_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PIO_APC_ROUTINE = Option<unsafe extern "system" fn(apccontext: *mut core::ffi::c_void, iostatusblock: *mut IO_STATUS_BLOCK, reserved: u32)>;

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
@@ -450,10 +450,6 @@ impl Default for CERT_CONTEXT_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security_Cryptography")]
-impl windows_core::TypeKind for CERT_CONTEXT_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLSID_IImgCtx: windows_core::GUID = windows_core::GUID::from_u128(0x3050f3d6_98b5_11cf_bb82_00aa00bdce0b);
 pub const CLSID_IisServiceControl: windows_core::GUID = windows_core::GUID::from_u128(0xe8fb8621_588f_11d2_9d61_00c04f79c5fe);
 pub const CLSID_MSAdminBase_W: windows_core::GUID = windows_core::GUID::from_u128(0xa9e69610_b80d_11d0_b9b9_00a0c922e750);
@@ -473,9 +469,6 @@ impl Default for CONFIGURATION_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONFIGURATION_ENTRY {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DISPID_HTTPREQUEST_ABORT: u32 = 12u32;
 pub const DISPID_HTTPREQUEST_BASE: u32 = 1u32;
@@ -528,9 +521,6 @@ impl Default for EXTENSION_CONTROL_BLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXTENSION_CONTROL_BLOCK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FP_MD_ID_BEGIN_RESERVED: u32 = 32768u32;
 pub const FP_MD_ID_END_RESERVED: u32 = 36863u32;
@@ -588,9 +578,6 @@ impl Default for HSE_CUSTOM_ERROR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSE_CUSTOM_ERROR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HSE_EXEC_UNICODE_URL_INFO {
@@ -606,9 +593,6 @@ impl Default for HSE_EXEC_UNICODE_URL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSE_EXEC_UNICODE_URL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HSE_EXEC_UNICODE_URL_USER_INFO {
@@ -621,9 +605,6 @@ impl Default for HSE_EXEC_UNICODE_URL_USER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSE_EXEC_UNICODE_URL_USER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HSE_EXEC_URL_DISABLE_CUSTOM_ERROR: u32 = 32u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -635,9 +616,6 @@ impl Default for HSE_EXEC_URL_ENTITY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HSE_EXEC_URL_ENTITY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HSE_EXEC_URL_HTTP_CACHE_ELIGIBLE: u32 = 128u32;
 pub const HSE_EXEC_URL_IGNORE_CURRENT_INTERCEPTOR: u32 = 4u32;
@@ -657,9 +635,6 @@ impl Default for HSE_EXEC_URL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSE_EXEC_URL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HSE_EXEC_URL_NO_HEADERS: u32 = 2u32;
 pub const HSE_EXEC_URL_SSI_CMD: u32 = 64u32;
 #[repr(C)]
@@ -674,9 +649,6 @@ impl Default for HSE_EXEC_URL_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSE_EXEC_URL_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HSE_EXEC_URL_USER_INFO {
@@ -688,9 +660,6 @@ impl Default for HSE_EXEC_URL_USER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HSE_EXEC_URL_USER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HSE_IO_ASYNC: u32 = 2u32;
 pub const HSE_IO_CACHE_RESPONSE: u32 = 32u32;
@@ -758,9 +727,6 @@ impl Default for HSE_RESPONSE_VECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSE_RESPONSE_VECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HSE_SEND_HEADER_EX_INFO {
@@ -774,9 +740,6 @@ impl Default for HSE_SEND_HEADER_EX_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HSE_SEND_HEADER_EX_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HSE_STATUS_ERROR: u32 = 4u32;
 pub const HSE_STATUS_PENDING: u32 = 3u32;
@@ -804,9 +767,6 @@ impl Default for HSE_TF_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSE_TF_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HSE_TRACE_INFO {
@@ -820,9 +780,6 @@ impl Default for HSE_TRACE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSE_TRACE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HSE_UNICODE_URL_MAPEX_INFO {
@@ -835,9 +792,6 @@ impl Default for HSE_UNICODE_URL_MAPEX_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HSE_UNICODE_URL_MAPEX_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HSE_URL_FLAGS_DONT_CACHE: u32 = 16u32;
 pub const HSE_URL_FLAGS_EXECUTE: u32 = 4u32;
@@ -865,9 +819,6 @@ impl Default for HSE_URL_MAPEX_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSE_URL_MAPEX_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HSE_VECTOR_ELEMENT {
@@ -881,9 +832,6 @@ impl Default for HSE_VECTOR_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HSE_VECTOR_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HSE_VECTOR_ELEMENT_TYPE_FILE_HANDLE: u32 = 1u32;
 pub const HSE_VECTOR_ELEMENT_TYPE_MEMORY_BUFFER: u32 = 0u32;
 #[repr(C)]
@@ -896,9 +844,6 @@ impl Default for HSE_VERSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HSE_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HSE_VERSION_MAJOR: u32 = 8u32;
 pub const HSE_VERSION_MINOR: u32 = 0u32;
@@ -914,9 +859,6 @@ impl Default for HTTP_FILTER_ACCESS_DENIED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_FILTER_ACCESS_DENIED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_FILTER_AUTHENT {
@@ -929,9 +871,6 @@ impl Default for HTTP_FILTER_AUTHENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_FILTER_AUTHENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -948,9 +887,6 @@ impl Default for HTTP_FILTER_AUTH_COMPLETE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_FILTER_AUTH_COMPLETE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -972,9 +908,6 @@ impl Default for HTTP_FILTER_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_FILTER_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_FILTER_LOG {
@@ -995,9 +928,6 @@ impl Default for HTTP_FILTER_LOG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_FILTER_LOG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_FILTER_PREPROC_HEADERS {
@@ -1012,9 +942,6 @@ impl Default for HTTP_FILTER_PREPROC_HEADERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_FILTER_PREPROC_HEADERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_FILTER_RAW_DATA {
@@ -1028,9 +955,6 @@ impl Default for HTTP_FILTER_RAW_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_FILTER_RAW_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_FILTER_URL_MAP {
@@ -1042,9 +966,6 @@ impl Default for HTTP_FILTER_URL_MAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_FILTER_URL_MAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1062,9 +983,6 @@ impl Default for HTTP_FILTER_URL_MAP_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_FILTER_URL_MAP_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_FILTER_VERSION {
@@ -1078,9 +996,6 @@ impl Default for HTTP_FILTER_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_FILTER_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HTTP_TRACE_CONFIGURATION {
@@ -1093,9 +1008,6 @@ impl Default for HTTP_TRACE_CONFIGURATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_TRACE_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1119,9 +1031,6 @@ impl Default for HTTP_TRACE_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_TRACE_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HTTP_TRACE_EVENT_FLAG_STATIC_DESCRIPTIVE_FIELDS: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1136,9 +1045,6 @@ impl Default for HTTP_TRACE_EVENT_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HTTP_TRACE_EVENT_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HTTP_TRACE_LEVEL_END: u32 = 7u32;
 pub const HTTP_TRACE_LEVEL_START: u32 = 6u32;
@@ -2277,9 +2183,6 @@ impl Default for LOGGING_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOGGING_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MB_DONT_IMPERSONATE: u32 = 9033u32;
 pub const MD_ACCESS_EXECUTE: u32 = 4u32;
 pub const MD_ACCESS_MAP_CERT: u32 = 128u32;
@@ -2498,9 +2401,6 @@ impl Default for MD_CHANGE_OBJECT_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MD_CHANGE_OBJECT_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MD_CHANGE_TYPE_ADD_OBJECT: u32 = 2u32;
 pub const MD_CHANGE_TYPE_DELETE_DATA: u32 = 8u32;
@@ -2954,9 +2854,6 @@ impl Default for METADATA_GETALL_INTERNAL_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for METADATA_GETALL_INTERNAL_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union METADATA_GETALL_INTERNAL_RECORD_0 {
@@ -2967,9 +2864,6 @@ impl Default for METADATA_GETALL_INTERNAL_RECORD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for METADATA_GETALL_INTERNAL_RECORD_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2987,9 +2881,6 @@ impl Default for METADATA_GETALL_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for METADATA_GETALL_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct METADATA_HANDLE_INFO {
@@ -3000,9 +2891,6 @@ impl Default for METADATA_HANDLE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for METADATA_HANDLE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const METADATA_INHERIT: u32 = 1u32;
 pub const METADATA_INSERT_PATH: u32 = 64u32;
@@ -3030,9 +2918,6 @@ impl Default for METADATA_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for METADATA_RECORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const METADATA_REFERENCE: u32 = 8u32;
 pub const METADATA_SECURE: u32 = 4u32;
@@ -3086,9 +2971,6 @@ impl Default for POST_PROCESS_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POST_PROCESS_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRE_PROCESS_PARAMETERS {
@@ -3110,9 +2992,6 @@ impl Default for PRE_PROCESS_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRE_PROCESS_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SF_DENIED_APPLICATION: u32 = 8u32;
 pub const SF_DENIED_BY_CONFIG: u32 = 65536u32;

--- a/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
@@ -21,9 +21,6 @@ impl Default for ASYNC_DUPLICATE_EXTENTS_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ASYNC_DUPLICATE_EXTENTS_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ATAPI_ID_CMD: u32 = 161u32;
 pub const AVATAR_F2: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(78i32);
 pub const AllElements: ELEMENT_TYPE = ELEMENT_TYPE(0i32);
@@ -41,9 +38,6 @@ impl Default for BIN_COUNT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BIN_COUNT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BIN_RANGE {
@@ -55,9 +49,6 @@ impl Default for BIN_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BIN_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BIN_RESULTS {
@@ -68,9 +59,6 @@ impl Default for BIN_RESULTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BIN_RESULTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -86,9 +74,6 @@ impl Default for BOOT_AREA_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BOOT_AREA_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BOOT_AREA_INFO_0 {
@@ -98,9 +83,6 @@ impl Default for BOOT_AREA_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BOOT_AREA_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -112,9 +94,6 @@ impl Default for BULK_SECURITY_TEST_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BULK_SECURITY_TEST_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CAP_ATAPI_ID_CMD: u32 = 2u32;
 pub const CAP_ATA_ID_CMD: u32 = 1u32;
@@ -147,9 +126,6 @@ impl Default for CHANGER_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGER_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CHANGER_ELEMENT_LIST {
@@ -160,9 +136,6 @@ impl Default for CHANGER_ELEMENT_LIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANGER_ELEMENT_LIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -181,9 +154,6 @@ impl Default for CHANGER_ELEMENT_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANGER_ELEMENT_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -205,9 +175,6 @@ impl Default for CHANGER_ELEMENT_STATUS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANGER_ELEMENT_STATUS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -261,9 +228,6 @@ impl Default for CHANGER_EXCHANGE_MEDIUM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGER_EXCHANGE_MEDIUM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CHANGER_FEATURES(pub u32);
@@ -313,9 +277,6 @@ impl Default for CHANGER_INITIALIZE_ELEMENT_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGER_INITIALIZE_ELEMENT_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CHANGER_INIT_ELEM_STAT_WITH_RANGE: CHANGER_FEATURES = CHANGER_FEATURES(2u32);
 pub const CHANGER_KEYPAD_ENABLE_DISABLE: CHANGER_FEATURES = CHANGER_FEATURES(268435456u32);
 pub const CHANGER_LOCK_UNLOCK: CHANGER_FEATURES = CHANGER_FEATURES(128u32);
@@ -333,9 +294,6 @@ impl Default for CHANGER_MOVE_MEDIUM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANGER_MOVE_MEDIUM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CHANGER_MOVE_RETRACTS_IEPORT: GET_CHANGER_PARAMETERS_FEATURES1 = GET_CHANGER_PARAMETERS_FEATURES1(2147484672u32);
 pub const CHANGER_OPEN_IEPORT: CHANGER_FEATURES = CHANGER_FEATURES(8u32);
@@ -358,9 +316,6 @@ impl Default for CHANGER_PRODUCT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGER_PRODUCT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CHANGER_READ_ELEMENT_STATUS {
@@ -371,9 +326,6 @@ impl Default for CHANGER_READ_ELEMENT_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANGER_READ_ELEMENT_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CHANGER_REPORT_IEPORT_STATE: CHANGER_FEATURES = CHANGER_FEATURES(2048u32);
 pub const CHANGER_RESERVED_BIT: u32 = 2147483648u32;
@@ -390,9 +342,6 @@ impl Default for CHANGER_SEND_VOLUME_TAG_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGER_SEND_VOLUME_TAG_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CHANGER_SERIAL_NUMBER_VALID: CHANGER_FEATURES = CHANGER_FEATURES(67108864u32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -405,9 +354,6 @@ impl Default for CHANGER_SET_ACCESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGER_SET_ACCESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CHANGER_SET_POSITION {
@@ -419,9 +365,6 @@ impl Default for CHANGER_SET_POSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANGER_SET_POSITION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CHANGER_SLOTS_USE_TRAYS: GET_CHANGER_PARAMETERS_FEATURES1 = GET_CHANGER_PARAMETERS_FEATURES1(2147483664u32);
 pub const CHANGER_STATUS_NON_VOLATILE: CHANGER_FEATURES = CHANGER_FEATURES(16u32);
@@ -456,9 +399,6 @@ impl Default for CLASS_MEDIA_CHANGE_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLASS_MEDIA_CHANGE_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CLEANER_CARTRIDGE: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(50i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -470,9 +410,6 @@ impl Default for CLUSTER_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLUSTER_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONTAINER_ROOT_INFO_FLAG_BIND_DO_NOT_MAP_NAME: u32 = 256u32;
 pub const CONTAINER_ROOT_INFO_FLAG_BIND_EXCEPTION_ROOT: u32 = 128u32;
@@ -494,9 +431,6 @@ impl Default for CONTAINER_ROOT_INFO_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONTAINER_ROOT_INFO_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONTAINER_ROOT_INFO_OUTPUT {
@@ -508,9 +442,6 @@ impl Default for CONTAINER_ROOT_INFO_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONTAINER_ROOT_INFO_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CONTAINER_ROOT_INFO_VALID_FLAGS: u32 = 1023u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -521,9 +452,6 @@ impl Default for CONTAINER_VOLUME_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONTAINER_VOLUME_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONTAINER_VOLUME_STATE_HOSTING_CONTAINER: u32 = 1u32;
 pub const COPYFILE_SIS_FLAGS: u32 = 3u32;
@@ -540,9 +468,6 @@ impl Default for CREATE_DISK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREATE_DISK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CREATE_DISK_0 {
@@ -553,9 +478,6 @@ impl Default for CREATE_DISK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_DISK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -568,9 +490,6 @@ impl Default for CREATE_DISK_GPT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREATE_DISK_GPT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CREATE_DISK_MBR {
@@ -580,9 +499,6 @@ impl Default for CREATE_DISK_MBR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_DISK_MBR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -594,9 +510,6 @@ impl Default for CREATE_USN_JOURNAL_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATE_USN_JOURNAL_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -615,9 +528,6 @@ impl Default for CSV_CONTROL_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSV_CONTROL_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CSV_INVALID_DEVICE_NUMBER: u32 = 4294967295u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -629,9 +539,6 @@ impl Default for CSV_IS_OWNED_BY_CSVFS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSV_IS_OWNED_BY_CSVFS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CSV_MGMTLOCK_CHECK_VOLUME_REDIRECTED: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -642,9 +549,6 @@ impl Default for CSV_MGMT_LOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CSV_MGMT_LOCK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -659,9 +563,6 @@ impl Default for CSV_NAMESPACE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSV_NAMESPACE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CSV_QUERY_FILE_REVISION {
@@ -672,9 +573,6 @@ impl Default for CSV_QUERY_FILE_REVISION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CSV_QUERY_FILE_REVISION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -689,10 +587,6 @@ impl Default for CSV_QUERY_FILE_REVISION_FILE_ID_128 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for CSV_QUERY_FILE_REVISION_FILE_ID_128 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CSV_QUERY_MDS_PATH {
@@ -705,9 +599,6 @@ impl Default for CSV_QUERY_MDS_PATH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CSV_QUERY_MDS_PATH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CSV_QUERY_MDS_PATH_FLAG_CSV_DIRECT_IO_ENABLED: u32 = 2u32;
 pub const CSV_QUERY_MDS_PATH_FLAG_SMB_BYPASS_CSV_ENABLED: u32 = 4u32;
@@ -732,9 +623,6 @@ impl Default for CSV_QUERY_MDS_PATH_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSV_QUERY_MDS_PATH_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CSV_QUERY_MDS_PATH_V2_VERSION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -748,9 +636,6 @@ impl Default for CSV_QUERY_REDIRECT_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSV_QUERY_REDIRECT_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CSV_QUERY_VETO_FILE_DIRECT_IO_OUTPUT {
@@ -763,9 +648,6 @@ impl Default for CSV_QUERY_VETO_FILE_DIRECT_IO_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSV_QUERY_VETO_FILE_DIRECT_IO_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CSV_QUERY_VOLUME_ID {
@@ -775,9 +657,6 @@ impl Default for CSV_QUERY_VOLUME_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CSV_QUERY_VOLUME_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -793,9 +672,6 @@ impl Default for CSV_QUERY_VOLUME_REDIRECT_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSV_QUERY_VOLUME_REDIRECT_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CSV_SET_VOLUME_ID {
@@ -805,9 +681,6 @@ impl Default for CSV_SET_VOLUME_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CSV_SET_VOLUME_ID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CYGNET_12_WO: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(69i32);
 pub const ChangerDoor: ELEMENT_TYPE = ELEMENT_TYPE(5i32);
@@ -853,9 +726,6 @@ impl Default for DECRYPTION_STATUS_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DECRYPTION_STATUS_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DELETE_USN_JOURNAL_DATA {
@@ -866,9 +736,6 @@ impl Default for DELETE_USN_JOURNAL_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DELETE_USN_JOURNAL_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -891,9 +758,6 @@ impl Default for DEVICEDUMP_PRIVATE_SUBSECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICEDUMP_PRIVATE_SUBSECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DEVICEDUMP_PUBLIC_SUBSECTION {
@@ -907,9 +771,6 @@ impl Default for DEVICEDUMP_PUBLIC_SUBSECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICEDUMP_PUBLIC_SUBSECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICEDUMP_RESTRICTED_SUBSECTION {
@@ -919,9 +780,6 @@ impl Default for DEVICEDUMP_RESTRICTED_SUBSECTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICEDUMP_RESTRICTED_SUBSECTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -941,9 +799,6 @@ impl Default for DEVICEDUMP_SECTION_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICEDUMP_SECTION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DEVICEDUMP_STORAGEDEVICE_DATA {
@@ -960,9 +815,6 @@ impl Default for DEVICEDUMP_STORAGEDEVICE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICEDUMP_STORAGEDEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_DUMP {
@@ -976,9 +828,6 @@ impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_DUMP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_DUMP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -996,9 +845,6 @@ impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
@@ -1011,9 +857,6 @@ impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
@@ -1023,9 +866,6 @@ impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1037,9 +877,6 @@ impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2 {
@@ -1049,9 +886,6 @@ impl Default for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICEDUMP_STORAGESTACK_PUBLIC_STATE_RECORD_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1065,9 +899,6 @@ impl Default for DEVICEDUMP_STRUCTURE_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICEDUMP_STRUCTURE_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEVICEDUMP_STRUCTURE_VERSION_V1: u32 = 1u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1080,9 +911,6 @@ impl Default for DEVICEDUMP_SUBSECTION_POINTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICEDUMP_SUBSECTION_POINTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1104,9 +932,6 @@ impl Default for DEVICE_COPY_OFFLOAD_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_COPY_OFFLOAD_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DATA_SET_LBP_STATE_PARAMETERS {
@@ -1119,9 +944,6 @@ impl Default for DEVICE_DATA_SET_LBP_STATE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DATA_SET_LBP_STATE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVICE_DATA_SET_LBP_STATE_PARAMETERS_VERSION_V1: u32 = 1u32;
 #[repr(C)]
@@ -1140,9 +962,6 @@ impl Default for DEVICE_DATA_SET_LB_PROVISIONING_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DATA_SET_LB_PROVISIONING_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DATA_SET_LB_PROVISIONING_STATE_V2 {
@@ -1159,9 +978,6 @@ impl Default for DEVICE_DATA_SET_LB_PROVISIONING_STATE_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DATA_SET_LB_PROVISIONING_STATE_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DATA_SET_RANGE {
@@ -1173,9 +989,6 @@ impl Default for DEVICE_DATA_SET_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DATA_SET_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DATA_SET_REPAIR_OUTPUT {
@@ -1185,9 +998,6 @@ impl Default for DEVICE_DATA_SET_REPAIR_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DATA_SET_REPAIR_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1200,9 +1010,6 @@ impl Default for DEVICE_DATA_SET_REPAIR_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DATA_SET_REPAIR_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1218,9 +1025,6 @@ impl Default for DEVICE_DATA_SET_SCRUB_EX_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DATA_SET_SCRUB_EX_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DATA_SET_SCRUB_OUTPUT {
@@ -1233,9 +1037,6 @@ impl Default for DEVICE_DATA_SET_SCRUB_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DATA_SET_SCRUB_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DATA_SET_TOPOLOGY_ID_QUERY_OUTPUT {
@@ -1247,9 +1048,6 @@ impl Default for DEVICE_DATA_SET_TOPOLOGY_ID_QUERY_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DATA_SET_TOPOLOGY_ID_QUERY_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DSM_CONVERSION_OUTPUT {
@@ -1260,9 +1058,6 @@ impl Default for DEVICE_DSM_CONVERSION_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DSM_CONVERSION_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1279,9 +1074,6 @@ impl Default for DEVICE_DSM_DEFINITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DSM_DEFINITION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVICE_DSM_FLAG_ALLOCATION_CONSOLIDATEABLE_ONLY: u32 = 1073741824u32;
 pub const DEVICE_DSM_FLAG_ENTIRE_DATA_SET_RANGE: u32 = 1u32;
@@ -1303,9 +1095,6 @@ impl Default for DEVICE_DSM_FREE_SPACE_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DSM_FREE_SPACE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DSM_LOST_QUERY_OUTPUT {
@@ -1320,9 +1109,6 @@ impl Default for DEVICE_DSM_LOST_QUERY_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DSM_LOST_QUERY_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DSM_LOST_QUERY_PARAMETERS {
@@ -1333,9 +1119,6 @@ impl Default for DEVICE_DSM_LOST_QUERY_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DSM_LOST_QUERY_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1349,9 +1132,6 @@ impl Default for DEVICE_DSM_NOTIFICATION_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DSM_NOTIFICATION_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVICE_DSM_NOTIFY_FLAG_BEGIN: u32 = 1u32;
 pub const DEVICE_DSM_NOTIFY_FLAG_END: u32 = 2u32;
@@ -1367,9 +1147,6 @@ impl Default for DEVICE_DSM_NVCACHE_CHANGE_PRIORITY_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DSM_NVCACHE_CHANGE_PRIORITY_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DSM_OFFLOAD_READ_PARAMETERS {
@@ -1381,9 +1158,6 @@ impl Default for DEVICE_DSM_OFFLOAD_READ_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DSM_OFFLOAD_READ_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1397,9 +1171,6 @@ impl Default for DEVICE_DSM_OFFLOAD_WRITE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DSM_OFFLOAD_WRITE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVICE_DSM_PARAMETERS_V1: u32 = 1u32;
 #[repr(C)]
@@ -1415,9 +1186,6 @@ impl Default for DEVICE_DSM_PHYSICAL_ADDRESSES_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DSM_PHYSICAL_ADDRESSES_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVICE_DSM_PHYSICAL_ADDRESSES_OUTPUT_V1: u32 = 1u32;
 pub const DEVICE_DSM_PHYSICAL_ADDRESSES_OUTPUT_VERSION_V1: u32 = 1u32;
@@ -1435,9 +1203,6 @@ impl Default for DEVICE_DSM_RANGE_ERROR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DSM_RANGE_ERROR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEVICE_DSM_RANGE_ERROR_INFO_VERSION_V1: u32 = 1u32;
 pub const DEVICE_DSM_RANGE_ERROR_OUTPUT_V1: u32 = 1u32;
 #[repr(C)]
@@ -1454,9 +1219,6 @@ impl Default for DEVICE_DSM_REPORT_ZONES_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_DSM_REPORT_ZONES_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_DSM_REPORT_ZONES_PARAMETERS {
@@ -1469,9 +1231,6 @@ impl Default for DEVICE_DSM_REPORT_ZONES_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DSM_REPORT_ZONES_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1486,9 +1245,6 @@ impl Default for DEVICE_DSM_TIERING_QUERY_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DSM_TIERING_QUERY_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1506,9 +1262,6 @@ impl Default for DEVICE_DSM_TIERING_QUERY_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_DSM_TIERING_QUERY_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1530,9 +1283,6 @@ impl Default for DEVICE_INTERNAL_STATUS_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_INTERNAL_STATUS_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1557,9 +1307,6 @@ impl Default for DEVICE_LB_PROVISIONING_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_LB_PROVISIONING_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DEVICE_LOCATION {
@@ -1574,9 +1321,6 @@ impl Default for DEVICE_LOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_LOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVICE_LOCATION_0 {
@@ -1587,9 +1331,6 @@ impl Default for DEVICE_LOCATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_LOCATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1602,9 +1343,6 @@ impl Default for DEVICE_LOCATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_LOCATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_LOCATION_0_1 {
@@ -1615,9 +1353,6 @@ impl Default for DEVICE_LOCATION_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_LOCATION_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1634,9 +1369,6 @@ impl Default for DEVICE_MANAGE_DATA_SET_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_MANAGE_DATA_SET_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1656,9 +1388,6 @@ impl Default for DEVICE_MANAGE_DATA_SET_ATTRIBUTES_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_MANAGE_DATA_SET_ATTRIBUTES_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
@@ -1670,10 +1399,6 @@ impl Default for DEVICE_MEDIA_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for DEVICE_MEDIA_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -1688,10 +1413,6 @@ impl Default for DEVICE_MEDIA_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for DEVICE_MEDIA_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -1711,10 +1432,6 @@ impl Default for DEVICE_MEDIA_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for DEVICE_MEDIA_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1733,10 +1450,6 @@ impl Default for DEVICE_MEDIA_INFO_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for DEVICE_MEDIA_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
@@ -1753,10 +1466,6 @@ impl Default for DEVICE_MEDIA_INFO_0_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for DEVICE_MEDIA_INFO_0_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy)]
@@ -1768,10 +1477,6 @@ impl Default for DEVICE_MEDIA_INFO_0_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for DEVICE_MEDIA_INFO_0_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -1785,10 +1490,6 @@ impl Default for DEVICE_MEDIA_INFO_0_2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for DEVICE_MEDIA_INFO_0_2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1809,9 +1510,6 @@ impl Default for DEVICE_POWER_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_POWER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_SEEK_PENALTY_DESCRIPTOR {
@@ -1824,9 +1522,6 @@ impl Default for DEVICE_SEEK_PENALTY_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_SEEK_PENALTY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_STORAGE_ADDRESS_RANGE {
@@ -1837,9 +1532,6 @@ impl Default for DEVICE_STORAGE_ADDRESS_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_STORAGE_ADDRESS_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVICE_STORAGE_NO_ERRORS: u32 = 1u32;
 #[repr(C)]
@@ -1854,9 +1546,6 @@ impl Default for DEVICE_STORAGE_RANGE_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_STORAGE_RANGE_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DEVICE_STORAGE_RANGE_ATTRIBUTES_0 {
@@ -1868,9 +1557,6 @@ impl Default for DEVICE_STORAGE_RANGE_ATTRIBUTES_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_STORAGE_RANGE_ATTRIBUTES_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_STORAGE_RANGE_ATTRIBUTES_0_0 {
@@ -1880,9 +1566,6 @@ impl Default for DEVICE_STORAGE_RANGE_ATTRIBUTES_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_STORAGE_RANGE_ATTRIBUTES_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1896,9 +1579,6 @@ impl Default for DEVICE_TRIM_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_TRIM_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_WRITE_AGGREGATION_DESCRIPTOR {
@@ -1910,9 +1590,6 @@ impl Default for DEVICE_WRITE_AGGREGATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_WRITE_AGGREGATION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVPKEY_Storage_Disk_Number: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 5 };
 pub const DEVPKEY_Storage_Gpt_Name: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 9 };
@@ -1943,9 +1620,6 @@ impl Default for DISK_CACHE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_CACHE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISK_CACHE_INFORMATION_0 {
@@ -1956,9 +1630,6 @@ impl Default for DISK_CACHE_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_CACHE_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1971,9 +1642,6 @@ impl Default for DISK_CACHE_INFORMATION_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_CACHE_INFORMATION_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_CACHE_INFORMATION_0_0 {
@@ -1985,9 +1653,6 @@ impl Default for DISK_CACHE_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_CACHE_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2003,9 +1668,6 @@ impl Default for DISK_CONTROLLER_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_CONTROLLER_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DISK_DETECTION_INFO {
@@ -2018,9 +1680,6 @@ impl Default for DISK_DETECTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_DETECTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISK_DETECTION_INFO_0 {
@@ -2030,9 +1689,6 @@ impl Default for DISK_DETECTION_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_DETECTION_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2045,9 +1701,6 @@ impl Default for DISK_DETECTION_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_DETECTION_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_EXTENT {
@@ -2059,9 +1712,6 @@ impl Default for DISK_EXTENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_EXTENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2080,9 +1730,6 @@ impl Default for DISK_EX_INT13_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_EX_INT13_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_GEOMETRY {
@@ -2097,9 +1744,6 @@ impl Default for DISK_GEOMETRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_GEOMETRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_GEOMETRY_EX {
@@ -2112,9 +1756,6 @@ impl Default for DISK_GEOMETRY_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_GEOMETRY_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_GROW_PARTITION {
@@ -2125,9 +1766,6 @@ impl Default for DISK_GROW_PARTITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_GROW_PARTITION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2149,9 +1787,6 @@ impl Default for DISK_HISTOGRAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_HISTOGRAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_INT13_INFO {
@@ -2166,9 +1801,6 @@ impl Default for DISK_INT13_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_INT13_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_LOGGING {
@@ -2180,9 +1812,6 @@ impl Default for DISK_LOGGING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_LOGGING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DISK_LOGGING_DUMP: u32 = 2u32;
 pub const DISK_LOGGING_START: u32 = 0u32;
@@ -2199,9 +1828,6 @@ impl Default for DISK_PARTITION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_PARTITION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DISK_PARTITION_INFO_0 {
@@ -2213,9 +1839,6 @@ impl Default for DISK_PARTITION_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_PARTITION_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_PARTITION_INFO_0_1 {
@@ -2225,9 +1848,6 @@ impl Default for DISK_PARTITION_INFO_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_PARTITION_INFO_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2239,9 +1859,6 @@ impl Default for DISK_PARTITION_INFO_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_PARTITION_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2264,9 +1881,6 @@ impl Default for DISK_PERFORMANCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_PERFORMANCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISK_RECORD {
@@ -2283,9 +1897,6 @@ impl Default for DISK_RECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISK_RECORD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DLT: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(39i32);
 pub const DMI: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(48i32);
 #[repr(C, packed(1))]
@@ -2301,9 +1912,6 @@ impl Default for DRIVERSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVERSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVE_LAYOUT_INFORMATION {
@@ -2315,9 +1923,6 @@ impl Default for DRIVE_LAYOUT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVE_LAYOUT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2332,9 +1937,6 @@ impl Default for DRIVE_LAYOUT_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVE_LAYOUT_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DRIVE_LAYOUT_INFORMATION_EX_0 {
@@ -2345,9 +1947,6 @@ impl Default for DRIVE_LAYOUT_INFORMATION_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVE_LAYOUT_INFORMATION_EX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2362,9 +1961,6 @@ impl Default for DRIVE_LAYOUT_INFORMATION_GPT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRIVE_LAYOUT_INFORMATION_GPT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DRIVE_LAYOUT_INFORMATION_MBR {
@@ -2375,9 +1971,6 @@ impl Default for DRIVE_LAYOUT_INFORMATION_MBR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DRIVE_LAYOUT_INFORMATION_MBR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DST_L: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(82i32);
 pub const DST_M: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(81i32);
@@ -2395,9 +1988,6 @@ impl Default for DUPLICATE_EXTENTS_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DUPLICATE_EXTENTS_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2413,10 +2003,6 @@ impl Default for DUPLICATE_EXTENTS_DATA32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DUPLICATE_EXTENTS_DATA32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DUPLICATE_EXTENTS_DATA_EX {
@@ -2431,9 +2017,6 @@ impl Default for DUPLICATE_EXTENTS_DATA_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DUPLICATE_EXTENTS_DATA_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -2451,10 +2034,6 @@ impl Default for DUPLICATE_EXTENTS_DATA_EX32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DUPLICATE_EXTENTS_DATA_EX32 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DUPLICATE_EXTENTS_DATA_EX_ASYNC: u32 = 2u32;
 pub const DUPLICATE_EXTENTS_DATA_EX_SOURCE_ATOMIC: u32 = 1u32;
@@ -2571,9 +2150,6 @@ impl Default for ENCRYPTED_DATA_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENCRYPTED_DATA_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ENCRYPTED_DATA_INFO_SPARSE_FILE: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2585,9 +2161,6 @@ impl Default for ENCRYPTION_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENCRYPTION_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENCRYPTION_FORMAT_DEFAULT: u32 = 1u32;
 #[repr(C)]
@@ -2605,9 +2178,6 @@ impl Default for ENCRYPTION_KEY_CTRL_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENCRYPTION_KEY_CTRL_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ERROR_DRIVE_NOT_INSTALLED: u32 = 8u32;
 pub const ERROR_HISTORY_DIRECTORY_ENTRY_DEFAULT_COUNT: u32 = 8u32;
@@ -2636,9 +2206,6 @@ impl Default for EXFAT_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXFAT_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EXTENDED_ENCRYPTED_DATA_INFO {
@@ -2651,9 +2218,6 @@ impl Default for EXTENDED_ENCRYPTED_DATA_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXTENDED_ENCRYPTED_DATA_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EXTEND_IEPORT: u32 = 2u32;
 pub const EqualPriority: DISK_CACHE_RETENTION_PRIORITY = DISK_CACHE_RETENTION_PRIORITY(0i32);
@@ -2698,9 +2262,6 @@ impl Default for FAT_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FAT_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILESYSTEM_STATISTICS {
@@ -2724,9 +2285,6 @@ impl Default for FILESYSTEM_STATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILESYSTEM_STATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2752,9 +2310,6 @@ impl Default for FILESYSTEM_STATISTICS_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILESYSTEM_STATISTICS_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FILESYSTEM_STATISTICS_TYPE(pub u16);
@@ -2773,9 +2328,6 @@ impl Default for FILE_ALLOCATED_RANGE_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_ALLOCATED_RANGE_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_ANY_ACCESS: u32 = 0u32;
 pub const FILE_CLEAR_ENCRYPTION: u32 = 2u32;
 #[repr(C)]
@@ -2788,9 +2340,6 @@ impl Default for FILE_DESIRED_STORAGE_CLASS_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_DESIRED_STORAGE_CLASS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_DEVICE_8042_PORT: u32 = 39u32;
 pub const FILE_DEVICE_ACPI: u32 = 50u32;
@@ -2889,9 +2438,6 @@ impl Default for FILE_FS_PERSISTENT_VOLUME_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_FS_PERSISTENT_VOLUME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_INITIATE_REPAIR_HINT1_ATTRIBUTE_NON_RESIDENT: u64 = 137438953472u64;
 pub const FILE_INITIATE_REPAIR_HINT1_ATTRIBUTE_NOT_FOUND: u64 = 4096u64;
 pub const FILE_INITIATE_REPAIR_HINT1_ATTRIBUTE_TOO_SMALL: u64 = 68719476736u64;
@@ -2948,9 +2494,6 @@ impl Default for FILE_INITIATE_REPAIR_OUTPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_INITIATE_REPAIR_OUTPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_LAYOUT_ENTRY {
@@ -2969,9 +2512,6 @@ impl Default for FILE_LAYOUT_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_LAYOUT_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_LAYOUT_INFO_ENTRY {
@@ -2986,9 +2526,6 @@ impl Default for FILE_LAYOUT_INFO_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_LAYOUT_INFO_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_LAYOUT_INFO_ENTRY_0 {
@@ -3002,9 +2539,6 @@ impl Default for FILE_LAYOUT_INFO_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_LAYOUT_INFO_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3021,9 +2555,6 @@ impl Default for FILE_LAYOUT_NAME_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_LAYOUT_NAME_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_LAYOUT_NAME_ENTRY_DOS: u32 = 2u32;
 pub const FILE_LAYOUT_NAME_ENTRY_PRIMARY: u32 = 1u32;
 #[repr(C)]
@@ -3038,9 +2569,6 @@ impl Default for FILE_LEVEL_TRIM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_LEVEL_TRIM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_LEVEL_TRIM_OUTPUT {
@@ -3050,9 +2578,6 @@ impl Default for FILE_LEVEL_TRIM_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_LEVEL_TRIM_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3065,9 +2590,6 @@ impl Default for FILE_LEVEL_TRIM_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_LEVEL_TRIM_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_MAKE_COMPATIBLE_BUFFER {
@@ -3077,9 +2599,6 @@ impl Default for FILE_MAKE_COMPATIBLE_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_MAKE_COMPATIBLE_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3092,9 +2611,6 @@ impl Default for FILE_OBJECTID_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_OBJECTID_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILE_OBJECTID_BUFFER_0 {
@@ -3105,9 +2621,6 @@ impl Default for FILE_OBJECTID_BUFFER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_OBJECTID_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3121,9 +2634,6 @@ impl Default for FILE_OBJECTID_BUFFER_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_OBJECTID_BUFFER_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_PREFETCH {
@@ -3135,9 +2645,6 @@ impl Default for FILE_PREFETCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_PREFETCH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3151,9 +2658,6 @@ impl Default for FILE_PREFETCH_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_PREFETCH_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_PREFETCH_TYPE_FOR_CREATE: u32 = 1u32;
 pub const FILE_PREFETCH_TYPE_FOR_CREATE_EX: u32 = 3u32;
@@ -3173,9 +2677,6 @@ impl Default for FILE_PROVIDER_EXTERNAL_INFO_V0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_PROVIDER_EXTERNAL_INFO_V0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_PROVIDER_EXTERNAL_INFO_V1 {
@@ -3187,9 +2688,6 @@ impl Default for FILE_PROVIDER_EXTERNAL_INFO_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_PROVIDER_EXTERNAL_INFO_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_PROVIDER_FLAG_COMPRESS_ON_WRITE: u32 = 1u32;
 pub const FILE_PROVIDER_SINGLE_FILE: u32 = 1u32;
@@ -3213,9 +2711,6 @@ impl Default for FILE_QUERY_ON_DISK_VOL_INFO_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_QUERY_ON_DISK_VOL_INFO_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_QUERY_SPARING_BUFFER {
@@ -3229,9 +2724,6 @@ impl Default for FILE_QUERY_SPARING_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_QUERY_SPARING_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_READ_ACCESS: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3243,9 +2735,6 @@ impl Default for FILE_REFERENCE_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_REFERENCE_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3260,9 +2749,6 @@ impl Default for FILE_REGION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_REGION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_REGION_INPUT {
@@ -3274,9 +2760,6 @@ impl Default for FILE_REGION_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_REGION_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3291,9 +2774,6 @@ impl Default for FILE_REGION_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_REGION_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_REGION_USAGE_HUGE_PAGE_ALIGNMENT: u32 = 16u32;
 pub const FILE_REGION_USAGE_LARGE_PAGE_ALIGNMENT: u32 = 8u32;
@@ -3311,9 +2791,6 @@ impl Default for FILE_SET_DEFECT_MGMT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_SET_DEFECT_MGMT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_SET_ENCRYPTION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3324,9 +2801,6 @@ impl Default for FILE_SET_SPARSE_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_SET_SPARSE_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_SPECIAL_ACCESS: u32 = 0u32;
 #[repr(C)]
@@ -3344,9 +2818,6 @@ impl Default for FILE_STORAGE_TIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_STORAGE_TIER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3409,9 +2880,6 @@ impl Default for FILE_STORAGE_TIER_REGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_STORAGE_TIER_REGION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_SYSTEM_RECOGNITION_INFORMATION {
@@ -3421,9 +2889,6 @@ impl Default for FILE_SYSTEM_RECOGNITION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_SYSTEM_RECOGNITION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_TYPE_NOTIFICATION_FLAG_USAGE_BEGIN: u32 = 1u32;
 pub const FILE_TYPE_NOTIFICATION_FLAG_USAGE_END: u32 = 2u32;
@@ -3442,9 +2907,6 @@ impl Default for FILE_TYPE_NOTIFICATION_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_TYPE_NOTIFICATION_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_WRITE_ACCESS: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3457,9 +2919,6 @@ impl Default for FILE_ZERO_DATA_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_ZERO_DATA_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILE_ZERO_DATA_INFORMATION_EX {
@@ -3471,9 +2930,6 @@ impl Default for FILE_ZERO_DATA_INFORMATION_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ZERO_DATA_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_ZERO_DATA_INFORMATION_FLAG_PRESERVE_CACHED_DATA: u32 = 1u32;
 #[repr(C)]
@@ -3489,10 +2945,6 @@ impl Default for FIND_BY_SID_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for FIND_BY_SID_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FIND_BY_SID_OUTPUT {
@@ -3505,9 +2957,6 @@ impl Default for FIND_BY_SID_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FIND_BY_SID_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLAG_USN_TRACK_MODIFIED_RANGES_ENABLE: u32 = 1u32;
 #[repr(C)]
@@ -3527,9 +2976,6 @@ impl Default for FORMAT_EX_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FORMAT_EX_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FORMAT_PARAMETERS {
@@ -3543,9 +2989,6 @@ impl Default for FORMAT_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FORMAT_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSBPIO_INFL_None: FS_BPIO_INFLAGS = FS_BPIO_INFLAGS(0i32);
 pub const FSBPIO_INFL_SKIP_STORAGE_STACK_QUERY: FS_BPIO_INFLAGS = FS_BPIO_INFLAGS(1i32);
@@ -3620,9 +3063,6 @@ impl Default for FSCTL_GET_INTEGRITY_INFORMATION_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSCTL_GET_INTEGRITY_INFORMATION_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FSCTL_GET_NTFS_FILE_RECORD: u32 = 589928u32;
 pub const FSCTL_GET_NTFS_VOLUME_DATA: u32 = 589924u32;
 pub const FSCTL_GET_OBJECT_ID: u32 = 589980u32;
@@ -3676,9 +3116,6 @@ impl Default for FSCTL_OFFLOAD_READ_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSCTL_OFFLOAD_READ_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSCTL_OFFLOAD_READ_OUTPUT {
@@ -3691,9 +3128,6 @@ impl Default for FSCTL_OFFLOAD_READ_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSCTL_OFFLOAD_READ_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSCTL_OFFLOAD_WRITE: u32 = 623208u32;
 #[repr(C)]
@@ -3711,9 +3145,6 @@ impl Default for FSCTL_OFFLOAD_WRITE_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSCTL_OFFLOAD_WRITE_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSCTL_OFFLOAD_WRITE_OUTPUT {
@@ -3725,9 +3156,6 @@ impl Default for FSCTL_OFFLOAD_WRITE_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSCTL_OFFLOAD_WRITE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSCTL_OPBATCH_ACK_CLOSE_PENDING: u32 = 589840u32;
 pub const FSCTL_OPLOCK_BREAK_ACKNOWLEDGE: u32 = 589836u32;
@@ -3750,9 +3178,6 @@ impl Default for FSCTL_QUERY_FAT_BPB_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSCTL_QUERY_FAT_BPB_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSCTL_QUERY_FILE_LAYOUT: u32 = 590455u32;
 pub const FSCTL_QUERY_FILE_METADATA_OPTIMIZATION: u32 = 590688u32;
@@ -3780,9 +3205,6 @@ impl Default for FSCTL_QUERY_REGION_INFO_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSCTL_QUERY_REGION_INFO_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSCTL_QUERY_REGION_INFO_OUTPUT {
@@ -3799,9 +3221,6 @@ impl Default for FSCTL_QUERY_REGION_INFO_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSCTL_QUERY_REGION_INFO_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSCTL_QUERY_RETRIEVAL_POINTERS: u32 = 589883u32;
 pub const FSCTL_QUERY_SHARED_VIRTUAL_DISK_SUPPORT: u32 = 590592u32;
@@ -3821,9 +3240,6 @@ impl Default for FSCTL_QUERY_STORAGE_CLASSES_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSCTL_QUERY_STORAGE_CLASSES_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSCTL_QUERY_USN_JOURNAL: u32 = 590068u32;
 pub const FSCTL_QUERY_VOLUME_CONTAINER_STATE: u32 = 590736u32;
@@ -3879,9 +3295,6 @@ impl Default for FSCTL_SET_INTEGRITY_INFORMATION_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FSCTL_SET_INTEGRITY_INFORMATION_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FSCTL_SET_INTEGRITY_INFORMATION_BUFFER_EX {
@@ -3896,9 +3309,6 @@ impl Default for FSCTL_SET_INTEGRITY_INFORMATION_BUFFER_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FSCTL_SET_INTEGRITY_INFORMATION_BUFFER_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FSCTL_SET_INTEGRITY_INFORMATION_EX: u32 = 590720u32;
 pub const FSCTL_SET_LAYER_ROOT: u32 = 590740u32;
@@ -4011,9 +3421,6 @@ impl Default for FS_BPIO_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FS_BPIO_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FS_BPIO_INPUT {
@@ -4026,9 +3433,6 @@ impl Default for FS_BPIO_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FS_BPIO_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4092,9 +3496,6 @@ impl Default for FS_BPIO_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FS_BPIO_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FS_BPIO_OUTPUT_0 {
@@ -4109,9 +3510,6 @@ impl Default for FS_BPIO_OUTPUT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FS_BPIO_OUTPUT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FS_BPIO_RESULTS {
@@ -4125,9 +3523,6 @@ impl Default for FS_BPIO_RESULTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FS_BPIO_RESULTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FW_ISSUEID_NO_ISSUE: u32 = 0u32;
 pub const FW_ISSUEID_UNKNOWN: u32 = 4294967295u32;
@@ -4170,9 +3565,6 @@ impl Default for GETVERSIONINPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GETVERSIONINPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_CHANGER_PARAMETERS {
@@ -4209,9 +3601,6 @@ impl Default for GET_CHANGER_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GET_CHANGER_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4262,9 +3651,6 @@ impl Default for GET_DEVICE_INTERNAL_STATUS_DATA_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_DEVICE_INTERNAL_STATUS_DATA_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_DISK_ATTRIBUTES {
@@ -4277,9 +3663,6 @@ impl Default for GET_DISK_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_DISK_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_FILTER_FILE_IDENTIFIER_INPUT {
@@ -4290,9 +3673,6 @@ impl Default for GET_FILTER_FILE_IDENTIFIER_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GET_FILTER_FILE_IDENTIFIER_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4305,9 +3685,6 @@ impl Default for GET_FILTER_FILE_IDENTIFIER_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GET_FILTER_FILE_IDENTIFIER_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GET_LENGTH_INFORMATION {
@@ -4317,9 +3694,6 @@ impl Default for GET_LENGTH_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GET_LENGTH_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -4334,10 +3708,6 @@ impl Default for GET_MEDIA_TYPES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for GET_MEDIA_TYPES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GET_VOLUME_BITMAP_FLAG_MASK_METADATA: u32 = 1u32;
 #[repr(transparent)]
@@ -4398,9 +3768,6 @@ impl Default for GP_LOG_PAGE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GP_LOG_PAGE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GUID_DEVICEDUMP_DRIVER_STORAGE_PORT: windows_core::GUID = windows_core::GUID::from_u128(0xda82441d_7142_4bc1_b844_0807c5a4b67f);
 pub const GUID_DEVICEDUMP_STORAGE_DEVICE: windows_core::GUID = windows_core::GUID::from_u128(0xd8e2592f_1aab_4d56_a746_1f7585df40f4);
 pub const GUID_DEVINTERFACE_CDCHANGER: windows_core::GUID = windows_core::GUID::from_u128(0x53f56312_b6bf_11d0_94f2_00a0c91efb8b);
@@ -4435,9 +3802,6 @@ impl Default for HISTOGRAM_BUCKET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HISTOGRAM_BUCKET {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HIST_NO_OF_BUCKETS: u32 = 24u32;
 pub const HITACHI_12_WO: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(68i32);
 pub const HealthStatusDisabled: STORAGE_COMPONENT_HEALTH_STATUS = STORAGE_COMPONENT_HEALTH_STATUS(4i32);
@@ -4467,9 +3831,6 @@ impl Default for IDEREGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IDEREGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ID_CMD: u32 = 236u32;
 pub const IOCTL_CHANGER_BASE: u32 = 48u32;
@@ -4632,9 +3993,6 @@ impl Default for IO_IRP_EXT_TRACK_OFFSET_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IO_IRP_EXT_TRACK_OFFSET_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KODAK_14_WO: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(70i32);
 pub const KeepPrefetchedData: DISK_CACHE_RETENTION_PRIORITY = DISK_CACHE_RETENTION_PRIORITY(1i32);
 pub const KeepReadData: DISK_CACHE_RETENTION_PRIORITY = DISK_CACHE_RETENTION_PRIORITY(2i32);
@@ -4652,9 +4010,6 @@ impl Default for LMR_QUERY_INFO_PARAM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LMR_QUERY_INFO_PARAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LMR_QUERY_SESSION_INFO {
@@ -4664,9 +4019,6 @@ impl Default for LMR_QUERY_SESSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LMR_QUERY_SESSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LOCK_ELEMENT: u32 = 0u32;
 pub const LOCK_UNLOCK_DOOR: u32 = 2u32;
@@ -4685,9 +4037,6 @@ impl Default for LOOKUP_STREAM_FROM_CLUSTER_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LOOKUP_STREAM_FROM_CLUSTER_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LOOKUP_STREAM_FROM_CLUSTER_ENTRY_ATTRIBUTE_DATA: u32 = 16777216u32;
 pub const LOOKUP_STREAM_FROM_CLUSTER_ENTRY_ATTRIBUTE_INDEX: u32 = 33554432u32;
@@ -4709,9 +4058,6 @@ impl Default for LOOKUP_STREAM_FROM_CLUSTER_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LOOKUP_STREAM_FROM_CLUSTER_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LOOKUP_STREAM_FROM_CLUSTER_OUTPUT {
@@ -4723,9 +4069,6 @@ impl Default for LOOKUP_STREAM_FROM_CLUSTER_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LOOKUP_STREAM_FROM_CLUSTER_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LTO_Accelis: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(87i32);
 pub const LTO_Ultrium: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(86i32);
@@ -4746,9 +4089,6 @@ impl Default for MARK_HANDLE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MARK_HANDLE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MARK_HANDLE_INFO_0 {
@@ -4759,9 +4099,6 @@ impl Default for MARK_HANDLE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MARK_HANDLE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -4777,10 +4114,6 @@ impl Default for MARK_HANDLE_INFO32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MARK_HANDLE_INFO32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -4793,10 +4126,6 @@ impl Default for MARK_HANDLE_INFO32_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MARK_HANDLE_INFO32_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MARK_HANDLE_NOT_READ_COPY: u32 = 256u32;
 pub const MARK_HANDLE_NOT_REALTIME: u32 = 64u32;
@@ -4840,9 +4169,6 @@ impl Default for MFT_ENUM_DATA_V0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFT_ENUM_DATA_V0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MFT_ENUM_DATA_V1 {
@@ -4857,9 +4183,6 @@ impl Default for MFT_ENUM_DATA_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MFT_ENUM_DATA_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MOVE_FILE_DATA {
@@ -4872,9 +4195,6 @@ impl Default for MOVE_FILE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MOVE_FILE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -4891,10 +4211,6 @@ impl Default for MOVE_FILE_DATA32 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MOVE_FILE_DATA32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MOVE_FILE_RECORD_DATA {
@@ -4906,9 +4222,6 @@ impl Default for MOVE_FILE_RECORD_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MOVE_FILE_RECORD_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MO_3_RW: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(57i32);
 pub const MO_5_LIMDOW: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(60i32);
@@ -4939,9 +4252,6 @@ impl Default for NTFS_EXTENDED_VOLUME_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTFS_EXTENDED_VOLUME_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTFS_FILE_RECORD_INPUT_BUFFER {
@@ -4951,9 +4261,6 @@ impl Default for NTFS_FILE_RECORD_INPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTFS_FILE_RECORD_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4966,9 +4273,6 @@ impl Default for NTFS_FILE_RECORD_OUTPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTFS_FILE_RECORD_OUTPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5025,9 +4329,6 @@ impl Default for NTFS_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTFS_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTFS_STATISTICS_4 {
@@ -5047,9 +4348,6 @@ impl Default for NTFS_STATISTICS_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTFS_STATISTICS_2 {
@@ -5061,9 +4359,6 @@ impl Default for NTFS_STATISTICS_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTFS_STATISTICS_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5078,9 +4373,6 @@ impl Default for NTFS_STATISTICS_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTFS_STATISTICS_3 {
@@ -5094,9 +4386,6 @@ impl Default for NTFS_STATISTICS_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTFS_STATISTICS_0 {
@@ -5109,9 +4398,6 @@ impl Default for NTFS_STATISTICS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTFS_STATISTICS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5179,9 +4465,6 @@ impl Default for NTFS_STATISTICS_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTFS_STATISTICS_EX_4 {
@@ -5201,9 +4484,6 @@ impl Default for NTFS_STATISTICS_EX_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_EX_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTFS_STATISTICS_EX_2 {
@@ -5216,9 +4496,6 @@ impl Default for NTFS_STATISTICS_EX_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTFS_STATISTICS_EX_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5233,9 +4510,6 @@ impl Default for NTFS_STATISTICS_EX_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_EX_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTFS_STATISTICS_EX_3 {
@@ -5249,9 +4523,6 @@ impl Default for NTFS_STATISTICS_EX_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NTFS_STATISTICS_EX_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NTFS_STATISTICS_EX_0 {
@@ -5264,9 +4535,6 @@ impl Default for NTFS_STATISTICS_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTFS_STATISTICS_EX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5290,9 +4558,6 @@ impl Default for NTFS_VOLUME_DATA_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NTFS_VOLUME_DATA_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NVMeDataTypeFeature: STORAGE_PROTOCOL_NVME_DATA_TYPE = STORAGE_PROTOCOL_NVME_DATA_TYPE(3i32);
 pub const NVMeDataTypeIdentify: STORAGE_PROTOCOL_NVME_DATA_TYPE = STORAGE_PROTOCOL_NVME_DATA_TYPE(1i32);
@@ -5336,9 +4601,6 @@ impl Default for PARTITION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PARTITION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PARTITION_INFORMATION_EX {
@@ -5355,9 +4617,6 @@ impl Default for PARTITION_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PARTITION_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PARTITION_INFORMATION_EX_0 {
@@ -5368,9 +4627,6 @@ impl Default for PARTITION_INFORMATION_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PARTITION_INFORMATION_EX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5385,9 +4641,6 @@ impl Default for PARTITION_INFORMATION_GPT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PARTITION_INFORMATION_GPT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PARTITION_INFORMATION_MBR {
@@ -5401,9 +4654,6 @@ impl Default for PARTITION_INFORMATION_MBR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PARTITION_INFORMATION_MBR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PARTITION_LDM: u32 = 66u32;
 pub const PARTITION_MAIN_OS: u32 = 40u32;
@@ -5438,9 +4688,6 @@ impl Default for PATHNAME_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PATHNAME_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PC_5_RW: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(62i32);
 pub const PC_5_WO: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(61i32);
 pub const PD_5_RW: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(63i32);
@@ -5456,9 +4703,6 @@ impl Default for PERF_BIN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERF_BIN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PERSISTENT_RESERVE_COMMAND {
@@ -5471,9 +4715,6 @@ impl Default for PERSISTENT_RESERVE_COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERSISTENT_RESERVE_COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PERSISTENT_RESERVE_COMMAND_0 {
@@ -5484,9 +4725,6 @@ impl Default for PERSISTENT_RESERVE_COMMAND_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERSISTENT_RESERVE_COMMAND_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5499,9 +4737,6 @@ impl Default for PERSISTENT_RESERVE_COMMAND_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERSISTENT_RESERVE_COMMAND_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERSISTENT_RESERVE_COMMAND_0_1 {
@@ -5513,9 +4748,6 @@ impl Default for PERSISTENT_RESERVE_COMMAND_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERSISTENT_RESERVE_COMMAND_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERSISTENT_VOLUME_STATE_BACKED_BY_WIM: u32 = 64u32;
 pub const PERSISTENT_VOLUME_STATE_CHKDSK_RAN_ONCE: u32 = 1024u32;
@@ -5549,9 +4781,6 @@ impl Default for PHYSICAL_ELEMENT_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_ELEMENT_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PHYSICAL_ELEMENT_STATUS_DESCRIPTOR {
@@ -5569,9 +4798,6 @@ impl Default for PHYSICAL_ELEMENT_STATUS_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_ELEMENT_STATUS_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PHYSICAL_ELEMENT_STATUS_REQUEST {
@@ -5587,9 +4813,6 @@ impl Default for PHYSICAL_ELEMENT_STATUS_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PHYSICAL_ELEMENT_STATUS_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PINNACLE_APEX_5_RW: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(65i32);
 pub type PIO_IRP_EXT_PROCESS_TRACKED_OFFSET_CALLBACK = Option<unsafe extern "system" fn(sourcecontext: *const IO_IRP_EXT_TRACK_OFFSET_HEADER, targetcontext: *mut IO_IRP_EXT_TRACK_OFFSET_HEADER, relativeoffset: i64)>;
 #[repr(C)]
@@ -5604,9 +4827,6 @@ impl Default for PLEX_READ_DATA_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PLEX_READ_DATA_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PREVENT_MEDIA_REMOVAL {
@@ -5616,9 +4836,6 @@ impl Default for PREVENT_MEDIA_REMOVAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PREVENT_MEDIA_REMOVAL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRODUCT_ID_LENGTH: u32 = 16u32;
 pub const PROJFS_PROTOCOL_VERSION: u32 = 3u32;
@@ -5650,9 +4867,6 @@ impl Default for QUERY_BAD_RANGES_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUERY_BAD_RANGES_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QUERY_BAD_RANGES_INPUT_RANGE {
@@ -5663,9 +4877,6 @@ impl Default for QUERY_BAD_RANGES_INPUT_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUERY_BAD_RANGES_INPUT_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5680,9 +4891,6 @@ impl Default for QUERY_BAD_RANGES_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUERY_BAD_RANGES_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QUERY_BAD_RANGES_OUTPUT_RANGE {
@@ -5695,9 +4903,6 @@ impl Default for QUERY_BAD_RANGES_OUTPUT_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUERY_BAD_RANGES_OUTPUT_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const QUERY_DEPENDENT_VOLUME_REQUEST_FLAG_GUEST_VOLUMES: u32 = 2u32;
 pub const QUERY_DEPENDENT_VOLUME_REQUEST_FLAG_HOST_VOLUMES: u32 = 1u32;
@@ -5737,9 +4942,6 @@ impl Default for QUERY_FILE_LAYOUT_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUERY_FILE_LAYOUT_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union QUERY_FILE_LAYOUT_INPUT_0 {
@@ -5750,9 +4952,6 @@ impl Default for QUERY_FILE_LAYOUT_INPUT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUERY_FILE_LAYOUT_INPUT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5765,9 +4964,6 @@ impl Default for QUERY_FILE_LAYOUT_INPUT_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUERY_FILE_LAYOUT_INPUT_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const QUERY_FILE_LAYOUT_NUM_FILTER_TYPES: QUERY_FILE_LAYOUT_FILTER_TYPE = QUERY_FILE_LAYOUT_FILTER_TYPE(4i32);
 #[repr(C)]
@@ -5782,9 +4978,6 @@ impl Default for QUERY_FILE_LAYOUT_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUERY_FILE_LAYOUT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const QUERY_FILE_LAYOUT_REPARSE_DATA_INVALID: u32 = 1u32;
 pub const QUERY_FILE_LAYOUT_REPARSE_TAG_INVALID: u32 = 2u32;
@@ -5809,9 +5002,6 @@ impl Default for READ_ELEMENT_ADDRESS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for READ_ELEMENT_ADDRESS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct READ_FILE_USN_DATA {
@@ -5822,9 +5012,6 @@ impl Default for READ_FILE_USN_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for READ_FILE_USN_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const READ_THRESHOLDS: u32 = 209u32;
 pub const READ_THRESHOLD_BUFFER_SIZE: u32 = 512u32;
@@ -5843,9 +5030,6 @@ impl Default for READ_USN_JOURNAL_DATA_V0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for READ_USN_JOURNAL_DATA_V0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct READ_USN_JOURNAL_DATA_V1 {
@@ -5863,9 +5047,6 @@ impl Default for READ_USN_JOURNAL_DATA_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for READ_USN_JOURNAL_DATA_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REASSIGN_BLOCKS {
@@ -5878,9 +5059,6 @@ impl Default for REASSIGN_BLOCKS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REASSIGN_BLOCKS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct REASSIGN_BLOCKS_EX {
@@ -5892,9 +5070,6 @@ impl Default for REASSIGN_BLOCKS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REASSIGN_BLOCKS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RECOVERED_READS_VALID: u32 = 4u32;
 pub const RECOVERED_WRITES_VALID: u32 = 1u32;
@@ -5920,9 +5095,6 @@ impl Default for REFS_SMR_VOLUME_GC_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_SMR_VOLUME_GC_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const REFS_SMR_VOLUME_GC_PARAMETERS_VERSION_V1: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5946,9 +5118,6 @@ impl Default for REFS_SMR_VOLUME_INFO_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REFS_SMR_VOLUME_INFO_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REFS_SMR_VOLUME_INFO_OUTPUT_VERSION_V0: u32 = 0u32;
 pub const REFS_SMR_VOLUME_INFO_OUTPUT_VERSION_V1: u32 = 1u32;
@@ -5979,9 +5148,6 @@ impl Default for REFS_VOLUME_DATA_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REFS_VOLUME_DATA_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REMOVE_ELEMENT_AND_TRUNCATE_REQUEST {
@@ -5995,9 +5161,6 @@ impl Default for REMOVE_ELEMENT_AND_TRUNCATE_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REMOVE_ELEMENT_AND_TRUNCATE_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6015,9 +5178,6 @@ impl Default for REPAIR_COPIES_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REPAIR_COPIES_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REPAIR_COPIES_OUTPUT {
@@ -6029,9 +5189,6 @@ impl Default for REPAIR_COPIES_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REPAIR_COPIES_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REPLACE_ALTERNATE: u32 = 11u32;
 pub const REPLACE_PRIMARY: u32 = 10u32;
@@ -6048,9 +5205,6 @@ impl Default for REQUEST_OPLOCK_INPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REQUEST_OPLOCK_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REQUEST_OPLOCK_INPUT_FLAG_ACK: u32 = 2u32;
 pub const REQUEST_OPLOCK_INPUT_FLAG_COMPLETE_ACK_ON_CLOSE: u32 = 4u32;
@@ -6071,9 +5225,6 @@ impl Default for REQUEST_OPLOCK_OUTPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REQUEST_OPLOCK_OUTPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const REQUEST_OPLOCK_OUTPUT_FLAG_ACK_REQUIRED: u32 = 1u32;
 pub const REQUEST_OPLOCK_OUTPUT_FLAG_MODES_PROVIDED: u32 = 2u32;
 pub const REQUEST_OPLOCK_OUTPUT_FLAG_WRITABLE_SECTION_PRESENT: u32 = 4u32;
@@ -6088,9 +5239,6 @@ impl Default for REQUEST_RAW_ENCRYPTED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REQUEST_RAW_ENCRYPTED_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RETRACT_IEPORT: u32 = 3u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6104,9 +5252,6 @@ impl Default for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER_0 {
@@ -6118,9 +5263,6 @@ impl Default for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RETRIEVAL_POINTERS_AND_REFCOUNT_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6134,9 +5276,6 @@ impl Default for RETRIEVAL_POINTERS_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RETRIEVAL_POINTERS_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RETRIEVAL_POINTERS_BUFFER_0 {
@@ -6148,9 +5287,6 @@ impl Default for RETRIEVAL_POINTERS_BUFFER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RETRIEVAL_POINTERS_BUFFER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RETRIEVAL_POINTER_BASE {
@@ -6161,9 +5297,6 @@ impl Default for RETRIEVAL_POINTER_BASE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RETRIEVAL_POINTER_BASE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RETRIEVAL_POINTER_COUNT {
@@ -6173,9 +5306,6 @@ impl Default for RETRIEVAL_POINTER_COUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RETRIEVAL_POINTER_COUNT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RETURN_SMART_STATUS: u32 = 218u32;
 pub const REVISION_LENGTH: u32 = 4u32;
@@ -6197,9 +5327,6 @@ impl Default for SCM_BUS_DEDICATED_MEMORY_DEVICES_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_BUS_DEDICATED_MEMORY_DEVICES_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO {
@@ -6213,9 +5340,6 @@ impl Default for SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO_0 {
@@ -6226,9 +5350,6 @@ impl Default for SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_BUS_DEDICATED_MEMORY_DEVICE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_BUS_DEDICATED_MEMORY_STATE {
@@ -6238,9 +5359,6 @@ impl Default for SCM_BUS_DEDICATED_MEMORY_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_BUS_DEDICATED_MEMORY_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6262,9 +5380,6 @@ impl Default for SCM_BUS_PROPERTY_QUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_BUS_PROPERTY_QUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_BUS_PROPERTY_SET {
@@ -6278,9 +5393,6 @@ impl Default for SCM_BUS_PROPERTY_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_BUS_PROPERTY_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6303,9 +5415,6 @@ impl Default for SCM_BUS_RUNTIME_FW_ACTIVATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_BUS_RUNTIME_FW_ACTIVATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_BUS_RUNTIME_FW_ACTIVATION_INFO_0 {
@@ -6315,9 +5424,6 @@ impl Default for SCM_BUS_RUNTIME_FW_ACTIVATION_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_BUS_RUNTIME_FW_ACTIVATION_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6333,9 +5439,6 @@ impl Default for SCM_INTERLEAVED_PD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_INTERLEAVED_PD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_LD_INTERLEAVE_SET_INFO {
@@ -6348,9 +5451,6 @@ impl Default for SCM_LD_INTERLEAVE_SET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_LD_INTERLEAVE_SET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6365,9 +5465,6 @@ impl Default for SCM_LOGICAL_DEVICES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_LOGICAL_DEVICES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_LOGICAL_DEVICE_INSTANCE {
@@ -6381,9 +5478,6 @@ impl Default for SCM_LOGICAL_DEVICE_INSTANCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_LOGICAL_DEVICE_INSTANCE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCM_MAX_SYMLINK_LEN_IN_CHARS: u32 = 256u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6395,9 +5489,6 @@ impl Default for SCM_PD_DESCRIPTOR_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_DESCRIPTOR_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6411,9 +5502,6 @@ impl Default for SCM_PD_DEVICE_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_DEVICE_HANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6446,9 +5534,6 @@ impl Default for SCM_PD_DEVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_DEVICE_SPECIFIC_INFO {
@@ -6462,9 +5547,6 @@ impl Default for SCM_PD_DEVICE_SPECIFIC_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_DEVICE_SPECIFIC_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_DEVICE_SPECIFIC_PROPERTY {
@@ -6475,9 +5557,6 @@ impl Default for SCM_PD_DEVICE_SPECIFIC_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_DEVICE_SPECIFIC_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6491,9 +5570,6 @@ impl Default for SCM_PD_FIRMWARE_ACTIVATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_FIRMWARE_ACTIVATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6515,9 +5591,6 @@ impl Default for SCM_PD_FIRMWARE_DOWNLOAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_FIRMWARE_DOWNLOAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_FIRMWARE_INFO {
@@ -6532,9 +5605,6 @@ impl Default for SCM_PD_FIRMWARE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_FIRMWARE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCM_PD_FIRMWARE_LAST_DOWNLOAD: u32 = 1u32;
 pub const SCM_PD_FIRMWARE_REVISION_LENGTH_BYTES: u32 = 32u32;
@@ -6553,9 +5623,6 @@ impl Default for SCM_PD_FIRMWARE_SLOT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_FIRMWARE_SLOT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_FRU_ID_STRING {
@@ -6569,9 +5636,6 @@ impl Default for SCM_PD_FRU_ID_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_FRU_ID_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_HEALTH_NOTIFICATION_DATA {
@@ -6581,9 +5645,6 @@ impl Default for SCM_PD_HEALTH_NOTIFICATION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_HEALTH_NOTIFICATION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6603,9 +5664,6 @@ impl Default for SCM_PD_LOCATION_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_LOCATION_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_MANAGEMENT_STATUS {
@@ -6621,9 +5679,6 @@ impl Default for SCM_PD_MANAGEMENT_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_MANAGEMENT_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCM_PD_MAX_OPERATIONAL_STATUS: u32 = 16u32;
 #[repr(transparent)]
@@ -6649,9 +5704,6 @@ impl Default for SCM_PD_PASSTHROUGH_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_PASSTHROUGH_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_PASSTHROUGH_INVDIMM_INPUT {
@@ -6663,9 +5715,6 @@ impl Default for SCM_PD_PASSTHROUGH_INVDIMM_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_PASSTHROUGH_INVDIMM_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6680,9 +5729,6 @@ impl Default for SCM_PD_PASSTHROUGH_INVDIMM_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_PASSTHROUGH_INVDIMM_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_PASSTHROUGH_OUTPUT {
@@ -6696,9 +5742,6 @@ impl Default for SCM_PD_PASSTHROUGH_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_PASSTHROUGH_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6718,9 +5761,6 @@ impl Default for SCM_PD_PROPERTY_QUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_PROPERTY_QUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_PROPERTY_SET {
@@ -6734,9 +5774,6 @@ impl Default for SCM_PD_PROPERTY_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_PROPERTY_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6753,9 +5790,6 @@ impl Default for SCM_PD_REINITIALIZE_MEDIA_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_REINITIALIZE_MEDIA_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_REINITIALIZE_MEDIA_INPUT_0 {
@@ -6765,9 +5799,6 @@ impl Default for SCM_PD_REINITIALIZE_MEDIA_INPUT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_REINITIALIZE_MEDIA_INPUT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6781,9 +5812,6 @@ impl Default for SCM_PD_REINITIALIZE_MEDIA_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PD_REINITIALIZE_MEDIA_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PD_RUNTIME_FW_ACTIVATION_ARM_STATE {
@@ -6793,9 +5821,6 @@ impl Default for SCM_PD_RUNTIME_FW_ACTIVATION_ARM_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_RUNTIME_FW_ACTIVATION_ARM_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6809,9 +5834,6 @@ impl Default for SCM_PD_RUNTIME_FW_ACTIVATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PD_RUNTIME_FW_ACTIVATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6829,9 +5851,6 @@ impl Default for SCM_PHYSICAL_DEVICES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_PHYSICAL_DEVICES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_PHYSICAL_DEVICE_INSTANCE {
@@ -6844,9 +5863,6 @@ impl Default for SCM_PHYSICAL_DEVICE_INSTANCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_PHYSICAL_DEVICE_INSTANCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6869,9 +5885,6 @@ impl Default for SCM_REGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCM_REGION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCM_REGIONS {
@@ -6884,9 +5897,6 @@ impl Default for SCM_REGIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCM_REGIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6904,9 +5914,6 @@ impl Default for SD_CHANGE_MACHINE_SID_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SD_CHANGE_MACHINE_SID_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SD_CHANGE_MACHINE_SID_OUTPUT {
@@ -6923,9 +5930,6 @@ impl Default for SD_CHANGE_MACHINE_SID_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SD_CHANGE_MACHINE_SID_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SD_ENUM_SDS_ENTRY {
@@ -6940,9 +5944,6 @@ impl Default for SD_ENUM_SDS_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SD_ENUM_SDS_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SD_ENUM_SDS_INPUT {
@@ -6953,9 +5954,6 @@ impl Default for SD_ENUM_SDS_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SD_ENUM_SDS_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6970,9 +5968,6 @@ impl Default for SD_ENUM_SDS_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SD_ENUM_SDS_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct SD_GLOBAL_CHANGE_INPUT {
@@ -6984,9 +5979,6 @@ impl Default for SD_GLOBAL_CHANGE_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SD_GLOBAL_CHANGE_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7000,9 +5992,6 @@ impl Default for SD_GLOBAL_CHANGE_INPUT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SD_GLOBAL_CHANGE_INPUT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct SD_GLOBAL_CHANGE_OUTPUT {
@@ -7014,9 +6003,6 @@ impl Default for SD_GLOBAL_CHANGE_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SD_GLOBAL_CHANGE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7030,9 +6016,6 @@ impl Default for SD_GLOBAL_CHANGE_OUTPUT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SD_GLOBAL_CHANGE_OUTPUT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SD_GLOBAL_CHANGE_TYPE_ENUM_SDS: u32 = 131072u32;
 pub const SD_GLOBAL_CHANGE_TYPE_MACHINE_SID: u32 = 1u32;
 pub const SD_GLOBAL_CHANGE_TYPE_QUERY_STATS: u32 = 65536u32;
@@ -7045,9 +6028,6 @@ impl Default for SD_QUERY_STATS_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SD_QUERY_STATS_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7065,9 +6045,6 @@ impl Default for SD_QUERY_STATS_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SD_QUERY_STATS_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SEARCH_ALL: u32 = 0u32;
 pub const SEARCH_ALL_NO_SEQ: u32 = 4u32;
@@ -7090,9 +6067,6 @@ impl Default for SENDCMDINPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SENDCMDINPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct SENDCMDOUTPARAMS {
@@ -7104,9 +6078,6 @@ impl Default for SENDCMDOUTPARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SENDCMDOUTPARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERIAL_IOC_FCR_DMA_MODE: u32 = 8u32;
 pub const SERIAL_IOC_FCR_FIFO_ENABLE: u32 = 1u32;
@@ -7135,9 +6106,6 @@ impl Default for SET_DAX_ALLOC_ALIGNMENT_HINT_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SET_DAX_ALLOC_ALIGNMENT_HINT_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SET_DISK_ATTRIBUTES {
@@ -7153,9 +6121,6 @@ impl Default for SET_DISK_ATTRIBUTES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SET_DISK_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SET_PARTITION_INFORMATION {
@@ -7165,9 +6130,6 @@ impl Default for SET_PARTITION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SET_PARTITION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7180,9 +6142,6 @@ impl Default for SET_PARTITION_INFORMATION_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SET_PARTITION_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SET_PARTITION_INFORMATION_EX_0 {
@@ -7193,9 +6152,6 @@ impl Default for SET_PARTITION_INFORMATION_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SET_PARTITION_INFORMATION_EX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SET_PURGE_FAILURE_MODE_DISABLED: u32 = 2u32;
 pub const SET_PURGE_FAILURE_MODE_ENABLED: u32 = 1u32;
@@ -7208,9 +6164,6 @@ impl Default for SET_PURGE_FAILURE_MODE_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SET_PURGE_FAILURE_MODE_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SET_REPAIR_DISABLED_AND_BUGCHECK_ON_CORRUPT: u32 = 16u32;
 pub const SET_REPAIR_ENABLED: u32 = 1u32;
@@ -7228,9 +6181,6 @@ impl Default for SHRINK_VOLUME_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHRINK_VOLUME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SHRINK_VOLUME_REQUEST_TYPES(pub i32);
@@ -7246,9 +6196,6 @@ impl Default for SI_COPYFILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SI_COPYFILE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SMART_ABORT_OFFLINE_SELFTEST: u32 = 127u32;
 pub const SMART_CMD: u32 = 176u32;
@@ -7287,9 +6234,6 @@ impl Default for SMB_SHARE_FLUSH_AND_PURGE_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SMB_SHARE_FLUSH_AND_PURGE_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SMB_SHARE_FLUSH_AND_PURGE_OUTPUT {
@@ -7299,9 +6243,6 @@ impl Default for SMB_SHARE_FLUSH_AND_PURGE_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SMB_SHARE_FLUSH_AND_PURGE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SONY_12_WO: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(66i32);
 pub const SONY_D2: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(49i32);
@@ -7319,9 +6260,6 @@ impl Default for STARTING_LCN_INPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STARTING_LCN_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STARTING_LCN_INPUT_BUFFER_EX {
@@ -7333,9 +6271,6 @@ impl Default for STARTING_LCN_INPUT_BUFFER_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STARTING_LCN_INPUT_BUFFER_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STARTING_VCN_INPUT_BUFFER {
@@ -7345,9 +6280,6 @@ impl Default for STARTING_VCN_INPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STARTING_VCN_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STK_9840: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(85i32);
 pub const STK_9940: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(92i32);
@@ -7367,9 +6299,6 @@ impl Default for STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_ACCESS_ALIGNMENT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7394,9 +6323,6 @@ impl Default for STORAGE_ADAPTER_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_ADAPTER_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_ADAPTER_SERIAL_NUMBER {
@@ -7408,9 +6334,6 @@ impl Default for STORAGE_ADAPTER_SERIAL_NUMBER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_ADAPTER_SERIAL_NUMBER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_ADAPTER_SERIAL_NUMBER_V1_MAX_LENGTH: u32 = 128u32;
 pub const STORAGE_ADDRESS_TYPE_BTL8: u32 = 0u32;
@@ -7431,9 +6354,6 @@ impl Default for STORAGE_ALLOCATE_BC_STREAM_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_ALLOCATE_BC_STREAM_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_ALLOCATE_BC_STREAM_OUTPUT {
@@ -7444,9 +6364,6 @@ impl Default for STORAGE_ALLOCATE_BC_STREAM_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_ALLOCATE_BC_STREAM_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7468,9 +6385,6 @@ impl Default for STORAGE_ATTRIBUTE_MGMT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_ATTRIBUTE_MGMT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct STORAGE_ATTRIBUTE_MGMT_ACTION(pub i32);
@@ -7490,9 +6404,6 @@ impl Default for STORAGE_BREAK_RESERVATION_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_BREAK_RESERVATION_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_BUS_RESET_REQUEST {
@@ -7502,9 +6413,6 @@ impl Default for STORAGE_BUS_RESET_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_BUS_RESET_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7523,9 +6431,6 @@ impl Default for STORAGE_COUNTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_COUNTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_COUNTER_0 {
@@ -7537,9 +6442,6 @@ impl Default for STORAGE_COUNTER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_COUNTER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_COUNTER_0_0 {
@@ -7550,9 +6452,6 @@ impl Default for STORAGE_COUNTER_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_COUNTER_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7566,9 +6465,6 @@ impl Default for STORAGE_COUNTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_COUNTERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7592,9 +6488,6 @@ impl Default for STORAGE_CRYPTO_CAPABILITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_CRYPTO_CAPABILITY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STORAGE_CRYPTO_CAPABILITY_VERSION_1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7609,9 +6502,6 @@ impl Default for STORAGE_CRYPTO_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_CRYPTO_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_CRYPTO_DESCRIPTOR_VERSION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -7628,9 +6518,6 @@ impl Default for STORAGE_DESCRIPTOR_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_DESCRIPTOR_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_DEVICE_ATTRIBUTES_DESCRIPTOR {
@@ -7642,9 +6529,6 @@ impl Default for STORAGE_DEVICE_ATTRIBUTES_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEVICE_ATTRIBUTES_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -7670,10 +6554,6 @@ impl Default for STORAGE_DEVICE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for STORAGE_DEVICE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_DEVICE_FAULT_DOMAIN_DESCRIPTOR {
@@ -7686,9 +6566,6 @@ impl Default for STORAGE_DEVICE_FAULT_DOMAIN_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEVICE_FAULT_DOMAIN_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_DEVICE_FLAGS_PAGE_83_DEVICEGUID: u32 = 4u32;
 pub const STORAGE_DEVICE_FLAGS_RANDOM_DEVICEGUID_REASON_CONFLICT: u32 = 1u32;
@@ -7709,9 +6586,6 @@ impl Default for STORAGE_DEVICE_ID_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_DEVICE_ID_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_DEVICE_IO_CAPABILITY_DESCRIPTOR {
@@ -7725,9 +6599,6 @@ impl Default for STORAGE_DEVICE_IO_CAPABILITY_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_DEVICE_IO_CAPABILITY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_DEVICE_LED_STATE_DESCRIPTOR {
@@ -7739,9 +6610,6 @@ impl Default for STORAGE_DEVICE_LED_STATE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEVICE_LED_STATE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7755,9 +6623,6 @@ impl Default for STORAGE_DEVICE_LOCATION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEVICE_LOCATION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -7775,9 +6640,6 @@ impl Default for STORAGE_DEVICE_MANAGEMENT_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_DEVICE_MANAGEMENT_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STORAGE_DEVICE_MAX_OPERATIONAL_STATUS: u32 = 16u32;
 pub const STORAGE_DEVICE_NUMA_NODE_UNKNOWN: u32 = 4294967295u32;
 #[repr(C)]
@@ -7792,9 +6654,6 @@ impl Default for STORAGE_DEVICE_NUMA_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_DEVICE_NUMA_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_DEVICE_NUMBER {
@@ -7806,9 +6665,6 @@ impl Default for STORAGE_DEVICE_NUMBER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEVICE_NUMBER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7822,9 +6678,6 @@ impl Default for STORAGE_DEVICE_NUMBERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEVICE_NUMBERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7842,9 +6695,6 @@ impl Default for STORAGE_DEVICE_NUMBER_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_DEVICE_NUMBER_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_DEVICE_POWER_CAP {
@@ -7857,9 +6707,6 @@ impl Default for STORAGE_DEVICE_POWER_CAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEVICE_POWER_CAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7882,9 +6729,6 @@ impl Default for STORAGE_DEVICE_RESILIENCY_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_DEVICE_RESILIENCY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_DEVICE_SELF_ENCRYPTION_PROPERTY {
@@ -7896,9 +6740,6 @@ impl Default for STORAGE_DEVICE_SELF_ENCRYPTION_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEVICE_SELF_ENCRYPTION_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7912,9 +6753,6 @@ impl Default for STORAGE_DEVICE_SELF_ENCRYPTION_PROPERTY_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEVICE_SELF_ENCRYPTION_PROPERTY_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_DEVICE_TELEMETRY_REGKEY: windows_core::PCWSTR = windows_core::w!("\\Registry\\Machine\\System\\CurrentControlSet\\Control\\Storage\\StorageTelemetry");
 #[repr(C)]
@@ -7932,9 +6770,6 @@ impl Default for STORAGE_DEVICE_TIERING_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_DEVICE_TIERING_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_DEVICE_UNSAFE_SHUTDOWN_COUNT {
@@ -7946,9 +6781,6 @@ impl Default for STORAGE_DEVICE_UNSAFE_SHUTDOWN_COUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DEVICE_UNSAFE_SHUTDOWN_COUNT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7964,9 +6796,6 @@ impl Default for STORAGE_DIAGNOSTIC_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DIAGNOSTIC_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_DIAGNOSTIC_FLAG_ADAPTER_REQUEST: u32 = 1u32;
 #[repr(transparent)]
@@ -7985,9 +6814,6 @@ impl Default for STORAGE_DIAGNOSTIC_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_DIAGNOSTIC_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8016,9 +6842,6 @@ impl Default for STORAGE_EVENT_NOTIFICATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_EVENT_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STORAGE_EVENT_NOTIFICATION_VERSION_V1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8034,9 +6857,6 @@ impl Default for STORAGE_FAILURE_PREDICTION_CONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_FAILURE_PREDICTION_CONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STORAGE_FAILURE_PREDICTION_CONFIG_V1: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8050,9 +6870,6 @@ impl Default for STORAGE_FRU_ID_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_FRU_ID_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8069,9 +6886,6 @@ impl Default for STORAGE_GET_BC_PROPERTIES_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_GET_BC_PROPERTIES_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_HOTPLUG_INFO {
@@ -8086,9 +6900,6 @@ impl Default for STORAGE_HOTPLUG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_HOTPLUG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_HW_ENDURANCE_DATA_DESCRIPTOR {
@@ -8100,9 +6911,6 @@ impl Default for STORAGE_HW_ENDURANCE_DATA_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_HW_ENDURANCE_DATA_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8119,9 +6927,6 @@ impl Default for STORAGE_HW_ENDURANCE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_HW_ENDURANCE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_HW_ENDURANCE_INFO_0 {
@@ -8131,9 +6936,6 @@ impl Default for STORAGE_HW_ENDURANCE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_HW_ENDURANCE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8148,9 +6950,6 @@ impl Default for STORAGE_HW_FIRMWARE_ACTIVATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_HW_FIRMWARE_ACTIVATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8168,9 +6967,6 @@ impl Default for STORAGE_HW_FIRMWARE_DOWNLOAD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_HW_FIRMWARE_DOWNLOAD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8190,9 +6986,6 @@ impl Default for STORAGE_HW_FIRMWARE_DOWNLOAD_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_HW_FIRMWARE_DOWNLOAD_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8214,9 +7007,6 @@ impl Default for STORAGE_HW_FIRMWARE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_HW_FIRMWARE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_HW_FIRMWARE_INFO_QUERY {
@@ -8229,9 +7019,6 @@ impl Default for STORAGE_HW_FIRMWARE_INFO_QUERY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_HW_FIRMWARE_INFO_QUERY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_HW_FIRMWARE_INVALID_SLOT: u32 = 255u32;
 pub const STORAGE_HW_FIRMWARE_REQUEST_FLAG_CONTROLLER: u32 = 1u32;
@@ -8255,9 +7042,6 @@ impl Default for STORAGE_HW_FIRMWARE_SLOT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_HW_FIRMWARE_SLOT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_IDENTIFIER {
@@ -8272,9 +7056,6 @@ impl Default for STORAGE_IDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8295,9 +7076,6 @@ impl Default for STORAGE_IDLE_POWER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_IDLE_POWER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_IDLE_POWERUP_REASON {
@@ -8309,9 +7087,6 @@ impl Default for STORAGE_IDLE_POWERUP_REASON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_IDLE_POWERUP_REASON {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_IDLE_POWERUP_REASON_VERSION_V1: u32 = 1u32;
 #[repr(transparent)]
@@ -8334,9 +7109,6 @@ impl Default for STORAGE_LB_PROVISIONING_MAP_RESOURCES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_LB_PROVISIONING_MAP_RESOURCES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_MEDIA_SERIAL_NUMBER_DATA {
@@ -8348,9 +7120,6 @@ impl Default for STORAGE_MEDIA_SERIAL_NUMBER_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_MEDIA_SERIAL_NUMBER_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8366,9 +7135,6 @@ impl Default for STORAGE_MEDIUM_PRODUCT_TYPE_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_MEDIUM_PRODUCT_TYPE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8389,9 +7155,6 @@ impl Default for STORAGE_MINIPORT_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_MINIPORT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_MINIPORT_DESCRIPTOR_0 {
@@ -8403,9 +7166,6 @@ impl Default for STORAGE_MINIPORT_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_MINIPORT_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_MINIPORT_DESCRIPTOR_0_0 {
@@ -8415,9 +7175,6 @@ impl Default for STORAGE_MINIPORT_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_MINIPORT_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_OFFLOAD_MAX_TOKEN_LENGTH: u32 = 512u32;
 #[repr(C)]
@@ -8434,9 +7191,6 @@ impl Default for STORAGE_OFFLOAD_READ_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_OFFLOAD_READ_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STORAGE_OFFLOAD_READ_RANGE_TRUNCATED: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8451,9 +7205,6 @@ impl Default for STORAGE_OFFLOAD_TOKEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_OFFLOAD_TOKEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_OFFLOAD_TOKEN_0 {
@@ -8465,9 +7216,6 @@ impl Default for STORAGE_OFFLOAD_TOKEN_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_OFFLOAD_TOKEN_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_OFFLOAD_TOKEN_0_0 {
@@ -8477,9 +7225,6 @@ impl Default for STORAGE_OFFLOAD_TOKEN_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_OFFLOAD_TOKEN_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_OFFLOAD_TOKEN_ID_LENGTH: u32 = 504u32;
 pub const STORAGE_OFFLOAD_TOKEN_INVALID: u32 = 2u32;
@@ -8496,9 +7241,6 @@ impl Default for STORAGE_OFFLOAD_WRITE_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_OFFLOAD_WRITE_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STORAGE_OFFLOAD_WRITE_RANGE_TRUNCATED: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8513,9 +7255,6 @@ impl Default for STORAGE_OPERATIONAL_REASON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_OPERATIONAL_REASON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_OPERATIONAL_REASON_0 {
@@ -8527,9 +7266,6 @@ impl Default for STORAGE_OPERATIONAL_REASON_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_OPERATIONAL_REASON_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8543,9 +7279,6 @@ impl Default for STORAGE_OPERATIONAL_REASON_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_OPERATIONAL_REASON_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_OPERATIONAL_REASON_0_0 {
@@ -8558,9 +7291,6 @@ impl Default for STORAGE_OPERATIONAL_REASON_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_OPERATIONAL_REASON_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8585,9 +7315,6 @@ impl Default for STORAGE_PHYSICAL_ADAPTER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_PHYSICAL_ADAPTER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct STORAGE_PHYSICAL_DEVICE_DATA {
@@ -8609,9 +7336,6 @@ impl Default for STORAGE_PHYSICAL_DEVICE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_PHYSICAL_DEVICE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_PHYSICAL_NODE_DATA {
@@ -8629,9 +7353,6 @@ impl Default for STORAGE_PHYSICAL_NODE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_PHYSICAL_NODE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_PHYSICAL_TOPOLOGY_DESCRIPTOR {
@@ -8645,9 +7366,6 @@ impl Default for STORAGE_PHYSICAL_TOPOLOGY_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_PHYSICAL_TOPOLOGY_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8666,9 +7384,6 @@ impl Default for STORAGE_PREDICT_FAILURE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_PREDICT_FAILURE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_PRIORITY_HINT_SUPPORT {
@@ -8678,9 +7393,6 @@ impl Default for STORAGE_PRIORITY_HINT_SUPPORT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_PRIORITY_HINT_SUPPORT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_PRIORITY_HINT_SUPPORTED: u32 = 1u32;
 #[repr(transparent)]
@@ -8698,9 +7410,6 @@ impl Default for STORAGE_PROPERTY_QUERY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_PROPERTY_QUERY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_PROPERTY_SET {
@@ -8712,9 +7421,6 @@ impl Default for STORAGE_PROPERTY_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_PROPERTY_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8747,9 +7453,6 @@ impl Default for STORAGE_PROTOCOL_COMMAND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_PROTOCOL_COMMAND {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STORAGE_PROTOCOL_COMMAND_FLAG_ADAPTER_REQUEST: u32 = 2147483648u32;
 pub const STORAGE_PROTOCOL_COMMAND_LENGTH_NVME: u32 = 64u32;
 #[repr(C)]
@@ -8764,9 +7467,6 @@ impl Default for STORAGE_PROTOCOL_DATA_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_PROTOCOL_DATA_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_PROTOCOL_DATA_DESCRIPTOR_EXT {
@@ -8779,9 +7479,6 @@ impl Default for STORAGE_PROTOCOL_DATA_DESCRIPTOR_EXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_PROTOCOL_DATA_DESCRIPTOR_EXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE {
@@ -8793,9 +7490,6 @@ impl Default for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE_0 {
@@ -8805,9 +7499,6 @@ impl Default for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_PROTOCOL_DATA_SUBVALUE_GET_LOG_PAGE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8831,9 +7522,6 @@ impl Default for STORAGE_PROTOCOL_SPECIFIC_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_PROTOCOL_SPECIFIC_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_PROTOCOL_SPECIFIC_DATA_EXT {
@@ -8854,9 +7542,6 @@ impl Default for STORAGE_PROTOCOL_SPECIFIC_DATA_EXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_PROTOCOL_SPECIFIC_DATA_EXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_PROTOCOL_SPECIFIC_NVME_ADMIN_COMMAND: u32 = 1u32;
 pub const STORAGE_PROTOCOL_SPECIFIC_NVME_NVM_COMMAND: u32 = 2u32;
@@ -8892,10 +7577,6 @@ impl Default for STORAGE_QUERY_DEPENDENT_VOLUME_LEV1_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_Vhd")]
-impl windows_core::TypeKind for STORAGE_QUERY_DEPENDENT_VOLUME_LEV1_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_Vhd")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8920,10 +7601,6 @@ impl Default for STORAGE_QUERY_DEPENDENT_VOLUME_LEV2_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_Vhd")]
-impl windows_core::TypeKind for STORAGE_QUERY_DEPENDENT_VOLUME_LEV2_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_QUERY_DEPENDENT_VOLUME_REQUEST {
@@ -8934,9 +7611,6 @@ impl Default for STORAGE_QUERY_DEPENDENT_VOLUME_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_QUERY_DEPENDENT_VOLUME_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_Vhd")]
@@ -8952,10 +7626,6 @@ impl Default for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_Vhd")]
-impl windows_core::TypeKind for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_Vhd")]
 #[derive(Clone, Copy)]
@@ -8968,10 +7638,6 @@ impl Default for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_Vhd")]
-impl windows_core::TypeKind for STORAGE_QUERY_DEPENDENT_VOLUME_RESPONSE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8990,9 +7656,6 @@ impl Default for STORAGE_READ_CAPACITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_READ_CAPACITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_REINITIALIZE_MEDIA {
@@ -9006,9 +7669,6 @@ impl Default for STORAGE_REINITIALIZE_MEDIA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_REINITIALIZE_MEDIA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_REINITIALIZE_MEDIA_0 {
@@ -9018,9 +7678,6 @@ impl Default for STORAGE_REINITIALIZE_MEDIA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_REINITIALIZE_MEDIA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9046,9 +7703,6 @@ impl Default for STORAGE_RPMB_DATA_FRAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_RPMB_DATA_FRAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_RPMB_DESCRIPTOR {
@@ -9062,9 +7716,6 @@ impl Default for STORAGE_RPMB_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_RPMB_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_RPMB_DESCRIPTOR_VERSION_1: u32 = 1u32;
 #[repr(transparent)]
@@ -9088,9 +7739,6 @@ impl Default for STORAGE_SPEC_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_SPEC_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct STORAGE_SPEC_VERSION_0 {
@@ -9101,9 +7749,6 @@ impl Default for STORAGE_SPEC_VERSION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_SPEC_VERSION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9116,9 +7761,6 @@ impl Default for STORAGE_SPEC_VERSION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_SPEC_VERSION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_SPEC_VERSION_0_0_0 {
@@ -9129,9 +7771,6 @@ impl Default for STORAGE_SPEC_VERSION_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_SPEC_VERSION_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_SUPPORTED_FEATURES_BYPASS_IO: u32 = 1u32;
 pub const STORAGE_SUPPORTED_FEATURES_MASK: u32 = 1u32;
@@ -9152,9 +7791,6 @@ impl Default for STORAGE_TEMPERATURE_DATA_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_TEMPERATURE_DATA_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_TEMPERATURE_INFO {
@@ -9173,9 +7809,6 @@ impl Default for STORAGE_TEMPERATURE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_TEMPERATURE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_TEMPERATURE_THRESHOLD {
@@ -9191,9 +7824,6 @@ impl Default for STORAGE_TEMPERATURE_THRESHOLD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_TEMPERATURE_THRESHOLD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STORAGE_TEMPERATURE_THRESHOLD_FLAG_ADAPTER_REQUEST: u32 = 1u32;
 pub const STORAGE_TEMPERATURE_VALUE_NOT_REPORTED: u32 = 32768u32;
@@ -9212,9 +7842,6 @@ impl Default for STORAGE_TIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_TIER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9241,9 +7868,6 @@ impl Default for STORAGE_TIER_REGION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_TIER_REGION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_WRITE_CACHE_PROPERTY {
@@ -9262,9 +7886,6 @@ impl Default for STORAGE_WRITE_CACHE_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_WRITE_CACHE_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR {
@@ -9281,9 +7902,6 @@ impl Default for STORAGE_ZONED_DEVICE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_ZONED_DEVICE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
@@ -9294,9 +7912,6 @@ impl Default for STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_ZONED_DEVICE_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9309,9 +7924,6 @@ impl Default for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
@@ -9323,9 +7935,6 @@ impl Default for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_ZONED_DEVICE_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9352,9 +7961,6 @@ impl Default for STORAGE_ZONE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STORAGE_ZONE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STORAGE_ZONE_GROUP {
@@ -9366,9 +7972,6 @@ impl Default for STORAGE_ZONE_GROUP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STORAGE_ZONE_GROUP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9387,9 +7990,6 @@ impl Default for STREAMS_ASSOCIATE_ID_INPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STREAMS_ASSOCIATE_ID_INPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STREAMS_ASSOCIATE_ID_SET: u32 = 2u32;
 pub const STREAMS_INVALID_ID: u32 = 0u32;
 pub const STREAMS_MAX_ID: u32 = 65535u32;
@@ -9402,9 +8002,6 @@ impl Default for STREAMS_QUERY_ID_OUTPUT_BUFFER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STREAMS_QUERY_ID_OUTPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9419,9 +8016,6 @@ impl Default for STREAMS_QUERY_PARAMETERS_OUTPUT_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STREAMS_QUERY_PARAMETERS_OUTPUT_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STREAM_CLEAR_ENCRYPTION: u32 = 4u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9434,9 +8028,6 @@ impl Default for STREAM_EXTENT_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STREAM_EXTENT_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STREAM_EXTENT_ENTRY_0 {
@@ -9446,9 +8037,6 @@ impl Default for STREAM_EXTENT_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STREAM_EXTENT_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STREAM_EXTENT_ENTRY_ALL_EXTENTS: u32 = 2u32;
 pub const STREAM_EXTENT_ENTRY_AS_RETRIEVAL_POINTERS: u32 = 1u32;
@@ -9464,9 +8052,6 @@ impl Default for STREAM_INFORMATION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STREAM_INFORMATION_ENTRY_0 {
@@ -9479,9 +8064,6 @@ impl Default for STREAM_INFORMATION_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9496,9 +8078,6 @@ impl Default for STREAM_INFORMATION_ENTRY_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STREAM_INFORMATION_ENTRY_0_0 {
@@ -9509,9 +8088,6 @@ impl Default for STREAM_INFORMATION_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9526,9 +8102,6 @@ impl Default for STREAM_INFORMATION_ENTRY_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STREAM_INFORMATION_ENTRY_0_2 {
@@ -9541,9 +8114,6 @@ impl Default for STREAM_INFORMATION_ENTRY_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STREAM_INFORMATION_ENTRY_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9564,9 +8134,6 @@ impl Default for STREAM_LAYOUT_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STREAM_LAYOUT_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STREAM_LAYOUT_ENTRY_HAS_INFORMATION: u32 = 16u32;
 pub const STREAM_LAYOUT_ENTRY_IMMOVABLE: u32 = 1u32;
@@ -9826,9 +8393,6 @@ impl Default for TAPE_GET_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TAPE_GET_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TAPE_RESET_STATISTICS: i32 = 2i32;
 pub const TAPE_RETURN_ENV_INFO: i32 = 1i32;
 pub const TAPE_RETURN_STATISTICS: i32 = 0i32;
@@ -9848,9 +8412,6 @@ impl Default for TAPE_STATISTICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TAPE_STATISTICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TCCollectionApplicationRequested: DEVICEDUMP_COLLECTION_TYPEIDE_NOTIFICATION_TYPE = DEVICEDUMP_COLLECTION_TYPEIDE_NOTIFICATION_TYPE(2i32);
 pub const TCCollectionBugCheck: DEVICEDUMP_COLLECTION_TYPEIDE_NOTIFICATION_TYPE = DEVICEDUMP_COLLECTION_TYPEIDE_NOTIFICATION_TYPE(1i32);
@@ -9875,9 +8436,6 @@ impl Default for TXFS_CREATE_MINIVERSION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TXFS_CREATE_MINIVERSION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TXFS_GET_METADATA_INFO_OUT {
@@ -9891,9 +8449,6 @@ impl Default for TXFS_GET_METADATA_INFO_OUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TXFS_GET_METADATA_INFO_OUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TXFS_GET_METADATA_INFO_OUT_0 {
@@ -9904,9 +8459,6 @@ impl Default for TXFS_GET_METADATA_INFO_OUT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXFS_GET_METADATA_INFO_OUT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9922,9 +8474,6 @@ impl Default for TXFS_GET_TRANSACTED_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TXFS_GET_TRANSACTED_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TXFS_LIST_TRANSACTIONS {
@@ -9935,9 +8484,6 @@ impl Default for TXFS_LIST_TRANSACTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXFS_LIST_TRANSACTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9953,9 +8499,6 @@ impl Default for TXFS_LIST_TRANSACTIONS_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TXFS_LIST_TRANSACTIONS_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TXFS_LIST_TRANSACTION_LOCKED_FILES {
@@ -9968,9 +8511,6 @@ impl Default for TXFS_LIST_TRANSACTION_LOCKED_FILES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXFS_LIST_TRANSACTION_LOCKED_FILES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9987,9 +8527,6 @@ impl Default for TXFS_LIST_TRANSACTION_LOCKED_FILES_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXFS_LIST_TRANSACTION_LOCKED_FILES_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TXFS_LIST_TRANSACTION_LOCKED_FILES_ENTRY_FLAG_CREATED: u32 = 1u32;
 pub const TXFS_LIST_TRANSACTION_LOCKED_FILES_ENTRY_FLAG_DELETED: u32 = 2u32;
@@ -10011,9 +8548,6 @@ impl Default for TXFS_MODIFY_RM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXFS_MODIFY_RM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10050,9 +8584,6 @@ impl Default for TXFS_QUERY_RM_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TXFS_QUERY_RM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct TXFS_READ_BACKUP_INFORMATION_OUT {
@@ -10062,9 +8593,6 @@ impl Default for TXFS_READ_BACKUP_INFORMATION_OUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXFS_READ_BACKUP_INFORMATION_OUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10076,9 +8604,6 @@ impl Default for TXFS_READ_BACKUP_INFORMATION_OUT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXFS_READ_BACKUP_INFORMATION_OUT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10152,9 +8677,6 @@ impl Default for TXFS_ROLLFORWARD_REDO_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TXFS_ROLLFORWARD_REDO_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TXFS_SAVEPOINT_CLEAR: u32 = 4u32;
 pub const TXFS_SAVEPOINT_CLEAR_ALL: u32 = 16u32;
 #[repr(C)]
@@ -10168,9 +8690,6 @@ impl Default for TXFS_SAVEPOINT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXFS_SAVEPOINT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TXFS_SAVEPOINT_ROLLBACK: u32 = 2u32;
 pub const TXFS_SAVEPOINT_SET: u32 = 1u32;
@@ -10208,9 +8727,6 @@ impl Default for TXFS_START_RM_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TXFS_START_RM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TXFS_TRANSACTED_VERSION_NONTRANSACTED: u32 = 4294967294u32;
 pub const TXFS_TRANSACTED_VERSION_UNCOMMITTED: u32 = 4294967295u32;
 #[repr(C)]
@@ -10222,9 +8738,6 @@ impl Default for TXFS_TRANSACTION_ACTIVE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXFS_TRANSACTION_ACTIVE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TXFS_TRANSACTION_STATE_ACTIVE: u32 = 1u32;
 pub const TXFS_TRANSACTION_STATE_NONE: u32 = 0u32;
@@ -10239,9 +8752,6 @@ impl Default for TXFS_WRITE_BACKUP_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TXFS_WRITE_BACKUP_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const Travan: STORAGE_MEDIA_TYPE = STORAGE_MEDIA_TYPE(34i32);
 pub const UNDEFINE_ALTERNATE: u32 = 13u32;
@@ -10304,9 +8814,6 @@ impl Default for USN_JOURNAL_DATA_V0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USN_JOURNAL_DATA_V0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USN_JOURNAL_DATA_V1 {
@@ -10324,9 +8831,6 @@ impl Default for USN_JOURNAL_DATA_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USN_JOURNAL_DATA_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10349,9 +8853,6 @@ impl Default for USN_JOURNAL_DATA_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USN_JOURNAL_DATA_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USN_PAGE_SIZE: u32 = 4096u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10362,9 +8863,6 @@ impl Default for USN_RANGE_TRACK_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USN_RANGE_TRACK_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const USN_REASON_BASIC_INFO_CHANGE: u32 = 32768u32;
 pub const USN_REASON_CLOSE: u32 = 2147483648u32;
@@ -10402,9 +8900,6 @@ impl Default for USN_RECORD_COMMON_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USN_RECORD_COMMON_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct USN_RECORD_EXTENT {
@@ -10415,9 +8910,6 @@ impl Default for USN_RECORD_EXTENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USN_RECORD_EXTENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -10433,10 +8925,6 @@ impl Default for USN_RECORD_UNION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for USN_RECORD_UNION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10460,9 +8948,6 @@ impl Default for USN_RECORD_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USN_RECORD_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
@@ -10489,10 +8974,6 @@ impl Default for USN_RECORD_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for USN_RECORD_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10514,10 +8995,6 @@ impl Default for USN_RECORD_V4 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for USN_RECORD_V4 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USN_SOURCE_AUXILIARY_DATA: USN_SOURCE_INFO_ID = USN_SOURCE_INFO_ID(2u32);
 pub const USN_SOURCE_CLIENT_REPLICATION_MANAGEMENT: USN_SOURCE_INFO_ID = USN_SOURCE_INFO_ID(8u32);
 pub const USN_SOURCE_DATA_MANAGEMENT: USN_SOURCE_INFO_ID = USN_SOURCE_INFO_ID(1u32);
@@ -10537,9 +9014,6 @@ impl Default for USN_TRACK_MODIFIED_RANGES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USN_TRACK_MODIFIED_RANGES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UfsDataTypeMax: STORAGE_PROTOCOL_UFS_DATA_TYPE = STORAGE_PROTOCOL_UFS_DATA_TYPE(6i32);
 pub const UfsDataTypeQueryAttribute: STORAGE_PROTOCOL_UFS_DATA_TYPE = STORAGE_PROTOCOL_UFS_DATA_TYPE(2i32);
@@ -10562,9 +9036,6 @@ impl Default for VERIFY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VERIFY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUALIZATION_INSTANCE_INFO_INPUT {
@@ -10575,9 +9046,6 @@ impl Default for VIRTUALIZATION_INSTANCE_INFO_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUALIZATION_INSTANCE_INFO_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10593,9 +9061,6 @@ impl Default for VIRTUALIZATION_INSTANCE_INFO_INPUT_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUALIZATION_INSTANCE_INFO_INPUT_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VIRTUALIZATION_INSTANCE_INFO_OUTPUT {
@@ -10605,9 +9070,6 @@ impl Default for VIRTUALIZATION_INSTANCE_INFO_OUTPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VIRTUALIZATION_INSTANCE_INFO_OUTPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10623,9 +9085,6 @@ impl Default for VIRTUAL_STORAGE_SET_BEHAVIOR_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VIRTUAL_STORAGE_SET_BEHAVIOR_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_BITMAP_BUFFER {
@@ -10638,9 +9097,6 @@ impl Default for VOLUME_BITMAP_BUFFER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VOLUME_BITMAP_BUFFER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_DISK_EXTENTS {
@@ -10652,9 +9108,6 @@ impl Default for VOLUME_DISK_EXTENTS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VOLUME_DISK_EXTENTS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VOLUME_GET_GPT_ATTRIBUTES_INFORMATION {
@@ -10664,9 +9117,6 @@ impl Default for VOLUME_GET_GPT_ATTRIBUTES_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VOLUME_GET_GPT_ATTRIBUTES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VOLUME_IS_DIRTY: u32 = 1u32;
 pub const VOLUME_SESSION_OPEN: u32 = 4u32;
@@ -10692,9 +9142,6 @@ impl Default for WIM_PROVIDER_ADD_OVERLAY_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIM_PROVIDER_ADD_OVERLAY_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WIM_PROVIDER_CURRENT_VERSION: u32 = 1u32;
 pub const WIM_PROVIDER_EXTERNAL_FLAG_NOT_ACTIVE: u32 = 1u32;
 pub const WIM_PROVIDER_EXTERNAL_FLAG_SUSPENDED: u32 = 2u32;
@@ -10710,9 +9157,6 @@ impl Default for WIM_PROVIDER_EXTERNAL_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIM_PROVIDER_EXTERNAL_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10730,9 +9174,6 @@ impl Default for WIM_PROVIDER_OVERLAY_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIM_PROVIDER_OVERLAY_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIM_PROVIDER_REMOVE_OVERLAY_INPUT {
@@ -10743,9 +9184,6 @@ impl Default for WIM_PROVIDER_REMOVE_OVERLAY_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIM_PROVIDER_REMOVE_OVERLAY_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIM_PROVIDER_SUSPEND_OVERLAY_INPUT {
@@ -10755,9 +9193,6 @@ impl Default for WIM_PROVIDER_SUSPEND_OVERLAY_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIM_PROVIDER_SUSPEND_OVERLAY_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10770,9 +9205,6 @@ impl Default for WIM_PROVIDER_UPDATE_OVERLAY_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIM_PROVIDER_UPDATE_OVERLAY_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WMI_DISK_GEOMETRY_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x25007f51_57c2_11d1_a528_00a0c9062910);
 pub const WOF_CURRENT_VERSION: u32 = 1u32;
@@ -10788,10 +9220,6 @@ impl Default for WOF_EXTERNAL_FILE_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Storage_FileSystem")]
-impl windows_core::TypeKind for WOF_EXTERNAL_FILE_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WOF_EXTERNAL_INFO {
@@ -10803,9 +9231,6 @@ impl Default for WOF_EXTERNAL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WOF_EXTERNAL_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WOF_PROVIDER_CLOUD: u32 = 3u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10816,9 +9241,6 @@ impl Default for WOF_VERSION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WOF_VERSION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10843,9 +9265,6 @@ impl Default for WRITE_USN_REASON_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WRITE_USN_REASON_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WriteCacheChangeUnknown: WRITE_CACHE_CHANGE = WRITE_CACHE_CHANGE(0i32);
 pub const WriteCacheChangeable: WRITE_CACHE_CHANGE = WRITE_CACHE_CHANGE(2i32);

--- a/crates/libs/windows/src/Windows/Win32/System/JobObjects/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/JobObjects/mod.rs
@@ -108,9 +108,6 @@ impl Default for JOBOBJECT_ASSOCIATE_COMPLETION_PORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_ASSOCIATE_COMPLETION_PORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOBOBJECT_BASIC_ACCOUNTING_INFORMATION {
@@ -128,9 +125,6 @@ impl Default for JOBOBJECT_BASIC_ACCOUNTING_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_BASIC_ACCOUNTING_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Threading")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -143,10 +137,6 @@ impl Default for JOBOBJECT_BASIC_AND_IO_ACCOUNTING_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Threading")]
-impl windows_core::TypeKind for JOBOBJECT_BASIC_AND_IO_ACCOUNTING_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -166,9 +156,6 @@ impl Default for JOBOBJECT_BASIC_LIMIT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_BASIC_LIMIT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOBOBJECT_BASIC_PROCESS_ID_LIST {
@@ -181,9 +168,6 @@ impl Default for JOBOBJECT_BASIC_PROCESS_ID_LIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_BASIC_PROCESS_ID_LIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOBOBJECT_BASIC_UI_RESTRICTIONS {
@@ -193,9 +177,6 @@ impl Default for JOBOBJECT_BASIC_UI_RESTRICTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_BASIC_UI_RESTRICTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -207,9 +188,6 @@ impl Default for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -223,9 +201,6 @@ impl Default for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0_0 {
@@ -237,9 +212,6 @@ impl Default for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_CPU_RATE_CONTROL_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOBOBJECT_END_OF_JOB_TIME_INFORMATION {
@@ -249,9 +221,6 @@ impl Default for JOBOBJECT_END_OF_JOB_TIME_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_END_OF_JOB_TIME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Threading")]
@@ -269,10 +238,6 @@ impl Default for JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Threading")]
-impl windows_core::TypeKind for JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JOBOBJECT_IO_ATTRIBUTION_CONTROL_DISABLE: JOBOBJECT_IO_ATTRIBUTION_CONTROL_FLAGS = JOBOBJECT_IO_ATTRIBUTION_CONTROL_FLAGS(2i32);
 pub const JOBOBJECT_IO_ATTRIBUTION_CONTROL_ENABLE: JOBOBJECT_IO_ATTRIBUTION_CONTROL_FLAGS = JOBOBJECT_IO_ATTRIBUTION_CONTROL_FLAGS(1i32);
@@ -292,9 +257,6 @@ impl Default for JOBOBJECT_IO_ATTRIBUTION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_IO_ATTRIBUTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOBOBJECT_IO_ATTRIBUTION_STATS {
@@ -307,9 +269,6 @@ impl Default for JOBOBJECT_IO_ATTRIBUTION_STATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_IO_ATTRIBUTION_STATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -326,9 +285,6 @@ impl Default for JOBOBJECT_IO_RATE_CONTROL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_IO_RATE_CONTROL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V1 {
@@ -344,9 +300,6 @@ impl Default for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -369,9 +322,6 @@ impl Default for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -401,9 +351,6 @@ impl Default for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_IO_RATE_CONTROL_INFORMATION_NATIVE_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JOBOBJECT_JOBSET_INFORMATION {
@@ -413,9 +360,6 @@ impl Default for JOBOBJECT_JOBSET_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_JOBSET_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -437,9 +381,6 @@ impl Default for JOBOBJECT_LIMIT_VIOLATION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_LIMIT_VIOLATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -467,9 +408,6 @@ impl Default for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_0 {
@@ -480,9 +418,6 @@ impl Default for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -495,9 +430,6 @@ impl Default for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_2 {
@@ -508,9 +440,6 @@ impl Default for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_LIMIT_VIOLATION_INFORMATION_2_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -523,9 +452,6 @@ impl Default for JOBOBJECT_NET_RATE_CONTROL_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_NET_RATE_CONTROL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -542,9 +468,6 @@ impl Default for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -567,9 +490,6 @@ impl Default for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_0 {
@@ -580,9 +500,6 @@ impl Default for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -595,9 +512,6 @@ impl Default for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_2 {
@@ -608,9 +522,6 @@ impl Default for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOBOBJECT_NOTIFICATION_LIMIT_INFORMATION_2_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -633,10 +544,6 @@ impl Default for JOBOBJECT_SECURITY_LIMIT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for JOBOBJECT_SECURITY_LIMIT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JOB_OBJECT_BASIC_LIMIT_VALID_FLAGS: JOB_OBJECT_LIMIT = JOB_OBJECT_LIMIT(255u32);
 #[repr(transparent)]
@@ -926,9 +833,6 @@ impl Default for JOB_SET_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JOB_SET_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const JobObjectAssociateCompletionPortInformation: JOBOBJECTINFOCLASS = JOBOBJECTINFOCLASS(7i32);
 pub const JobObjectBasicAccountingInformation: JOBOBJECTINFOCLASS = JOBOBJECTINFOCLASS(1i32);

--- a/crates/libs/windows/src/Windows/Win32/System/Kernel/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Kernel/mod.rs
@@ -52,9 +52,6 @@ impl Default for CSTRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CSTRING {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CommunicationServer: SUITE_TYPE = SUITE_TYPE(3i32);
 pub const ComputeServer: SUITE_TYPE = SUITE_TYPE(14i32);
 pub const DEFAULT_COMPARTMENT_ID: COMPARTMENT_ID = COMPARTMENT_ID(1i32);
@@ -77,10 +74,6 @@ impl Default for EXCEPTION_REGISTRATION_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for EXCEPTION_REGISTRATION_RECORD {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 pub type EXCEPTION_ROUTINE = Option<unsafe extern "system" fn(exceptionrecord: *mut super::Diagnostics::Debug::EXCEPTION_RECORD, establisherframe: *const core::ffi::c_void, contextrecord: *mut super::Diagnostics::Debug::CONTEXT, dispatchercontext: *const core::ffi::c_void) -> EXCEPTION_DISPOSITION>;
@@ -111,10 +104,6 @@ impl Default for FLOATING_SAVE_AREA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FLOATING_SAVE_AREA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -135,10 +124,6 @@ impl Default for FLOATING_SAVE_AREA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FLOATING_SAVE_AREA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LIST_ENTRY {
@@ -149,9 +134,6 @@ impl Default for LIST_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LIST_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -164,9 +146,6 @@ impl Default for LIST_ENTRY32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LIST_ENTRY32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LIST_ENTRY64 {
@@ -177,9 +156,6 @@ impl Default for LIST_ENTRY64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LIST_ENTRY64 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MAXUCHAR: u32 = 255u32;
 pub const MAXULONG: u32 = 4294967295u32;
@@ -207,10 +183,6 @@ impl Default for NT_TIB {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for NT_TIB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Diagnostics_Debug")]
 #[derive(Clone, Copy)]
@@ -223,10 +195,6 @@ impl Default for NT_TIB_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Diagnostics_Debug")]
-impl windows_core::TypeKind for NT_TIB_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NULL64: u32 = 0u32;
 pub const NotificationEvent: EVENT_TYPE = EVENT_TYPE(0i32);
@@ -245,9 +213,6 @@ impl Default for OBJECTID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OBJECTID {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OBJ_HANDLE_TAGBITS: i32 = 3i32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -261,9 +226,6 @@ impl Default for PROCESSOR_NUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSOR_NUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const Personal: SUITE_TYPE = SUITE_TYPE(9i32);
 pub const PhoneNT: SUITE_TYPE = SUITE_TYPE(16i32);
 #[repr(C)]
@@ -276,9 +238,6 @@ impl Default for QUAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUAD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union QUAD_0 {
@@ -289,9 +248,6 @@ impl Default for QUAD_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUAD_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -304,9 +260,6 @@ impl Default for RTL_BALANCED_NODE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_BALANCED_NODE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RTL_BALANCED_NODE_0 {
@@ -317,9 +270,6 @@ impl Default for RTL_BALANCED_NODE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTL_BALANCED_NODE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -332,9 +282,6 @@ impl Default for RTL_BALANCED_NODE_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RTL_BALANCED_NODE_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RTL_BALANCED_NODE_1 {
@@ -345,9 +292,6 @@ impl Default for RTL_BALANCED_NODE_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTL_BALANCED_NODE_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RTL_BALANCED_NODE_RESERVED_PARENT_MASK: u32 = 3u32;
 #[repr(C)]
@@ -360,9 +304,6 @@ impl Default for SINGLE_LIST_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SINGLE_LIST_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SINGLE_LIST_ENTRY32 {
@@ -373,9 +314,6 @@ impl Default for SINGLE_LIST_ENTRY32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SINGLE_LIST_ENTRY32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SLIST_ENTRY {
@@ -385,9 +323,6 @@ impl Default for SLIST_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SLIST_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -401,10 +336,6 @@ impl Default for SLIST_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SLIST_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -420,10 +351,6 @@ impl Default for SLIST_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SLIST_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -436,10 +363,6 @@ impl Default for SLIST_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SLIST_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -454,10 +377,6 @@ impl Default for SLIST_HEADER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SLIST_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -470,10 +389,6 @@ impl Default for SLIST_HEADER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SLIST_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "aarch64")]
@@ -488,10 +403,6 @@ impl Default for SLIST_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "aarch64")]
-impl windows_core::TypeKind for SLIST_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "aarch64")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -504,10 +415,6 @@ impl Default for SLIST_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "aarch64")]
-impl windows_core::TypeKind for SLIST_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "aarch64")]
@@ -522,10 +429,6 @@ impl Default for SLIST_HEADER_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "aarch64")]
-impl windows_core::TypeKind for SLIST_HEADER_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STRING {
@@ -537,9 +440,6 @@ impl Default for STRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STRING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -553,9 +453,6 @@ impl Default for STRING32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STRING32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STRING64 {
@@ -567,9 +464,6 @@ impl Default for STRING64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STRING64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -599,9 +493,6 @@ impl Default for WNF_STATE_NAME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WNF_STATE_NAME {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WaitAll: WAIT_TYPE = WAIT_TYPE(0i32);
 pub const WaitAny: WAIT_TYPE = WAIT_TYPE(1i32);

--- a/crates/libs/windows/src/Windows/Win32/System/LibraryLoader/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/LibraryLoader/mod.rs
@@ -387,9 +387,6 @@ impl Default for ENUMUILANG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENUMUILANG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FIND_RESOURCE_DIRECTORY_LANGUAGES: u32 = 1024u32;
 pub const FIND_RESOURCE_DIRECTORY_NAMES: u32 = 512u32;
 pub const FIND_RESOURCE_DIRECTORY_TYPES: u32 = 256u32;
@@ -460,9 +457,6 @@ impl Default for REDIRECTION_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REDIRECTION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct REDIRECTION_FUNCTION_DESCRIPTOR {
@@ -474,9 +468,6 @@ impl Default for REDIRECTION_FUNCTION_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REDIRECTION_FUNCTION_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RESOURCE_ENUM_LN: u32 = 1u32;
 pub const RESOURCE_ENUM_MODULE_EXACT: u32 = 16u32;

--- a/crates/libs/windows/src/Windows/Win32/System/Mapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Mapi/mod.rs
@@ -85,9 +85,6 @@ impl Default for MapiFileDesc {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MapiFileDesc {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MapiFileDescW {
@@ -103,9 +100,6 @@ impl Default for MapiFileDescW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MapiFileDescW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MapiFileTagExt {
@@ -119,9 +113,6 @@ impl Default for MapiFileTagExt {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MapiFileTagExt {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -144,9 +135,6 @@ impl Default for MapiMessage {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MapiMessage {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MapiMessageW {
@@ -168,9 +156,6 @@ impl Default for MapiMessageW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MapiMessageW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MapiRecipDesc {
@@ -186,9 +171,6 @@ impl Default for MapiRecipDesc {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MapiRecipDesc {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MapiRecipDescW {
@@ -203,8 +185,5 @@ impl Default for MapiRecipDescW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MapiRecipDescW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SUCCESS_SUCCESS: u32 = 0u32;

--- a/crates/libs/windows/src/Windows/Win32/System/Memory/NonVolatile/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Memory/NonVolatile/mod.rs
@@ -51,6 +51,3 @@ impl Default for NV_MEMORY_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NV_MEMORY_RANGE {
-    type TypeKind = windows_core::CopyType;
-}

--- a/crates/libs/windows/src/Windows/Win32/System/Memory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Memory/mod.rs
@@ -620,9 +620,6 @@ impl Default for CFG_CALL_TARGET_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CFG_CALL_TARGET_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const FILE_CACHE_MAX_HARD_DISABLE: u32 = 2u32;
 pub const FILE_CACHE_MAX_HARD_ENABLE: u32 = 1u32;
 pub const FILE_CACHE_MIN_HARD_DISABLE: u32 = 8u32;
@@ -779,9 +776,6 @@ impl Default for HEAP_SUMMARY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HEAP_SUMMARY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HEAP_TAG_SHIFT: HEAP_FLAGS = HEAP_FLAGS(18u32);
 pub const HEAP_TAIL_CHECKING_ENABLED: HEAP_FLAGS = HEAP_FLAGS(32u32);
 pub const HEAP_ZERO_MEMORY: HEAP_FLAGS = HEAP_FLAGS(8u32);
@@ -851,10 +845,6 @@ impl Default for MEMORY_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for MEMORY_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -874,10 +864,6 @@ impl Default for MEMORY_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MEMORY_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MEMORY_BASIC_INFORMATION32 {
@@ -893,9 +879,6 @@ impl Default for MEMORY_BASIC_INFORMATION32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEMORY_BASIC_INFORMATION32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -915,9 +898,6 @@ impl Default for MEMORY_BASIC_INFORMATION64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEMORY_BASIC_INFORMATION64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MEMORY_MAPPED_VIEW_ADDRESS {
@@ -927,9 +907,6 @@ impl Default for MEMORY_MAPPED_VIEW_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEMORY_MAPPED_VIEW_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -942,9 +919,6 @@ impl Default for MEMORY_PARTITION_DEDICATED_MEMORY_ATTRIBUTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEMORY_PARTITION_DEDICATED_MEMORY_ATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -962,9 +936,6 @@ impl Default for MEMORY_PARTITION_DEDICATED_MEMORY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEMORY_PARTITION_DEDICATED_MEMORY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MEMORY_RESOURCE_NOTIFICATION_TYPE(pub i32);
@@ -979,9 +950,6 @@ impl Default for MEM_ADDRESS_REQUIREMENTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEM_ADDRESS_REQUIREMENTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MEM_COMMIT: VIRTUAL_ALLOCATION_TYPE = VIRTUAL_ALLOCATION_TYPE(4096u32);
 pub const MEM_DECOMMIT: VIRTUAL_FREE_TYPE = VIRTUAL_FREE_TYPE(16384u32);
@@ -999,9 +967,6 @@ impl Default for MEM_EXTENDED_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEM_EXTENDED_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MEM_EXTENDED_PARAMETER_0 {
@@ -1011,9 +976,6 @@ impl Default for MEM_EXTENDED_PARAMETER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEM_EXTENDED_PARAMETER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1028,9 +990,6 @@ impl Default for MEM_EXTENDED_PARAMETER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEM_EXTENDED_PARAMETER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1194,9 +1153,6 @@ impl Default for PROCESS_HEAP_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_HEAP_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROCESS_HEAP_ENTRY_0 {
@@ -1208,9 +1164,6 @@ impl Default for PROCESS_HEAP_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_HEAP_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_HEAP_ENTRY_0_0 {
@@ -1221,9 +1174,6 @@ impl Default for PROCESS_HEAP_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_HEAP_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1237,9 +1187,6 @@ impl Default for PROCESS_HEAP_ENTRY_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_HEAP_ENTRY_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PSECURE_MEMORY_CACHE_CALLBACK = Option<unsafe extern "system" fn(addr: *const core::ffi::c_void, range: usize) -> super::super::Foundation::BOOLEAN>;
 pub const QUOTA_LIMITS_HARDWS_MAX_DISABLE: SETPROCESSWORKINGSETSIZEEX_FLAGS = SETPROCESSWORKINGSETSIZEEX_FLAGS(8u32);
@@ -1411,9 +1358,6 @@ impl Default for WIN32_MEMORY_PARTITION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIN32_MEMORY_PARTITION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WIN32_MEMORY_PARTITION_INFORMATION_CLASS(pub i32);
@@ -1427,9 +1371,6 @@ impl Default for WIN32_MEMORY_RANGE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIN32_MEMORY_RANGE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1445,9 +1386,6 @@ impl Default for WIN32_MEMORY_REGION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIN32_MEMORY_REGION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WIN32_MEMORY_REGION_INFORMATION_0 {
@@ -1459,9 +1397,6 @@ impl Default for WIN32_MEMORY_REGION_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WIN32_MEMORY_REGION_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WIN32_MEMORY_REGION_INFORMATION_0_0 {
@@ -1471,7 +1406,4 @@ impl Default for WIN32_MEMORY_REGION_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WIN32_MEMORY_REGION_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/mod.rs
@@ -11828,9 +11828,6 @@ impl Default for MQCOLUMNSET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MQCOLUMNSET {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MQCONN_BIND_SOCKET_FAILURE: MQConnectionState = MQConnectionState(-2147483645i32);
 pub const MQCONN_CONNECT_SOCKET_FAILURE: MQConnectionState = MQConnectionState(-2147483644i32);
 pub const MQCONN_CREATE_SOCKET_FAILURE: MQConnectionState = MQConnectionState(-2147483646i32);
@@ -11878,10 +11875,6 @@ impl Default for MQMGMTPROPS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for MQMGMTPROPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MQMSGACKNOWLEDGEMENT(pub i32);
@@ -11926,10 +11919,6 @@ impl Default for MQMSGPROPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for MQMSGPROPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12036,10 +12025,6 @@ impl Default for MQPRIVATEPROPS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for MQPRIVATEPROPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MQPRIVLEVEL(pub i32);
@@ -12062,10 +12047,6 @@ impl Default for MQPROPERTYRESTRICTION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for MQPROPERTYRESTRICTION {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12080,10 +12061,6 @@ impl Default for MQQMPROPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for MQQMPROPS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12136,10 +12113,6 @@ impl Default for MQQUEUEPROPS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for MQQUEUEPROPS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12152,10 +12125,6 @@ impl Default for MQRESTRICTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for MQRESTRICTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MQSEC_CHANGE_QUEUE_PERMISSIONS: MQQUEUEACCESSMASK = MQQUEUEACCESSMASK(262144u32);
 pub const MQSEC_DELETE_JOURNAL_MESSAGE: MQQUEUEACCESSMASK = MQQUEUEACCESSMASK(8u32);
@@ -12187,9 +12156,6 @@ impl Default for MQSORTKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MQSORTKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MQSORTSET {
@@ -12200,9 +12166,6 @@ impl Default for MQSORTSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MQSORTSET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12618,9 +12581,6 @@ impl Default for SEQUENCE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEQUENCE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/MixedReality/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/MixedReality/mod.rs
@@ -11,9 +11,6 @@ impl Default for PERCEPTION_PAYLOAD_FIELD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERCEPTION_PAYLOAD_FIELD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERCEPTION_STATE_STREAM_TIMESTAMPS {
@@ -24,7 +21,4 @@ impl Default for PERCEPTION_STATE_STREAM_TIMESTAMPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERCEPTION_STATE_STREAM_TIMESTAMPS {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Mmc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Mmc/mod.rs
@@ -89,9 +89,6 @@ impl Default for CONTEXTMENUITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONTEXTMENUITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONTEXTMENUITEM2 {
@@ -107,9 +104,6 @@ impl Default for CONTEXTMENUITEM2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONTEXTMENUITEM2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
 windows_core::imp::define_interface!(Column, Column_Vtbl, 0xfd1c5f63_2b16_4d06_9ab3_f45350b940ab);
@@ -4408,9 +4402,6 @@ impl Default for MENUBUTTONDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MENUBUTTONDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MFCC_DISABLE: MMC_FILTER_CHANGE_CODE = MMC_FILTER_CHANGE_CODE(0i32);
 pub const MFCC_ENABLE: MMC_FILTER_CHANGE_CODE = MMC_FILTER_CHANGE_CODE(1i32);
 pub const MFCC_VALUE_CHANGE: MMC_FILTER_CHANGE_CODE = MMC_FILTER_CHANGE_CODE(2i32);
@@ -4428,9 +4419,6 @@ impl Default for MMCBUTTON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMCBUTTON {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MMCC_STANDARD_VIEW_SELECT: MMC_MENU_COMMAND_IDS = MMC_MENU_COMMAND_IDS(-1i32);
 pub const MMCLV_AUTO: i32 = -1i32;
@@ -4503,9 +4491,6 @@ impl Default for MMC_COLUMN_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MMC_COLUMN_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MMC_COLUMN_SET_DATA {
@@ -4517,9 +4502,6 @@ impl Default for MMC_COLUMN_SET_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMC_COLUMN_SET_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4541,9 +4523,6 @@ impl Default for MMC_EXPANDSYNC_STRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MMC_EXPANDSYNC_STRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MMC_EXT_VIEW_DATA {
@@ -4558,9 +4537,6 @@ impl Default for MMC_EXT_VIEW_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MMC_EXT_VIEW_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MMC_FILTERDATA {
@@ -4572,9 +4548,6 @@ impl Default for MMC_FILTERDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMC_FILTERDATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4599,9 +4572,6 @@ impl Default for MMC_LISTPAD_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMC_LISTPAD_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4646,9 +4616,6 @@ impl Default for MMC_RESTORE_VIEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MMC_RESTORE_VIEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MMC_RESULT_VIEW_STYLE(pub i32);
@@ -4679,10 +4646,6 @@ impl Default for MMC_SNAPIN_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for MMC_SNAPIN_PROPERTY {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MMC_SORT_DATA {
@@ -4695,9 +4658,6 @@ impl Default for MMC_SORT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MMC_SORT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MMC_SORT_SET_DATA {
@@ -4709,9 +4669,6 @@ impl Default for MMC_SORT_SET_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMC_SORT_SET_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MMC_STRING_FILTER: MMC_FILTER_TYPE = MMC_FILTER_TYPE(0i32);
 #[repr(C)]
@@ -4728,9 +4685,6 @@ impl Default for MMC_TASK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MMC_TASK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MMC_TASK_0 {
@@ -4743,9 +4697,6 @@ impl Default for MMC_TASK_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MMC_TASK_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MMC_TASK_DISPLAY_BITMAP {
@@ -4756,9 +4707,6 @@ impl Default for MMC_TASK_DISPLAY_BITMAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMC_TASK_DISPLAY_BITMAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4771,9 +4719,6 @@ impl Default for MMC_TASK_DISPLAY_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MMC_TASK_DISPLAY_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MMC_TASK_DISPLAY_OBJECT_0 {
@@ -4784,9 +4729,6 @@ impl Default for MMC_TASK_DISPLAY_OBJECT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMC_TASK_DISPLAY_OBJECT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4799,9 +4741,6 @@ impl Default for MMC_TASK_DISPLAY_SYMBOL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMC_TASK_DISPLAY_SYMBOL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4850,9 +4789,6 @@ impl Default for MMC_VISIBLE_COLUMNS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MMC_VISIBLE_COLUMNS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MMC_WINDOW_COOKIE: i32 = -3i32;
 #[cfg(feature = "Win32_System_Com")]
@@ -5390,9 +5326,6 @@ impl Default for RDCOMPARE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RDCOMPARE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RDITEMHDR {
@@ -5404,9 +5337,6 @@ impl Default for RDITEMHDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RDITEMHDR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RDI_IMAGE: u32 = 4u32;
 pub const RDI_INDENT: u32 = 64u32;
@@ -5433,9 +5363,6 @@ impl Default for RESULTDATAITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESULTDATAITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RESULTFINDINFO {
@@ -5447,9 +5374,6 @@ impl Default for RESULTFINDINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESULTFINDINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 pub struct RESULT_VIEW_TYPE_INFO {
@@ -5468,9 +5392,6 @@ impl Default for RESULT_VIEW_TYPE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESULT_VIEW_TYPE_INFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 pub union RESULT_VIEW_TYPE_INFO_0 {
     pub dwListOptions: u32,
@@ -5487,9 +5408,6 @@ impl Default for RESULT_VIEW_TYPE_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESULT_VIEW_TYPE_INFO_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RESULT_VIEW_TYPE_INFO_0_0 {
@@ -5501,9 +5419,6 @@ impl Default for RESULT_VIEW_TYPE_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESULT_VIEW_TYPE_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct RESULT_VIEW_TYPE_INFO_0_1 {
@@ -5514,9 +5429,6 @@ impl Default for RESULT_VIEW_TYPE_INFO_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESULT_VIEW_TYPE_INFO_0_1 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const RFI_PARTIAL: u32 = 1u32;
 pub const RFI_WRAP: u32 = 2u32;
@@ -5554,9 +5466,6 @@ impl Default for SCOPEDATAITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCOPEDATAITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SColumnSetID {
@@ -5568,9 +5477,6 @@ impl Default for SColumnSetID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SColumnSetID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SDI_CHILDREN: u32 = 64u32;
 pub const SDI_FIRST: u32 = 134217728u32;
@@ -5595,10 +5501,6 @@ impl Default for SMMCDataObjects {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SMMCDataObjects {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SMMCObjectTypes {
@@ -5609,9 +5511,6 @@ impl Default for SMMCObjectTypes {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SMMCObjectTypes {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5624,9 +5523,6 @@ impl Default for SNodeID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SNodeID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SNodeID2 {
@@ -5638,9 +5534,6 @@ impl Default for SNodeID2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SNodeID2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPECIAL_COOKIE_MAX: i32 = -1i32;
 pub const SPECIAL_COOKIE_MIN: i32 = -10i32;

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
@@ -3132,10 +3132,6 @@ impl Default for ARRAYDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for ARRAYDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BINDSPEED(pub i32);
@@ -3193,9 +3189,6 @@ impl Default for CADWORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CADWORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CALPOLESTR {
@@ -3207,9 +3200,6 @@ impl Default for CALPOLESTR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CALPOLESTR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CAUUID {
@@ -3220,9 +3210,6 @@ impl Default for CAUUID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CAUUID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CF_BITMAP: CLIPBOARD_FORMAT = CLIPBOARD_FORMAT(2u16);
 pub const CF_CONVERTONLY: UI_CONVERT_FLAGS = UI_CONVERT_FLAGS(256u32);
@@ -3360,9 +3347,6 @@ impl Default for CLEANLOCALSTORAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLEANLOCALSTORAGE {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CLIPBOARD_FORMAT(pub u16);
@@ -3395,10 +3379,6 @@ impl Default for CONTROLINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for CONTROLINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CSF_EXPLORER: CHANGE_SOURCE_FLAGS = CHANGE_SOURCE_FLAGS(8u32);
 pub const CSF_ONLYGETSOURCE: CHANGE_SOURCE_FLAGS = CHANGE_SOURCE_FLAGS(4u32);
@@ -3597,9 +3577,6 @@ impl Default for DVASPECTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DVASPECTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DVASPECTINFOFLAG(pub i32);
@@ -3615,9 +3592,6 @@ impl Default for DVEXTENTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DVEXTENTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3762,10 +3736,6 @@ impl Default for FONTDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for FONTDESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GCW_WCH_SIBLING: ENUM_CONTROLS_WHICH_FLAGS = ENUM_CONTROLS_WHICH_FLAGS(1u32);
 pub const GC_WCH_ALL: ENUM_CONTROLS_WHICH_FLAGS = ENUM_CONTROLS_WHICH_FLAGS(4u32);
@@ -6313,10 +6283,6 @@ impl Default for INTERFACEDATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for INTERFACEDATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IOF_CHECKDISPLAYASICON: INSERT_OBJECT_FLAGS = INSERT_OBJECT_FLAGS(16u32);
 pub const IOF_CHECKLINK: INSERT_OBJECT_FLAGS = INSERT_OBJECT_FLAGS(8u32);
@@ -12398,9 +12364,6 @@ impl Default for LICINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LICINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct LOAD_PICTURE_FLAGS(pub u32);
@@ -12472,10 +12435,6 @@ impl Default for METHODDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for METHODDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MK_ALT: u32 = 32u32;
 pub const MSOCMDERR_E_CANCELED: i32 = -2147221245i32;
 pub const MSOCMDERR_E_DISABLED: i32 = -2147221247i32;
@@ -12504,9 +12463,6 @@ impl Default for NUMPARSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NUMPARSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12577,9 +12533,6 @@ impl Default for OBJECTDESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OBJECTDESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct OBJECT_PROPERTIES_FLAGS(pub u32);
@@ -12637,9 +12590,6 @@ impl Default for OCPFIPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OCPFIPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OF_GET: u32 = 2u32;
 pub const OF_HANDLER: u32 = 4u32;
 pub const OF_SET: u32 = 1u32;
@@ -12659,9 +12609,6 @@ impl Default for OLECMD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OLECMD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OLECMDARGINDEX_ACTIVEXINSTALL_CLSID: u32 = 2u32;
 pub const OLECMDARGINDEX_ACTIVEXINSTALL_DISPLAYNAME: u32 = 1u32;
@@ -12885,9 +12832,6 @@ impl Default for OLECMDTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OLECMDTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct OLECMDTEXTF(pub i32);
@@ -12937,10 +12881,6 @@ impl Default for OLEINPLACEFRAMEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for OLEINPLACEFRAMEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct OLEIVERB(pub i32);
@@ -12965,9 +12905,6 @@ impl Default for OLEMENUGROUPWIDTHS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OLEMENUGROUPWIDTHS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13027,10 +12964,6 @@ impl Default for OLEUIBUSYA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Media")]
-impl windows_core::TypeKind for OLEUIBUSYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Media")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13052,10 +12985,6 @@ impl Default for OLEUIBUSYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Media")]
-impl windows_core::TypeKind for OLEUIBUSYW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13079,9 +13008,6 @@ impl Default for OLEUICHANGEICONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OLEUICHANGEICONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OLEUICHANGEICONW {
@@ -13103,9 +13029,6 @@ impl Default for OLEUICHANGEICONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OLEUICHANGEICONW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Controls_Dialogs")]
@@ -13135,10 +13058,6 @@ impl Default for OLEUICHANGESOURCEA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Controls_Dialogs")]
-impl windows_core::TypeKind for OLEUICHANGESOURCEA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Controls_Dialogs")]
 #[derive(Clone, Debug, PartialEq)]
@@ -13166,10 +13085,6 @@ impl Default for OLEUICHANGESOURCEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Controls_Dialogs")]
-impl windows_core::TypeKind for OLEUICHANGESOURCEW {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13202,9 +13117,6 @@ impl Default for OLEUICONVERTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OLEUICONVERTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OLEUICONVERTW {
@@ -13236,9 +13148,6 @@ impl Default for OLEUICONVERTW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OLEUICONVERTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct OLEUIEDITLINKSA {
@@ -13257,9 +13166,6 @@ impl Default for OLEUIEDITLINKSA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OLEUIEDITLINKSA {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -13280,9 +13186,6 @@ impl Default for OLEUIEDITLINKSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OLEUIEDITLINKSW {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13301,10 +13204,6 @@ impl Default for OLEUIGNRLPROPSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for OLEUIGNRLPROPSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13322,10 +13221,6 @@ impl Default for OLEUIGNRLPROPSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for OLEUIGNRLPROPSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
@@ -13360,10 +13255,6 @@ impl Default for OLEUIINSERTOBJECTA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl windows_core::TypeKind for OLEUIINSERTOBJECTA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 #[derive(Clone, Debug, PartialEq)]
@@ -13397,10 +13288,6 @@ impl Default for OLEUIINSERTOBJECTW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com_StructuredStorage")]
-impl windows_core::TypeKind for OLEUIINSERTOBJECTW {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13419,10 +13306,6 @@ impl Default for OLEUILINKPROPSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for OLEUILINKPROPSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13440,10 +13323,6 @@ impl Default for OLEUILINKPROPSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for OLEUILINKPROPSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -13466,10 +13345,6 @@ impl Default for OLEUIOBJECTPROPSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for OLEUIOBJECTPROPSA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -13491,10 +13366,6 @@ impl Default for OLEUIOBJECTPROPSW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for OLEUIOBJECTPROPSW {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13511,10 +13382,6 @@ impl Default for OLEUIPASTEENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for OLEUIPASTEENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13530,10 +13397,6 @@ impl Default for OLEUIPASTEENTRYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for OLEUIPASTEENTRYW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13569,10 +13432,6 @@ impl Default for OLEUIPASTESPECIALA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for OLEUIPASTESPECIALA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Debug, PartialEq)]
@@ -13603,10 +13462,6 @@ impl Default for OLEUIPASTESPECIALW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for OLEUIPASTESPECIALW {
-    type TypeKind = windows_core::CloneType;
 }
 pub const OLEUIPASTE_ENABLEICON: OLEUIPASTEFLAG = OLEUIPASTEFLAG(2048i32);
 pub const OLEUIPASTE_LINKANYTYPE: OLEUIPASTEFLAG = OLEUIPASTEFLAG(1024i32);
@@ -13640,10 +13495,6 @@ impl Default for OLEUIVIEWPROPSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for OLEUIVIEWPROPSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13663,10 +13514,6 @@ impl Default for OLEUIVIEWPROPSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for OLEUIVIEWPROPSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OLEUI_BZERR_HTASKINVALID: u32 = 116u32;
 pub const OLEUI_BZ_CALLUNBLOCKED: u32 = 119u32;
@@ -13771,10 +13618,6 @@ impl Default for OLEVERB {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for OLEVERB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct OLEVERBATTRIB(pub i32);
@@ -13826,9 +13669,6 @@ impl Default for PAGERANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PAGERANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PAGESET {
@@ -13843,9 +13683,6 @@ impl Default for PAGESET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PAGESET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13859,10 +13696,6 @@ impl Default for PARAMDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for PARAMDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13875,10 +13708,6 @@ impl Default for PARAMDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for PARAMDESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
@@ -13897,10 +13726,6 @@ impl Default for PARAMDESCEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for PARAMDESCEX {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14001,10 +13826,6 @@ impl Default for PICTDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PICTDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -14020,10 +13841,6 @@ impl Default for PICTDESC_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PICTDESC_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14037,10 +13854,6 @@ impl Default for PICTDESC_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PICTDESC_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14053,10 +13866,6 @@ impl Default for PICTDESC_0_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PICTDESC_0_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14068,10 +13877,6 @@ impl Default for PICTDESC_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PICTDESC_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -14086,10 +13891,6 @@ impl Default for PICTDESC_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PICTDESC_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14121,9 +13922,6 @@ impl Default for POINTF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POINTF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14193,9 +13991,6 @@ impl Default for PROPPAGEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROPPAGEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PROPPAGESTATUS(pub i32);
@@ -14239,10 +14034,6 @@ impl Default for QACONTAINER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
-impl windows_core::TypeKind for QACONTAINER {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct QACONTAINERFLAGS(pub i32);
@@ -14268,9 +14059,6 @@ impl Default for QACONTROL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QACONTROL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14299,10 +14087,6 @@ impl Default for SAFEARRAYUNION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SAFEARRAYUNION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -14324,10 +14108,6 @@ impl Default for SAFEARRAYUNION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SAFEARRAYUNION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SAFEARR_BRECORD {
@@ -14338,9 +14118,6 @@ impl Default for SAFEARR_BRECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SAFEARR_BRECORD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -14355,10 +14132,6 @@ impl Default for SAFEARR_BSTR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SAFEARR_BSTR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14372,10 +14145,6 @@ impl Default for SAFEARR_DISPATCH {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SAFEARR_DISPATCH {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SAFEARR_HAVEIID {
@@ -14388,9 +14157,6 @@ impl Default for SAFEARR_HAVEIID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SAFEARR_HAVEIID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SAFEARR_UNKNOWN {
@@ -14401,9 +14167,6 @@ impl Default for SAFEARR_UNKNOWN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SAFEARR_UNKNOWN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -14417,10 +14180,6 @@ impl Default for SAFEARR_VARIANT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SAFEARR_VARIANT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SELFREG_E_CLASS: windows_core::HRESULT = windows_core::HRESULT(0x80040201_u32 as _);
 pub const SELFREG_E_FIRST: i32 = -2147220992i32;
@@ -14498,9 +14257,6 @@ impl Default for UDATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UDATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14730,9 +14486,6 @@ impl Default for _wireBRECORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _wireBRECORD {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -14749,10 +14502,6 @@ impl Default for _wireSAFEARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for _wireSAFEARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -14776,10 +14525,6 @@ impl Default for _wireVARIANT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for _wireVARIANT {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -14840,10 +14585,6 @@ impl Default for _wireVARIANT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for _wireVARIANT_0 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const fdexEnumAll: i32 = 2i32;
 pub const fdexEnumDefault: i32 = 1i32;

--- a/crates/libs/windows/src/Windows/Win32/System/PasswordManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/PasswordManagement/mod.rs
@@ -28,9 +28,6 @@ impl Default for CYPHER_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CYPHER_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENCRYPTED_LM_OWF_PASSWORD {
@@ -40,9 +37,6 @@ impl Default for ENCRYPTED_LM_OWF_PASSWORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENCRYPTED_LM_OWF_PASSWORD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -54,9 +48,6 @@ impl Default for LM_OWF_PASSWORD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LM_OWF_PASSWORD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SAMPR_ENCRYPTED_USER_PASSWORD {
@@ -66,7 +57,4 @@ impl Default for SAMPR_ENCRYPTED_USER_PASSWORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SAMPR_ENCRYPTED_USER_PASSWORD {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/HardwareCounterProfiling/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/HardwareCounterProfiling/mod.rs
@@ -30,9 +30,6 @@ impl Default for HARDWARE_COUNTER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HARDWARE_COUNTER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HARDWARE_COUNTER_TYPE(pub i32);
@@ -54,8 +51,5 @@ impl Default for PERFORMANCE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERFORMANCE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PMCCounter: HARDWARE_COUNTER_TYPE = HARDWARE_COUNTER_TYPE(0i32);

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/mod.rs
@@ -8223,9 +8223,6 @@ impl Default for PDH_BROWSE_DLG_CONFIG_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_BROWSE_DLG_CONFIG_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PDH_BROWSE_DLG_CONFIG_HA {
@@ -8244,9 +8241,6 @@ impl Default for PDH_BROWSE_DLG_CONFIG_HA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_BROWSE_DLG_CONFIG_HA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8267,9 +8261,6 @@ impl Default for PDH_BROWSE_DLG_CONFIG_HW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_BROWSE_DLG_CONFIG_HW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PDH_BROWSE_DLG_CONFIG_W {
@@ -8288,9 +8279,6 @@ impl Default for PDH_BROWSE_DLG_CONFIG_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_BROWSE_DLG_CONFIG_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PDH_CALC_NEGATIVE_DENOMINATOR: u32 = 2147485654u32;
 pub const PDH_CALC_NEGATIVE_TIMEBASE: u32 = 2147485655u32;
@@ -8321,9 +8309,6 @@ impl Default for PDH_COUNTER_INFO_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_COUNTER_INFO_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PDH_COUNTER_INFO_A_0 {
@@ -8335,9 +8320,6 @@ impl Default for PDH_COUNTER_INFO_A_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_COUNTER_INFO_A_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8353,9 +8335,6 @@ impl Default for PDH_COUNTER_INFO_A_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_COUNTER_INFO_A_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -8378,9 +8357,6 @@ impl Default for PDH_COUNTER_INFO_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_COUNTER_INFO_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PDH_COUNTER_INFO_W_0 {
@@ -8392,9 +8368,6 @@ impl Default for PDH_COUNTER_INFO_W_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_COUNTER_INFO_W_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8411,9 +8384,6 @@ impl Default for PDH_COUNTER_INFO_W_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_COUNTER_INFO_W_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PDH_COUNTER_PATH_ELEMENTS_A {
@@ -8429,9 +8399,6 @@ impl Default for PDH_COUNTER_PATH_ELEMENTS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_COUNTER_PATH_ELEMENTS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PDH_COUNTER_PATH_ELEMENTS_W {
@@ -8446,9 +8413,6 @@ impl Default for PDH_COUNTER_PATH_ELEMENTS_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_COUNTER_PATH_ELEMENTS_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PDH_CSTATUS_BAD_COUNTERNAME: u32 = 3221228480u32;
 pub const PDH_CSTATUS_INVALID_DATA: u32 = 3221228474u32;
@@ -8474,9 +8438,6 @@ impl Default for PDH_DATA_ITEM_PATH_ELEMENTS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_DATA_ITEM_PATH_ELEMENTS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PDH_DATA_ITEM_PATH_ELEMENTS_W {
@@ -8489,9 +8450,6 @@ impl Default for PDH_DATA_ITEM_PATH_ELEMENTS_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_DATA_ITEM_PATH_ELEMENTS_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PDH_DATA_SOURCE_IS_LOG_FILE: u32 = 3221228494u32;
 pub const PDH_DATA_SOURCE_IS_REAL_TIME: u32 = 3221228495u32;
@@ -8519,9 +8477,6 @@ impl Default for PDH_FMT_COUNTERVALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_FMT_COUNTERVALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PDH_FMT_COUNTERVALUE_0 {
@@ -8536,9 +8491,6 @@ impl Default for PDH_FMT_COUNTERVALUE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_FMT_COUNTERVALUE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PDH_FMT_COUNTERVALUE_ITEM_A {
@@ -8550,9 +8502,6 @@ impl Default for PDH_FMT_COUNTERVALUE_ITEM_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_FMT_COUNTERVALUE_ITEM_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PDH_FMT_COUNTERVALUE_ITEM_W {
@@ -8563,9 +8512,6 @@ impl Default for PDH_FMT_COUNTERVALUE_ITEM_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_FMT_COUNTERVALUE_ITEM_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PDH_FMT_DOUBLE: PDH_FMT = PDH_FMT(512u32);
 pub const PDH_FMT_LARGE: PDH_FMT = PDH_FMT(1024u32);
@@ -8676,9 +8622,6 @@ impl Default for PDH_LOG_SERVICE_QUERY_INFO_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_LOG_SERVICE_QUERY_INFO_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PDH_LOG_SERVICE_QUERY_INFO_A_0 {
@@ -8689,9 +8632,6 @@ impl Default for PDH_LOG_SERVICE_QUERY_INFO_A_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_LOG_SERVICE_QUERY_INFO_A_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8709,9 +8649,6 @@ impl Default for PDH_LOG_SERVICE_QUERY_INFO_A_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_LOG_SERVICE_QUERY_INFO_A_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8732,9 +8669,6 @@ impl Default for PDH_LOG_SERVICE_QUERY_INFO_A_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_LOG_SERVICE_QUERY_INFO_A_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PDH_LOG_SERVICE_QUERY_INFO_W {
@@ -8753,9 +8687,6 @@ impl Default for PDH_LOG_SERVICE_QUERY_INFO_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_LOG_SERVICE_QUERY_INFO_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PDH_LOG_SERVICE_QUERY_INFO_W_0 {
@@ -8766,9 +8697,6 @@ impl Default for PDH_LOG_SERVICE_QUERY_INFO_W_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_LOG_SERVICE_QUERY_INFO_W_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8786,9 +8714,6 @@ impl Default for PDH_LOG_SERVICE_QUERY_INFO_W_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_LOG_SERVICE_QUERY_INFO_W_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8808,9 +8733,6 @@ impl Default for PDH_LOG_SERVICE_QUERY_INFO_W_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_LOG_SERVICE_QUERY_INFO_W_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8877,9 +8799,6 @@ impl Default for PDH_RAW_COUNTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_RAW_COUNTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PDH_RAW_COUNTER_ITEM_A {
@@ -8891,9 +8810,6 @@ impl Default for PDH_RAW_COUNTER_ITEM_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_RAW_COUNTER_ITEM_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PDH_RAW_COUNTER_ITEM_W {
@@ -8904,9 +8820,6 @@ impl Default for PDH_RAW_COUNTER_ITEM_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_RAW_COUNTER_ITEM_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8920,9 +8833,6 @@ impl Default for PDH_RAW_LOG_RECORD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_RAW_LOG_RECORD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PDH_REFRESHCOUNTERS: u32 = 4u32;
 pub const PDH_RETRY: u32 = 2147485652u32;
@@ -8952,9 +8862,6 @@ impl Default for PDH_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PDH_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PDH_STRING_NOT_FOUND: u32 = 3221228500u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8967,9 +8874,6 @@ impl Default for PDH_TIME_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PDH_TIME_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PDH_UNABLE_MAP_NAME_FILES: u32 = 2147486677u32;
 pub const PDH_UNABLE_READ_LOG_HEADER: u32 = 3221228496u32;
@@ -9011,9 +8915,6 @@ impl Default for PERF_COUNTERSET_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERF_COUNTERSET_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERF_COUNTERSET_INSTANCE {
@@ -9027,9 +8928,6 @@ impl Default for PERF_COUNTERSET_INSTANCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_COUNTERSET_INSTANCE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERF_COUNTERSET_MULTI_INSTANCES: u32 = 2u32;
 #[repr(C)]
@@ -9045,9 +8943,6 @@ impl Default for PERF_COUNTERSET_REG_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_COUNTERSET_REG_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERF_COUNTERSET_SINGLE_AGGREGATE: u32 = 4u32;
 pub const PERF_COUNTERSET_SINGLE_INSTANCE: u32 = 0u32;
@@ -9065,9 +8960,6 @@ impl Default for PERF_COUNTER_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERF_COUNTER_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERF_COUNTER_DATA {
@@ -9078,9 +8970,6 @@ impl Default for PERF_COUNTER_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_COUNTER_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -9103,10 +8992,6 @@ impl Default for PERF_COUNTER_DEFINITION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for PERF_COUNTER_DEFINITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9128,10 +9013,6 @@ impl Default for PERF_COUNTER_DEFINITION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for PERF_COUNTER_DEFINITION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PERF_COUNTER_ELAPSED: u32 = 262144u32;
 pub const PERF_COUNTER_FRACTION: u32 = 131072u32;
 #[repr(C)]
@@ -9146,9 +9027,6 @@ impl Default for PERF_COUNTER_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_COUNTER_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERF_COUNTER_HISTOGRAM: u32 = 393216u32;
 pub const PERF_COUNTER_HISTOGRAM_TYPE: u32 = 2147483648u32;
@@ -9168,9 +9046,6 @@ impl Default for PERF_COUNTER_IDENTIFIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERF_COUNTER_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERF_COUNTER_IDENTITY {
@@ -9187,9 +9062,6 @@ impl Default for PERF_COUNTER_IDENTITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERF_COUNTER_IDENTITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERF_COUNTER_INFO {
@@ -9205,9 +9077,6 @@ impl Default for PERF_COUNTER_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_COUNTER_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERF_COUNTER_PRECISION: u32 = 458752u32;
 pub const PERF_COUNTER_QUEUELEN: u32 = 327680u32;
@@ -9231,9 +9100,6 @@ impl Default for PERF_COUNTER_REG_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_COUNTER_REG_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERF_COUNTER_VALUE: u32 = 0u32;
 #[repr(C)]
@@ -9259,9 +9125,6 @@ impl Default for PERF_DATA_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERF_DATA_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERF_DATA_HEADER {
@@ -9276,9 +9139,6 @@ impl Default for PERF_DATA_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_DATA_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERF_DATA_REVISION: u32 = 1u32;
 pub const PERF_DATA_VERSION: u32 = 1u32;
@@ -9314,9 +9174,6 @@ impl Default for PERF_INSTANCE_DEFINITION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERF_INSTANCE_DEFINITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERF_INSTANCE_HEADER {
@@ -9327,9 +9184,6 @@ impl Default for PERF_INSTANCE_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_INSTANCE_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERF_INVERSE_COUNTER: u32 = 16777216u32;
 pub const PERF_MAX_INSTANCE_NAME: u32 = 1024u32;
@@ -9351,9 +9205,6 @@ impl Default for PERF_MULTI_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERF_MULTI_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERF_MULTI_INSTANCES {
@@ -9364,9 +9215,6 @@ impl Default for PERF_MULTI_INSTANCES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_MULTI_INSTANCES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERF_NO_INSTANCES: i32 = -1i32;
 pub const PERF_NO_UNIQUE_ID: i32 = -1i32;
@@ -9399,10 +9247,6 @@ impl Default for PERF_OBJECT_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for PERF_OBJECT_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9428,10 +9272,6 @@ impl Default for PERF_OBJECT_TYPE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for PERF_OBJECT_TYPE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERF_PROVIDER_CONTEXT {
@@ -9446,9 +9286,6 @@ impl Default for PERF_PROVIDER_CONTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_PROVIDER_CONTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERF_PROVIDER_DRIVER: u32 = 2u32;
 pub const PERF_PROVIDER_KERNEL_MODE: u32 = 1u32;
@@ -9480,9 +9317,6 @@ impl Default for PERF_STRING_BUFFER_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERF_STRING_BUFFER_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERF_STRING_COUNTER_HEADER {
@@ -9493,9 +9327,6 @@ impl Default for PERF_STRING_COUNTER_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERF_STRING_COUNTER_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PERF_TEXT_ASCII: u32 = 65536u32;
 pub const PERF_TEXT_UNICODE: u32 = 0u32;

--- a/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
@@ -605,9 +605,6 @@ impl Default for ACPI_REAL_TIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACPI_REAL_TIME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ACPI_TIME_ADJUST_DAYLIGHT: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -627,9 +624,6 @@ impl Default for ACPI_TIME_AND_ALARM_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACPI_TIME_AND_ALARM_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACPI_TIME_IN_DAYLIGHT: u32 = 2u32;
 #[repr(transparent)]
@@ -651,9 +645,6 @@ impl Default for ADMINISTRATOR_POWER_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ADMINISTRATOR_POWER_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ALTITUDE_GROUP_POLICY: POWER_SETTING_ALTITUDE = POWER_SETTING_ALTITUDE(0i32);
 pub const ALTITUDE_INTERNAL_OVERRIDE: POWER_SETTING_ALTITUDE = POWER_SETTING_ALTITUDE(5i32);
@@ -678,9 +669,6 @@ impl Default for BATTERY_CHARGER_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BATTERY_CHARGER_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BATTERY_CHARGING: u32 = 4u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -693,9 +681,6 @@ impl Default for BATTERY_CHARGING_SOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BATTERY_CHARGING_SOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BATTERY_CHARGING_SOURCE_INFORMATION {
@@ -706,9 +691,6 @@ impl Default for BATTERY_CHARGING_SOURCE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BATTERY_CHARGING_SOURCE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -739,9 +721,6 @@ impl Default for BATTERY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BATTERY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BATTERY_IS_SHORT_TERM: u32 = 536870912u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -754,9 +733,6 @@ impl Default for BATTERY_MANUFACTURE_DATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BATTERY_MANUFACTURE_DATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BATTERY_MINIPORT_UPDATE_DATA_VER_1: u32 = 1u32;
 pub const BATTERY_MINIPORT_UPDATE_DATA_VER_2: u32 = 2u32;
@@ -773,9 +749,6 @@ impl Default for BATTERY_QUERY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BATTERY_QUERY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BATTERY_QUERY_INFORMATION_LEVEL(pub i32);
@@ -789,9 +762,6 @@ impl Default for BATTERY_REPORTING_SCALE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BATTERY_REPORTING_SCALE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BATTERY_RUNTIME_WMI_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x535a3767_1ac2_49bc_a077_3f7a02e40aec);
 pub const BATTERY_SEALED: u32 = 268435456u32;
@@ -811,9 +781,6 @@ impl Default for BATTERY_SET_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BATTERY_SET_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BATTERY_SET_INFORMATION_LEVEL(pub i32);
@@ -830,9 +797,6 @@ impl Default for BATTERY_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BATTERY_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BATTERY_STATUS_CHANGE_WMI_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xcddfa0c3_7c5b_4e43_a034_059fa5b84364);
 pub const BATTERY_STATUS_WMI_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xfc4670d1_ebbf_416e_87ce_374a4ebc111a);
@@ -863,9 +827,6 @@ impl Default for BATTERY_USB_CHARGER_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BATTERY_USB_CHARGER_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BATTERY_USB_CHARGER_STATUS_FN_DEFAULT_USB: u32 = 1u32;
 pub const BATTERY_USB_CHARGER_STATUS_UCM_PD: u32 = 2u32;
 #[repr(C)]
@@ -881,9 +842,6 @@ impl Default for BATTERY_WAIT_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BATTERY_WAIT_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BatteryCharge: BATTERY_SET_INFORMATION_LEVEL = BATTERY_SET_INFORMATION_LEVEL(1i32);
 pub const BatteryChargerId: BATTERY_SET_INFORMATION_LEVEL = BATTERY_SET_INFORMATION_LEVEL(4i32);
@@ -923,9 +881,6 @@ impl Default for CM_POWER_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CM_POWER_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CsDeviceNotification: POWER_INFORMATION_LEVEL = POWER_INFORMATION_LEVEL(74i32);
 pub const DEVICEPOWER_AND_OPERATION: u32 = 1073741824u32;
 pub const DEVICEPOWER_CLEAR_WAKEENABLED: u32 = 2u32;
@@ -946,9 +901,6 @@ impl Default for DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1007,9 +959,6 @@ impl Default for EMI_CHANNEL_MEASUREMENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMI_CHANNEL_MEASUREMENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMI_CHANNEL_V2 {
@@ -1022,9 +971,6 @@ impl Default for EMI_CHANNEL_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMI_CHANNEL_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMI_MEASUREMENT_DATA_V2 {
@@ -1034,9 +980,6 @@ impl Default for EMI_MEASUREMENT_DATA_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMI_MEASUREMENT_DATA_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1050,9 +993,6 @@ impl Default for EMI_METADATA_SIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMI_METADATA_SIZE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1069,9 +1009,6 @@ impl Default for EMI_METADATA_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMI_METADATA_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EMI_METADATA_V2 {
@@ -1086,9 +1023,6 @@ impl Default for EMI_METADATA_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EMI_METADATA_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EMI_NAME_MAX: u32 = 16u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1099,9 +1033,6 @@ impl Default for EMI_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EMI_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EMI_VERSION_V1: u32 = 1u32;
 pub const EMI_VERSION_V2: u32 = 2u32;
@@ -1176,9 +1107,6 @@ impl Default for GLOBAL_MACHINE_POWER_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GLOBAL_MACHINE_POWER_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GLOBAL_POWER_POLICY {
@@ -1189,9 +1117,6 @@ impl Default for GLOBAL_POWER_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GLOBAL_POWER_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1210,9 +1135,6 @@ impl Default for GLOBAL_USER_POWER_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GLOBAL_USER_POWER_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GUID_CLASS_INPUT: windows_core::GUID = windows_core::GUID::from_u128(0x4d1e55b2_f16f_11cf_88cb_001111000030);
 pub const GUID_DEVICE_ACPI_TIME: windows_core::GUID = windows_core::GUID::from_u128(0x97f99bf6_4497_4f18_bb22_4b9fb2fbef9c);
@@ -1313,9 +1235,6 @@ impl Default for MACHINE_POWER_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MACHINE_POWER_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MACHINE_PROCESSOR_POWER_POLICY {
@@ -1327,9 +1246,6 @@ impl Default for MACHINE_PROCESSOR_POWER_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MACHINE_PROCESSOR_POWER_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MAX_ACTIVE_COOLING_LEVELS: u32 = 10u32;
 pub const MAX_BATTERY_STRING_SIZE: u32 = 128u32;
@@ -1429,9 +1345,6 @@ impl Default for POWERBROADCAST_SETTING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POWERBROADCAST_SETTING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct POWER_ACTION(pub i32);
@@ -1446,9 +1359,6 @@ impl Default for POWER_ACTION_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_ACTION_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1506,9 +1416,6 @@ impl Default for POWER_IDLE_RESILIENCY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POWER_IDLE_RESILIENCY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct POWER_INFORMATION_LEVEL(pub i32);
@@ -1526,9 +1433,6 @@ impl Default for POWER_MONITOR_INVOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POWER_MONITOR_INVOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct POWER_MONITOR_REQUEST_REASON(pub i32);
@@ -1544,9 +1448,6 @@ impl Default for POWER_PLATFORM_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_PLATFORM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1567,9 +1468,6 @@ impl Default for POWER_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POWER_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct POWER_REQUEST_TYPE(pub i32);
@@ -1583,9 +1481,6 @@ impl Default for POWER_SESSION_ALLOW_EXTERNAL_DMA_DEVICES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POWER_SESSION_ALLOW_EXTERNAL_DMA_DEVICES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POWER_SESSION_CONNECT {
@@ -1596,9 +1491,6 @@ impl Default for POWER_SESSION_CONNECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_SESSION_CONNECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1611,9 +1503,6 @@ impl Default for POWER_SESSION_RIT_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POWER_SESSION_RIT_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POWER_SESSION_TIMEOUTS {
@@ -1624,9 +1513,6 @@ impl Default for POWER_SESSION_TIMEOUTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_SESSION_TIMEOUTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1639,9 +1525,6 @@ impl Default for POWER_SESSION_WINLOGON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_SESSION_WINLOGON {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1657,9 +1540,6 @@ impl Default for POWER_USER_PRESENCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POWER_USER_PRESENCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1701,9 +1581,6 @@ impl Default for PPM_IDLESTATE_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPM_IDLESTATE_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPM_IDLE_ACCOUNTING {
@@ -1717,9 +1594,6 @@ impl Default for PPM_IDLE_ACCOUNTING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPM_IDLE_ACCOUNTING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1735,9 +1609,6 @@ impl Default for PPM_IDLE_ACCOUNTING_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPM_IDLE_ACCOUNTING_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PPM_IDLE_ACCOUNTING_EX_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xd67abd39_81f8_4a5e_8152_72e31ec912ee);
 pub const PPM_IDLE_ACCOUNTING_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xe2a26f78_ae07_4ee0_a30f_ce54f55a94cd);
@@ -1760,9 +1631,6 @@ impl Default for PPM_IDLE_STATE_ACCOUNTING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPM_IDLE_STATE_ACCOUNTING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPM_IDLE_STATE_ACCOUNTING_EX {
@@ -1780,9 +1648,6 @@ impl Default for PPM_IDLE_STATE_ACCOUNTING_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPM_IDLE_STATE_ACCOUNTING_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPM_IDLE_STATE_BUCKET_EX {
@@ -1795,9 +1660,6 @@ impl Default for PPM_IDLE_STATE_BUCKET_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPM_IDLE_STATE_BUCKET_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PPM_PERFMON_PERFSTATE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x7fd18652_0cfe_40d2_b0a1_0b066a87759e);
 pub const PPM_PERFORMANCE_IMPLEMENTATION_CPPC: u32 = 3u32;
@@ -1821,9 +1683,6 @@ impl Default for PPM_PERFSTATE_DOMAIN_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPM_PERFSTATE_DOMAIN_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPM_PERFSTATE_EVENT {
@@ -1838,9 +1697,6 @@ impl Default for PPM_PERFSTATE_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPM_PERFSTATE_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPM_THERMALCHANGE_EVENT {
@@ -1851,9 +1707,6 @@ impl Default for PPM_THERMALCHANGE_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPM_THERMALCHANGE_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PPM_THERMALCONSTRAINT_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xa852c2c8_1a4c_423b_8c2c_f30d82931a88);
 pub const PPM_THERMAL_POLICY_CHANGE_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x48f377b8_6880_4c7b_8bdc_380176c6654d);
@@ -1867,9 +1720,6 @@ impl Default for PPM_THERMAL_POLICY_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPM_THERMAL_POLICY_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1891,9 +1741,6 @@ impl Default for PPM_WMI_IDLE_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPM_WMI_IDLE_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPM_WMI_IDLE_STATES {
@@ -1908,9 +1755,6 @@ impl Default for PPM_WMI_IDLE_STATES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPM_WMI_IDLE_STATES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1927,9 +1771,6 @@ impl Default for PPM_WMI_IDLE_STATES_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPM_WMI_IDLE_STATES_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPM_WMI_LEGACY_PERFSTATE {
@@ -1941,9 +1782,6 @@ impl Default for PPM_WMI_LEGACY_PERFSTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPM_WMI_LEGACY_PERFSTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1967,9 +1805,6 @@ impl Default for PPM_WMI_PERF_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PPM_WMI_PERF_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2001,9 +1836,6 @@ impl Default for PPM_WMI_PERF_STATES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPM_WMI_PERF_STATES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PPM_WMI_PERF_STATES_EX {
@@ -2034,9 +1866,6 @@ impl Default for PPM_WMI_PERF_STATES_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PPM_WMI_PERF_STATES_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PROCESSOR_NUMBER_PKEY: super::super::Foundation::DEVPROPKEY = super::super::Foundation::DEVPROPKEY { fmtid: windows_core::GUID::from_u128(0x5724c81d_d5af_4c1f_a103_a06e28f204c6), pid: 1 };
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2050,9 +1879,6 @@ impl Default for PROCESSOR_OBJECT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSOR_OBJECT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESSOR_OBJECT_INFO_EX {
@@ -2065,9 +1891,6 @@ impl Default for PROCESSOR_OBJECT_INFO_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESSOR_OBJECT_INFO_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2084,9 +1907,6 @@ impl Default for PROCESSOR_POWER_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSOR_POWER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESSOR_POWER_POLICY {
@@ -2101,9 +1921,6 @@ impl Default for PROCESSOR_POWER_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESSOR_POWER_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2120,9 +1937,6 @@ impl Default for PROCESSOR_POWER_POLICY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESSOR_POWER_POLICY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PWRSCHEMESENUMPROC = Option<unsafe extern "system" fn(index: u32, namesize: u32, name: windows_core::PCWSTR, descriptionsize: u32, description: windows_core::PCWSTR, policy: *const POWER_POLICY, context: super::super::Foundation::LPARAM) -> super::super::Foundation::BOOLEAN>;
 pub type PWRSCHEMESENUMPROC_V1 = Option<unsafe extern "system" fn(index: u32, namesize: u32, name: *const i8, descriptionsize: u32, description: *const i8, policy: *const POWER_POLICY, context: super::super::Foundation::LPARAM) -> super::super::Foundation::BOOLEAN>;
@@ -2217,9 +2031,6 @@ impl Default for RESUME_PERFORMANCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESUME_PERFORMANCE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RegisterSpmPowerSettings: POWER_INFORMATION_LEVEL = POWER_INFORMATION_LEVEL(79i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2234,9 +2045,6 @@ impl Default for SET_POWER_SETTING_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SET_POWER_SETTING_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2258,9 +2066,6 @@ impl Default for SYSTEM_BATTERY_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_BATTERY_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2304,9 +2109,6 @@ impl Default for SYSTEM_POWER_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_POWER_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SYSTEM_POWER_CONDITION(pub i32);
@@ -2323,9 +2125,6 @@ impl Default for SYSTEM_POWER_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_POWER_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_POWER_LEVEL {
@@ -2339,9 +2138,6 @@ impl Default for SYSTEM_POWER_LEVEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_POWER_LEVEL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2380,9 +2176,6 @@ impl Default for SYSTEM_POWER_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_POWER_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SYSTEM_POWER_STATE(pub i32);
@@ -2400,9 +2193,6 @@ impl Default for SYSTEM_POWER_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_POWER_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SYS_BUTTON_LID: u32 = 4u32;
 pub const SYS_BUTTON_LID_CHANGED: u32 = 524288u32;
@@ -2462,9 +2252,6 @@ impl Default for THERMAL_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for THERMAL_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const THERMAL_EVENT_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2485,9 +2272,6 @@ impl Default for THERMAL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for THERMAL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct THERMAL_POLICY {
@@ -2506,9 +2290,6 @@ impl Default for THERMAL_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for THERMAL_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const THERMAL_POLICY_VERSION_1: u32 = 1u32;
 pub const THERMAL_POLICY_VERSION_2: u32 = 2u32;
 #[repr(C)]
@@ -2522,9 +2303,6 @@ impl Default for THERMAL_WAIT_READ {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for THERMAL_WAIT_READ {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TZ_ACTIVATION_REASON_CURRENT: u32 = 2u32;
 pub const TZ_ACTIVATION_REASON_THERMAL: u32 = 1u32;
@@ -2574,9 +2352,6 @@ impl Default for USER_POWER_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_POWER_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const UpdateBlackBoxRecorder: POWER_INFORMATION_LEVEL = POWER_INFORMATION_LEVEL(94i32);
 pub const UsbChargerPort_Legacy: USB_CHARGER_PORT = USB_CHARGER_PORT(0i32);
 pub const UsbChargerPort_Max: USB_CHARGER_PORT = USB_CHARGER_PORT(2i32);
@@ -2599,8 +2374,5 @@ impl Default for WAKE_ALARM_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WAKE_ALARM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WakeTimerList: POWER_INFORMATION_LEVEL = POWER_INFORMATION_LEVEL(50i32);

--- a/crates/libs/windows/src/Windows/Win32/System/ProcessStatus/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ProcessStatus/mod.rs
@@ -282,9 +282,6 @@ impl Default for ENUM_PAGE_FILE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENUM_PAGE_FILE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ENUM_PROCESS_MODULES_EX_FLAGS(pub u32);
@@ -303,9 +300,6 @@ impl Default for MODULEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MODULEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PENUM_PAGE_FILE_CALLBACKA = Option<unsafe extern "system" fn(pcontext: *mut core::ffi::c_void, ppagefileinfo: *mut ENUM_PAGE_FILE_INFORMATION, lpfilename: windows_core::PCSTR) -> super::super::Foundation::BOOL>;
 pub type PENUM_PAGE_FILE_CALLBACKW = Option<unsafe extern "system" fn(pcontext: *mut core::ffi::c_void, ppagefileinfo: *mut ENUM_PAGE_FILE_INFORMATION, lpfilename: windows_core::PCWSTR) -> super::super::Foundation::BOOL>;
@@ -332,9 +326,6 @@ impl Default for PERFORMANCE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERFORMANCE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MEMORY_COUNTERS {
@@ -353,9 +344,6 @@ impl Default for PROCESS_MEMORY_COUNTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MEMORY_COUNTERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -376,9 +364,6 @@ impl Default for PROCESS_MEMORY_COUNTERS_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MEMORY_COUNTERS_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -402,9 +387,6 @@ impl Default for PROCESS_MEMORY_COUNTERS_EX2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MEMORY_COUNTERS_EX2 {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PSAPI_VERSION: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -417,9 +399,6 @@ impl Default for PSAPI_WORKING_SET_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSAPI_WORKING_SET_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSAPI_WORKING_SET_BLOCK_0 {
@@ -429,9 +408,6 @@ impl Default for PSAPI_WORKING_SET_BLOCK_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSAPI_WORKING_SET_BLOCK_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -444,9 +420,6 @@ impl Default for PSAPI_WORKING_SET_EX_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSAPI_WORKING_SET_EX_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PSAPI_WORKING_SET_EX_BLOCK_0 {
@@ -458,9 +431,6 @@ impl Default for PSAPI_WORKING_SET_EX_BLOCK_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSAPI_WORKING_SET_EX_BLOCK_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSAPI_WORKING_SET_EX_BLOCK_0_0 {
@@ -471,9 +441,6 @@ impl Default for PSAPI_WORKING_SET_EX_BLOCK_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSAPI_WORKING_SET_EX_BLOCK_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSAPI_WORKING_SET_EX_BLOCK_0_1 {
@@ -483,9 +450,6 @@ impl Default for PSAPI_WORKING_SET_EX_BLOCK_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSAPI_WORKING_SET_EX_BLOCK_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -498,9 +462,6 @@ impl Default for PSAPI_WORKING_SET_EX_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSAPI_WORKING_SET_EX_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PSAPI_WORKING_SET_INFORMATION {
@@ -511,9 +472,6 @@ impl Default for PSAPI_WORKING_SET_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSAPI_WORKING_SET_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -526,9 +484,6 @@ impl Default for PSAPI_WS_WATCH_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PSAPI_WS_WATCH_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PSAPI_WS_WATCH_INFORMATION_EX {
@@ -540,7 +495,4 @@ impl Default for PSAPI_WS_WATCH_INFORMATION_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSAPI_WS_WATCH_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/mod.rs
@@ -7544,7 +7544,3 @@ impl Default for TRANSPORT_SETTING {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for TRANSPORT_SETTING {
-    type TypeKind = windows_core::CopyType;
-}

--- a/crates/libs/windows/src/Windows/Win32/System/Registry/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Registry/mod.rs
@@ -730,9 +730,6 @@ impl Default for DSKTLSYSTEMTIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DSKTLSYSTEMTIME {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DTRESULTFIX: u32 = 1u32;
 pub const DTRESULTOK: u32 = 0u32;
 pub const DTRESULTPART: u32 = 3u32;
@@ -855,9 +852,6 @@ impl Default for PVALUEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PVALUEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PVALUEW {
@@ -870,9 +864,6 @@ impl Default for PVALUEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PVALUEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const REGDF_CONFLICTDMA: u32 = 524288u32;
 pub const REGDF_CONFLICTIO: u32 = 65536u32;
@@ -1758,9 +1749,6 @@ impl Default for REG_PROVIDER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REG_PROVIDER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const REG_QWORD: REG_VALUE_TYPE = REG_VALUE_TYPE(11u32);
 pub const REG_QWORD_LITTLE_ENDIAN: REG_VALUE_TYPE = REG_VALUE_TYPE(11u32);
 pub const REG_RESOURCE_LIST: REG_VALUE_TYPE = REG_VALUE_TYPE(8u32);
@@ -1888,9 +1876,6 @@ impl Default for VALENTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VALENTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VALENTW {
@@ -1903,9 +1888,6 @@ impl Default for VALENTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VALENTW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VPDF_DISABLEPWRMGMT: u32 = 1u32;
 pub const VPDF_DISABLEPWRSTATUSPOLL: u32 = 8u32;
@@ -1924,7 +1906,4 @@ impl Default for val_context {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for val_context {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
@@ -449,9 +449,6 @@ impl Default for AAAccountingData {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AAAccountingData {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct AAAccountingDataType(pub i32);
@@ -498,9 +495,6 @@ impl Default for AE_CURRENT_POSITION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AE_CURRENT_POSITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct AE_POSITION_FLAGS(pub i32);
@@ -516,9 +510,6 @@ impl Default for BITMAP_RENDERER_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BITMAP_RENDERER_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CHANNEL_BUFFER_SIZE: u32 = 65535u32;
 pub const CHANNEL_CHUNK_LENGTH: u32 = 1600u32;
 #[repr(C, packed(1))]
@@ -531,9 +522,6 @@ impl Default for CHANNEL_DEF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANNEL_DEF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -549,9 +537,6 @@ impl Default for CHANNEL_ENTRY_POINTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHANNEL_ENTRY_POINTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CHANNEL_EVENT_CONNECTED: u32 = 1u32;
 pub const CHANNEL_EVENT_DATA_RECEIVED: u32 = 10u32;
@@ -589,9 +574,6 @@ impl Default for CHANNEL_PDU_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANNEL_PDU_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CHANNEL_RC_ALREADY_CONNECTED: u32 = 3u32;
 pub const CHANNEL_RC_ALREADY_INITIALIZED: u32 = 1u32;
 pub const CHANNEL_RC_ALREADY_OPEN: u32 = 14u32;
@@ -626,9 +608,6 @@ impl Default for CLIENT_DISPLAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLIENT_DISPLAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CLIENT_MESSAGE_CONNECTION_ERROR: CLIENT_MESSAGE_TYPE = CLIENT_MESSAGE_TYPE(2i32);
 pub const CLIENT_MESSAGE_CONNECTION_INVALID: CLIENT_MESSAGE_TYPE = CLIENT_MESSAGE_TYPE(0i32);
@@ -8884,9 +8863,6 @@ impl Default for PRODUCT_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PRODUCT_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PRODUCT_INFOW {
@@ -8897,9 +8873,6 @@ impl Default for PRODUCT_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PRODUCT_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROPERTY_DYNAMIC_TIME_ZONE_INFORMATION: windows_core::GUID = windows_core::GUID::from_u128(0x0cdfd28e_d0b9_4c1f_a5eb_6d1f6c6535b9);
 pub const PROPERTY_TYPE_ENABLE_UNIVERSAL_APPS_FOR_CUSTOM_SHELL: windows_core::GUID = windows_core::GUID::from_u128(0xed2c3fda_338d_4d3f_81a3_e767310d908e);
@@ -8973,9 +8946,6 @@ impl Default for RFX_GFX_MONITOR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RFX_GFX_MONITOR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RFX_GFX_MSG_CLIENT_DESKTOP_INFO_REQUEST {
@@ -8985,9 +8955,6 @@ impl Default for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -9003,9 +8970,6 @@ impl Default for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_RESPONSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RFX_GFX_MSG_CLIENT_DESKTOP_INFO_RESPONSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_CONFIRM {
@@ -9015,9 +8979,6 @@ impl Default for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_CONFIRM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_CONFIRM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -9033,9 +8994,6 @@ impl Default for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_NOTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RFX_GFX_MSG_DESKTOP_CONFIG_CHANGE_NOTIFY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct RFX_GFX_MSG_DESKTOP_INPUT_RESET {
@@ -9048,9 +9006,6 @@ impl Default for RFX_GFX_MSG_DESKTOP_INPUT_RESET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RFX_GFX_MSG_DESKTOP_INPUT_RESET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RFX_GFX_MSG_DESKTOP_RESEND_REQUEST {
@@ -9061,9 +9016,6 @@ impl Default for RFX_GFX_MSG_DESKTOP_RESEND_REQUEST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RFX_GFX_MSG_DESKTOP_RESEND_REQUEST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -9076,9 +9028,6 @@ impl Default for RFX_GFX_MSG_DISCONNECT_NOTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RFX_GFX_MSG_DISCONNECT_NOTIFY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct RFX_GFX_MSG_HEADER {
@@ -9089,9 +9038,6 @@ impl Default for RFX_GFX_MSG_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RFX_GFX_MSG_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RFX_GFX_MSG_PREFIX: u32 = 48u32;
 pub const RFX_GFX_MSG_PREFIX_MASK: u32 = 48u32;
@@ -9106,9 +9052,6 @@ impl Default for RFX_GFX_MSG_RDP_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RFX_GFX_MSG_RDP_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct RFX_GFX_RECT {
@@ -9121,9 +9064,6 @@ impl Default for RFX_GFX_RECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RFX_GFX_RECT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RFX_RDP_MSG_PREFIX: u32 = 0u32;
 pub const RemoteActionAppSwitch: RemoteActionType = RemoteActionType(4i32);
@@ -9242,9 +9182,6 @@ impl Default for TSSD_ConnectionPoint {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TSSD_ConnectionPoint {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TSSESSION_STATE(pub i32);
@@ -9280,9 +9217,6 @@ impl Default for VM_NOTIFY_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VM_NOTIFY_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VM_NOTIFY_INFO {
@@ -9293,9 +9227,6 @@ impl Default for VM_NOTIFY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VM_NOTIFY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9316,9 +9247,6 @@ impl Default for VM_PATCH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VM_PATCH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WINSTATIONNAME_LENGTH: u32 = 32u32;
 pub const WKS_FLAG_CLEAR_CREDS_ON_LAST_RESOURCE: u32 = 1u32;
 pub const WKS_FLAG_CREDS_AUTHENTICATED: u32 = 4u32;
@@ -9336,9 +9264,6 @@ impl Default for WRDS_CONNECTION_SETTING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WRDS_CONNECTION_SETTING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WRDS_CONNECTION_SETTINGS {
@@ -9349,9 +9274,6 @@ impl Default for WRDS_CONNECTION_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WRDS_CONNECTION_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9427,9 +9349,6 @@ impl Default for WRDS_CONNECTION_SETTINGS_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WRDS_CONNECTION_SETTINGS_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WRDS_CONNECTION_SETTING_LEVEL(pub i32);
@@ -9457,9 +9376,6 @@ impl Default for WRDS_DYNAMIC_TIME_ZONE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WRDS_DYNAMIC_TIME_ZONE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WRDS_IMEFILENAME_LENGTH: u32 = 32u32;
 pub const WRDS_INITIALPROGRAM_LENGTH: u32 = 256u32;
 pub const WRDS_KEY_EXCHANGE_ALG_DH: u32 = 2u32;
@@ -9476,9 +9392,6 @@ impl Default for WRDS_LISTENER_SETTING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WRDS_LISTENER_SETTING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WRDS_LISTENER_SETTINGS {
@@ -9489,9 +9402,6 @@ impl Default for WRDS_LISTENER_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WRDS_LISTENER_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9504,9 +9414,6 @@ impl Default for WRDS_LISTENER_SETTINGS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WRDS_LISTENER_SETTINGS_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9541,9 +9448,6 @@ impl Default for WRDS_SETTING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WRDS_SETTING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WRDS_SETTINGS {
@@ -9555,9 +9459,6 @@ impl Default for WRDS_SETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WRDS_SETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9598,9 +9499,6 @@ impl Default for WRDS_SETTINGS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WRDS_SETTINGS_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9662,9 +9560,6 @@ impl Default for WTSCLIENTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSCLIENTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTSCLIENTW {
@@ -9693,9 +9588,6 @@ impl Default for WTSCLIENTW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSCLIENTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTSCONFIGINFOA {
@@ -9716,9 +9608,6 @@ impl Default for WTSCONFIGINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSCONFIGINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTSCONFIGINFOW {
@@ -9738,9 +9627,6 @@ impl Default for WTSCONFIGINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTSCONFIGINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTSClientAddress: WTS_INFO_CLASS = WTS_INFO_CLASS(14i32);
 pub const WTSClientBuildNumber: WTS_INFO_CLASS = WTS_INFO_CLASS(9i32);
@@ -9783,9 +9669,6 @@ impl Default for WTSINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WTSINFOEXA {
@@ -9797,9 +9680,6 @@ impl Default for WTSINFOEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSINFOEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WTSINFOEXW {
@@ -9810,9 +9690,6 @@ impl Default for WTSINFOEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTSINFOEXW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9840,9 +9717,6 @@ impl Default for WTSINFOEX_LEVEL1_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSINFOEX_LEVEL1_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTSINFOEX_LEVEL1_W {
@@ -9869,9 +9743,6 @@ impl Default for WTSINFOEX_LEVEL1_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSINFOEX_LEVEL1_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WTSINFOEX_LEVEL_A {
@@ -9882,9 +9753,6 @@ impl Default for WTSINFOEX_LEVEL_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSINFOEX_LEVEL_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WTSINFOEX_LEVEL_W {
@@ -9894,9 +9762,6 @@ impl Default for WTSINFOEX_LEVEL_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTSINFOEX_LEVEL_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9922,9 +9787,6 @@ impl Default for WTSINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTSINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTSIdle: WTS_CONNECTSTATE_CLASS = WTS_CONNECTSTATE_CLASS(5i32);
 pub const WTSIdleTime: WTS_INFO_CLASS = WTS_INFO_CLASS(17i32);
@@ -9973,9 +9835,6 @@ impl Default for WTSLISTENERCONFIGA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSLISTENERCONFIGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTSLISTENERCONFIGW {
@@ -10016,9 +9875,6 @@ impl Default for WTSLISTENERCONFIGW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSLISTENERCONFIGW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WTSListen: WTS_CONNECTSTATE_CLASS = WTS_CONNECTSTATE_CLASS(6i32);
 pub const WTSLogonTime: WTS_INFO_CLASS = WTS_INFO_CLASS(18i32);
 pub const WTSOEMId: WTS_INFO_CLASS = WTS_INFO_CLASS(3i32);
@@ -10046,9 +9902,6 @@ impl Default for WTSSBX_IP_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSSBX_IP_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTSSBX_MACHINE_CONNECT_INFO {
@@ -10061,9 +9914,6 @@ impl Default for WTSSBX_MACHINE_CONNECT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTSSBX_MACHINE_CONNECT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10087,9 +9937,6 @@ impl Default for WTSSBX_MACHINE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTSSBX_MACHINE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10126,9 +9973,6 @@ impl Default for WTSSBX_SESSION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSSBX_SESSION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WTSSBX_SESSION_STATE(pub i32);
@@ -10145,9 +9989,6 @@ impl Default for WTSSESSION_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTSSESSION_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTSSessionAddressV4: WTS_INFO_CLASS = WTS_INFO_CLASS(28i32);
 pub const WTSSessionId: WTS_INFO_CLASS = WTS_INFO_CLASS(4i32);
@@ -10184,9 +10025,6 @@ impl Default for WTSUSERCONFIGA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTSUSERCONFIGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTSUSERCONFIGW {
@@ -10213,9 +10051,6 @@ impl Default for WTSUSERCONFIGW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTSUSERCONFIGW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTSUserConfigBrokenTimeoutSettings: WTS_CONFIG_CLASS = WTS_CONFIG_CLASS(10i32);
 pub const WTSUserConfigInitialProgram: WTS_CONFIG_CLASS = WTS_CONFIG_CLASS(0i32);
@@ -10257,9 +10092,6 @@ impl Default for WTS_CACHE_STATS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_CACHE_STATS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WTS_CACHE_STATS_UN {
@@ -10271,9 +10103,6 @@ impl Default for WTS_CACHE_STATS_UN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_CACHE_STATS_UN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10299,9 +10128,6 @@ impl Default for WTS_CLIENT_ADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_CLIENT_ADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10367,9 +10193,6 @@ impl Default for WTS_CLIENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_CLIENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_CLIENT_DISPLAY {
@@ -10381,9 +10204,6 @@ impl Default for WTS_CLIENT_DISPLAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_CLIENT_DISPLAY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTS_CLIENT_PRODUCT_ID_LENGTH: u32 = 32u32;
 pub const WTS_COMMENT_LENGTH: u32 = 60u32;
@@ -10412,9 +10232,6 @@ impl Default for WTS_DISPLAY_IOCTL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_DISPLAY_IOCTL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTS_DOMAIN_LENGTH: u32 = 255u32;
 pub const WTS_DRAIN_IN_DRAIN: WTS_RCM_DRAIN_STATE = WTS_RCM_DRAIN_STATE(1i32);
@@ -10455,9 +10272,6 @@ impl Default for WTS_LICENSE_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_LICENSE_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTS_LICENSE_PREAMBLE_VERSION: u32 = 3u32;
 pub const WTS_LICENSE_PROTOCOL_VERSION: u32 = 65536u32;
@@ -10507,9 +10321,6 @@ impl Default for WTS_POLICY_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_POLICY_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10525,10 +10336,6 @@ impl Default for WTS_PROCESS_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for WTS_PROCESS_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10543,10 +10350,6 @@ impl Default for WTS_PROCESS_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for WTS_PROCESS_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
@@ -10571,10 +10374,6 @@ impl Default for WTS_PROCESS_INFO_EXA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for WTS_PROCESS_INFO_EXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10598,10 +10397,6 @@ impl Default for WTS_PROCESS_INFO_EXW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for WTS_PROCESS_INFO_EXW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WTS_PROCESS_INFO_LEVEL_0: u32 = 0u32;
 pub const WTS_PROCESS_INFO_LEVEL_1: u32 = 1u32;
 pub const WTS_PROPERTY_DEFAULT_CONFIG: windows_core::PCWSTR = windows_core::w!("DefaultConfig");
@@ -10616,9 +10411,6 @@ impl Default for WTS_PROPERTY_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_PROPERTY_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WTS_PROPERTY_VALUE_0 {
@@ -10632,9 +10424,6 @@ impl Default for WTS_PROPERTY_VALUE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_PROPERTY_VALUE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_PROPERTY_VALUE_0_1 {
@@ -10645,9 +10434,6 @@ impl Default for WTS_PROPERTY_VALUE_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_PROPERTY_VALUE_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10660,9 +10446,6 @@ impl Default for WTS_PROPERTY_VALUE_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_PROPERTY_VALUE_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_PROTOCOL_CACHE {
@@ -10673,9 +10456,6 @@ impl Default for WTS_PROTOCOL_CACHE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_PROTOCOL_CACHE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10704,9 +10484,6 @@ impl Default for WTS_PROTOCOL_COUNTERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_PROTOCOL_COUNTERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WTS_PROTOCOL_NAME_LENGTH: u32 = 8u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10722,9 +10499,6 @@ impl Default for WTS_PROTOCOL_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_PROTOCOL_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTS_PROTOCOL_TYPE_CONSOLE: u32 = 0u32;
 pub const WTS_PROTOCOL_TYPE_ICA: u32 = 1u32;
@@ -10800,9 +10574,6 @@ impl Default for WTS_SERVER_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_SERVER_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_SERVER_INFOW {
@@ -10812,9 +10583,6 @@ impl Default for WTS_SERVER_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_SERVER_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTS_SERVICE_NONE: WTS_RCM_SERVICE_STATE = WTS_RCM_SERVICE_STATE(0i32);
 pub const WTS_SERVICE_START: WTS_RCM_SERVICE_STATE = WTS_RCM_SERVICE_STATE(1i32);
@@ -10828,9 +10596,6 @@ impl Default for WTS_SERVICE_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_SERVICE_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTS_SERVICE_STOP: WTS_RCM_SERVICE_STATE = WTS_RCM_SERVICE_STATE(2i32);
 pub const WTS_SESSIONSTATE_LOCK: u32 = 0u32;
@@ -10847,9 +10612,6 @@ impl Default for WTS_SESSION_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_SESSION_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_SESSION_ID {
@@ -10860,9 +10622,6 @@ impl Default for WTS_SESSION_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_SESSION_ID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10876,9 +10635,6 @@ impl Default for WTS_SESSION_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_SESSION_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_SESSION_INFOW {
@@ -10890,9 +10646,6 @@ impl Default for WTS_SESSION_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_SESSION_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10911,9 +10664,6 @@ impl Default for WTS_SESSION_INFO_1A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_SESSION_INFO_1A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_SESSION_INFO_1W {
@@ -10931,9 +10681,6 @@ impl Default for WTS_SESSION_INFO_1W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_SESSION_INFO_1W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_SMALL_RECT {
@@ -10947,9 +10694,6 @@ impl Default for WTS_SMALL_RECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_SMALL_RECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WTS_SOCKADDR {
@@ -10961,9 +10705,6 @@ impl Default for WTS_SOCKADDR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_SOCKADDR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WTS_SOCKADDR_0 {
@@ -10974,9 +10715,6 @@ impl Default for WTS_SOCKADDR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_SOCKADDR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10990,9 +10728,6 @@ impl Default for WTS_SOCKADDR_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_SOCKADDR_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_SOCKADDR_0_1 {
@@ -11005,9 +10740,6 @@ impl Default for WTS_SOCKADDR_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_SOCKADDR_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11026,9 +10758,6 @@ impl Default for WTS_SYSTEMTIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_SYSTEMTIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_TIME_ZONE_INFORMATION {
@@ -11044,9 +10773,6 @@ impl Default for WTS_TIME_ZONE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_TIME_ZONE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11064,9 +10790,6 @@ impl Default for WTS_USER_CREDENTIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_USER_CREDENTIAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_USER_DATA {
@@ -11078,9 +10801,6 @@ impl Default for WTS_USER_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_USER_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11096,9 +10816,6 @@ impl Default for WTS_VALIDATION_INFORMATIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WTS_VALIDATION_INFORMATIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WTS_VALIDATION_INFORMATIONW {
@@ -11112,9 +10829,6 @@ impl Default for WTS_VALIDATION_INFORMATIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_VALIDATION_INFORMATIONW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTS_VALUE_TYPE_BINARY: u32 = 3u32;
 pub const WTS_VALUE_TYPE_GUID: u32 = 4u32;
@@ -11178,9 +10892,6 @@ impl Default for pluginResource {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for pluginResource {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct pluginResource2 {
@@ -11196,9 +10907,6 @@ impl Default for pluginResource2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for pluginResource2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct pluginResource2FileAssociation {
@@ -11211,7 +10919,4 @@ impl Default for pluginResource2FileAssociation {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for pluginResource2FileAssociation {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
@@ -2357,9 +2357,6 @@ impl Default for WSMAN_AUTHENTICATION_CREDENTIALS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_AUTHENTICATION_CREDENTIALS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WSMAN_AUTHENTICATION_CREDENTIALS_0 {
@@ -2370,9 +2367,6 @@ impl Default for WSMAN_AUTHENTICATION_CREDENTIALS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_AUTHENTICATION_CREDENTIALS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2387,9 +2381,6 @@ impl Default for WSMAN_AUTHZ_QUOTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_AUTHZ_QUOTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSMAN_CERTIFICATE_DETAILS {
@@ -2402,9 +2393,6 @@ impl Default for WSMAN_CERTIFICATE_DETAILS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_CERTIFICATE_DETAILS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSMAN_CMDSHELL_OPTION_CODEPAGE: windows_core::PCWSTR = windows_core::w!("WINRS_CODEPAGE");
 pub const WSMAN_CMDSHELL_OPTION_CONSOLEMODE_STDIN: windows_core::PCWSTR = windows_core::w!("WINRS_CONSOLEMODE_STDIN");
@@ -2419,9 +2407,6 @@ impl Default for WSMAN_COMMAND_ARG_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_COMMAND_ARG_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2439,9 +2424,6 @@ impl Default for WSMAN_CONNECT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_CONNECT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WSMAN_CREATE_SHELL_DATA {
@@ -2451,9 +2433,6 @@ impl Default for WSMAN_CREATE_SHELL_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_CREATE_SHELL_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2465,9 +2444,6 @@ impl Default for WSMAN_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2481,9 +2457,6 @@ impl Default for WSMAN_DATA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_DATA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSMAN_DATA_BINARY {
@@ -2494,9 +2467,6 @@ impl Default for WSMAN_DATA_BINARY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_DATA_BINARY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSMAN_DATA_NONE: WSManDataType = WSManDataType(0i32);
 #[repr(C)]
@@ -2509,9 +2479,6 @@ impl Default for WSMAN_DATA_TEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_DATA_TEXT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSMAN_DATA_TYPE_BINARY: WSManDataType = WSManDataType(2i32);
 pub const WSMAN_DATA_TYPE_DWORD: WSManDataType = WSManDataType(4i32);
@@ -2528,9 +2495,6 @@ impl Default for WSMAN_ENVIRONMENT_VARIABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_ENVIRONMENT_VARIABLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSMAN_ENVIRONMENT_VARIABLE_SET {
@@ -2541,9 +2505,6 @@ impl Default for WSMAN_ENVIRONMENT_VARIABLE_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_ENVIRONMENT_VARIABLE_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2559,9 +2520,6 @@ impl Default for WSMAN_ERROR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_ERROR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSMAN_FILTER {
@@ -2572,9 +2530,6 @@ impl Default for WSMAN_FILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_FILTER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSMAN_FLAG_AUTH_BASIC: WSManAuthenticationFlags = WSManAuthenticationFlags(8i32);
 pub const WSMAN_FLAG_AUTH_CLIENT_CERTIFICATE: WSManAuthenticationFlags = WSManAuthenticationFlags(32i32);
@@ -2616,9 +2571,6 @@ impl Default for WSMAN_FRAGMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_FRAGMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSMAN_KEY {
@@ -2629,9 +2581,6 @@ impl Default for WSMAN_KEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_KEY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2654,9 +2603,6 @@ impl Default for WSMAN_OPERATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_OPERATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSMAN_OPERATION_INFOEX {
@@ -2673,9 +2619,6 @@ impl Default for WSMAN_OPERATION_INFOEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_OPERATION_INFOEX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WSMAN_OPERATION_INFOV1: u32 = 0u32;
 pub const WSMAN_OPERATION_INFOV2: u32 = 2864434397u32;
 #[repr(C)]
@@ -2689,9 +2632,6 @@ impl Default for WSMAN_OPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_OPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSMAN_OPTION_ALLOW_NEGOTIATE_IMPLICIT_CREDENTIALS: WSManSessionOption = WSManSessionOption(32i32);
 pub const WSMAN_OPTION_DEFAULT_OPERATION_TIMEOUTMS: WSManSessionOption = WSManSessionOption(1i32);
@@ -2717,9 +2657,6 @@ impl Default for WSMAN_OPTION_SET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_OPTION_SET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSMAN_OPTION_SETEX {
@@ -2732,9 +2669,6 @@ impl Default for WSMAN_OPTION_SETEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_OPTION_SETEX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSMAN_OPTION_SHELL_MAX_DATA_SIZE_PER_MESSAGE_KB: WSManSessionOption = WSManSessionOption(29i32);
 pub const WSMAN_OPTION_SKIP_CA_CHECK: WSManSessionOption = WSManSessionOption(18i32);
@@ -2787,9 +2721,6 @@ impl Default for WSMAN_PLUGIN_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_PLUGIN_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WSMAN_PLUGIN_SEND = Option<unsafe extern "system" fn(requestdetails: *const WSMAN_PLUGIN_REQUEST, flags: u32, shellcontext: *const core::ffi::c_void, commandcontext: *const core::ffi::c_void, stream: windows_core::PCWSTR, inbounddata: *const WSMAN_DATA)>;
 pub type WSMAN_PLUGIN_SHELL = Option<unsafe extern "system" fn(plugincontext: *const core::ffi::c_void, requestdetails: *const WSMAN_PLUGIN_REQUEST, flags: u32, startupinfo: *const WSMAN_SHELL_STARTUP_INFO_V11, inboundshellinformation: *const WSMAN_DATA)>;
 pub type WSMAN_PLUGIN_SHUTDOWN = Option<unsafe extern "system" fn(plugincontext: *const core::ffi::c_void, flags: u32, reason: u32) -> u32>;
@@ -2813,9 +2744,6 @@ impl Default for WSMAN_PROXY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_PROXY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct WSMAN_RECEIVE_DATA_RESULT {
@@ -2829,9 +2757,6 @@ impl Default for WSMAN_RECEIVE_DATA_RESULT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_RECEIVE_DATA_RESULT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union WSMAN_RESPONSE_DATA {
@@ -2844,9 +2769,6 @@ impl Default for WSMAN_RESPONSE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_RESPONSE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSMAN_SELECTOR_SET {
@@ -2857,9 +2779,6 @@ impl Default for WSMAN_SELECTOR_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_SELECTOR_SET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2874,9 +2793,6 @@ impl Default for WSMAN_SENDER_DETAILS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_SENDER_DETAILS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2895,9 +2811,6 @@ impl Default for WSMAN_SHELL_ASYNC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_SHELL_ASYNC {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WSMAN_SHELL_COMPLETION_FUNCTION = Option<unsafe extern "system" fn(operationcontext: *const core::ffi::c_void, flags: u32, error: *const WSMAN_ERROR, shell: WSMAN_SHELL_HANDLE, command: WSMAN_COMMAND_HANDLE, operationhandle: WSMAN_OPERATION_HANDLE, data: *const WSMAN_RESPONSE_DATA)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2908,9 +2821,6 @@ impl Default for WSMAN_SHELL_DISCONNECT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_SHELL_DISCONNECT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -2934,9 +2844,6 @@ impl Default for WSMAN_SHELL_STARTUP_INFO_V10 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_SHELL_STARTUP_INFO_V10 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSMAN_SHELL_STARTUP_INFO_V11 {
@@ -2948,9 +2855,6 @@ impl Default for WSMAN_SHELL_STARTUP_INFO_V11 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSMAN_SHELL_STARTUP_INFO_V11 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSMAN_STREAM_ID_SET {
@@ -2961,9 +2865,6 @@ impl Default for WSMAN_STREAM_ID_SET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_STREAM_ID_SET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSMAN_STREAM_ID_STDERR: windows_core::PCWSTR = windows_core::w!("stderr");
 pub const WSMAN_STREAM_ID_STDIN: windows_core::PCWSTR = windows_core::w!("stdin");
@@ -2978,9 +2879,6 @@ impl Default for WSMAN_USERNAME_PASSWORD_CREDS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSMAN_USERNAME_PASSWORD_CREDS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WSMan: windows_core::GUID = windows_core::GUID::from_u128(0xbced617b_ec03_420b_8508_977dc7a686bd);
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/System/RestartManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RestartManager/mod.rs
@@ -97,9 +97,6 @@ impl Default for RM_FILTER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RM_FILTER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RM_FILTER_INFO_0 {
@@ -111,9 +108,6 @@ impl Default for RM_FILTER_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RM_FILTER_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -136,9 +130,6 @@ impl Default for RM_PROCESS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RM_PROCESS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct RM_REBOOT_REASON(pub i32);
@@ -155,9 +146,6 @@ impl Default for RM_UNIQUE_PROCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RM_UNIQUE_PROCESS {
-    type TypeKind = windows_core::CopyType;
 }
 pub type RM_WRITE_STATUS_CALLBACK = Option<unsafe extern "system" fn(npercentcomplete: u32)>;
 pub const RmConsole: RM_APP_TYPE = RM_APP_TYPE(5i32);

--- a/crates/libs/windows/src/Windows/Win32/System/Restore/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Restore/mod.rs
@@ -53,9 +53,6 @@ impl Default for RESTOREPOINTINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESTOREPOINTINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct RESTOREPOINTINFOEX {
@@ -70,9 +67,6 @@ impl Default for RESTOREPOINTINFOEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESTOREPOINTINFOEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct RESTOREPOINTINFOW {
@@ -85,9 +79,6 @@ impl Default for RESTOREPOINTINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESTOREPOINTINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -105,9 +96,6 @@ impl Default for STATEMGRSTATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STATEMGRSTATUS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WINDOWS_BOOT: u32 = 9u32;
 pub const WINDOWS_SHUTDOWN: u32 = 8u32;

--- a/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
@@ -3027,9 +3027,6 @@ impl Default for ARRAY_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ARRAY_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BinaryParam {
@@ -3040,9 +3037,6 @@ impl Default for BinaryParam {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BinaryParam {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3055,9 +3049,6 @@ impl Default for CLIENT_CALL_RETURN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CLIENT_CALL_RETURN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COMM_FAULT_OFFSETS {
@@ -3068,9 +3059,6 @@ impl Default for COMM_FAULT_OFFSETS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COMM_FAULT_OFFSETS {
-    type TypeKind = windows_core::CopyType;
 }
 pub type CS_TAG_GETTING_ROUTINE = Option<unsafe extern "system" fn(hbinding: *mut core::ffi::c_void, fserverside: i32, pulsendingtag: *mut u32, puldesiredreceivingtag: *mut u32, pulreceivingtag: *mut u32, pstatus: *mut u32)>;
 pub type CS_TYPE_FROM_NETCS_ROUTINE = Option<unsafe extern "system" fn(hbinding: *mut core::ffi::c_void, ulnetworkcodeset: u32, pnetworkdata: *mut u8, ulnetworkdatalength: u32, ullocalbuffersize: u32, plocaldata: *mut core::ffi::c_void, pullocaldatalength: *mut u32, pstatus: *mut u32)>;
@@ -3116,9 +3104,6 @@ impl Default for FULL_PTR_XLAT_TABLES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FULL_PTR_XLAT_TABLES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GENERIC_BINDING_INFO {
@@ -3132,9 +3117,6 @@ impl Default for GENERIC_BINDING_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GENERIC_BINDING_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub type GENERIC_BINDING_ROUTINE = Option<unsafe extern "system" fn(param0: *mut core::ffi::c_void) -> *mut core::ffi::c_void>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3146,9 +3128,6 @@ impl Default for GENERIC_BINDING_ROUTINE_PAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GENERIC_BINDING_ROUTINE_PAIR {
-    type TypeKind = windows_core::CopyType;
 }
 pub type GENERIC_UNBIND_ROUTINE = Option<unsafe extern "system" fn(param0: *mut core::ffi::c_void, param1: *mut u8)>;
 #[repr(transparent)]
@@ -3181,9 +3160,6 @@ impl Default for I_RpcProxyCallbackInterface {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for I_RpcProxyCallbackInterface {
-    type TypeKind = windows_core::CopyType;
-}
 pub type I_RpcProxyFilterIfFn = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, ifuuid: *const windows_core::GUID, ifmajorversion: u16, fallow: *mut i32) -> RPC_STATUS>;
 pub type I_RpcProxyGetClientAddressFn = Option<unsafe extern "system" fn(context: *mut core::ffi::c_void, buffer: windows_core::PCSTR, bufferlength: *mut u32) -> RPC_STATUS>;
 pub type I_RpcProxyGetClientSessionAndResourceUUID = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, sessionidpresent: *mut i32, sessionid: *mut windows_core::GUID, resourceidpresent: *mut i32, resourceid: *mut windows_core::GUID) -> RPC_STATUS>;
@@ -3204,9 +3180,6 @@ impl Default for MALLOC_FREE_STRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MALLOC_FREE_STRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MES_DECODE: MIDL_ES_CODE = MIDL_ES_CODE(1i32);
 pub const MES_DYNAMIC_BUFFER_HANDLE: MIDL_ES_HANDLE_STYLE = MIDL_ES_HANDLE_STYLE(2i32);
@@ -3234,9 +3207,6 @@ impl Default for MIDL_FORMAT_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDL_FORMAT_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIDL_INTERCEPTION_INFO {
@@ -3251,9 +3221,6 @@ impl Default for MIDL_INTERCEPTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDL_INTERCEPTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIDL_INTERFACE_METHOD_PROPERTIES {
@@ -3264,9 +3231,6 @@ impl Default for MIDL_INTERFACE_METHOD_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIDL_INTERFACE_METHOD_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3279,9 +3243,6 @@ impl Default for MIDL_METHOD_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDL_METHOD_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIDL_METHOD_PROPERTY_MAP {
@@ -3292,9 +3253,6 @@ impl Default for MIDL_METHOD_PROPERTY_MAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIDL_METHOD_PROPERTY_MAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3315,10 +3273,6 @@ impl Default for MIDL_SERVER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MIDL_SERVER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3335,10 +3289,6 @@ impl Default for MIDL_STUBLESS_PROXY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MIDL_STUBLESS_PROXY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3371,10 +3321,6 @@ impl Default for MIDL_STUB_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MIDL_STUB_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -3388,10 +3334,6 @@ impl Default for MIDL_STUB_DESC_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MIDL_STUB_DESC_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3463,10 +3405,6 @@ impl Default for MIDL_STUB_MESSAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MIDL_STUB_MESSAGE {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIDL_SYNTAX_INFO {
@@ -3484,9 +3422,6 @@ impl Default for MIDL_SYNTAX_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MIDL_SYNTAX_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MIDL_TYPE_PICKLING_INFO {
@@ -3498,9 +3433,6 @@ impl Default for MIDL_TYPE_PICKLING_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MIDL_TYPE_PICKLING_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -3517,10 +3449,6 @@ impl Default for MIDL_WINRT_TYPE_SERIALIZATION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for MIDL_WINRT_TYPE_SERIALIZATION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIDL_WINRT_TYPE_SERIALIZATION_INFO_CURRENT_VERSION: i32 = 1i32;
 pub const MarshalDirectionMarshal: LRPC_SYSTEM_HANDLE_MARSHAL_DIRECTION = LRPC_SYSTEM_HANDLE_MARSHAL_DIRECTION(0i32);
@@ -3539,9 +3467,6 @@ impl Default for NDR64_ARRAY_ELEMENT_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_ARRAY_ELEMENT_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_ARRAY_FLAGS {
@@ -3551,9 +3476,6 @@ impl Default for NDR64_ARRAY_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_ARRAY_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3567,9 +3489,6 @@ impl Default for NDR64_BINDINGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_BINDINGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_BIND_AND_NOTIFY_EXTENSION {
@@ -3580,9 +3499,6 @@ impl Default for NDR64_BIND_AND_NOTIFY_EXTENSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_BIND_AND_NOTIFY_EXTENSION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3598,9 +3514,6 @@ impl Default for NDR64_BIND_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_BIND_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_BIND_GENERIC {
@@ -3615,9 +3528,6 @@ impl Default for NDR64_BIND_GENERIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_BIND_GENERIC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_BIND_PRIMITIVE {
@@ -3630,9 +3540,6 @@ impl Default for NDR64_BIND_PRIMITIVE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_BIND_PRIMITIVE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3648,9 +3555,6 @@ impl Default for NDR64_BOGUS_ARRAY_HEADER_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_BOGUS_ARRAY_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3669,9 +3573,6 @@ impl Default for NDR64_BOGUS_STRUCTURE_HEADER_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_BOGUS_STRUCTURE_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_BUFFER_ALIGN_FORMAT {
@@ -3685,9 +3586,6 @@ impl Default for NDR64_BUFFER_ALIGN_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_BUFFER_ALIGN_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_CONFORMANT_STRING_FORMAT {
@@ -3697,9 +3595,6 @@ impl Default for NDR64_CONFORMANT_STRING_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_CONFORMANT_STRING_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3715,9 +3610,6 @@ impl Default for NDR64_CONF_ARRAY_HEADER_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_CONF_ARRAY_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3737,9 +3629,6 @@ impl Default for NDR64_CONF_BOGUS_STRUCTURE_HEADER_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_CONF_BOGUS_STRUCTURE_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_CONF_STRUCTURE_HEADER_FORMAT {
@@ -3754,9 +3643,6 @@ impl Default for NDR64_CONF_STRUCTURE_HEADER_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_CONF_STRUCTURE_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3774,9 +3660,6 @@ impl Default for NDR64_CONF_VAR_ARRAY_HEADER_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_CONF_VAR_ARRAY_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_CONF_VAR_BOGUS_ARRAY_HEADER_FORMAT {
@@ -3789,9 +3672,6 @@ impl Default for NDR64_CONF_VAR_BOGUS_ARRAY_HEADER_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_CONF_VAR_BOGUS_ARRAY_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3806,9 +3686,6 @@ impl Default for NDR64_CONSTANT_IID_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_CONSTANT_IID_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_CONTEXT_HANDLE_FLAGS {
@@ -3818,9 +3695,6 @@ impl Default for NDR64_CONTEXT_HANDLE_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_CONTEXT_HANDLE_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3835,9 +3709,6 @@ impl Default for NDR64_CONTEXT_HANDLE_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_CONTEXT_HANDLE_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_EMBEDDED_COMPLEX_FORMAT {
@@ -3850,9 +3721,6 @@ impl Default for NDR64_EMBEDDED_COMPLEX_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_EMBEDDED_COMPLEX_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3870,9 +3738,6 @@ impl Default for NDR64_ENCAPSULATED_UNION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_ENCAPSULATED_UNION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_EXPR_CONST32 {
@@ -3885,9 +3750,6 @@ impl Default for NDR64_EXPR_CONST32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_EXPR_CONST32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3902,9 +3764,6 @@ impl Default for NDR64_EXPR_CONST64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_EXPR_CONST64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_EXPR_NOOP {
@@ -3916,9 +3775,6 @@ impl Default for NDR64_EXPR_NOOP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_EXPR_NOOP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3933,9 +3789,6 @@ impl Default for NDR64_EXPR_OPERATOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_EXPR_OPERATOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_EXPR_VAR {
@@ -3948,9 +3801,6 @@ impl Default for NDR64_EXPR_VAR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_EXPR_VAR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NDR64_FC_AUTO_HANDLE: u32 = 3u32;
 pub const NDR64_FC_BIND_GENERIC: u32 = 1u32;
@@ -3970,9 +3820,6 @@ impl Default for NDR64_FIXED_REPEAT_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_FIXED_REPEAT_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_FIX_ARRAY_HEADER_FORMAT {
@@ -3987,9 +3834,6 @@ impl Default for NDR64_FIX_ARRAY_HEADER_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_FIX_ARRAY_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_IID_FLAGS {
@@ -3999,9 +3843,6 @@ impl Default for NDR64_IID_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_IID_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4016,9 +3857,6 @@ impl Default for NDR64_IID_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_IID_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_MEMPAD_FORMAT {
@@ -4032,9 +3870,6 @@ impl Default for NDR64_MEMPAD_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_MEMPAD_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_NON_CONFORMANT_STRING_FORMAT {
@@ -4045,9 +3880,6 @@ impl Default for NDR64_NON_CONFORMANT_STRING_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_NON_CONFORMANT_STRING_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4065,9 +3897,6 @@ impl Default for NDR64_NON_ENCAPSULATED_UNION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_NON_ENCAPSULATED_UNION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_NO_REPEAT_FORMAT {
@@ -4081,9 +3910,6 @@ impl Default for NDR64_NO_REPEAT_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_NO_REPEAT_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_PARAM_FLAGS {
@@ -4093,9 +3919,6 @@ impl Default for NDR64_PARAM_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_PARAM_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4110,9 +3933,6 @@ impl Default for NDR64_PARAM_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_PARAM_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_PIPE_FLAGS {
@@ -4122,9 +3942,6 @@ impl Default for NDR64_PIPE_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_PIPE_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4142,9 +3959,6 @@ impl Default for NDR64_PIPE_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_PIPE_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_POINTER_FORMAT {
@@ -4158,9 +3972,6 @@ impl Default for NDR64_POINTER_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_POINTER_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_POINTER_INSTANCE_HEADER_FORMAT {
@@ -4172,9 +3983,6 @@ impl Default for NDR64_POINTER_INSTANCE_HEADER_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_POINTER_INSTANCE_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_POINTER_REPEAT_FLAGS {
@@ -4185,9 +3993,6 @@ impl Default for NDR64_POINTER_REPEAT_FLAGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_POINTER_REPEAT_FLAGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_PROC_FLAGS {
@@ -4197,9 +4002,6 @@ impl Default for NDR64_PROC_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_PROC_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4218,9 +4020,6 @@ impl Default for NDR64_PROC_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_PROC_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_RANGED_STRING_FORMAT {
@@ -4233,9 +4032,6 @@ impl Default for NDR64_RANGED_STRING_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_RANGED_STRING_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4250,9 +4046,6 @@ impl Default for NDR64_RANGE_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_RANGE_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4272,9 +4065,6 @@ impl Default for NDR64_RANGE_PIPE_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_RANGE_PIPE_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_REPEAT_FORMAT {
@@ -4290,9 +4080,6 @@ impl Default for NDR64_REPEAT_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_REPEAT_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_RPC_FLAGS {
@@ -4302,9 +4089,6 @@ impl Default for NDR64_RPC_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_RPC_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4319,9 +4103,6 @@ impl Default for NDR64_SIMPLE_MEMBER_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_SIMPLE_MEMBER_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_SIMPLE_REGION_FORMAT {
@@ -4335,9 +4116,6 @@ impl Default for NDR64_SIMPLE_REGION_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_SIMPLE_REGION_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_SIZED_CONFORMANT_STRING_FORMAT {
@@ -4349,9 +4127,6 @@ impl Default for NDR64_SIZED_CONFORMANT_STRING_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_SIZED_CONFORMANT_STRING_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_STRING_FLAGS {
@@ -4361,9 +4136,6 @@ impl Default for NDR64_STRING_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_STRING_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4377,9 +4149,6 @@ impl Default for NDR64_STRING_HEADER_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_STRING_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_STRUCTURE_FLAGS {
@@ -4389,9 +4158,6 @@ impl Default for NDR64_STRUCTURE_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_STRUCTURE_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4407,9 +4173,6 @@ impl Default for NDR64_STRUCTURE_HEADER_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_STRUCTURE_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_SYSTEM_HANDLE_FORMAT {
@@ -4422,9 +4185,6 @@ impl Default for NDR64_SYSTEM_HANDLE_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_SYSTEM_HANDLE_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_TRANSMIT_AS_FLAGS {
@@ -4434,9 +4194,6 @@ impl Default for NDR64_TRANSMIT_AS_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_TRANSMIT_AS_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4455,9 +4212,6 @@ impl Default for NDR64_TRANSMIT_AS_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_TRANSMIT_AS_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_TYPE_STRICT_CONTEXT_HANDLE {
@@ -4473,9 +4227,6 @@ impl Default for NDR64_TYPE_STRICT_CONTEXT_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_TYPE_STRICT_CONTEXT_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_UNION_ARM {
@@ -4487,9 +4238,6 @@ impl Default for NDR64_UNION_ARM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_UNION_ARM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4504,9 +4252,6 @@ impl Default for NDR64_UNION_ARM_SELECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_UNION_ARM_SELECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_USER_MARSHAL_FLAGS {
@@ -4516,9 +4261,6 @@ impl Default for NDR64_USER_MARSHAL_FLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_USER_MARSHAL_FLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4537,9 +4279,6 @@ impl Default for NDR64_USER_MARSHAL_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR64_USER_MARSHAL_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR64_VAR_ARRAY_HEADER_FORMAT {
@@ -4555,9 +4294,6 @@ impl Default for NDR64_VAR_ARRAY_HEADER_FORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR64_VAR_ARRAY_HEADER_FORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
@@ -4576,9 +4312,6 @@ impl Default for NDR_CS_ROUTINES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR_CS_ROUTINES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NDR_CS_SIZE_CONVERT_ROUTINES {
@@ -4592,9 +4325,6 @@ impl Default for NDR_CS_SIZE_CONVERT_ROUTINES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR_CS_SIZE_CONVERT_ROUTINES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDR_CUSTOM_OR_DEFAULT_ALLOCATOR: u32 = 268435456u32;
 pub const NDR_DEFAULT_ALLOCATOR: u32 = 536870912u32;
 #[repr(C)]
@@ -4607,9 +4337,6 @@ impl Default for NDR_EXPR_DESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NDR_EXPR_DESC {
-    type TypeKind = windows_core::CopyType;
 }
 pub type NDR_NOTIFY2_ROUTINE = Option<unsafe extern "system" fn(flag: u8)>;
 pub type NDR_NOTIFY_ROUTINE = Option<unsafe extern "system" fn()>;
@@ -4631,9 +4358,6 @@ impl Default for NDR_SCONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NDR_SCONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 pub struct NDR_USER_MARSHAL_INFO {
@@ -4652,10 +4376,6 @@ impl Default for NDR_USER_MARSHAL_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for NDR_USER_MARSHAL_INFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 pub union NDR_USER_MARSHAL_INFO_0 {
@@ -4673,10 +4393,6 @@ impl Default for NDR_USER_MARSHAL_INFO_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for NDR_USER_MARSHAL_INFO_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Debug, PartialEq)]
@@ -4693,10 +4409,6 @@ impl Default for NDR_USER_MARSHAL_INFO_LEVEL1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for NDR_USER_MARSHAL_INFO_LEVEL1 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const NT351_INTERFACE_SIZE: u32 = 64u32;
 #[cfg(feature = "Win32_System_IO")]
@@ -4750,9 +4462,6 @@ impl Default for RDR_CALLOUT_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RDR_CALLOUT_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RPCFLG_ACCESSIBILITY_BIT1: u32 = 1048576u32;
 pub const RPCFLG_ACCESSIBILITY_BIT2: u32 = 2097152u32;
 pub const RPCFLG_ACCESS_LOCAL: u32 = 4194304u32;
@@ -4797,10 +4506,6 @@ impl Default for RPC_ASYNC_NOTIFICATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for RPC_ASYNC_NOTIFICATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4813,10 +4518,6 @@ impl Default for RPC_ASYNC_NOTIFICATION_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for RPC_ASYNC_NOTIFICATION_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
@@ -4833,10 +4534,6 @@ impl Default for RPC_ASYNC_NOTIFICATION_INFO_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for RPC_ASYNC_NOTIFICATION_INFO_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4849,10 +4546,6 @@ impl Default for RPC_ASYNC_NOTIFICATION_INFO_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for RPC_ASYNC_NOTIFICATION_INFO_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_IO")]
@@ -4875,10 +4568,6 @@ impl Default for RPC_ASYNC_STATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_IO")]
-impl windows_core::TypeKind for RPC_ASYNC_STATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub type RPC_AUTH_KEY_RETRIEVAL_FN = Option<unsafe extern "system" fn(arg: *const core::ffi::c_void, serverprincname: windows_core::PCWSTR, keyver: u32, key: *mut *mut core::ffi::c_void, status: *mut RPC_STATUS)>;
 pub const RPC_BHO_DONTLINGER: RPC_BINDING_HANDLE_OPTIONS_FLAGS = RPC_BINDING_HANDLE_OPTIONS_FLAGS(2u32);
@@ -4934,9 +4623,6 @@ impl Default for RPC_BINDING_HANDLE_OPTIONS_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_BINDING_HANDLE_OPTIONS_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4953,10 +4639,6 @@ impl Default for RPC_BINDING_HANDLE_SECURITY_V1_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_BINDING_HANDLE_SECURITY_V1_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -4975,10 +4657,6 @@ impl Default for RPC_BINDING_HANDLE_SECURITY_V1_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_BINDING_HANDLE_SECURITY_V1_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RPC_BINDING_HANDLE_TEMPLATE_V1_A {
@@ -4995,9 +4673,6 @@ impl Default for RPC_BINDING_HANDLE_TEMPLATE_V1_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_BINDING_HANDLE_TEMPLATE_V1_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RPC_BINDING_HANDLE_TEMPLATE_V1_A_0 {
@@ -5007,9 +4682,6 @@ impl Default for RPC_BINDING_HANDLE_TEMPLATE_V1_A_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_BINDING_HANDLE_TEMPLATE_V1_A_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5027,9 +4699,6 @@ impl Default for RPC_BINDING_HANDLE_TEMPLATE_V1_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_BINDING_HANDLE_TEMPLATE_V1_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RPC_BINDING_HANDLE_TEMPLATE_V1_W_0 {
@@ -5039,9 +4708,6 @@ impl Default for RPC_BINDING_HANDLE_TEMPLATE_V1_W_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_BINDING_HANDLE_TEMPLATE_V1_W_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5053,9 +4719,6 @@ impl Default for RPC_BINDING_VECTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_BINDING_VECTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub type RPC_BLOCKING_FN = Option<unsafe extern "system" fn(hwnd: *mut core::ffi::c_void, context: *mut core::ffi::c_void, hsyncevent: *mut core::ffi::c_void) -> RPC_STATUS>;
 pub const RPC_BUFFER_ASYNC: u32 = 32768u32;
@@ -5081,9 +4744,6 @@ impl Default for RPC_CALL_ATTRIBUTES_V1_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_CALL_ATTRIBUTES_V1_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_CALL_ATTRIBUTES_V1_W {
@@ -5101,9 +4761,6 @@ impl Default for RPC_CALL_ATTRIBUTES_V1_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_CALL_ATTRIBUTES_V1_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5132,9 +4789,6 @@ impl Default for RPC_CALL_ATTRIBUTES_V2_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_CALL_ATTRIBUTES_V2_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_CALL_ATTRIBUTES_V2_W {
@@ -5161,9 +4815,6 @@ impl Default for RPC_CALL_ATTRIBUTES_V2_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_CALL_ATTRIBUTES_V2_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5194,9 +4845,6 @@ impl Default for RPC_CALL_ATTRIBUTES_V3_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_CALL_ATTRIBUTES_V3_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_CALL_ATTRIBUTES_V3_W {
@@ -5226,9 +4874,6 @@ impl Default for RPC_CALL_ATTRIBUTES_V3_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_CALL_ATTRIBUTES_V3_W {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RPC_CALL_ATTRIBUTES_VERSION: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5242,9 +4887,6 @@ impl Default for RPC_CALL_LOCAL_ADDRESS_V1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_CALL_LOCAL_ADDRESS_V1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RPC_CALL_STATUS_CANCELLED: u32 = 1u32;
 pub const RPC_CALL_STATUS_DISCONNECTED: u32 = 2u32;
@@ -5263,9 +4905,6 @@ impl Default for RPC_CLIENT_INFORMATION1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_CLIENT_INFORMATION1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_CLIENT_INTERFACE {
@@ -5283,9 +4922,6 @@ impl Default for RPC_CLIENT_INTERFACE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_CLIENT_INTERFACE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RPC_CONTEXT_HANDLE_DEFAULT_FLAGS: u32 = 0u32;
 pub const RPC_CONTEXT_HANDLE_DONT_SERIALIZE: u32 = 536870912u32;
@@ -5453,9 +5089,6 @@ impl Default for RPC_C_OPT_COOKIE_AUTH_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_C_OPT_COOKIE_AUTH_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RPC_C_OPT_DONT_LINGER: u32 = 13u32;
 pub const RPC_C_OPT_MAX_OPTIONS: u32 = 12u32;
 pub const RPC_C_OPT_MQ_ACKNOWLEDGE: u32 = 4u32;
@@ -5565,9 +5198,6 @@ impl Default for RPC_DISPATCH_TABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_DISPATCH_TABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RPC_EEINFO_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5579,9 +5209,6 @@ impl Default for RPC_EE_INFO_PARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_EE_INFO_PARAM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5598,9 +5225,6 @@ impl Default for RPC_EE_INFO_PARAM_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_EE_INFO_PARAM_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_ENDPOINT_TEMPLATEA {
@@ -5614,9 +5238,6 @@ impl Default for RPC_ENDPOINT_TEMPLATEA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_ENDPOINT_TEMPLATEA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5632,9 +5253,6 @@ impl Default for RPC_ENDPOINT_TEMPLATEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_ENDPOINT_TEMPLATEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_ERROR_ENUM_HANDLE {
@@ -5646,9 +5264,6 @@ impl Default for RPC_ERROR_ENUM_HANDLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_ERROR_ENUM_HANDLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5669,9 +5284,6 @@ impl Default for RPC_EXTENDED_ERROR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_EXTENDED_ERROR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RPC_EXTENDED_ERROR_INFO_0 {
@@ -5682,9 +5294,6 @@ impl Default for RPC_EXTENDED_ERROR_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_EXTENDED_ERROR_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RPC_FLAGS_VALID_BIT: u32 = 32768u32;
 pub type RPC_FORWARD_FUNCTION = Option<unsafe extern "system" fn(interfaceid: *mut windows_core::GUID, interfaceversion: *mut RPC_VERSION, objectid: *mut windows_core::GUID, rpcpro: *mut u8, ppdestendpoint: *mut *mut core::ffi::c_void) -> RPC_STATUS>;
@@ -5708,9 +5317,6 @@ impl Default for RPC_HTTP_TRANSPORT_CREDENTIALS_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_HTTP_TRANSPORT_CREDENTIALS_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_HTTP_TRANSPORT_CREDENTIALS_V2_A {
@@ -5728,9 +5334,6 @@ impl Default for RPC_HTTP_TRANSPORT_CREDENTIALS_V2_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_HTTP_TRANSPORT_CREDENTIALS_V2_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5750,9 +5353,6 @@ impl Default for RPC_HTTP_TRANSPORT_CREDENTIALS_V2_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_HTTP_TRANSPORT_CREDENTIALS_V2_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_HTTP_TRANSPORT_CREDENTIALS_V3_A {
@@ -5770,9 +5370,6 @@ impl Default for RPC_HTTP_TRANSPORT_CREDENTIALS_V3_A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_HTTP_TRANSPORT_CREDENTIALS_V3_A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5792,9 +5389,6 @@ impl Default for RPC_HTTP_TRANSPORT_CREDENTIALS_V3_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_HTTP_TRANSPORT_CREDENTIALS_V3_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_HTTP_TRANSPORT_CREDENTIALS_W {
@@ -5809,9 +5403,6 @@ impl Default for RPC_HTTP_TRANSPORT_CREDENTIALS_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_HTTP_TRANSPORT_CREDENTIALS_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RPC_IF_ALLOW_CALLBACKS_WITH_NO_AUTH: u32 = 16u32;
 pub const RPC_IF_ALLOW_LOCAL_ONLY: u32 = 32u32;
@@ -5832,9 +5423,6 @@ impl Default for RPC_IF_ID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_IF_ID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_IF_ID_VECTOR {
@@ -5845,9 +5433,6 @@ impl Default for RPC_IF_ID_VECTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_IF_ID_VECTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RPC_IF_OLE: u32 = 2u32;
 pub const RPC_IF_SEC_CACHE_PER_PROC: u32 = 128u32;
@@ -5863,9 +5448,6 @@ impl Default for RPC_IMPORT_CONTEXT_P {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_IMPORT_CONTEXT_P {
-    type TypeKind = windows_core::CopyType;
 }
 pub type RPC_INTERFACE_GROUP_IDLE_CALLBACK_FN = Option<unsafe extern "system" fn(ifgroup: *const core::ffi::c_void, idlecallbackcontext: *const core::ffi::c_void, isgroupidle: u32)>;
 pub const RPC_INTERFACE_HAS_PIPES: u32 = 1u32;
@@ -5889,9 +5471,6 @@ impl Default for RPC_INTERFACE_TEMPLATEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_INTERFACE_TEMPLATEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_INTERFACE_TEMPLATEW {
@@ -5912,9 +5491,6 @@ impl Default for RPC_INTERFACE_TEMPLATEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_INTERFACE_TEMPLATEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_MESSAGE {
@@ -5934,9 +5510,6 @@ impl Default for RPC_MESSAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_MESSAGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub type RPC_MGMT_AUTHORIZATION_FN = Option<unsafe extern "system" fn(clientbinding: *const core::ffi::c_void, requestedmgmtoperation: u32, status: *mut RPC_STATUS) -> i32>;
 pub const RPC_NCA_FLAGS_BROADCAST: u32 = 2u32;
@@ -5963,9 +5536,6 @@ impl Default for RPC_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_PROTSEQ_ENDPOINT {
@@ -5976,9 +5546,6 @@ impl Default for RPC_PROTSEQ_ENDPOINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_PROTSEQ_ENDPOINT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RPC_PROTSEQ_HTTP: u32 = 4u32;
 pub const RPC_PROTSEQ_LRPC: u32 = 3u32;
@@ -5995,9 +5562,6 @@ impl Default for RPC_PROTSEQ_VECTORA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_PROTSEQ_VECTORA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_PROTSEQ_VECTORW {
@@ -6008,9 +5572,6 @@ impl Default for RPC_PROTSEQ_VECTORW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_PROTSEQ_VECTORW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RPC_PROXY_CONNECTION_TYPE_IN_PROXY: u32 = 0u32;
 pub const RPC_PROXY_CONNECTION_TYPE_OUT_PROXY: u32 = 1u32;
@@ -6039,10 +5600,6 @@ impl Default for RPC_SECURITY_QOS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6060,10 +5617,6 @@ impl Default for RPC_SECURITY_QOS_V2_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V2_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6075,10 +5628,6 @@ impl Default for RPC_SECURITY_QOS_V2_A_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V2_A_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6097,10 +5646,6 @@ impl Default for RPC_SECURITY_QOS_V2_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V2_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6112,10 +5657,6 @@ impl Default for RPC_SECURITY_QOS_V2_W_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V2_W_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6135,10 +5676,6 @@ impl Default for RPC_SECURITY_QOS_V3_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V3_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6150,10 +5687,6 @@ impl Default for RPC_SECURITY_QOS_V3_A_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V3_A_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6173,10 +5706,6 @@ impl Default for RPC_SECURITY_QOS_V3_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V3_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6188,10 +5717,6 @@ impl Default for RPC_SECURITY_QOS_V3_W_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V3_W_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6212,10 +5737,6 @@ impl Default for RPC_SECURITY_QOS_V4_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V4_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6227,10 +5748,6 @@ impl Default for RPC_SECURITY_QOS_V4_A_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V4_A_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6251,10 +5768,6 @@ impl Default for RPC_SECURITY_QOS_V4_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V4_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6266,10 +5779,6 @@ impl Default for RPC_SECURITY_QOS_V4_W_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V4_W_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6291,10 +5800,6 @@ impl Default for RPC_SECURITY_QOS_V5_A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V5_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6306,10 +5811,6 @@ impl Default for RPC_SECURITY_QOS_V5_A_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V5_A_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6331,10 +5832,6 @@ impl Default for RPC_SECURITY_QOS_V5_W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V5_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6347,10 +5844,6 @@ impl Default for RPC_SECURITY_QOS_V5_W_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RPC_SECURITY_QOS_V5_W_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RPC_SEC_CONTEXT_KEY_INFO {
@@ -6362,9 +5855,6 @@ impl Default for RPC_SEC_CONTEXT_KEY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_SEC_CONTEXT_KEY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6384,9 +5874,6 @@ impl Default for RPC_SERVER_INTERFACE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_SERVER_INTERFACE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type RPC_SETFILTER_FUNC = Option<unsafe extern "system" fn(pfnfilter: RPCLT_PDU_FILTER_FUNC)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6398,9 +5885,6 @@ impl Default for RPC_STATS_VECTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_STATS_VECTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[must_use]
 #[repr(transparent)]
@@ -6416,9 +5900,6 @@ impl Default for RPC_SYNTAX_IDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_SYNTAX_IDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RPC_SYSTEM_HANDLE_FREE_ALL: u32 = 3u32;
 pub const RPC_SYSTEM_HANDLE_FREE_ERROR_ON_CLOSE: u32 = 4u32;
@@ -6546,9 +6027,6 @@ impl Default for RPC_TRANSFER_SYNTAX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RPC_TRANSFER_SYNTAX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RPC_TYPE_DISCONNECT_EVENT_CONTEXT_HANDLE: u32 = 2147483648u32;
 pub const RPC_TYPE_STRICT_CONTEXT_HANDLE: u32 = 1073741824u32;
 #[repr(C)]
@@ -6561,9 +6039,6 @@ impl Default for RPC_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RPC_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RpcAttemptedLbsDecisions: RpcPerfCounters = RpcPerfCounters(8i32);
 pub const RpcAttemptedLbsMessages: RpcPerfCounters = RpcPerfCounters(10i32);
@@ -6614,9 +6089,6 @@ impl Default for SCONTEXT_QUEUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCONTEXT_QUEUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SEC_WINNT_AUTH_IDENTITY(pub u32);
@@ -6636,9 +6108,6 @@ impl Default for SEC_WINNT_AUTH_IDENTITY_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEC_WINNT_AUTH_IDENTITY_A {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SEC_WINNT_AUTH_IDENTITY_ANSI: SEC_WINNT_AUTH_IDENTITY = SEC_WINNT_AUTH_IDENTITY(1u32);
 pub const SEC_WINNT_AUTH_IDENTITY_UNICODE: SEC_WINNT_AUTH_IDENTITY = SEC_WINNT_AUTH_IDENTITY(2u32);
 #[repr(C)]
@@ -6656,9 +6125,6 @@ impl Default for SEC_WINNT_AUTH_IDENTITY_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEC_WINNT_AUTH_IDENTITY_W {
-    type TypeKind = windows_core::CopyType;
 }
 pub type SERVER_ROUTINE = Option<unsafe extern "system" fn() -> i32>;
 pub const STUB_CALL_SERVER: STUB_PHASE = STUB_PHASE(1i32);
@@ -6720,10 +6186,6 @@ impl Default for USER_MARSHAL_CB {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for USER_MARSHAL_CB {
-    type TypeKind = windows_core::CopyType;
-}
 pub const USER_MARSHAL_CB_BUFFER_SIZE: USER_MARSHAL_CB_TYPE = USER_MARSHAL_CB_TYPE(0i32);
 pub const USER_MARSHAL_CB_FREE: USER_MARSHAL_CB_TYPE = USER_MARSHAL_CB_TYPE(3i32);
 pub const USER_MARSHAL_CB_MARSHALL: USER_MARSHAL_CB_TYPE = USER_MARSHAL_CB_TYPE(1i32);
@@ -6758,9 +6220,6 @@ impl Default for USER_MARSHAL_ROUTINE_QUADRUPLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for USER_MARSHAL_ROUTINE_QUADRUPLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type USER_MARSHAL_SIZING_ROUTINE = Option<unsafe extern "system" fn(param0: *mut u32, param1: u32, param2: *mut core::ffi::c_void) -> u32>;
 pub type USER_MARSHAL_UNMARSHALLING_ROUTINE = Option<unsafe extern "system" fn(param0: *mut u32, param1: *mut u8, param2: *mut core::ffi::c_void) -> *mut u8>;
 #[repr(C)]
@@ -6773,9 +6232,6 @@ impl Default for UUID_VECTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UUID_VECTOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const XLAT_CLIENT: XLAT_SIDE = XLAT_SIDE(2i32);
 pub const XLAT_SERVER: XLAT_SIDE = XLAT_SIDE(1i32);
@@ -6798,10 +6254,6 @@ impl Default for XMIT_ROUTINE_QUINTUPLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for XMIT_ROUTINE_QUINTUPLE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -1637,9 +1637,6 @@ impl Default for AUTHENTICATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTHENTICATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct AUTH_TYPE(pub i32);
@@ -1685,9 +1682,6 @@ impl Default for BUCKETCATEGORIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BUCKETCATEGORIZE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BUCKET_EXPONENTIAL: u32 = 1u32;
 pub const BUCKET_LINEAR: u32 = 0u32;
 #[repr(transparent)]
@@ -1727,10 +1721,6 @@ impl Default for CATEGORIZATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for CATEGORIZATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy)]
@@ -1745,10 +1735,6 @@ impl Default for CATEGORIZATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for CATEGORIZATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1761,10 +1747,6 @@ impl Default for CATEGORIZATIONSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for CATEGORIZATIONSET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CATEGORIZE_BUCKETS: u32 = 2u32;
 pub const CATEGORIZE_CLUSTER: u32 = 1u32;
@@ -1855,10 +1837,6 @@ impl Default for COLUMNSET {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl windows_core::TypeKind for COLUMNSET {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CONDITION_CREATION_DEFAULT: CONDITION_CREATION_OPTIONS = CONDITION_CREATION_OPTIONS(0i32);
 pub const CONDITION_CREATION_NONE: CONDITION_CREATION_OPTIONS = CONDITION_CREATION_OPTIONS(0i32);
 #[repr(transparent)]
@@ -1916,10 +1894,6 @@ impl Default for CONTENTRESTRICTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl windows_core::TypeKind for CONTENTRESTRICTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONTENT_SOURCE_E_CONTENT_CLASS_READ: i32 = -2147208188i32;
 pub const CONTENT_SOURCE_E_CONTENT_SOURCE_COLUMN_TYPE: i32 = -2147208185i32;
@@ -2014,9 +1988,6 @@ impl Default for DATE_STRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DATE_STRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DBACCESSORFLAGSENUM(pub i32);
@@ -2050,10 +2021,6 @@ impl Default for DBBINDEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBBINDEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2066,10 +2033,6 @@ impl Default for DBBINDEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBBINDEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2102,11 +2065,6 @@ impl Default for DBBINDING {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for DBBINDING {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Com")]
@@ -2134,11 +2092,6 @@ impl Default for DBBINDING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for DBBINDING {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2207,11 +2160,6 @@ impl Default for DBCOLUMNACCESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl windows_core::TypeKind for DBCOLUMNACCESS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Storage_IndexServer")]
@@ -2233,11 +2181,6 @@ impl Default for DBCOLUMNACCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl windows_core::TypeKind for DBCOLUMNACCESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[cfg(target_arch = "x86")]
@@ -2268,11 +2211,6 @@ impl Default for DBCOLUMNDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBCOLUMNDESC {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -2301,11 +2239,6 @@ impl Default for DBCOLUMNDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBCOLUMNDESC {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2387,11 +2320,6 @@ impl Default for DBCOLUMNINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
-impl windows_core::TypeKind for DBCOLUMNINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
@@ -2419,11 +2347,6 @@ impl Default for DBCOLUMNINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
-impl windows_core::TypeKind for DBCOLUMNINFO {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2492,11 +2415,6 @@ impl Default for DBCONSTRAINTDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBCONSTRAINTDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -2523,11 +2441,6 @@ impl Default for DBCONSTRAINTDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBCONSTRAINTDESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2569,10 +2482,6 @@ impl Default for DBCOST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBCOST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2586,10 +2495,6 @@ impl Default for DBCOST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBCOST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2614,9 +2519,6 @@ impl Default for DBDATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DBDATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DBDATETIM4 {
@@ -2628,9 +2530,6 @@ impl Default for DBDATETIM4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DBDATETIM4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DBDATETIME {
@@ -2641,9 +2540,6 @@ impl Default for DBDATETIME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DBDATETIME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2683,10 +2579,6 @@ impl Default for DBFAILUREINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBFAILUREINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2700,10 +2592,6 @@ impl Default for DBFAILUREINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBFAILUREINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DBGUID_MSSQLXML: windows_core::GUID = windows_core::GUID::from_u128(0x5d531cb2_e6ed_11d2_b252_00c04f681b71);
 pub const DBGUID_ROWDEFAULTSTREAM: windows_core::GUID = windows_core::GUID::from_u128(0x0c733ab7_2a1c_11ce_ade5_00aa0044773d);
@@ -2722,10 +2610,6 @@ impl Default for DBIMPLICITSESSION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBIMPLICITSESSION {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -2739,10 +2623,6 @@ impl Default for DBIMPLICITSESSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBIMPLICITSESSION {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C, packed(2))]
 #[cfg(target_arch = "x86")]
@@ -2759,11 +2639,6 @@ impl Default for DBINDEXCOLUMNDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl windows_core::TypeKind for DBINDEXCOLUMNDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Storage_IndexServer")]
@@ -2778,11 +2653,6 @@ impl Default for DBINDEXCOLUMNDESC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl windows_core::TypeKind for DBINDEXCOLUMNDESC {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2815,10 +2685,6 @@ impl Default for DBLITERALINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBLITERALINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2835,10 +2701,6 @@ impl Default for DBLITERALINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBLITERALINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DBLITERAL_BINARY_LITERAL: DBLITERALENUM = DBLITERALENUM(1i32);
 pub const DBLITERAL_CATALOG_NAME: DBLITERALENUM = DBLITERALENUM(2i32);
@@ -2894,9 +2756,6 @@ impl Default for DBMONEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DBMONEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DBMOVEFLAGSENUM(pub i32);
@@ -2918,10 +2777,6 @@ impl Default for DBOBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBOBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2934,10 +2789,6 @@ impl Default for DBOBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBOBJECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[cfg(target_arch = "x86")]
@@ -2956,10 +2807,6 @@ impl Default for DBPARAMBINDINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBPARAMBINDINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2976,10 +2823,6 @@ impl Default for DBPARAMBINDINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBPARAMBINDINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3013,11 +2856,6 @@ impl Default for DBPARAMINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for DBPARAMINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Com")]
@@ -3039,11 +2877,6 @@ impl Default for DBPARAMINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for DBPARAMINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DBPARAMIOENUM(pub i32);
@@ -3064,10 +2897,6 @@ impl Default for DBPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3081,10 +2910,6 @@ impl Default for DBPARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBPARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DBPARAMTYPE_INPUT: u32 = 1u32;
 pub const DBPARAMTYPE_INPUTOUTPUT: u32 = 2u32;
@@ -3149,11 +2974,6 @@ impl Default for DBPROP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBPROP {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -3177,11 +2997,6 @@ impl Default for DBPROP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBPROP {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3251,10 +3066,6 @@ impl Default for DBPROPIDSET {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBPROPIDSET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3268,10 +3079,6 @@ impl Default for DBPROPIDSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBPROPIDSET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[cfg(target_arch = "x86")]
@@ -3297,11 +3104,6 @@ impl Default for DBPROPINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBPROPINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -3325,11 +3127,6 @@ impl Default for DBPROPINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBPROPINFO {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C, packed(2))]
 #[cfg(target_arch = "x86")]
@@ -3347,11 +3144,6 @@ impl Default for DBPROPINFOSET {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBPROPINFOSET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -3367,11 +3159,6 @@ impl Default for DBPROPINFOSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBPROPINFOSET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3395,11 +3182,6 @@ impl Default for DBPROPSET {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBPROPSET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -3415,11 +3197,6 @@ impl Default for DBPROPSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DBPROPSET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DBPROPSET_MSDAORA8_ROWSET: windows_core::GUID = windows_core::GUID::from_u128(0x7f06a375_dd6a_43db_b4e0_1fc121e5e62b);
 pub const DBPROPSET_MSDAORA_ROWSET: windows_core::GUID = windows_core::GUID::from_u128(0xe8cc4cbd_fdff_11d0_b865_00a0c9081c1d);
@@ -4011,10 +3788,6 @@ impl Default for DBROWWATCHCHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBROWWATCHCHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4029,10 +3802,6 @@ impl Default for DBROWWATCHCHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBROWWATCHCHANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DBSCHEMA_LINKEDSERVERS: windows_core::GUID = windows_core::GUID::from_u128(0x9093caf4_2eac_11d1_9809_00c04fc2ad98);
 #[repr(transparent)]
@@ -4127,9 +3896,6 @@ impl Default for DBTIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DBTIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -4148,10 +3914,6 @@ impl Default for DBTIMESTAMP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBTIMESTAMP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4169,10 +3931,6 @@ impl Default for DBTIMESTAMP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBTIMESTAMP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4258,9 +4016,6 @@ impl Default for DBVARYBIN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DBVARYBIN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DBVARYCHAR {
@@ -4271,9 +4026,6 @@ impl Default for DBVARYCHAR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DBVARYCHAR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[cfg(target_arch = "x86")]
@@ -4288,10 +4040,6 @@ impl Default for DBVECTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DBVECTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4304,10 +4052,6 @@ impl Default for DBVECTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DBVECTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4499,9 +4243,6 @@ impl Default for DB_NUMERIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DB_NUMERIC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DB_OUT: u32 = 2u32;
 pub const DB_PROT_LEVEL_CALL: u32 = 2u32;
 pub const DB_PROT_LEVEL_CONNECT: u32 = 1u32;
@@ -4560,9 +4301,6 @@ impl Default for DB_VARNUMERIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DB_VARNUMERIC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
 pub struct DCINFO {
@@ -4580,10 +4318,6 @@ impl Default for DCINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for DCINFO {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4845,10 +4579,6 @@ impl Default for ERRORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ERRORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4864,10 +4594,6 @@ impl Default for ERRORINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ERRORINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ERROR_FTE: u32 = 13824u32;
 pub const ERROR_FTE_CB: u32 = 51968u32;
@@ -5105,9 +4831,6 @@ impl Default for FILTERED_DATA_SOURCES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILTERED_DATA_SOURCES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLTRDMN_E_CANNOT_DECRYPT_PASSWORD: i32 = -2147212282i32;
 pub const FLTRDMN_E_ENCRYPTED_DOCUMENT: i32 = -2147212283i32;
@@ -5377,9 +5100,6 @@ impl Default for HITRANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HITRANGE {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IAccessor, IAccessor_Vtbl, 0x0c733a8c_2a1c_11ce_ade5_00aa0044773d);
 windows_core::imp::interface_hierarchy!(IAccessor, windows_core::IUnknown);
@@ -9407,9 +9127,6 @@ impl Default for INCREMENTAL_ACCESS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INCREMENTAL_ACCESS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INET_E_AGENT_CACHE_SIZE_EXCEEDED: windows_core::HRESULT = windows_core::HRESULT(0x800C0F82_u32 as _);
 pub const INET_E_AGENT_CONNECTION_FAILED: windows_core::HRESULT = windows_core::HRESULT(0x800C0F83_u32 as _);
@@ -15743,10 +15460,6 @@ impl Default for ITEMPROP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for ITEMPROP {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ITEM_INFO {
@@ -15760,9 +15473,6 @@ impl Default for ITEM_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ITEM_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(ITableCreation, ITableCreation_Vtbl, 0x0c733abc_2a1c_11ce_ade5_00aa0044773d);
 impl core::ops::Deref for ITableCreation {
@@ -17384,10 +17094,6 @@ impl Default for KAGGETDIAG {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for KAGGETDIAG {
-    type TypeKind = windows_core::CloneType;
-}
 pub const KAGPROPVAL_CONCUR_LOCK: u32 = 4u32;
 pub const KAGPROPVAL_CONCUR_READ_ONLY: u32 = 8u32;
 pub const KAGPROPVAL_CONCUR_ROWVER: u32 = 1u32;
@@ -17443,10 +17149,6 @@ impl Default for KAGREQDIAG {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for KAGREQDIAG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KAGREQDIAGFLAGSENUM(pub i32);
@@ -17480,10 +17182,6 @@ impl Default for MDAXISINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for MDAXISINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -17500,10 +17198,6 @@ impl Default for MDAXISINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MDAXISINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MDAXIS_CHAPTERS: u32 = 4u32;
 pub const MDAXIS_COLUMNS: u32 = 0u32;
@@ -17730,10 +17424,6 @@ impl Default for NATLANGUAGERESTRICTION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl windows_core::TypeKind for NATLANGUAGERESTRICTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NEC_HIGH: NAMED_ENTITY_CERTAINTY = NAMED_ENTITY_CERTAINTY(2i32);
 pub const NEC_LOW: NAMED_ENTITY_CERTAINTY = NAMED_ENTITY_CERTAINTY(0i32);
 pub const NEC_MEDIUM: NAMED_ENTITY_CERTAINTY = NAMED_ENTITY_CERTAINTY(1i32);
@@ -17759,10 +17449,6 @@ impl Default for NODERESTRICTION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for NODERESTRICTION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NOTESPH_E_ATTACHMENTS: i32 = -2147211770i32;
 pub const NOTESPH_E_DB_ACCESS_DENIED: i32 = -2147211768i32;
 pub const NOTESPH_E_FAIL: i32 = -2147211759i32;
@@ -17785,10 +17471,6 @@ impl Default for NOTRESTRICTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for NOTRESTRICTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NOT_N_PARSE_ERROR: windows_core::HRESULT = windows_core::HRESULT(0x8092E_u32 as _);
 pub const NegationCondition: windows_core::GUID = windows_core::GUID::from_u128(0x8de9c74c_605a_4acd_bee3_2b222aa2d23d);
@@ -17848,9 +17530,6 @@ impl Default for ODBC_VS_ARGS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ODBC_VS_ARGS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ODBC_VS_ARGS_0 {
@@ -17862,9 +17541,6 @@ impl Default for ODBC_VS_ARGS_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ODBC_VS_ARGS_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union ODBC_VS_ARGS_1 {
@@ -17875,9 +17551,6 @@ impl Default for ODBC_VS_ARGS_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ODBC_VS_ARGS_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ODBC_VS_FLAG_RETCODE: i32 = 4i32;
 pub const ODBC_VS_FLAG_STOP: i32 = 8i32;
@@ -18349,10 +18022,6 @@ impl Default for PROPERTYRESTRICTION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for PROPERTYRESTRICTION {
-    type TypeKind = windows_core::CloneType;
-}
 pub const PROPID_DBBMK_BOOKMARK: u32 = 2u32;
 pub const PROPID_DBBMK_CHAPTER: u32 = 3u32;
 pub const PROPID_DBSELF_SELF: u32 = 2u32;
@@ -18377,9 +18046,6 @@ impl Default for PROXY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROXY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRRE: u32 = 6u32;
 pub const PRSomeBits: u32 = 8u32;
@@ -18493,10 +18159,6 @@ impl Default for RANGECATEGORIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for RANGECATEGORIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
 pub struct RESTRICTION {
@@ -18515,10 +18177,6 @@ impl Default for RESTRICTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for RESTRICTION {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
@@ -18543,10 +18201,6 @@ impl Default for RESTRICTION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for RESTRICTION_0 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const REXSPH_E_DUPLICATE_PROPERTY: i32 = -2147207927i32;
 pub const REXSPH_E_INVALID_CALL: i32 = -2147207936i32;
@@ -18584,11 +18238,6 @@ impl Default for RMTPACK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for RMTPACK {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -18615,11 +18264,6 @@ impl Default for RMTPACK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for RMTPACK {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18704,10 +18348,6 @@ impl Default for SEARCH_COLUMN_PROPERTIES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for SEARCH_COLUMN_PROPERTIES {
-    type TypeKind = windows_core::CloneType;
-}
 pub const SEARCH_HIGH_PRIORITY: SEARCH_NOTIFICATION_PRIORITY = SEARCH_NOTIFICATION_PRIORITY(1i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18731,10 +18371,6 @@ impl Default for SEARCH_ITEM_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SEARCH_ITEM_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SEARCH_ITEM_INDEXING_STATUS {
@@ -18745,9 +18381,6 @@ impl Default for SEARCH_ITEM_INDEXING_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEARCH_ITEM_INDEXING_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18761,9 +18394,6 @@ impl Default for SEARCH_ITEM_PERSISTENT_CHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SEARCH_ITEM_PERSISTENT_CHANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18811,11 +18441,6 @@ impl Default for SEC_OBJECT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl windows_core::TypeKind for SEC_OBJECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Storage_IndexServer")]
@@ -18830,11 +18455,6 @@ impl Default for SEC_OBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl windows_core::TypeKind for SEC_OBJECT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[cfg(target_arch = "x86")]
@@ -18851,11 +18471,6 @@ impl Default for SEC_OBJECT_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl windows_core::TypeKind for SEC_OBJECT_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Storage_IndexServer")]
@@ -18870,11 +18485,6 @@ impl Default for SEC_OBJECT_ELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Storage_IndexServer")]
-impl windows_core::TypeKind for SEC_OBJECT_ELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SI_TEMPORARY: u32 = 2147483648u32;
 #[repr(C)]
@@ -18891,10 +18501,6 @@ impl Default for SORTKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl windows_core::TypeKind for SORTKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18907,10 +18513,6 @@ impl Default for SORTSET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
-impl windows_core::TypeKind for SORTSET {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SPS_WS_ERROR: i32 = -2147211753i32;
 pub const SQLAOPANY: u32 = 83u32;
@@ -18998,9 +18600,6 @@ impl Default for SQLPERF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SQLPERF {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SQLTEXT: u32 = 35u32;
 pub const SQLUNIQUEID: u32 = 36u32;
@@ -19633,9 +19232,6 @@ impl Default for SQL_DAY_SECOND_STRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SQL_DAY_SECOND_STRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SQL_DAY_TO_HOUR: u32 = 8u32;
 pub const SQL_DAY_TO_MINUTE: u32 = 9u32;
 pub const SQL_DAY_TO_SECOND: u32 = 10u32;
@@ -20078,9 +19674,6 @@ impl Default for SQL_INTERVAL_STRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SQL_INTERVAL_STRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SQL_INTERVAL_STRUCT_0 {
@@ -20091,9 +19684,6 @@ impl Default for SQL_INTERVAL_STRUCT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SQL_INTERVAL_STRUCT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SQL_INTERVAL_YEAR: i32 = -80i32;
 pub const SQL_INTERVAL_YEAR_TO_MONTH: i32 = -82i32;
@@ -20278,9 +19868,6 @@ impl Default for SQL_NUMERIC_STRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SQL_NUMERIC_STRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SQL_NUM_FUNCTIONS: u32 = 23u32;
 pub const SQL_OAC_LEVEL1: u32 = 1u32;
@@ -20719,9 +20306,6 @@ impl Default for SQL_YEAR_MONTH_STRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SQL_YEAR_MONTH_STRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SQL_YEAR_TO_MONTH: u32 = 7u32;
 pub const SQLudtBINARY: u32 = 3u32;
 pub const SQLudtBIT: u32 = 16u32;
@@ -20804,9 +20388,6 @@ impl Default for SSERRORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SSERRORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SSPROPVAL_COMMANDTYPE_BULKLOAD: u32 = 22u32;
 pub const SSPROPVAL_COMMANDTYPE_REGULAR: u32 = 21u32;
 pub const SSPROPVAL_USEPROCFORPREP_OFF: u32 = 0u32;
@@ -20869,10 +20450,6 @@ impl Default for SSVARIANT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 pub union SSVARIANT_0 {
@@ -20905,10 +20482,6 @@ impl Default for SSVARIANT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Debug, PartialEq)]
@@ -20921,10 +20494,6 @@ impl Default for SSVARIANT_0_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT_0_4 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -20940,10 +20509,6 @@ impl Default for SSVARIANT_0_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT_0_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -20962,10 +20527,6 @@ impl Default for SSVARIANT_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -20983,10 +20544,6 @@ impl Default for SSVARIANT_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21000,10 +20557,6 @@ impl Default for SSVARIANT_0_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SSVARIANT_0_3 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STD_BOOKMARKLENGTH: u32 = 1u32;
 pub const STGM_COLLECTION: i32 = 8192i32;
@@ -21097,9 +20650,6 @@ impl Default for SUBSCRIPTIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SUBSCRIPTIONINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SUBSCRIPTIONINFOFLAGS(pub i32);
@@ -21116,9 +20666,6 @@ impl Default for SUBSCRIPTIONITEMINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SUBSCRIPTIONITEMINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -21172,9 +20719,6 @@ impl Default for TEXT_SOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TEXT_SOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TIMEOUT_INFO {
@@ -21186,9 +20730,6 @@ impl Default for TIMEOUT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TIMEOUT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -21206,9 +20747,6 @@ impl Default for TIMESTAMP_STRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TIMESTAMP_STRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TIME_STRUCT {
@@ -21220,9 +20758,6 @@ impl Default for TIME_STRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TIME_STRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRACE_ON: i32 = 1i32;
 pub const TRACE_VERSION: u32 = 1000u32;
@@ -21239,10 +20774,6 @@ impl Default for VECTORRESTRICTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for VECTORRESTRICTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VT_SS_BINARY: SQLVARENUM = SQLVARENUM(207i32);
 pub const VT_SS_BIT: SQLVARENUM = SQLVARENUM(11i32);

--- a/crates/libs/windows/src/Windows/Win32/System/ServerBackup/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ServerBackup/mod.rs
@@ -186,9 +186,6 @@ impl Default for WSB_OB_REGISTRATION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSB_OB_REGISTRATION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSB_OB_STATUS_ENTRY {
@@ -202,9 +199,6 @@ impl Default for WSB_OB_STATUS_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSB_OB_STATUS_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -220,9 +214,6 @@ impl Default for WSB_OB_STATUS_ENTRY_VALUE_TYPE_PAIR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WSB_OB_STATUS_ENTRY_VALUE_TYPE_PAIR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WSB_OB_STATUS_INFO {
@@ -234,7 +225,4 @@ impl Default for WSB_OB_STATUS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WSB_OB_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
@@ -429,9 +429,6 @@ impl Default for ENUM_SERVICE_STATUSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENUM_SERVICE_STATUSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENUM_SERVICE_STATUSW {
@@ -443,9 +440,6 @@ impl Default for ENUM_SERVICE_STATUSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENUM_SERVICE_STATUSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -459,9 +453,6 @@ impl Default for ENUM_SERVICE_STATUS_PROCESSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENUM_SERVICE_STATUS_PROCESSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENUM_SERVICE_STATUS_PROCESSW {
@@ -473,9 +464,6 @@ impl Default for ENUM_SERVICE_STATUS_PROCESSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENUM_SERVICE_STATUS_PROCESSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -552,9 +540,6 @@ impl Default for QUERY_SERVICE_CONFIGA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUERY_SERVICE_CONFIGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QUERY_SERVICE_CONFIGW {
@@ -573,9 +558,6 @@ impl Default for QUERY_SERVICE_CONFIGW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUERY_SERVICE_CONFIGW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QUERY_SERVICE_LOCK_STATUSA {
@@ -587,9 +569,6 @@ impl Default for QUERY_SERVICE_LOCK_STATUSA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QUERY_SERVICE_LOCK_STATUSA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -603,9 +582,6 @@ impl Default for QUERY_SERVICE_LOCK_STATUSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUERY_SERVICE_LOCK_STATUSW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RPC_INTERFACE_EVENT_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xbc90d167_9470_4139_a9ba_be0bbbf5b74d);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -617,9 +593,6 @@ impl Default for SC_ACTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SC_ACTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SC_ACTION_NONE: SC_ACTION_TYPE = SC_ACTION_TYPE(0i32);
 pub const SC_ACTION_OWN_RESTART: SC_ACTION_TYPE = SC_ACTION_TYPE(4i32);
@@ -744,9 +717,6 @@ impl Default for SERVICE_CONTROL_STATUS_REASON_PARAMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_CONTROL_STATUS_REASON_PARAMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_CONTROL_STATUS_REASON_PARAMSW {
@@ -758,9 +728,6 @@ impl Default for SERVICE_CONTROL_STATUS_REASON_PARAMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_CONTROL_STATUS_REASON_PARAMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_CONTROL_STOP: u32 = 1u32;
 pub const SERVICE_CONTROL_SYSTEMLOWRESOURCES: u32 = 97u32;
@@ -776,9 +743,6 @@ impl Default for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0 {
@@ -789,9 +753,6 @@ impl Default for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -804,9 +765,6 @@ impl Default for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_CUSTOM_SYSTEM_STATE_CHANGE_DATA_ITEM_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_DELAYED_AUTO_START_INFO {
@@ -816,9 +774,6 @@ impl Default for SERVICE_DELAYED_AUTO_START_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_DELAYED_AUTO_START_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_DEMAND_START: SERVICE_START_TYPE = SERVICE_START_TYPE(3u32);
 #[repr(C)]
@@ -831,9 +786,6 @@ impl Default for SERVICE_DESCRIPTIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_DESCRIPTIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_DESCRIPTIONW {
@@ -843,9 +795,6 @@ impl Default for SERVICE_DESCRIPTIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_DESCRIPTIONW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -875,9 +824,6 @@ impl Default for SERVICE_FAILURE_ACTIONSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_FAILURE_ACTIONSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_FAILURE_ACTIONSW {
@@ -892,9 +838,6 @@ impl Default for SERVICE_FAILURE_ACTIONSW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_FAILURE_ACTIONSW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_FAILURE_ACTIONS_FLAG {
@@ -904,9 +847,6 @@ impl Default for SERVICE_FAILURE_ACTIONS_FLAG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_FAILURE_ACTIONS_FLAG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_FILE_SYSTEM_DRIVER: ENUM_SERVICE_TYPE = ENUM_SERVICE_TYPE(2u32);
 pub const SERVICE_INACTIVE: ENUM_SERVICE_STATE = ENUM_SERVICE_STATE(2u32);
@@ -922,9 +862,6 @@ impl Default for SERVICE_LAUNCH_PROTECTED_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_LAUNCH_PROTECTED_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_LAUNCH_PROTECTED_NONE: u32 = 0u32;
 pub const SERVICE_LAUNCH_PROTECTED_WINDOWS: u32 = 1u32;
@@ -981,9 +918,6 @@ impl Default for SERVICE_NOTIFY_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_NOTIFY_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_NOTIFY_2A {
@@ -1000,9 +934,6 @@ impl Default for SERVICE_NOTIFY_2A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_NOTIFY_2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_NOTIFY_2W {
@@ -1018,9 +949,6 @@ impl Default for SERVICE_NOTIFY_2W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_NOTIFY_2W {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_NOTIFY_CONTINUE_PENDING: SERVICE_NOTIFY = SERVICE_NOTIFY(16u32);
 pub const SERVICE_NOTIFY_CREATED: SERVICE_NOTIFY = SERVICE_NOTIFY(128u32);
@@ -1050,9 +978,6 @@ impl Default for SERVICE_PREFERRED_NODE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_PREFERRED_NODE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_PRESHUTDOWN_INFO {
@@ -1062,9 +987,6 @@ impl Default for SERVICE_PRESHUTDOWN_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_PRESHUTDOWN_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_QUERY_CONFIG: u32 = 1u32;
 pub const SERVICE_QUERY_STATUS: u32 = 4u32;
@@ -1082,9 +1004,6 @@ impl Default for SERVICE_REQUIRED_PRIVILEGES_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_REQUIRED_PRIVILEGES_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_REQUIRED_PRIVILEGES_INFOW {
@@ -1094,9 +1013,6 @@ impl Default for SERVICE_REQUIRED_PRIVILEGES_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_REQUIRED_PRIVILEGES_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_RUNNING: SERVICE_STATUS_CURRENT_STATE = SERVICE_STATUS_CURRENT_STATE(4u32);
 pub const SERVICE_RUNS_IN_NON_SYSTEM_OR_NOT_RUNNING: SERVICE_RUNS_IN_PROCESS = SERVICE_RUNS_IN_PROCESS(0u32);
@@ -1120,9 +1036,6 @@ impl Default for SERVICE_SID_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_SID_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SERVICE_SID_TYPE_NONE: u32 = 0u32;
 pub const SERVICE_SID_TYPE_UNRESTRICTED: u32 = 1u32;
 pub const SERVICE_START: u32 = 16u32;
@@ -1136,9 +1049,6 @@ impl Default for SERVICE_START_REASON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_START_REASON {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_START_REASON_AUTO: u32 = 2u32;
 pub const SERVICE_START_REASON_DELAYEDAUTO: u32 = 16u32;
@@ -1164,9 +1074,6 @@ impl Default for SERVICE_STATUS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_STATUS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1204,9 +1111,6 @@ impl Default for SERVICE_STATUS_PROCESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_STATUS_PROCESS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_STOP: u32 = 32u32;
 pub const SERVICE_STOPPED: SERVICE_STATUS_CURRENT_STATE = SERVICE_STATUS_CURRENT_STATE(1u32);
@@ -1266,9 +1170,6 @@ impl Default for SERVICE_TABLE_ENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_TABLE_ENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_TABLE_ENTRYW {
@@ -1280,9 +1181,6 @@ impl Default for SERVICE_TABLE_ENTRYW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_TABLE_ENTRYW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_TIMECHANGE_INFO {
@@ -1293,9 +1191,6 @@ impl Default for SERVICE_TIMECHANGE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_TIMECHANGE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1311,9 +1206,6 @@ impl Default for SERVICE_TRIGGER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_TRIGGER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SERVICE_TRIGGER_ACTION(pub u32);
@@ -1328,9 +1220,6 @@ impl Default for SERVICE_TRIGGER_CUSTOM_STATE_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_TRIGGER_CUSTOM_STATE_ID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVICE_TRIGGER_DATA_TYPE_BINARY: SERVICE_TRIGGER_SPECIFIC_DATA_ITEM_DATA_TYPE = SERVICE_TRIGGER_SPECIFIC_DATA_ITEM_DATA_TYPE(1u32);
 pub const SERVICE_TRIGGER_DATA_TYPE_KEYWORD_ALL: SERVICE_TRIGGER_SPECIFIC_DATA_ITEM_DATA_TYPE = SERVICE_TRIGGER_SPECIFIC_DATA_ITEM_DATA_TYPE(5u32);
@@ -1349,9 +1238,6 @@ impl Default for SERVICE_TRIGGER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERVICE_TRIGGER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERVICE_TRIGGER_SPECIFIC_DATA_ITEM {
@@ -1363,9 +1249,6 @@ impl Default for SERVICE_TRIGGER_SPECIFIC_DATA_ITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVICE_TRIGGER_SPECIFIC_DATA_ITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/SideShow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SideShow/mod.rs
@@ -13,9 +13,6 @@ impl Default for APPLICATION_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APPLICATION_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CONTENT_ID_GLANCE: u32 = 0u32;
 pub const CONTENT_ID_HOME: u32 = 1u32;
 #[repr(C, packed(1))]
@@ -31,9 +28,6 @@ impl Default for CONTENT_MISSING_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONTENT_MISSING_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DEVICE_USER_CHANGE_EVENT_DATA {
@@ -44,9 +38,6 @@ impl Default for DEVICE_USER_CHANGE_EVENT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_USER_CHANGE_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -60,9 +51,6 @@ impl Default for EVENT_DATA_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENT_DATA_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GUID_DEVINTERFACE_SIDESHOW: windows_core::GUID = windows_core::GUID::from_u128(0x152e5811_feb9_4b00_90f4_d32947ae1681);
 windows_core::imp::define_interface!(ISideShowBulkCapabilities, ISideShowBulkCapabilities_Vtbl, 0x3a2b7fbc_3ad5_48bd_bbf1_0e6cfbd10807);
@@ -866,9 +854,6 @@ impl Default for NEW_EVENT_DATA_AVAILABLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NEW_EVENT_DATA_AVAILABLE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCF_BUTTON_BACK: SCF_BUTTON_IDS = SCF_BUTTON_IDS(65280i32);
 pub const SCF_BUTTON_DOWN: SCF_BUTTON_IDS = SCF_BUTTON_IDS(4i32);
 pub const SCF_BUTTON_FASTFORWARD: SCF_BUTTON_IDS = SCF_BUTTON_IDS(9i32);
@@ -898,9 +883,6 @@ impl Default for SCF_CONTEXTMENU_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCF_CONTEXTMENU_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCF_EVENT_CONTEXTMENU: SCF_EVENT_IDS = SCF_EVENT_IDS(3i32);
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -912,9 +894,6 @@ impl Default for SCF_EVENT_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCF_EVENT_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -934,9 +913,6 @@ impl Default for SCF_MENUACTION_EVENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCF_MENUACTION_EVENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCF_NAVIGATION_EVENT {
@@ -948,9 +924,6 @@ impl Default for SCF_NAVIGATION_EVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCF_NAVIGATION_EVENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SIDESHOW_APPLICATION_EVENT: windows_core::GUID = windows_core::GUID::from_u128(0x4cb572fa_1d3b_49b3_a17a_2e6bff052854);
 pub const SIDESHOW_CAPABILITY_CLIENT_AREA_HEIGHT: super::super::Foundation::PROPERTYKEY = super::super::Foundation::PROPERTYKEY { fmtid: windows_core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 16 };

--- a/crates/libs/windows/src/Windows/Win32/System/StationsAndDesktops/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/StationsAndDesktops/mod.rs
@@ -310,9 +310,6 @@ impl Default for BSMINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BSMINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BSM_ALLCOMPONENTS: BROADCAST_SYSTEM_MESSAGE_INFO = BROADCAST_SYSTEM_MESSAGE_INFO(0u32);
 pub const BSM_ALLDESKTOPS: BROADCAST_SYSTEM_MESSAGE_INFO = BROADCAST_SYSTEM_MESSAGE_INFO(16u32);
 pub const BSM_APPLICATIONS: BROADCAST_SYSTEM_MESSAGE_INFO = BROADCAST_SYSTEM_MESSAGE_INFO(8u32);
@@ -406,9 +403,6 @@ impl Default for USEROBJECTFLAGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USEROBJECTFLAGS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/SystemInformation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemInformation/mod.rs
@@ -362,9 +362,6 @@ impl Default for CACHE_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CACHE_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CACHE_RELATIONSHIP {
@@ -382,9 +379,6 @@ impl Default for CACHE_RELATIONSHIP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CACHE_RELATIONSHIP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union CACHE_RELATIONSHIP_0 {
@@ -395,9 +389,6 @@ impl Default for CACHE_RELATIONSHIP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CACHE_RELATIONSHIP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -529,9 +520,6 @@ impl Default for GROUP_AFFINITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GROUP_AFFINITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GROUP_RELATIONSHIP {
@@ -544,9 +532,6 @@ impl Default for GROUP_RELATIONSHIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GROUP_RELATIONSHIP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GlobalDataIdConsoleSharedDataFlags: RTL_SYSTEM_GLOBAL_DATA_ID = RTL_SYSTEM_GLOBAL_DATA_ID(14i32);
 pub const GlobalDataIdCyclesPerYield: RTL_SYSTEM_GLOBAL_DATA_ID = RTL_SYSTEM_GLOBAL_DATA_ID(11i32);
@@ -623,9 +608,6 @@ impl Default for MEMORYSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEMORYSTATUS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MEMORYSTATUSEX {
@@ -643,9 +625,6 @@ impl Default for MEMORYSTATUSEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MEMORYSTATUSEX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NTDDI_LONGHORN: u32 = 100663296u32;
 pub const NTDDI_VERSION: u32 = 167772172u32;
@@ -709,9 +688,6 @@ impl Default for NUMA_NODE_RELATIONSHIP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NUMA_NODE_RELATIONSHIP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NUMA_NODE_RELATIONSHIP_0 {
@@ -722,9 +698,6 @@ impl Default for NUMA_NODE_RELATIONSHIP_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NUMA_NODE_RELATIONSHIP_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -740,9 +713,6 @@ impl Default for OSVERSIONINFOA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OSVERSIONINFOA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -764,9 +734,6 @@ impl Default for OSVERSIONINFOEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OSVERSIONINFOEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OSVERSIONINFOEXW {
@@ -787,9 +754,6 @@ impl Default for OSVERSIONINFOEXW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OSVERSIONINFOEXW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OSVERSIONINFOW {
@@ -804,9 +768,6 @@ impl Default for OSVERSIONINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OSVERSIONINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OSVERSION_MASK: u32 = 4294901760u32;
 #[repr(transparent)]
@@ -854,9 +815,6 @@ impl Default for PROCESSOR_GROUP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSOR_GROUP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESSOR_RELATIONSHIP {
@@ -870,9 +828,6 @@ impl Default for PROCESSOR_RELATIONSHIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESSOR_RELATIONSHIP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PRODUCT_BUSINESS: OS_PRODUCT_TYPE = OS_PRODUCT_TYPE(6u32);
 pub const PRODUCT_BUSINESS_N: OS_PRODUCT_TYPE = OS_PRODUCT_TYPE(16u32);
@@ -998,9 +953,6 @@ impl Default for SYSTEM_CPU_SET_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_CPU_SET_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SYSTEM_CPU_SET_INFORMATION_0 {
@@ -1010,9 +962,6 @@ impl Default for SYSTEM_CPU_SET_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_CPU_SET_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1033,9 +982,6 @@ impl Default for SYSTEM_CPU_SET_INFORMATION_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_CPU_SET_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SYSTEM_CPU_SET_INFORMATION_0_0_0 {
@@ -1047,9 +993,6 @@ impl Default for SYSTEM_CPU_SET_INFORMATION_0_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_CPU_SET_INFORMATION_0_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_CPU_SET_INFORMATION_0_0_0_0 {
@@ -1059,9 +1002,6 @@ impl Default for SYSTEM_CPU_SET_INFORMATION_0_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_CPU_SET_INFORMATION_0_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1073,9 +1013,6 @@ impl Default for SYSTEM_CPU_SET_INFORMATION_0_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_CPU_SET_INFORMATION_0_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SYSTEM_CPU_SET_INFORMATION_ALLOCATED: u32 = 2u32;
 pub const SYSTEM_CPU_SET_INFORMATION_ALLOCATED_TO_TARGET_PROCESS: u32 = 4u32;
@@ -1100,9 +1037,6 @@ impl Default for SYSTEM_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union SYSTEM_INFO_0 {
@@ -1113,9 +1047,6 @@ impl Default for SYSTEM_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1128,9 +1059,6 @@ impl Default for SYSTEM_INFO_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_INFO_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION {
@@ -1142,9 +1070,6 @@ impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_LOGICAL_PROCESSOR_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1159,9 +1084,6 @@ impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
@@ -1172,9 +1094,6 @@ impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
@@ -1184,9 +1103,6 @@ impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1199,9 +1115,6 @@ impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1216,9 +1129,6 @@ impl Default for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_POOL_ZEROING_INFORMATION {
@@ -1228,9 +1138,6 @@ impl Default for SYSTEM_POOL_ZEROING_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_POOL_ZEROING_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1242,9 +1149,6 @@ impl Default for SYSTEM_PROCESSOR_CYCLE_TIME_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_PROCESSOR_CYCLE_TIME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_SUPPORTED_PROCESSOR_ARCHITECTURES_INFORMATION {
@@ -1254,9 +1158,6 @@ impl Default for SYSTEM_SUPPORTED_PROCESSOR_ARCHITECTURES_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_SUPPORTED_PROCESSOR_ARCHITECTURES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
@@ -83,9 +83,6 @@ impl Default for ANON_OBJECT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ANON_OBJECT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ANON_OBJECT_HEADER_BIGOBJ {
@@ -108,9 +105,6 @@ impl Default for ANON_OBJECT_HEADER_BIGOBJ {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ANON_OBJECT_HEADER_BIGOBJ {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ANON_OBJECT_HEADER_V2 {
@@ -129,9 +123,6 @@ impl Default for ANON_OBJECT_HEADER_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ANON_OBJECT_HEADER_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ANYSIZE_ARRAY: u32 = 1u32;
 pub const APPCOMMAND_BASS_BOOST: APPCOMMAND_ID = APPCOMMAND_ID(20u32);
@@ -202,9 +193,6 @@ impl Default for APPLICATIONLAUNCH_SETTING_VALUE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APPLICATIONLAUNCH_SETTING_VALUE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const APPLICATION_ERROR_MASK: u32 = 536870912u32;
 #[repr(transparent)]
@@ -389,9 +377,6 @@ impl Default for COMPONENT_FILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMPONENT_FILTER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const COMPONENT_KTM: u32 = 1u32;
 pub const COMPONENT_VALID_FLAGS: u32 = 1u32;
 pub const COMPRESSION_ENGINE_HIBER: u32 = 512u32;
@@ -440,9 +425,6 @@ impl Default for DISPATCHER_CONTEXT_NONVOLREG_ARM64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DISPATCHER_CONTEXT_NONVOLREG_ARM64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DISPATCHER_CONTEXT_NONVOLREG_ARM64_0 {
@@ -453,9 +435,6 @@ impl Default for DISPATCHER_CONTEXT_NONVOLREG_ARM64_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISPATCHER_CONTEXT_NONVOLREG_ARM64_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DLL_PROCESS_ATTACH: u32 = 1u32;
 pub const DLL_PROCESS_DETACH: u32 = 0u32;
@@ -577,9 +556,6 @@ impl Default for ENLISTMENT_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENLISTMENT_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENLISTMENT_CRM_INFORMATION {
@@ -591,9 +567,6 @@ impl Default for ENLISTMENT_CRM_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENLISTMENT_CRM_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -735,9 +708,6 @@ impl Default for FILE_NOTIFY_FULL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILE_NOTIFY_FULL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union FILE_NOTIFY_FULL_INFORMATION_0 {
@@ -748,9 +718,6 @@ impl Default for FILE_NOTIFY_FULL_INFORMATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_NOTIFY_FULL_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FILE_PERSISTENT_ACLS: u32 = 8u32;
 pub const FILE_READ_ONLY_VOLUME: u32 = 524288u32;
@@ -817,10 +784,6 @@ impl Default for GDI_NONREMOTE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for GDI_NONREMOTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -833,10 +796,6 @@ impl Default for GDI_NONREMOTE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for GDI_NONREMOTE_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1099,9 +1058,6 @@ impl Default for HEAP_OPTIMIZE_RESOURCES_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HEAP_OPTIMIZE_RESOURCES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HIBERFILE_BUCKET {
@@ -1112,9 +1068,6 @@ impl Default for HIBERFILE_BUCKET {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HIBERFILE_BUCKET {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1155,9 +1108,6 @@ impl Default for IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_ALPHA_RUNTIME_FUNCTION_ENTRY {
@@ -1172,9 +1122,6 @@ impl Default for IMAGE_ALPHA_RUNTIME_FUNCTION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_ALPHA_RUNTIME_FUNCTION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_ARCHITECTURE_ENTRY {
@@ -1186,9 +1133,6 @@ impl Default for IMAGE_ARCHITECTURE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_ARCHITECTURE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_ARCHITECTURE_HEADER {
@@ -1199,9 +1143,6 @@ impl Default for IMAGE_ARCHITECTURE_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_ARCHITECTURE_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_ARCHIVE_END: windows_core::PCSTR = windows_core::s!("`\n");
 pub const IMAGE_ARCHIVE_HYBRIDMAP_MEMBER: windows_core::PCSTR = windows_core::s!("/<HYBRIDMAP>/   ");
@@ -1223,9 +1164,6 @@ impl Default for IMAGE_ARCHIVE_MEMBER_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_ARCHIVE_MEMBER_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_ARCHIVE_PAD: windows_core::PCSTR = windows_core::s!("\n");
 pub const IMAGE_ARCHIVE_START: windows_core::PCSTR = windows_core::s!("!<arch>\n");
 pub const IMAGE_ARCHIVE_START_SIZE: u32 = 8u32;
@@ -1240,9 +1178,6 @@ impl Default for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA_0 {
@@ -1252,9 +1187,6 @@ impl Default for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY_XDATA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1267,9 +1199,6 @@ impl Default for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0 {
@@ -1281,9 +1210,6 @@ impl Default for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0_0 {
@@ -1293,9 +1219,6 @@ impl Default for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_ARM_RUNTIME_FUNCTION_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1311,9 +1234,6 @@ impl Default for IMAGE_AUX_SYMBOL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_AUX_SYMBOL_3 {
@@ -1325,9 +1245,6 @@ impl Default for IMAGE_AUX_SYMBOL_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_AUX_SYMBOL_1 {
@@ -1337,9 +1254,6 @@ impl Default for IMAGE_AUX_SYMBOL_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1358,9 +1272,6 @@ impl Default for IMAGE_AUX_SYMBOL_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_AUX_SYMBOL_0 {
@@ -1374,9 +1285,6 @@ impl Default for IMAGE_AUX_SYMBOL_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_AUX_SYMBOL_0_1 {
@@ -1388,9 +1296,6 @@ impl Default for IMAGE_AUX_SYMBOL_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_AUX_SYMBOL_0_1_1 {
@@ -1400,9 +1305,6 @@ impl Default for IMAGE_AUX_SYMBOL_0_1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0_1_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1415,9 +1317,6 @@ impl Default for IMAGE_AUX_SYMBOL_0_1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0_1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub union IMAGE_AUX_SYMBOL_0_0 {
@@ -1429,9 +1328,6 @@ impl Default for IMAGE_AUX_SYMBOL_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_AUX_SYMBOL_0_0_0 {
@@ -1442,9 +1338,6 @@ impl Default for IMAGE_AUX_SYMBOL_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -1460,9 +1353,6 @@ impl Default for IMAGE_AUX_SYMBOL_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IMAGE_AUX_SYMBOL_EX_3 {
@@ -1473,9 +1363,6 @@ impl Default for IMAGE_AUX_SYMBOL_EX_3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1488,9 +1375,6 @@ impl Default for IMAGE_AUX_SYMBOL_EX_4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_AUX_SYMBOL_EX_1 {
@@ -1500,9 +1384,6 @@ impl Default for IMAGE_AUX_SYMBOL_EX_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1522,9 +1403,6 @@ impl Default for IMAGE_AUX_SYMBOL_EX_2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_AUX_SYMBOL_EX_0 {
@@ -1536,9 +1414,6 @@ impl Default for IMAGE_AUX_SYMBOL_EX_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_EX_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -1552,9 +1427,6 @@ impl Default for IMAGE_AUX_SYMBOL_TOKEN_DEF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_AUX_SYMBOL_TOKEN_DEF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1571,9 +1443,6 @@ impl Default for IMAGE_BASE_RELOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_BASE_RELOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_BDD_DYNAMIC_RELOCATION {
@@ -1586,9 +1455,6 @@ impl Default for IMAGE_BDD_DYNAMIC_RELOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_BDD_DYNAMIC_RELOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_BDD_INFO {
@@ -1599,9 +1465,6 @@ impl Default for IMAGE_BDD_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_BDD_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1615,9 +1478,6 @@ impl Default for IMAGE_BOUND_FORWARDER_REF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_BOUND_FORWARDER_REF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_BOUND_IMPORT_DESCRIPTOR {
@@ -1630,9 +1490,6 @@ impl Default for IMAGE_BOUND_IMPORT_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_BOUND_IMPORT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_CE_RUNTIME_FUNCTION_ENTRY {
@@ -1643,9 +1500,6 @@ impl Default for IMAGE_CE_RUNTIME_FUNCTION_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_CE_RUNTIME_FUNCTION_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_COMDAT_SELECT_ANY: u32 = 2u32;
 pub const IMAGE_COMDAT_SELECT_ASSOCIATIVE: u32 = 5u32;
@@ -1671,9 +1525,6 @@ impl Default for IMAGE_DEBUG_MISC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_DEBUG_MISC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_DEBUG_MISC_EXENAME: u32 = 1u32;
 pub const IMAGE_DEBUG_TYPE_BBT: u32 = 10u32;
@@ -1716,9 +1567,6 @@ impl Default for IMAGE_DOS_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_DOS_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_DOS_SIGNATURE: u16 = 23117u16;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1730,9 +1578,6 @@ impl Default for IMAGE_DYNAMIC_RELOCATION32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_DYNAMIC_RELOCATION32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1748,9 +1593,6 @@ impl Default for IMAGE_DYNAMIC_RELOCATION32_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_DYNAMIC_RELOCATION32_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_DYNAMIC_RELOCATION64 {
@@ -1761,9 +1603,6 @@ impl Default for IMAGE_DYNAMIC_RELOCATION64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_DYNAMIC_RELOCATION64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -1778,9 +1617,6 @@ impl Default for IMAGE_DYNAMIC_RELOCATION64_V2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_DYNAMIC_RELOCATION64_V2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_DYNAMIC_RELOCATION_FUNCTION_OVERRIDE: u32 = 7u32;
 pub const IMAGE_DYNAMIC_RELOCATION_GUARD_IMPORT_CONTROL_TRANSFER: u32 = 3u32;
@@ -1798,9 +1634,6 @@ impl Default for IMAGE_DYNAMIC_RELOCATION_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_DYNAMIC_RELOCATION_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_ENCLAVE_FLAG_PRIMARY_IMAGE: u32 = 1u32;
 pub const IMAGE_ENCLAVE_IMPORT_MATCH_AUTHOR_ID: u32 = 2u32;
@@ -1824,9 +1657,6 @@ impl Default for IMAGE_EPILOGUE_DYNAMIC_RELOCATION_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_EPILOGUE_DYNAMIC_RELOCATION_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_EXPORT_DIRECTORY {
@@ -1847,9 +1677,6 @@ impl Default for IMAGE_EXPORT_DIRECTORY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_EXPORT_DIRECTORY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_FUNCTION_OVERRIDE_ARM64_BRANCH26: u32 = 2u32;
 pub const IMAGE_FUNCTION_OVERRIDE_ARM64_THUNK: u32 = 3u32;
 #[repr(C, packed(1))]
@@ -1865,9 +1692,6 @@ impl Default for IMAGE_FUNCTION_OVERRIDE_DYNAMIC_RELOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_FUNCTION_OVERRIDE_DYNAMIC_RELOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_FUNCTION_OVERRIDE_HEADER {
@@ -1877,9 +1701,6 @@ impl Default for IMAGE_FUNCTION_OVERRIDE_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_FUNCTION_OVERRIDE_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_FUNCTION_OVERRIDE_INVALID: u32 = 0u32;
 pub const IMAGE_FUNCTION_OVERRIDE_X64_REL32: u32 = 1u32;
@@ -1924,9 +1745,6 @@ impl Default for IMAGE_HOT_PATCH_BASE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_HOT_PATCH_BASE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_HOT_PATCH_BASE_CAN_ROLL_BACK: u32 = 2u32;
 pub const IMAGE_HOT_PATCH_BASE_OBLIGATORY: u32 = 1u32;
 pub const IMAGE_HOT_PATCH_CALL_TARGET: u32 = 278528u32;
@@ -1950,9 +1768,6 @@ impl Default for IMAGE_HOT_PATCH_HASHES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_HOT_PATCH_HASHES {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_HOT_PATCH_INDIRECT: u32 = 376832u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1970,9 +1785,6 @@ impl Default for IMAGE_HOT_PATCH_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_HOT_PATCH_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_HOT_PATCH_NONE: u32 = 0u32;
 pub const IMAGE_HOT_PATCH_NO_CALL_TARGET: u32 = 409600u32;
 pub const IMAGE_HOT_PATCH_REL32: u32 = 245760u32;
@@ -1987,9 +1799,6 @@ impl Default for IMAGE_IMPORT_BY_NAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_IMPORT_BY_NAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
@@ -1999,9 +1808,6 @@ impl Default for IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_IMPORT_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2017,9 +1823,6 @@ impl Default for IMAGE_IMPORT_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_IMPORT_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_IMPORT_DESCRIPTOR_0 {
@@ -2031,9 +1834,6 @@ impl Default for IMAGE_IMPORT_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_IMPORT_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
@@ -2043,9 +1843,6 @@ impl Default for IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_INDIR_CONTROL_TRANSFER_DYNAMIC_RELOCATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2058,9 +1855,6 @@ impl Default for IMAGE_LINENUMBER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_LINENUMBER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub union IMAGE_LINENUMBER_0 {
@@ -2071,9 +1865,6 @@ impl Default for IMAGE_LINENUMBER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_LINENUMBER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_NT_SIGNATURE: u32 = 17744u32;
 pub const IMAGE_NUMBEROF_DIRECTORY_ENTRIES: u32 = 16u32;
@@ -2118,9 +1909,6 @@ impl Default for IMAGE_OS2_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_OS2_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_OS2_SIGNATURE: u16 = 17742u16;
 pub const IMAGE_OS2_SIGNATURE_LE: u16 = 17740u16;
 #[repr(C)]
@@ -2134,9 +1922,6 @@ impl Default for IMAGE_POLICY_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_POLICY_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2159,9 +1944,6 @@ impl Default for IMAGE_POLICY_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_POLICY_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct IMAGE_POLICY_ENTRY_TYPE(pub i32);
@@ -2181,9 +1963,6 @@ impl Default for IMAGE_POLICY_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_POLICY_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_POLICY_METADATA_VERSION: u32 = 1u32;
 pub const IMAGE_POLICY_SECTION_NAME: windows_core::PCSTR = windows_core::s!(".tPolicy");
 #[repr(C)]
@@ -2195,9 +1974,6 @@ impl Default for IMAGE_PROLOGUE_DYNAMIC_RELOCATION_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_PROLOGUE_DYNAMIC_RELOCATION_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -2211,9 +1987,6 @@ impl Default for IMAGE_RELOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_RELOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub union IMAGE_RELOCATION_0 {
@@ -2224,9 +1997,6 @@ impl Default for IMAGE_RELOCATION_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_RELOCATION_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_REL_ALPHA_ABSOLUTE: u32 = 0u32;
 pub const IMAGE_REL_ALPHA_BRADDR: u32 = 7u32;
@@ -2501,9 +2271,6 @@ impl Default for IMAGE_RESOURCE_DATA_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_RESOURCE_DATA_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_RESOURCE_DATA_IS_DIRECTORY: u32 = 2147483648u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2520,9 +2287,6 @@ impl Default for IMAGE_RESOURCE_DIRECTORY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_RESOURCE_DIRECTORY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IMAGE_RESOURCE_DIRECTORY_ENTRY {
@@ -2533,9 +2297,6 @@ impl Default for IMAGE_RESOURCE_DIRECTORY_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_RESOURCE_DIRECTORY_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2549,9 +2310,6 @@ impl Default for IMAGE_RESOURCE_DIRECTORY_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_RESOURCE_DIRECTORY_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_RESOURCE_DIRECTORY_ENTRY_0_0 {
@@ -2561,9 +2319,6 @@ impl Default for IMAGE_RESOURCE_DIRECTORY_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_RESOURCE_DIRECTORY_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2576,9 +2331,6 @@ impl Default for IMAGE_RESOURCE_DIRECTORY_ENTRY_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_RESOURCE_DIRECTORY_ENTRY_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_RESOURCE_DIRECTORY_ENTRY_1_0 {
@@ -2588,9 +2340,6 @@ impl Default for IMAGE_RESOURCE_DIRECTORY_ENTRY_1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_RESOURCE_DIRECTORY_ENTRY_1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2603,9 +2352,6 @@ impl Default for IMAGE_RESOURCE_DIRECTORY_STRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_RESOURCE_DIRECTORY_STRING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_RESOURCE_DIR_STRING_U {
@@ -2616,9 +2362,6 @@ impl Default for IMAGE_RESOURCE_DIR_STRING_U {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_RESOURCE_DIR_STRING_U {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_RESOURCE_NAME_IS_STRING: u32 = 2147483648u32;
 pub const IMAGE_SEPARATE_DEBUG_FLAGS_MASK: u32 = 32768u32;
@@ -2644,9 +2387,6 @@ impl Default for IMAGE_SEPARATE_DEBUG_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_SEPARATE_DEBUG_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_SEPARATE_DEBUG_MISMATCH: u32 = 32768u32;
 pub const IMAGE_SEPARATE_DEBUG_SIGNATURE: u32 = 18756u32;
 pub const IMAGE_SIZEOF_ARCHIVE_MEMBER_HDR: u32 = 60u32;
@@ -2664,9 +2404,6 @@ impl Default for IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_SWITCHTABLE_BRANCH_DYNAMIC_RELOCATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_SYMBOL {
@@ -2682,9 +2419,6 @@ impl Default for IMAGE_SYMBOL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_SYMBOL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub union IMAGE_SYMBOL_0 {
@@ -2697,9 +2431,6 @@ impl Default for IMAGE_SYMBOL_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_SYMBOL_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_SYMBOL_0_0 {
@@ -2710,9 +2441,6 @@ impl Default for IMAGE_SYMBOL_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_SYMBOL_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -2729,9 +2457,6 @@ impl Default for IMAGE_SYMBOL_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_SYMBOL_EX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub union IMAGE_SYMBOL_EX_0 {
@@ -2744,9 +2469,6 @@ impl Default for IMAGE_SYMBOL_EX_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_SYMBOL_EX_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
 pub struct IMAGE_SYMBOL_EX_0_0 {
@@ -2757,9 +2479,6 @@ impl Default for IMAGE_SYMBOL_EX_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_SYMBOL_EX_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_SYM_CLASS_ARGUMENT: u32 = 9u32;
 pub const IMAGE_SYM_CLASS_AUTOMATIC: u32 = 1u32;
@@ -2826,9 +2545,6 @@ impl Default for IMAGE_TLS_DIRECTORY32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_TLS_DIRECTORY32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_TLS_DIRECTORY32_0 {
@@ -2840,9 +2556,6 @@ impl Default for IMAGE_TLS_DIRECTORY32_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_TLS_DIRECTORY32_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_TLS_DIRECTORY32_0_0 {
@@ -2852,9 +2565,6 @@ impl Default for IMAGE_TLS_DIRECTORY32_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_TLS_DIRECTORY32_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[derive(Clone, Copy)]
@@ -2871,9 +2581,6 @@ impl Default for IMAGE_TLS_DIRECTORY64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_TLS_DIRECTORY64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_TLS_DIRECTORY64_0 {
@@ -2885,9 +2592,6 @@ impl Default for IMAGE_TLS_DIRECTORY64_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_TLS_DIRECTORY64_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_TLS_DIRECTORY64_0_0 {
@@ -2897,9 +2601,6 @@ impl Default for IMAGE_TLS_DIRECTORY64_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_TLS_DIRECTORY64_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -2961,9 +2662,6 @@ impl Default for IMAGE_VXD_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_VXD_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IMAGE_VXD_SIGNATURE: u16 = 17740u16;
 pub const IMAGE_WEAK_EXTERN_ANTI_DEPENDENCY: u32 = 4u32;
 pub const IMAGE_WEAK_EXTERN_SEARCH_ALIAS: u32 = 3u32;
@@ -2990,9 +2688,6 @@ impl Default for IMPORT_OBJECT_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMPORT_OBJECT_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMPORT_OBJECT_HEADER_0 {
@@ -3003,9 +2698,6 @@ impl Default for IMPORT_OBJECT_HEADER_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMPORT_OBJECT_HEADER_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMPORT_OBJECT_NAME: IMPORT_OBJECT_NAME_TYPE = IMPORT_OBJECT_NAME_TYPE(1i32);
 pub const IMPORT_OBJECT_NAME_EXPORTAS: IMPORT_OBJECT_NAME_TYPE = IMPORT_OBJECT_NAME_TYPE(4i32);
@@ -3141,9 +2833,6 @@ impl Default for KERNEL_CET_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERNEL_CET_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union KERNEL_CET_CONTEXT_0 {
@@ -3155,9 +2844,6 @@ impl Default for KERNEL_CET_CONTEXT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KERNEL_CET_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KERNEL_CET_CONTEXT_0_0 {
@@ -3167,9 +2853,6 @@ impl Default for KERNEL_CET_CONTEXT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KERNEL_CET_CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3182,9 +2865,6 @@ impl Default for KTMOBJECT_CURSOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KTMOBJECT_CURSOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KTMOBJECT_ENLISTMENT: KTMOBJECT_TYPE = KTMOBJECT_TYPE(3i32);
 pub const KTMOBJECT_INVALID: KTMOBJECT_TYPE = KTMOBJECT_TYPE(4i32);
@@ -3374,9 +3054,6 @@ impl Default for MAXVERSIONTESTED_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MAXVERSIONTESTED_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MAXWORD: u32 = 65535u32;
 pub const MAX_ACL_REVISION: u32 = 4u32;
 pub const MAX_CLASS_NAME: ReplacesCorHdrNumericDefines = ReplacesCorHdrNumericDefines(1024i32);
@@ -3471,9 +3148,6 @@ impl Default for NETWORK_APP_INSTANCE_EA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NETWORK_APP_INSTANCE_EA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NLS_VALID_LOCALE_MASK: u32 = 1048575u32;
 pub const NONVOL_FP_NUMREG_ARM64: u32 = 8u32;
 pub const NONVOL_INT_NUMREG_ARM64: u32 = 11u32;
@@ -3495,9 +3169,6 @@ impl Default for NON_PAGED_DEBUG_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NON_PAGED_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NON_PAGED_DEBUG_SIGNATURE: u32 = 18766u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3508,9 +3179,6 @@ impl Default for NOTIFY_USER_POWER_SETTING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NOTIFY_USER_POWER_SETTING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NO_SUBGROUP_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xfea3413e_7e05_4911_9a71_700331f1c294);
 #[repr(C)]
@@ -3529,9 +3197,6 @@ impl Default for NT_TIB32 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NT_TIB32 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NT_TIB32_0 {
@@ -3542,9 +3207,6 @@ impl Default for NT_TIB32_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NT_TIB32_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3562,9 +3224,6 @@ impl Default for NT_TIB64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NT_TIB64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union NT_TIB64_0 {
@@ -3575,9 +3234,6 @@ impl Default for NT_TIB64_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NT_TIB64_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NUMA_NO_PREFERRED_NODE: u32 = 4294967295u32;
 pub const NUM_DISCHARGE_POLICIES: u32 = 4u32;
@@ -3600,9 +3256,6 @@ impl Default for PACKEDEVENTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PACKEDEVENTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PARKING_TOPOLOGY_POLICY_DISABLED: u32 = 0u32;
 pub const PARKING_TOPOLOGY_POLICY_ROUNDROBIN: u32 = 1u32;
@@ -3695,9 +3348,6 @@ impl Default for PROCESSOR_IDLESTATE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSOR_IDLESTATE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESSOR_IDLESTATE_POLICY {
@@ -3711,9 +3361,6 @@ impl Default for PROCESSOR_IDLESTATE_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSOR_IDLESTATE_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROCESSOR_IDLESTATE_POLICY_0 {
@@ -3725,9 +3372,6 @@ impl Default for PROCESSOR_IDLESTATE_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSOR_IDLESTATE_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESSOR_IDLESTATE_POLICY_0_0 {
@@ -3737,9 +3381,6 @@ impl Default for PROCESSOR_IDLESTATE_POLICY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESSOR_IDLESTATE_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROCESSOR_IDLESTATE_POLICY_COUNT: u32 = 3u32;
 pub const PROCESSOR_INTEL_386: u32 = 386u32;
@@ -3768,9 +3409,6 @@ impl Default for PROCESSOR_PERFSTATE_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSOR_PERFSTATE_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROCESSOR_PERFSTATE_POLICY_0 {
@@ -3781,9 +3419,6 @@ impl Default for PROCESSOR_PERFSTATE_POLICY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESSOR_PERFSTATE_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3796,9 +3431,6 @@ impl Default for PROCESSOR_PERFSTATE_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESSOR_PERFSTATE_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESSOR_PERFSTATE_POLICY_0_0_0 {
@@ -3808,9 +3440,6 @@ impl Default for PROCESSOR_PERFSTATE_POLICY_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESSOR_PERFSTATE_POLICY_0_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROCESSOR_PERF_AUTONOMOUS_MODE_DISABLED: u32 = 0u32;
 pub const PROCESSOR_PERF_AUTONOMOUS_MODE_ENABLED: u32 = 1u32;
@@ -3854,9 +3483,6 @@ impl Default for PROCESS_MITIGATION_ACTIVATION_CONTEXT_TRUST_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_ACTIVATION_CONTEXT_TRUST_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROCESS_MITIGATION_ACTIVATION_CONTEXT_TRUST_POLICY_0 {
@@ -3868,9 +3494,6 @@ impl Default for PROCESS_MITIGATION_ACTIVATION_CONTEXT_TRUST_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_ACTIVATION_CONTEXT_TRUST_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_ACTIVATION_CONTEXT_TRUST_POLICY_0_0 {
@@ -3881,9 +3504,6 @@ impl Default for PROCESS_MITIGATION_ACTIVATION_CONTEXT_TRUST_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_ACTIVATION_CONTEXT_TRUST_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_ASLR_POLICY {
@@ -3893,9 +3513,6 @@ impl Default for PROCESS_MITIGATION_ASLR_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_ASLR_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3908,9 +3525,6 @@ impl Default for PROCESS_MITIGATION_ASLR_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_ASLR_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_ASLR_POLICY_0_0 {
@@ -3921,9 +3535,6 @@ impl Default for PROCESS_MITIGATION_ASLR_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_ASLR_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY {
@@ -3933,9 +3544,6 @@ impl Default for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3948,9 +3556,6 @@ impl Default for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0_0 {
@@ -3961,9 +3566,6 @@ impl Default for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_CHILD_PROCESS_POLICY {
@@ -3973,9 +3575,6 @@ impl Default for PROCESS_MITIGATION_CHILD_PROCESS_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_CHILD_PROCESS_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3988,9 +3587,6 @@ impl Default for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0_0 {
@@ -4001,9 +3597,6 @@ impl Default for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_CHILD_PROCESS_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY {
@@ -4013,9 +3606,6 @@ impl Default for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4028,9 +3618,6 @@ impl Default for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0_0 {
@@ -4040,9 +3627,6 @@ impl Default for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_CONTROL_FLOW_GUARD_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4055,9 +3639,6 @@ impl Default for PROCESS_MITIGATION_DEP_POLICY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_DEP_POLICY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PROCESS_MITIGATION_DEP_POLICY_0 {
@@ -4069,9 +3650,6 @@ impl Default for PROCESS_MITIGATION_DEP_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_DEP_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_DEP_POLICY_0_0 {
@@ -4082,9 +3660,6 @@ impl Default for PROCESS_MITIGATION_DEP_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_DEP_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_DYNAMIC_CODE_POLICY {
@@ -4094,9 +3669,6 @@ impl Default for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4109,9 +3681,6 @@ impl Default for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0_0 {
@@ -4122,9 +3691,6 @@ impl Default for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_DYNAMIC_CODE_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY {
@@ -4134,9 +3700,6 @@ impl Default for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4149,9 +3712,6 @@ impl Default for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0_0 {
@@ -4162,9 +3722,6 @@ impl Default for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_EXTENSION_POINT_DISABLE_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_FONT_DISABLE_POLICY {
@@ -4174,9 +3731,6 @@ impl Default for PROCESS_MITIGATION_FONT_DISABLE_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_FONT_DISABLE_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4189,9 +3743,6 @@ impl Default for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_FONT_DISABLE_POLICY_0_0 {
@@ -4202,9 +3753,6 @@ impl Default for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_FONT_DISABLE_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_IMAGE_LOAD_POLICY {
@@ -4214,9 +3762,6 @@ impl Default for PROCESS_MITIGATION_IMAGE_LOAD_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_IMAGE_LOAD_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4229,9 +3774,6 @@ impl Default for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0_0 {
@@ -4242,9 +3784,6 @@ impl Default for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_IMAGE_LOAD_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY {
@@ -4254,9 +3793,6 @@ impl Default for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4269,9 +3805,6 @@ impl Default for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0_0 {
@@ -4282,9 +3815,6 @@ impl Default for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_PAYLOAD_RESTRICTION_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY {
@@ -4294,9 +3824,6 @@ impl Default for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4309,9 +3836,6 @@ impl Default for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0_0 {
@@ -4322,9 +3846,6 @@ impl Default for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_REDIRECTION_TRUST_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_SEHOP_POLICY {
@@ -4334,9 +3855,6 @@ impl Default for PROCESS_MITIGATION_SEHOP_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_SEHOP_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4349,9 +3867,6 @@ impl Default for PROCESS_MITIGATION_SEHOP_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_SEHOP_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_SEHOP_POLICY_0_0 {
@@ -4362,9 +3877,6 @@ impl Default for PROCESS_MITIGATION_SEHOP_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_SEHOP_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY {
@@ -4374,9 +3886,6 @@ impl Default for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4389,9 +3898,6 @@ impl Default for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0_0 {
@@ -4402,9 +3908,6 @@ impl Default for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_SIDE_CHANNEL_ISOLATION_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY {
@@ -4414,9 +3917,6 @@ impl Default for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4429,9 +3929,6 @@ impl Default for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0_0 {
@@ -4442,9 +3939,6 @@ impl Default for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY {
@@ -4454,9 +3948,6 @@ impl Default for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4469,9 +3960,6 @@ impl Default for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0_0 {
@@ -4482,9 +3970,6 @@ impl Default for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY {
@@ -4494,9 +3979,6 @@ impl Default for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4509,9 +3991,6 @@ impl Default for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0_0 {
@@ -4522,9 +4001,6 @@ impl Default for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_SYSTEM_CALL_FILTER_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_USER_POINTER_AUTH_POLICY {
@@ -4534,9 +4010,6 @@ impl Default for PROCESS_MITIGATION_USER_POINTER_AUTH_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_USER_POINTER_AUTH_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4549,9 +4022,6 @@ impl Default for PROCESS_MITIGATION_USER_POINTER_AUTH_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_USER_POINTER_AUTH_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_USER_POINTER_AUTH_POLICY_0_0 {
@@ -4562,9 +4032,6 @@ impl Default for PROCESS_MITIGATION_USER_POINTER_AUTH_POLICY_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_USER_POINTER_AUTH_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY {
@@ -4574,9 +4041,6 @@ impl Default for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4589,9 +4053,6 @@ impl Default for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0_0 {
@@ -4601,9 +4062,6 @@ impl Default for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MITIGATION_USER_SHADOW_STACK_POLICY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROCESS_TRUST_LABEL_SECURITY_INFORMATION: i32 = 128i32;
 pub const PROC_IDLE_BUCKET_COUNT: u32 = 6u32;
@@ -4722,9 +4180,6 @@ impl Default for QUOTA_LIMITS_EX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QUOTA_LIMITS_EX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const QUOTA_LIMITS_USE_DEFAULT_LIMITS: u32 = 16u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -4737,9 +4192,6 @@ impl Default for RATE_QUOTA_LIMIT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RATE_QUOTA_LIMIT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RATE_QUOTA_LIMIT_0 {
@@ -4749,9 +4201,6 @@ impl Default for RATE_QUOTA_LIMIT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RATE_QUOTA_LIMIT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const READ_THREAD_PROFILING_FLAG_DISPATCHING: u32 = 1u32;
 pub const READ_THREAD_PROFILING_FLAG_HARDWARE_COUNTERS: u32 = 2u32;
@@ -4769,9 +4218,6 @@ impl Default for REARRANGE_FILE_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REARRANGE_FILE_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4787,10 +4233,6 @@ impl Default for REARRANGE_FILE_DATA32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for REARRANGE_FILE_DATA32 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RECO_COPY: RECO_FLAGS = RECO_FLAGS(2u32);
 pub const RECO_CUT: RECO_FLAGS = RECO_FLAGS(3u32);
@@ -4846,9 +4288,6 @@ impl Default for REDBOOK_DIGITAL_AUDIO_EXTRACTION_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REDBOOK_DIGITAL_AUDIO_EXTRACTION_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const REDBOOK_DIGITAL_AUDIO_EXTRACTION_INFO_VERSION: u32 = 1u32;
 pub const REG_APP_HIVE: i32 = 16i32;
 pub const REG_APP_HIVE_OPEN_READ_ONLY: i32 = 8192i32;
@@ -4879,9 +4318,6 @@ impl Default for RESOURCEMANAGER_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RESOURCEMANAGER_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RESOURCEMANAGER_COMPLETE_PROPAGATION: u32 = 64u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4893,9 +4329,6 @@ impl Default for RESOURCEMANAGER_COMPLETION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RESOURCEMANAGER_COMPLETION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RESOURCEMANAGER_ENLIST: u32 = 8u32;
 pub const RESOURCEMANAGER_GET_NOTIFICATION: u32 = 16u32;
@@ -4925,9 +4358,6 @@ impl Default for RemHBITMAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RemHBITMAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RemHBRUSH {
@@ -4938,9 +4368,6 @@ impl Default for RemHBRUSH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RemHBRUSH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4953,9 +4380,6 @@ impl Default for RemHENHMETAFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RemHENHMETAFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RemHGLOBAL {
@@ -4967,9 +4391,6 @@ impl Default for RemHGLOBAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RemHGLOBAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4985,9 +4406,6 @@ impl Default for RemHMETAFILEPICT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RemHMETAFILEPICT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RemHPALETTE {
@@ -4998,9 +4416,6 @@ impl Default for RemHPALETTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RemHPALETTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5013,9 +4428,6 @@ impl Default for RemotableHandle {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RemotableHandle {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RemotableHandle_0 {
@@ -5026,9 +4438,6 @@ impl Default for RemotableHandle_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RemotableHandle_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5047,9 +4456,6 @@ impl Default for SCOPE_TABLE_AMD64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCOPE_TABLE_AMD64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCOPE_TABLE_AMD64_0 {
@@ -5063,9 +4469,6 @@ impl Default for SCOPE_TABLE_AMD64_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCOPE_TABLE_AMD64_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCOPE_TABLE_ARM {
@@ -5076,9 +4479,6 @@ impl Default for SCOPE_TABLE_ARM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCOPE_TABLE_ARM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5093,9 +4493,6 @@ impl Default for SCOPE_TABLE_ARM_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCOPE_TABLE_ARM_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCOPE_TABLE_ARM64 {
@@ -5106,9 +4503,6 @@ impl Default for SCOPE_TABLE_ARM64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCOPE_TABLE_ARM64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5122,9 +4516,6 @@ impl Default for SCOPE_TABLE_ARM64_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCOPE_TABLE_ARM64_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5140,9 +4531,6 @@ impl Default for SCRUB_DATA_INPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCRUB_DATA_INPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SCRUB_DATA_INPUT_FLAG_IGNORE_REDUNDANCY: u32 = 8u32;
 pub const SCRUB_DATA_INPUT_FLAG_OPLOCK_NOT_ACQUIRED: u32 = 64u32;
@@ -5184,9 +4572,6 @@ impl Default for SCRUB_DATA_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCRUB_DATA_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SCRUB_DATA_OUTPUT_FLAG_INCOMPLETE: u32 = 1u32;
 pub const SCRUB_DATA_OUTPUT_FLAG_NON_USER_DATA_RANGE: u32 = 65536u32;
 pub const SCRUB_DATA_OUTPUT_FLAG_PARITY_EXTENT_DATA_RETURNED: u32 = 131072u32;
@@ -5202,9 +4587,6 @@ impl Default for SCRUB_PARITY_EXTENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCRUB_PARITY_EXTENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SCRUB_PARITY_EXTENT_DATA {
@@ -5218,9 +4600,6 @@ impl Default for SCRUB_PARITY_EXTENT_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCRUB_PARITY_EXTENT_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SECURITY_ANONYMOUS_LOGON_RID: i32 = 7i32;
 pub const SECURITY_APPPOOL_ID_BASE_RID: i32 = 82i32;
@@ -5320,9 +4699,6 @@ impl Default for SECURITY_OBJECT_AI_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SECURITY_OBJECT_AI_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SECURITY_OTHER_ORGANIZATION_RID: i32 = 1000i32;
 pub const SECURITY_PACKAGE_BASE_RID: i32 = 64i32;
 pub const SECURITY_PACKAGE_DIGEST_RID: i32 = 21i32;
@@ -5392,9 +4768,6 @@ impl Default for SERVERSILO_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERVERSILO_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SERVERSILO_INITING: SERVERSILO_STATE = SERVERSILO_STATE(0i32);
 pub const SERVERSILO_SHUTTING_DOWN: SERVERSILO_STATE = SERVERSILO_STATE(2i32);
@@ -5479,10 +4852,6 @@ impl Default for SE_TOKEN_USER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SE_TOKEN_USER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -5496,10 +4865,6 @@ impl Default for SE_TOKEN_USER_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SE_TOKEN_USER_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy)]
@@ -5512,10 +4877,6 @@ impl Default for SE_TOKEN_USER_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for SE_TOKEN_USER_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SFGAO_BROWSABLE: SFGAO_FLAGS = SFGAO_FLAGS(134217728u32);
 pub const SFGAO_CANCOPY: SFGAO_FLAGS = SFGAO_FLAGS(1u32);
@@ -5600,9 +4961,6 @@ impl Default for SHARED_VIRTUAL_DISK_SUPPORT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHARED_VIRTUAL_DISK_SUPPORT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SHUFFLE_FILE_DATA {
@@ -5614,9 +4972,6 @@ impl Default for SHUFFLE_FILE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHUFFLE_FILE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHUFFLE_FILE_FLAG_SKIP_INITIALIZING_NEW_CLUSTERS: u32 = 1u32;
 pub const SID_HASH_SIZE: u32 = 32u32;
@@ -5636,9 +4991,6 @@ impl Default for SILOOBJECT_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SILOOBJECT_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SIZEOF_RFPO_DATA: u32 = 16u32;
 pub const SIZE_OF_80387_REGISTERS: u32 = 80u32;
@@ -5955,9 +5307,6 @@ impl Default for SUPPORTED_OS_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SUPPORTED_OS_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SYSTEM_ACCESS_FILTER_ACE_TYPE: u32 = 21u32;
 pub const SYSTEM_ACCESS_FILTER_NOCONSTRAINT_MASK: u32 = 4294967295u32;
 pub const SYSTEM_ACCESS_FILTER_VALID_MASK: u32 = 16777215u32;
@@ -6014,9 +5363,6 @@ impl Default for TAPE_CREATE_PARTITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TAPE_CREATE_PARTITION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TAPE_DRIVE_ABSOLUTE_BLK: TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH = TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH(2147487744u32);
 pub const TAPE_DRIVE_ABS_BLK_IMMED: TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH = TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH(2147491840u32);
@@ -6097,9 +5443,6 @@ impl Default for TAPE_GET_DRIVE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TAPE_GET_DRIVE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH(pub u32);
@@ -6150,9 +5493,6 @@ impl Default for TAPE_GET_MEDIA_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TAPE_GET_MEDIA_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TAPE_PSEUDO_LOGICAL_BLOCK: i32 = 3i32;
 pub const TAPE_PSEUDO_LOGICAL_POSITION: i32 = 2i32;
 pub const TAPE_QUERY_DEVICE_ERROR_DATA: i32 = 4i32;
@@ -6173,9 +5513,6 @@ impl Default for TAPE_SET_DRIVE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TAPE_SET_DRIVE_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TAPE_SET_MEDIA_PARAMETERS {
@@ -6185,9 +5522,6 @@ impl Default for TAPE_SET_MEDIA_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TAPE_SET_MEDIA_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6200,9 +5534,6 @@ impl Default for TAPE_WMI_OPERATIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TAPE_WMI_OPERATIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const THREAD_BASE_PRIORITY_IDLE: i32 = -15i32;
 pub const THREAD_BASE_PRIORITY_LOWRT: u32 = 15u32;
@@ -6225,9 +5556,6 @@ impl Default for TOKEN_BNO_ISOLATION_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOKEN_BNO_ISOLATION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Security")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6240,10 +5568,6 @@ impl Default for TOKEN_SID_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Security")]
-impl windows_core::TypeKind for TOKEN_SID_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TOKEN_SOURCE_LENGTH: u32 = 8u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6255,9 +5579,6 @@ impl Default for TRANSACTIONMANAGER_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSACTIONMANAGER_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRANSACTIONMANAGER_BIND_TRANSACTION: u32 = 32u32;
 pub const TRANSACTIONMANAGER_CREATE_RM: u32 = 16u32;
@@ -6275,9 +5596,6 @@ impl Default for TRANSACTIONMANAGER_LOGPATH_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSACTIONMANAGER_LOGPATH_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSACTIONMANAGER_LOG_INFORMATION {
@@ -6288,9 +5606,6 @@ impl Default for TRANSACTIONMANAGER_LOG_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSACTIONMANAGER_LOG_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSACTIONMANAGER_OLDEST_INFORMATION {
@@ -6300,9 +5615,6 @@ impl Default for TRANSACTIONMANAGER_OLDEST_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSACTIONMANAGER_OLDEST_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRANSACTIONMANAGER_QUERY_INFORMATION: u32 = 1u32;
 pub const TRANSACTIONMANAGER_RECOVER: u32 = 4u32;
@@ -6315,9 +5627,6 @@ impl Default for TRANSACTIONMANAGER_RECOVERY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSACTIONMANAGER_RECOVERY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRANSACTIONMANAGER_RENAME: u32 = 8u32;
 pub const TRANSACTIONMANAGER_SET_INFORMATION: u32 = 2u32;
@@ -6333,9 +5642,6 @@ impl Default for TRANSACTION_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSACTION_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSACTION_BIND_INFORMATION {
@@ -6345,9 +5651,6 @@ impl Default for TRANSACTION_BIND_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSACTION_BIND_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRANSACTION_COMMIT: u32 = 8u32;
 pub const TRANSACTION_ENLIST: u32 = 4u32;
@@ -6362,9 +5665,6 @@ impl Default for TRANSACTION_ENLISTMENTS_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSACTION_ENLISTMENTS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSACTION_ENLISTMENT_PAIR {
@@ -6375,9 +5675,6 @@ impl Default for TRANSACTION_ENLISTMENT_PAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSACTION_ENLISTMENT_PAIR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6392,9 +5689,6 @@ impl Default for TRANSACTION_LIST_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSACTION_LIST_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSACTION_LIST_INFORMATION {
@@ -6405,9 +5699,6 @@ impl Default for TRANSACTION_LIST_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSACTION_LIST_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TRANSACTION_PROPAGATE: u32 = 32u32;
 #[repr(C)]
@@ -6425,9 +5716,6 @@ impl Default for TRANSACTION_PROPERTIES_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSACTION_PROPERTIES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TRANSACTION_QUERY_INFORMATION: u32 = 1u32;
 pub const TRANSACTION_RIGHT_RESERVED1: u32 = 64u32;
 pub const TRANSACTION_ROLLBACK: u32 = 16u32;
@@ -6444,9 +5732,6 @@ impl Default for TRANSACTION_SUPERIOR_ENLISTMENT_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSACTION_SUPERIOR_ENLISTMENT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TREE_CONNECT_ATTRIBUTE_GLOBAL: u32 = 4u32;
 pub const TREE_CONNECT_ATTRIBUTE_INTEGRITY: u32 = 32768u32;
@@ -6494,9 +5779,6 @@ impl Default for UMS_CREATE_THREAD_ATTRIBUTES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UMS_CREATE_THREAD_ATTRIBUTES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UNICODE_STRING_MAX_CHARS: u32 = 32767u32;
 pub const UNIFIEDBUILDREVISION_KEY: windows_core::PCWSTR = windows_core::w!("\\Registry\\Machine\\Software\\Microsoft\\Windows NT\\CurrentVersion");
@@ -6649,9 +5931,6 @@ impl Default for XSAVE_CET_U_FORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XSAVE_CET_U_FORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const XSTATE_ALIGN_BIT: u32 = 1u32;
 pub const XSTATE_AMX_TILE_CONFIG: u32 = 17u32;
 pub const XSTATE_AMX_TILE_DATA: u32 = 18u32;
@@ -6693,10 +5972,6 @@ impl Default for remoteMETAFILEPICT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for remoteMETAFILEPICT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct userBITMAP {
@@ -6714,9 +5989,6 @@ impl Default for userBITMAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for userBITMAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct userCLIPFORMAT {
@@ -6727,9 +5999,6 @@ impl Default for userCLIPFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for userCLIPFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6742,9 +6011,6 @@ impl Default for userCLIPFORMAT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for userCLIPFORMAT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct userHBITMAP {
@@ -6755,9 +6021,6 @@ impl Default for userHBITMAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for userHBITMAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -6771,9 +6034,6 @@ impl Default for userHBITMAP_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for userHBITMAP_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6786,10 +6046,6 @@ impl Default for userHENHMETAFILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for userHENHMETAFILE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6805,10 +6061,6 @@ impl Default for userHENHMETAFILE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for userHENHMETAFILE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6821,10 +6073,6 @@ impl Default for userHGLOBAL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for userHGLOBAL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6840,10 +6088,6 @@ impl Default for userHGLOBAL_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for userHGLOBAL_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6856,10 +6100,6 @@ impl Default for userHMETAFILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for userHMETAFILE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6875,10 +6115,6 @@ impl Default for userHMETAFILE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for userHMETAFILE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy)]
@@ -6891,10 +6127,6 @@ impl Default for userHMETAFILEPICT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for userHMETAFILEPICT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
@@ -6910,10 +6142,6 @@ impl Default for userHMETAFILEPICT_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for userHMETAFILEPICT_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -6926,10 +6154,6 @@ impl Default for userHPALETTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for userHPALETTE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -6944,8 +6168,4 @@ impl Default for userHPALETTE_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for userHPALETTE_0 {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/mod.rs
@@ -10,9 +10,6 @@ impl Default for DAILY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DAILY {
-    type TypeKind = windows_core::CopyType;
-}
 #[cfg(feature = "Win32_System_Com")]
 windows_core::imp::define_interface!(IAction, IAction_Vtbl, 0xbae54997_48b1_4cbe_9965_d6be263ebea4);
 #[cfg(feature = "Win32_System_Com")]
@@ -6191,9 +6188,6 @@ impl Default for MONTHLYDATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MONTHLYDATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MONTHLYDOW {
@@ -6205,9 +6199,6 @@ impl Default for MONTHLYDOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MONTHLYDOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6367,9 +6358,6 @@ impl Default for TASK_TRIGGER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TASK_TRIGGER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TASK_TRIGGER_BOOT: TASK_TRIGGER_TYPE2 = TASK_TRIGGER_TYPE2(8i32);
 pub const TASK_TRIGGER_CUSTOM_TRIGGER_01: TASK_TRIGGER_TYPE2 = TASK_TRIGGER_TYPE2(12i32);
 pub const TASK_TRIGGER_DAILY: TASK_TRIGGER_TYPE2 = TASK_TRIGGER_TYPE2(2i32);
@@ -6408,9 +6396,6 @@ impl Default for TRIGGER_TYPE_UNION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRIGGER_TYPE_UNION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TaskHandlerPS: windows_core::GUID = windows_core::GUID::from_u128(0xf2a69db7_da2c_4352_9066_86fee6dacac9);
 pub const TaskHandlerStatusPS: windows_core::GUID = windows_core::GUID::from_u128(0x9f15266d_d7ba_48f0_93c1_e6895f6fe5ac);
 pub const TaskScheduler: windows_core::GUID = windows_core::GUID::from_u128(0x0f87369f_a4e5_4cfc_bd3e_73e6154572dd);
@@ -6424,7 +6409,4 @@ impl Default for WEEKLY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WEEKLY {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
@@ -2114,9 +2114,6 @@ impl Default for APP_MEMORY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APP_MEMORY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct AVRT_PRIORITY(pub i32);
@@ -2135,9 +2132,6 @@ impl Default for CONDITION_VARIABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONDITION_VARIABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONDITION_VARIABLE_INIT: CONDITION_VARIABLE = CONDITION_VARIABLE { Ptr: core::ptr::null_mut() };
 pub const CONDITION_VARIABLE_LOCKMODE_SHARED: u32 = 1u32;
@@ -2216,10 +2210,6 @@ impl Default for CRITICAL_SECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for CRITICAL_SECTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2239,10 +2229,6 @@ impl Default for CRITICAL_SECTION_DEBUG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for CRITICAL_SECTION_DEBUG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEBUG_ONLY_THIS_PROCESS: PROCESS_CREATION_FLAGS = PROCESS_CREATION_FLAGS(2u32);
 pub const DEBUG_PROCESS: PROCESS_CREATION_FLAGS = PROCESS_CREATION_FLAGS(1u32);
@@ -2274,9 +2260,6 @@ impl Default for INIT_ONCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INIT_ONCE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INIT_ONCE_ASYNC: u32 = 2u32;
 pub const INIT_ONCE_CHECK_ONLY: u32 = 1u32;
 pub const INIT_ONCE_CTX_RESERVED_BITS: u32 = 2u32;
@@ -2296,9 +2279,6 @@ impl Default for IO_COUNTERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IO_COUNTERS {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IRtwqAsyncCallback, IRtwqAsyncCallback_Vtbl, 0xa27003cf_2354_4f2a_8d6a_ab7cff15437e);
 windows_core::imp::interface_hierarchy!(IRtwqAsyncCallback, windows_core::IUnknown);
@@ -2560,9 +2540,6 @@ impl Default for MEMORY_PRIORITY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEMORY_PRIORITY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MEMORY_PRIORITY_LOW: MEMORY_PRIORITY = MEMORY_PRIORITY(2u32);
 pub const MEMORY_PRIORITY_MEDIUM: MEMORY_PRIORITY = MEMORY_PRIORITY(3u32);
 pub const MEMORY_PRIORITY_NORMAL: MEMORY_PRIORITY = MEMORY_PRIORITY(5u32);
@@ -2580,9 +2557,6 @@ impl Default for OVERRIDE_PREFETCH_PARAMETER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OVERRIDE_PREFETCH_PARAMETER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -2614,10 +2588,6 @@ impl Default for PEB {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for PEB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2631,10 +2601,6 @@ impl Default for PEB_LDR_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for PEB_LDR_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PFLS_CALLBACK_FUNCTION = Option<unsafe extern "system" fn(lpflsdata: *const core::ffi::c_void)>;
 pub const PF_3DNOW_INSTRUCTIONS_AVAILABLE: PROCESSOR_FEATURE_ID = PROCESSOR_FEATURE_ID(7u32);
@@ -2758,10 +2724,6 @@ impl Default for PROCESS_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for PROCESS_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PROCESS_CREATE_PROCESS: PROCESS_ACCESS_RIGHTS = PROCESS_ACCESS_RIGHTS(128u32);
 pub const PROCESS_CREATE_THREAD: PROCESS_ACCESS_RIGHTS = PROCESS_ACCESS_RIGHTS(2u32);
 #[repr(transparent)]
@@ -2852,9 +2814,6 @@ impl Default for PROCESS_DYNAMIC_EH_CONTINUATION_TARGET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_DYNAMIC_EH_CONTINUATION_TARGET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_DYNAMIC_EH_CONTINUATION_TARGETS_INFORMATION {
@@ -2868,9 +2827,6 @@ impl Default for PROCESS_DYNAMIC_EH_CONTINUATION_TARGETS_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_DYNAMIC_EH_CONTINUATION_TARGETS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGE {
@@ -2882,9 +2838,6 @@ impl Default for PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2899,9 +2852,6 @@ impl Default for PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGES_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_DYNAMIC_ENFORCED_ADDRESS_RANGES_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_INFORMATION {
@@ -2914,9 +2864,6 @@ impl Default for PROCESS_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2931,9 +2878,6 @@ impl Default for PROCESS_LEAP_SECOND_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_LEAP_SECOND_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROCESS_LEAP_SECOND_INFO_FLAG_ENABLE_SIXTY_SECOND: u32 = 1u32;
 pub const PROCESS_LEAP_SECOND_INFO_VALID_FLAGS: u32 = 1u32;
@@ -2951,10 +2895,6 @@ impl Default for PROCESS_MACHINE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_SystemInformation")]
-impl windows_core::TypeKind for PROCESS_MACHINE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROCESS_MEMORY_EXHAUSTION_INFO {
@@ -2967,9 +2907,6 @@ impl Default for PROCESS_MEMORY_EXHAUSTION_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_MEMORY_EXHAUSTION_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2999,9 +2936,6 @@ impl Default for PROCESS_POWER_THROTTLING_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROCESS_POWER_THROTTLING_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PROCESS_PROTECTION_LEVEL(pub u32);
@@ -3014,9 +2948,6 @@ impl Default for PROCESS_PROTECTION_LEVEL_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROCESS_PROTECTION_LEVEL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROCESS_QUERY_INFORMATION: PROCESS_ACCESS_RIGHTS = PROCESS_ACCESS_RIGHTS(1024u32);
 pub const PROCESS_QUERY_LIMITED_INFORMATION: PROCESS_ACCESS_RIGHTS = PROCESS_ACCESS_RIGHTS(4096u32);
@@ -3283,9 +3214,6 @@ impl Default for REASON_CONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REASON_CONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union REASON_CONTEXT_0 {
@@ -3296,9 +3224,6 @@ impl Default for REASON_CONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REASON_CONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3312,9 +3237,6 @@ impl Default for REASON_CONTEXT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REASON_CONTEXT_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RTL_CRITICAL_SECTION_ALL_FLAG_BITS: u32 = 4278190080u32;
 pub const RTL_CRITICAL_SECTION_DEBUG_FLAG_STATIC_INIT: u32 = 1u32;
@@ -3335,9 +3257,6 @@ impl Default for RTL_USER_PROCESS_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RTL_USER_PROCESS_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(RTWQASYNCRESULT, RTWQASYNCRESULT_Vtbl, 0);
 impl core::ops::Deref for RTWQASYNCRESULT {
@@ -3379,9 +3298,6 @@ impl Default for SRWLOCK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SRWLOCK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SRWLOCK_INIT: SRWLOCK = SRWLOCK { Ptr: core::ptr::null_mut() };
 pub const STACK_SIZE_PARAM_IS_A_RESERVATION: THREAD_CREATION_FLAGS = THREAD_CREATION_FLAGS(65536u32);
@@ -3426,9 +3342,6 @@ impl Default for STARTUPINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STARTUPINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STARTUPINFOEXA {
@@ -3440,9 +3353,6 @@ impl Default for STARTUPINFOEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STARTUPINFOEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STARTUPINFOEXW {
@@ -3453,9 +3363,6 @@ impl Default for STARTUPINFOEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STARTUPINFOEXW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3483,9 +3390,6 @@ impl Default for STARTUPINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STARTUPINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3573,9 +3477,6 @@ impl Default for SYNCHRONIZATION_BARRIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYNCHRONIZATION_BARRIER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SYNCHRONIZATION_BARRIER_FLAGS_BLOCK_ONLY: u32 = 2u32;
 pub const SYNCHRONIZATION_BARRIER_FLAGS_NO_DELETE: u32 = 4u32;
 pub const SYNCHRONIZATION_BARRIER_FLAGS_SPIN_ONLY: u32 = 1u32;
@@ -3604,10 +3505,6 @@ impl Default for TEB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for TEB {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3707,9 +3604,6 @@ impl Default for THREAD_POWER_THROTTLING_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for THREAD_POWER_THROTTLING_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const THREAD_POWER_THROTTLING_VALID_FLAGS: u32 = 1u32;
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3759,9 +3653,6 @@ impl Default for TP_CALLBACK_ENVIRON_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TP_CALLBACK_ENVIRON_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TP_CALLBACK_ENVIRON_V3_0 {
@@ -3773,9 +3664,6 @@ impl Default for TP_CALLBACK_ENVIRON_V3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TP_CALLBACK_ENVIRON_V3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TP_CALLBACK_ENVIRON_V3_0_0 {
@@ -3785,9 +3673,6 @@ impl Default for TP_CALLBACK_ENVIRON_V3_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TP_CALLBACK_ENVIRON_V3_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3807,9 +3692,6 @@ impl Default for TP_POOL_STACK_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TP_POOL_STACK_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ThreadAbsoluteCpuPriority: THREAD_INFORMATION_CLASS = THREAD_INFORMATION_CLASS(1i32);
 pub const ThreadDynamicCodePolicy: THREAD_INFORMATION_CLASS = THREAD_INFORMATION_CLASS(2i32);
@@ -3831,10 +3713,6 @@ impl Default for UMS_SCHEDULER_STARTUP_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_SystemServices")]
-impl windows_core::TypeKind for UMS_SCHEDULER_STARTUP_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct UMS_SYSTEM_THREAD_INFORMATION {
@@ -3845,9 +3723,6 @@ impl Default for UMS_SYSTEM_THREAD_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UMS_SYSTEM_THREAD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3860,9 +3735,6 @@ impl Default for UMS_SYSTEM_THREAD_INFORMATION_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UMS_SYSTEM_THREAD_INFORMATION_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UMS_SYSTEM_THREAD_INFORMATION_0_0 {
@@ -3872,9 +3744,6 @@ impl Default for UMS_SYSTEM_THREAD_INFORMATION_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UMS_SYSTEM_THREAD_INFORMATION_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/Time/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Time/mod.rs
@@ -91,9 +91,6 @@ impl Default for DYNAMIC_TIME_ZONE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DYNAMIC_TIME_ZONE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TIME_ZONE_ID_INVALID: u32 = 4294967295u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -110,9 +107,6 @@ impl Default for TIME_ZONE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TIME_ZONE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TSF_Authenticated: u32 = 2u32;
 pub const TSF_Hardware: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/System/TpmBaseServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TpmBaseServices/mod.rs
@@ -94,9 +94,6 @@ impl Default for TBS_CONTEXT_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TBS_CONTEXT_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct TBS_CONTEXT_PARAMS2 {
@@ -107,9 +104,6 @@ impl Default for TBS_CONTEXT_PARAMS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TBS_CONTEXT_PARAMS2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -122,9 +116,6 @@ impl Default for TBS_CONTEXT_PARAMS2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TBS_CONTEXT_PARAMS2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TBS_CONTEXT_PARAMS2_0_0 {
@@ -134,9 +125,6 @@ impl Default for TBS_CONTEXT_PARAMS2_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TBS_CONTEXT_PARAMS2_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TBS_CONTEXT_VERSION_ONE: u32 = 1u32;
 pub const TBS_CONTEXT_VERSION_TWO: u32 = 2u32;
@@ -166,9 +154,6 @@ impl Default for TPM_DEVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TPM_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TPM_IFTYPE_1: u32 = 1u32;
 pub const TPM_IFTYPE_EMULATOR: u32 = 4u32;
 pub const TPM_IFTYPE_HW: u32 = 3u32;
@@ -191,7 +176,4 @@ impl Default for TPM_WNF_PROVISIONING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TPM_WNF_PROVISIONING {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/mod.rs
@@ -52,9 +52,6 @@ impl Default for OSUpdateAssessment {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OSUpdateAssessment {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UpdateAssessment {
@@ -66,9 +63,6 @@ impl Default for UpdateAssessment {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UpdateAssessment {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/UserAccessLogging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UserAccessLogging/mod.rs
@@ -42,7 +42,3 @@ impl Default for UAL_DATA_BLOB {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Networking_WinSock")]
-impl windows_core::TypeKind for UAL_DATA_BLOB {
-    type TypeKind = windows_core::CopyType;
-}

--- a/crates/libs/windows/src/Windows/Win32/System/Variant/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Variant/mod.rs
@@ -680,10 +680,6 @@ impl Default for VARIANT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl windows_core::TypeKind for VARIANT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub union VARIANT_0 {
@@ -701,10 +697,6 @@ impl Default for VARIANT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl windows_core::TypeKind for VARIANT_0 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -726,10 +718,6 @@ impl Default for VARIANT_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl windows_core::TypeKind for VARIANT_0_0 {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -793,10 +781,6 @@ impl Default for VARIANT_0_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl windows_core::TypeKind for VARIANT_0_0_0 {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -809,10 +793,6 @@ impl Default for VARIANT_0_0_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-impl windows_core::TypeKind for VARIANT_0_0_0_0 {
-    type TypeKind = windows_core::CloneType;
 }
 pub const VARIANT_ALPHABOOL: VAR_CHANGE_FLAGS = VAR_CHANGE_FLAGS(2u16);
 pub const VARIANT_CALENDAR_GREGORIAN: VAR_CHANGE_FLAGS = VAR_CHANGE_FLAGS(64u16);

--- a/crates/libs/windows/src/Windows/Win32/System/VirtualDosMachines/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/VirtualDosMachines/mod.rs
@@ -60,9 +60,6 @@ impl Default for GLOBALENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GLOBALENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GLOBAL_ALL: u32 = 0u32;
 pub const GLOBAL_FREE: u32 = 2u32;
 pub const GLOBAL_LRU: u32 = 1u32;
@@ -90,9 +87,6 @@ impl Default for IMAGE_NOTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_NOTE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MAX_MODULE_NAME: u32 = 9u32;
 pub const MAX_PATH16: u32 = 255u32;
 #[repr(C, packed(4))]
@@ -109,9 +103,6 @@ impl Default for MODULEENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MODULEENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PROCESSENUMPROC = Option<unsafe extern "system" fn(dwprocessid: u32, dwattributes: u32, lpuserdefined: super::super::Foundation::LPARAM) -> super::super::Foundation::BOOL>;
 #[repr(C)]
@@ -130,9 +121,6 @@ impl Default for SEGMENT_NOTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SEGMENT_NOTE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SN_CODE: u32 = 0u32;
 pub const SN_DATA: u32 = 1u32;
 pub const SN_V86: u32 = 2u32;
@@ -150,9 +138,6 @@ impl Default for TEMP_BP_NOTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TEMP_BP_NOTE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const V86FLAGS_ALIGNMENT: u32 = 262144u32;
 pub const V86FLAGS_AUXCARRY: u32 = 16u32;
@@ -210,11 +195,6 @@ impl Default for VDMCONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for VDMCONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -249,10 +229,6 @@ impl Default for VDMCONTEXT_WITHOUT_XSAVE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for VDMCONTEXT_WITHOUT_XSAVE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VDMCONTEXT_i386: u32 = 65536u32;
 pub const VDMCONTEXT_i486: u32 = 65536u32;
@@ -313,10 +289,6 @@ impl Default for VDMLDT_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for VDMLDT_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -330,10 +302,6 @@ impl Default for VDMLDT_ENTRY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for VDMLDT_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -345,10 +313,6 @@ impl Default for VDMLDT_ENTRY_0_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for VDMLDT_ENTRY_0_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -364,10 +328,6 @@ impl Default for VDMLDT_ENTRY_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for VDMLDT_ENTRY_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(all(feature = "Win32_System_Diagnostics_Debug", feature = "Win32_System_Threading"))]
 pub type VDMMODULEFIRSTPROC = Option<unsafe extern "system" fn(param0: super::super::Foundation::HANDLE, param1: super::super::Foundation::HANDLE, param2: *mut MODULEENTRY, param3: DEBUGEVENTPROC, param4: *mut core::ffi::c_void) -> super::super::Foundation::BOOL>;
@@ -400,8 +360,5 @@ impl Default for VDM_SEGINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VDM_SEGINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WOW_SYSTEM: u32 = 1u32;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Metadata/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Metadata/mod.rs
@@ -100,9 +100,6 @@ impl Default for ASSEMBLYMETADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ASSEMBLYMETADATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ASSEMBLY_METADATA_TYPE: windows_core::PCSTR = windows_core::s!("System.Reflection.AssemblyMetadataAttribute");
 pub const ASSEMBLY_METADATA_TYPE_W: windows_core::PCWSTR = windows_core::w!("System.Reflection.AssemblyMetadataAttribute");
 pub const CLSID_CLR_v1_MetaData: windows_core::GUID = windows_core::GUID::from_u128(0x005023ca_72b1_11d3_9fc4_00c04f79a0a3);
@@ -162,9 +159,6 @@ impl Default for COR_FIELD_OFFSET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COR_FIELD_OFFSET {
-    type TypeKind = windows_core::CopyType;
-}
 pub const COR_ILEXCEPTION_CLAUSE_DEPRECATED: CorExceptionFlag = CorExceptionFlag(0i32);
 pub const COR_ILEXCEPTION_CLAUSE_DUPLICATED: CorExceptionFlag = CorExceptionFlag(8i32);
 pub const COR_ILEXCEPTION_CLAUSE_FAULT: CorExceptionFlag = CorExceptionFlag(4i32);
@@ -184,9 +178,6 @@ impl Default for COR_NATIVE_LINK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COR_NATIVE_LINK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const COR_NATIVE_LINK_CUSTOM_VALUE: windows_core::PCWSTR = windows_core::w!("COMPLUS_NativeLink");
 pub const COR_NATIVE_LINK_CUSTOM_VALUE_ANSI: windows_core::PCSTR = windows_core::s!("COMPLUS_NativeLink");
 pub const COR_NATIVE_LINK_CUSTOM_VALUE_CC: u32 = 18u32;
@@ -203,9 +194,6 @@ impl Default for COR_SECATTR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COR_SECATTR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const COR_SUPPRESS_UNMANAGED_CODE_CHECK_ATTRIBUTE: windows_core::PCWSTR = windows_core::w!("System.Security.SuppressUnmanagedCodeSecurityAttribute");
 pub const COR_SUPPRESS_UNMANAGED_CODE_CHECK_ATTRIBUTE_ANSI: windows_core::PCSTR = windows_core::s!("System.Security.SuppressUnmanagedCodeSecurityAttribute");
@@ -231,9 +219,6 @@ impl Default for CVStruct {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CVStruct {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CeeSectionAttr(pub i64);
@@ -246,9 +231,6 @@ impl Default for CeeSectionRelocExtra {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CeeSectionRelocExtra {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -719,9 +701,6 @@ impl Default for IMAGE_COR_ILMETHOD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_COR_ILMETHOD_FAT {
@@ -734,9 +713,6 @@ impl Default for IMAGE_COR_ILMETHOD_FAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_FAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_COR_ILMETHOD_SECT_EH {
@@ -747,9 +723,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_EH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_EH {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -766,9 +739,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT_0 {
@@ -779,9 +749,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -797,10 +764,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -813,10 +776,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -832,10 +791,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -849,10 +804,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IMAGE_COR_ILMETHOD_SECT_EH_FAT {
@@ -863,9 +814,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_EH_FAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_EH_FAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -879,9 +827,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_EH_SMALL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_EH_SMALL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_COR_ILMETHOD_SECT_FAT {
@@ -891,9 +836,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_FAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_FAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -906,9 +848,6 @@ impl Default for IMAGE_COR_ILMETHOD_SECT_SMALL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_SECT_SMALL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_COR_ILMETHOD_TINY {
@@ -918,9 +857,6 @@ impl Default for IMAGE_COR_ILMETHOD_TINY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_COR_ILMETHOD_TINY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -933,9 +869,6 @@ impl Default for IMAGE_COR_VTABLEFIXUP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_COR_VTABLEFIXUP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMAGE_DIRECTORY_ENTRY_COMHEADER: ReplacesGeneralNumericDefines = ReplacesGeneralNumericDefines(14i32);
 windows_core::imp::define_interface!(IMapToken, IMapToken_Vtbl, 0x06a3ea8b_0225_11d1_bf72_00c04fc31e12);
@@ -4005,9 +3938,6 @@ impl Default for OSINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for OSINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/mod.rs
@@ -84,9 +84,5 @@ impl Default for PDF_RENDER_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-impl windows_core::TypeKind for PDF_RENDER_PARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 pub type PFN_PDF_CREATE_RENDERER = Option<unsafe extern "system" fn(param0: Option<super::super::super::Graphics::Dxgi::IDXGIDevice>, param1: *mut Option<IPdfRendererNative>) -> windows_core::HRESULT>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -517,9 +517,6 @@ impl Default for DispatcherQueueOptions {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DispatcherQueueOptions {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EventRegistrationToken {
@@ -529,9 +526,6 @@ impl Default for EventRegistrationToken {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EventRegistrationToken {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FullTrust: TrustLevel = TrustLevel(2i32);
 #[repr(transparent)]
@@ -572,9 +566,6 @@ impl Default for HSTRING_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HSTRING_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IAccountsSettingsPaneInterop, IAccountsSettingsPaneInterop_Vtbl, 0xd3ee12ad_3865_4362_9746_b75a682df0e6);
 windows_core::imp::interface_hierarchy!(IAccountsSettingsPaneInterop, windows_core::IUnknown, windows_core::IInspectable);
@@ -2354,9 +2345,6 @@ impl Default for ServerInformation {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ServerInformation {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
@@ -1539,9 +1539,6 @@ impl Default for ACTCTX_SECTION_KEYED_DATA_2600 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTCTX_SECTION_KEYED_DATA_2600 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTCTX_SECTION_KEYED_DATA_ASSEMBLY_METADATA {
@@ -1556,9 +1553,6 @@ impl Default for ACTCTX_SECTION_KEYED_DATA_ASSEMBLY_METADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACTCTX_SECTION_KEYED_DATA_ASSEMBLY_METADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ACTIVATION_CONTEXT_BASIC_INFORMATION {
@@ -1569,9 +1563,6 @@ impl Default for ACTIVATION_CONTEXT_BASIC_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ACTIVATION_CONTEXT_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ACTIVATION_CONTEXT_BASIC_INFORMATION_DEFINED: u32 = 1u32;
 pub const AC_LINE_BACKUP_POWER: u32 = 2u32;
@@ -1663,9 +1654,6 @@ impl Default for CABINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CABINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CABINFOW {
@@ -1679,9 +1667,6 @@ impl Default for CABINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CABINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CATID_DeleteBrowsingHistory: windows_core::GUID = windows_core::GUID::from_u128(0x31caf6e4_d6aa_4090_a050_a5ac8972e9ef);
 pub const CBR_110: u32 = 110u32;
@@ -1715,9 +1700,6 @@ impl Default for CLIENT_ID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLIENT_ID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CL_NL_ENTITY: TDIENTITY_ENTITY_TYPE = TDIENTITY_ENTITY_TYPE(769u32);
 pub const CL_NL_IP: u32 = 771u32;
@@ -1764,9 +1746,6 @@ impl Default for CUSTOM_SYSTEM_EVENT_TRIGGER_CONFIG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CUSTOM_SYSTEM_EVENT_TRIGGER_CONFIG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CameraUIControl: windows_core::GUID = windows_core::GUID::from_u128(0x16d5a2be_b1c5_47b3_8eae_ccbcf452c7e8);
 #[repr(transparent)]
@@ -1828,9 +1807,6 @@ impl Default for DATETIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DATETIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DCICMD {
@@ -1844,9 +1820,6 @@ impl Default for DCICMD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DCICMD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1865,9 +1838,6 @@ impl Default for DCICREATEINPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DCICREATEINPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DCICREATEOFFSCREENSURFACE: u32 = 2u32;
 pub const DCICREATEOVERLAYSURFACE: u32 = 3u32;
 pub const DCICREATEPRIMARYSURFACE: u32 = 1u32;
@@ -1885,9 +1855,6 @@ impl Default for DCIENUMINPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DCIENUMINPUT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DCIENUMSURFACE: u32 = 4u32;
 pub const DCIESCAPE: u32 = 5u32;
 #[repr(C)]
@@ -1903,9 +1870,6 @@ impl Default for DCIOFFSCREEN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DCIOFFSCREEN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DCIOVERLAY {
@@ -1917,9 +1881,6 @@ impl Default for DCIOVERLAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DCIOVERLAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1946,9 +1907,6 @@ impl Default for DCISURFACEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DCISURFACEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DCI_1632_ACCESS: u32 = 64u32;
 pub const DCI_ASYNC: u32 = 1024u32;
@@ -2029,10 +1987,6 @@ impl Default for DELAYLOAD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DELAYLOAD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -2052,10 +2006,6 @@ impl Default for DELAYLOAD_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DELAYLOAD_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DELAYLOAD_PROC_DESCRIPTOR {
@@ -2067,9 +2017,6 @@ impl Default for DELAYLOAD_PROC_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DELAYLOAD_PROC_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union DELAYLOAD_PROC_DESCRIPTOR_0 {
@@ -2080,9 +2027,6 @@ impl Default for DELAYLOAD_PROC_DESCRIPTOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DELAYLOAD_PROC_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DELETE_BROWSING_HISTORY_COOKIES: u32 = 2u32;
 pub const DELETE_BROWSING_HISTORY_DOWNLOADHISTORY: u32 = 64u32;
@@ -2154,9 +2098,6 @@ impl Default for FEATURE_ERROR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FEATURE_ERROR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2281,9 +2222,6 @@ impl Default for HW_PROFILE_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HW_PROFILE_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HW_PROFILE_INFOW {
@@ -2295,9 +2233,6 @@ impl Default for HW_PROFILE_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HW_PROFILE_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(ICameraUIControl, ICameraUIControl_Vtbl, 0xb8733adf_3d68_4b8f_bb08_e28a0bed0376);
 windows_core::imp::interface_hierarchy!(ICameraUIControl, windows_core::IUnknown);
@@ -2865,9 +2800,6 @@ impl Default for IMAGE_DELAYLOAD_DESCRIPTOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_DELAYLOAD_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union IMAGE_DELAYLOAD_DESCRIPTOR_0 {
@@ -2879,9 +2811,6 @@ impl Default for IMAGE_DELAYLOAD_DESCRIPTOR_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_DELAYLOAD_DESCRIPTOR_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGE_DELAYLOAD_DESCRIPTOR_0_0 {
@@ -2892,9 +2821,6 @@ impl Default for IMAGE_DELAYLOAD_DESCRIPTOR_0_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_DELAYLOAD_DESCRIPTOR_0_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IMAGE_THUNK_DATA32 {
@@ -2904,9 +2830,6 @@ impl Default for IMAGE_THUNK_DATA32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_THUNK_DATA32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2921,9 +2844,6 @@ impl Default for IMAGE_THUNK_DATA32_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMAGE_THUNK_DATA32_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct IMAGE_THUNK_DATA64 {
@@ -2933,9 +2853,6 @@ impl Default for IMAGE_THUNK_DATA64 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_THUNK_DATA64 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -2949,9 +2866,6 @@ impl Default for IMAGE_THUNK_DATA64_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGE_THUNK_DATA64_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMEA_INIT: u32 = 1u32;
 pub const IMEA_NEXT: u32 = 2u32;
@@ -2971,9 +2885,6 @@ impl Default for IMEPROA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEPROA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMEPROW {
@@ -2988,9 +2899,6 @@ impl Default for IMEPROW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMEPROW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3008,9 +2916,6 @@ impl Default for IMESTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMESTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IME_BANJAtoJUNJA: u32 = 19u32;
 pub const IME_ENABLE_CONVERT: u32 = 2u32;
@@ -3128,9 +3033,6 @@ impl Default for JAVA_TRUST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JAVA_TRUST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JIT_DEBUG_INFO {
@@ -3146,9 +3048,6 @@ impl Default for JIT_DEBUG_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JIT_DEBUG_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KEY_ALL_KEYS: WLDP_KEY = WLDP_KEY(2i32);
 pub const KEY_OVERRIDE: WLDP_KEY = WLDP_KEY(1i32);
@@ -3174,10 +3073,6 @@ impl Default for LDR_DATA_TABLE_ENTRY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for LDR_DATA_TABLE_ENTRY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Kernel")]
 #[derive(Clone, Copy)]
@@ -3190,10 +3085,6 @@ impl Default for LDR_DATA_TABLE_ENTRY_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Kernel")]
-impl windows_core::TypeKind for LDR_DATA_TABLE_ENTRY_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LIS_NOGRPCONV: u32 = 2u32;
 pub const LIS_QUIET: u32 = 1u32;
@@ -3244,9 +3135,6 @@ impl Default for PERUSERSECTIONA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PERUSERSECTIONA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PERUSERSECTIONW {
@@ -3263,9 +3151,6 @@ impl Default for PERUSERSECTIONW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PERUSERSECTIONW {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PFEATURE_STATE_CHANGE_CALLBACK = Option<unsafe extern "system" fn(context: *const core::ffi::c_void)>;
 pub type PFIBER_CALLOUT_ROUTINE = Option<unsafe extern "system" fn(lpparameter: *mut core::ffi::c_void) -> *mut core::ffi::c_void>;
@@ -3312,9 +3197,6 @@ impl Default for PUBLIC_OBJECT_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PUBLIC_OBJECT_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PUBLIC_OBJECT_TYPE_INFORMATION {
@@ -3325,9 +3207,6 @@ impl Default for PUBLIC_OBJECT_TYPE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PUBLIC_OBJECT_TYPE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub type PWINSTATIONQUERYINFORMATIONW = Option<unsafe extern "system" fn(param0: super::super::Foundation::HANDLE, param1: u32, param2: WINSTATIONINFOCLASS, param3: *mut core::ffi::c_void, param4: u32, param5: *mut u32) -> super::super::Foundation::BOOLEAN>;
 pub type PWLDP_CANEXECUTEBUFFER_API = Option<unsafe extern "system" fn(host: *const windows_core::GUID, options: WLDP_EXECUTION_EVALUATION_OPTIONS, buffer: *const u8, buffersize: u32, auditinfo: windows_core::PCWSTR, result: *mut WLDP_EXECUTION_POLICY) -> windows_core::HRESULT>;
@@ -3426,9 +3305,6 @@ impl Default for STRENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STRENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STRENTRYW {
@@ -3439,9 +3315,6 @@ impl Default for STRENTRYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STRENTRYW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3457,9 +3330,6 @@ impl Default for STRINGEXSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STRINGEXSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STRTABLEA {
@@ -3471,9 +3341,6 @@ impl Default for STRTABLEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STRTABLEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STRTABLEW {
@@ -3484,9 +3351,6 @@ impl Default for STRTABLEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STRTABLEW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3500,9 +3364,6 @@ impl Default for SYSTEM_BASIC_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_BASIC_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_CODEINTEGRITY_INFORMATION {
@@ -3514,9 +3375,6 @@ impl Default for SYSTEM_CODEINTEGRITY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_CODEINTEGRITY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_EXCEPTION_INFORMATION {
@@ -3526,9 +3384,6 @@ impl Default for SYSTEM_EXCEPTION_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_EXCEPTION_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3540,9 +3395,6 @@ impl Default for SYSTEM_INTERRUPT_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_INTERRUPT_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_LOOKASIDE_INFORMATION {
@@ -3552,9 +3404,6 @@ impl Default for SYSTEM_LOOKASIDE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_LOOKASIDE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3566,9 +3415,6 @@ impl Default for SYSTEM_PERFORMANCE_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_PERFORMANCE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_POLICY_INFORMATION {
@@ -3579,9 +3425,6 @@ impl Default for SYSTEM_POLICY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_POLICY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3596,9 +3439,6 @@ impl Default for SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3632,9 +3472,6 @@ impl Default for SYSTEM_PROCESS_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_PROCESS_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_REGISTRY_QUOTA_INFORMATION {
@@ -3646,9 +3483,6 @@ impl Default for SYSTEM_REGISTRY_QUOTA_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_REGISTRY_QUOTA_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SYSTEM_STATUS_FLAG_POWER_SAVING_ON: u32 = 1u32;
 #[repr(C)]
@@ -3669,9 +3503,6 @@ impl Default for SYSTEM_THREAD_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_THREAD_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYSTEM_TIMEOFDAY_INFORMATION {
@@ -3681,9 +3512,6 @@ impl Default for SYSTEM_TIMEOFDAY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYSTEM_TIMEOFDAY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const S_ALLTHRESHOLD: u32 = 2u32;
 pub const S_LEGATO: u32 = 1u32;
@@ -3730,10 +3558,6 @@ impl Default for TCP_REQUEST_QUERY_INFORMATION_EX32_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for TCP_REQUEST_QUERY_INFORMATION_EX32_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_REQUEST_QUERY_INFORMATION_EX_W2K {
@@ -3744,9 +3568,6 @@ impl Default for TCP_REQUEST_QUERY_INFORMATION_EX_W2K {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_REQUEST_QUERY_INFORMATION_EX_W2K {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3759,9 +3580,6 @@ impl Default for TCP_REQUEST_QUERY_INFORMATION_EX_XP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCP_REQUEST_QUERY_INFORMATION_EX_XP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCP_REQUEST_SET_INFORMATION_EX {
@@ -3773,9 +3591,6 @@ impl Default for TCP_REQUEST_SET_INFORMATION_EX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCP_REQUEST_SET_INFORMATION_EX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TC_GP_TRAP: u32 = 2u32;
 pub const TC_HARDERR: u32 = 1u32;
@@ -3795,9 +3610,6 @@ impl Default for TDIEntityID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TDIEntityID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TDIObjectID {
@@ -3810,9 +3622,6 @@ impl Default for TDIObjectID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TDIObjectID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -3830,9 +3639,6 @@ impl Default for TDI_TL_IO_CONTROL_ENDPOINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TDI_TL_IO_CONTROL_ENDPOINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TDI_TL_IO_CONTROL_ENDPOINT_0 {
@@ -3843,9 +3649,6 @@ impl Default for TDI_TL_IO_CONTROL_ENDPOINT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TDI_TL_IO_CONTROL_ENDPOINT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3859,9 +3662,6 @@ impl Default for THREAD_NAME_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for THREAD_NAME_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const THREAD_PRIORITY_ERROR_RETURN: u32 = 2147483647u32;
 pub const UMS_VERSION: u32 = 256u32;
@@ -3888,9 +3688,6 @@ impl Default for UNDETERMINESTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UNDETERMINESTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct VALUENAME(pub i32);
@@ -3912,9 +3709,6 @@ impl Default for WINSTATIONINFORMATIONW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINSTATIONINFORMATIONW {
-    type TypeKind = windows_core::CopyType;
-}
 pub type WINWATCHNOTIFYPROC = Option<unsafe extern "system" fn(hww: HWINWATCH, hwnd: super::super::Foundation::HWND, code: u32, lparam: super::super::Foundation::LPARAM)>;
 pub const WINWATCHNOTIFY_CHANGED: u32 = 4u32;
 pub const WINWATCHNOTIFY_CHANGING: u32 = 3u32;
@@ -3935,9 +3729,6 @@ impl Default for WLDP_DEVICE_SECURITY_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLDP_DEVICE_SECURITY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLDP_DLL: windows_core::PCWSTR = windows_core::w!("WLDP.DLL");
 #[repr(transparent)]
@@ -4015,9 +3806,6 @@ impl Default for WLDP_HOST_INFORMATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WLDP_HOST_INFORMATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WLDP_HOST_INFORMATION_REVISION: u32 = 1u32;
 pub const WLDP_HOST_JAVASCRIPT: windows_core::GUID = windows_core::GUID::from_u128(0x5629f0d5_1cca_4fed_a1a3_36a8c18d74c0);

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsSync/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsSync/mod.rs
@@ -863,9 +863,6 @@ impl Default for ID_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ID_PARAMETERS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ID_PARAMETER_PAIR {
@@ -876,9 +873,6 @@ impl Default for ID_PARAMETER_PAIR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ID_PARAMETER_PAIR {
-    type TypeKind = windows_core::CopyType;
 }
 windows_core::imp::define_interface!(IDataRetrieverCallback, IDataRetrieverCallback_Vtbl, 0x71b4863b_f969_4676_bbc3_3d9fdc3fb2c7);
 windows_core::imp::interface_hierarchy!(IDataRetrieverCallback, windows_core::IUnknown);
@@ -5760,9 +5754,6 @@ impl Default for SYNC_FILTER_CHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYNC_FILTER_CHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SYNC_FILTER_INFO_COMBINED: u32 = 8u32;
 pub const SYNC_FILTER_INFO_FLAG_CHANGE_UNIT_LIST: u32 = 2u32;
 pub const SYNC_FILTER_INFO_FLAG_CUSTOM: u32 = 4u32;
@@ -5791,9 +5782,6 @@ impl Default for SYNC_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYNC_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SYNC_REGISTRATION_EVENT(pub i32);
@@ -5818,9 +5806,6 @@ impl Default for SYNC_SESSION_STATISTICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYNC_SESSION_STATISTICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SYNC_STATISTICS(pub i32);
@@ -5836,9 +5821,6 @@ impl Default for SYNC_TIME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYNC_TIME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SYNC_VERSION {
@@ -5849,9 +5831,6 @@ impl Default for SYNC_VERSION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYNC_VERSION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SYNC_VERSION_FLAG_FROM_FEED: u32 = 1u32;
 pub const SYNC_VERSION_FLAG_HAS_BY: u32 = 2u32;
@@ -5871,9 +5850,6 @@ impl Default for SyncProviderConfigUIConfiguration {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SyncProviderConfigUIConfiguration {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SyncProviderConfiguration {
@@ -5889,8 +5865,5 @@ impl Default for SyncProviderConfiguration {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SyncProviderConfiguration {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SyncProviderRegistration: windows_core::GUID = windows_core::GUID::from_u128(0xf82b4ef1_93a9_4dde_8015_f7950a1a6e31);

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
@@ -7915,9 +7915,6 @@ impl Default for MI_Application {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Application {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ApplicationFT {
@@ -7938,9 +7935,6 @@ impl Default for MI_ApplicationFT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ApplicationFT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Array {
@@ -7951,9 +7945,6 @@ impl Default for MI_Array {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Array {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7966,9 +7957,6 @@ impl Default for MI_ArrayField {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ArrayField {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MI_BOOLEAN: MI_Type = MI_Type(0i32);
 pub const MI_BOOLEANA: MI_Type = MI_Type(16i32);
@@ -7983,9 +7971,6 @@ impl Default for MI_BooleanA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_BooleanA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_BooleanAField {
@@ -7998,9 +7983,6 @@ impl Default for MI_BooleanAField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_BooleanAField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_BooleanField {
@@ -8012,9 +7994,6 @@ impl Default for MI_BooleanField {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_BooleanField {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MI_CALLBACKMODE_IGNORE: MI_CallbackMode = MI_CallbackMode(2i32);
 pub const MI_CALLBACKMODE_INQUIRE: MI_CallbackMode = MI_CallbackMode(1i32);
@@ -8041,9 +8020,6 @@ impl Default for MI_Char16A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Char16A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Char16AField {
@@ -8056,9 +8032,6 @@ impl Default for MI_Char16AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Char16AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Char16Field {
@@ -8070,9 +8043,6 @@ impl Default for MI_Char16Field {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Char16Field {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8087,9 +8057,6 @@ impl Default for MI_Class {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Class {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8115,9 +8082,6 @@ impl Default for MI_ClassDecl {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ClassDecl {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ClassFT {
@@ -8141,9 +8105,6 @@ impl Default for MI_ClassFT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ClassFT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ClientFT_V1 {
@@ -8163,9 +8124,6 @@ impl Default for MI_ClientFT_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ClientFT_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstBooleanA {
@@ -8176,9 +8134,6 @@ impl Default for MI_ConstBooleanA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstBooleanA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8192,9 +8147,6 @@ impl Default for MI_ConstBooleanAField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstBooleanAField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstBooleanField {
@@ -8207,9 +8159,6 @@ impl Default for MI_ConstBooleanField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstBooleanField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstChar16A {
@@ -8220,9 +8169,6 @@ impl Default for MI_ConstChar16A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstChar16A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8236,9 +8182,6 @@ impl Default for MI_ConstChar16AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstChar16AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstChar16Field {
@@ -8251,9 +8194,6 @@ impl Default for MI_ConstChar16Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstChar16Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstDatetimeA {
@@ -8264,9 +8204,6 @@ impl Default for MI_ConstDatetimeA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstDatetimeA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8280,9 +8217,6 @@ impl Default for MI_ConstDatetimeAField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstDatetimeAField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MI_ConstDatetimeField {
@@ -8295,9 +8229,6 @@ impl Default for MI_ConstDatetimeField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstDatetimeField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstInstanceA {
@@ -8308,9 +8239,6 @@ impl Default for MI_ConstInstanceA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstInstanceA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8324,9 +8252,6 @@ impl Default for MI_ConstInstanceAField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstInstanceAField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstInstanceField {
@@ -8339,9 +8264,6 @@ impl Default for MI_ConstInstanceField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstInstanceField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstReal32A {
@@ -8352,9 +8274,6 @@ impl Default for MI_ConstReal32A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstReal32A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8368,9 +8287,6 @@ impl Default for MI_ConstReal32AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstReal32AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstReal32Field {
@@ -8383,9 +8299,6 @@ impl Default for MI_ConstReal32Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstReal32Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstReal64A {
@@ -8396,9 +8309,6 @@ impl Default for MI_ConstReal64A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstReal64A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8412,9 +8322,6 @@ impl Default for MI_ConstReal64AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstReal64AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstReal64Field {
@@ -8427,9 +8334,6 @@ impl Default for MI_ConstReal64Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstReal64Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstReferenceA {
@@ -8440,9 +8344,6 @@ impl Default for MI_ConstReferenceA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstReferenceA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8456,9 +8357,6 @@ impl Default for MI_ConstReferenceAField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstReferenceAField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstReferenceField {
@@ -8471,9 +8369,6 @@ impl Default for MI_ConstReferenceField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstReferenceField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstSint16A {
@@ -8484,9 +8379,6 @@ impl Default for MI_ConstSint16A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstSint16A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8500,9 +8392,6 @@ impl Default for MI_ConstSint16AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstSint16AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstSint16Field {
@@ -8515,9 +8404,6 @@ impl Default for MI_ConstSint16Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstSint16Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstSint32A {
@@ -8528,9 +8414,6 @@ impl Default for MI_ConstSint32A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstSint32A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8544,9 +8427,6 @@ impl Default for MI_ConstSint32AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstSint32AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstSint32Field {
@@ -8559,9 +8439,6 @@ impl Default for MI_ConstSint32Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstSint32Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstSint64A {
@@ -8572,9 +8449,6 @@ impl Default for MI_ConstSint64A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstSint64A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8588,9 +8462,6 @@ impl Default for MI_ConstSint64AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstSint64AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstSint64Field {
@@ -8603,9 +8474,6 @@ impl Default for MI_ConstSint64Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstSint64Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstSint8A {
@@ -8616,9 +8484,6 @@ impl Default for MI_ConstSint8A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstSint8A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8632,9 +8497,6 @@ impl Default for MI_ConstSint8AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstSint8AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstSint8Field {
@@ -8647,9 +8509,6 @@ impl Default for MI_ConstSint8Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstSint8Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstStringA {
@@ -8660,9 +8519,6 @@ impl Default for MI_ConstStringA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstStringA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8676,9 +8532,6 @@ impl Default for MI_ConstStringAField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstStringAField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstStringField {
@@ -8691,9 +8544,6 @@ impl Default for MI_ConstStringField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstStringField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstUint16A {
@@ -8704,9 +8554,6 @@ impl Default for MI_ConstUint16A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstUint16A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8720,9 +8567,6 @@ impl Default for MI_ConstUint16AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstUint16AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstUint16Field {
@@ -8735,9 +8579,6 @@ impl Default for MI_ConstUint16Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstUint16Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstUint32A {
@@ -8748,9 +8589,6 @@ impl Default for MI_ConstUint32A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstUint32A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8764,9 +8602,6 @@ impl Default for MI_ConstUint32AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstUint32AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstUint32Field {
@@ -8779,9 +8614,6 @@ impl Default for MI_ConstUint32Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstUint32Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstUint64A {
@@ -8792,9 +8624,6 @@ impl Default for MI_ConstUint64A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstUint64A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8808,9 +8637,6 @@ impl Default for MI_ConstUint64AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstUint64AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstUint64Field {
@@ -8823,9 +8649,6 @@ impl Default for MI_ConstUint64Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstUint64Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstUint8A {
@@ -8836,9 +8659,6 @@ impl Default for MI_ConstUint8A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ConstUint8A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8852,9 +8672,6 @@ impl Default for MI_ConstUint8AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstUint8AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ConstUint8Field {
@@ -8867,9 +8684,6 @@ impl Default for MI_ConstUint8Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ConstUint8Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Context {
@@ -8880,9 +8694,6 @@ impl Default for MI_Context {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Context {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8923,9 +8734,6 @@ impl Default for MI_ContextFT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ContextFT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MI_DATETIME: MI_Type = MI_Type(12i32);
 pub const MI_DATETIMEA: MI_Type = MI_Type(28i32);
 #[repr(C)]
@@ -8939,9 +8747,6 @@ impl Default for MI_Datetime {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Datetime {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MI_Datetime_0 {
@@ -8953,9 +8758,6 @@ impl Default for MI_Datetime_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Datetime_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_DatetimeA {
@@ -8966,9 +8768,6 @@ impl Default for MI_DatetimeA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_DatetimeA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8982,9 +8781,6 @@ impl Default for MI_DatetimeAField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_DatetimeAField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MI_DatetimeField {
@@ -8997,9 +8793,6 @@ impl Default for MI_DatetimeField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_DatetimeField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Deserializer {
@@ -9010,9 +8803,6 @@ impl Default for MI_Deserializer {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Deserializer {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9029,9 +8819,6 @@ impl Default for MI_DeserializerFT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_DeserializerFT {
-    type TypeKind = windows_core::CopyType;
-}
 pub type MI_Deserializer_ClassObjectNeeded = Option<unsafe extern "system" fn(context: *const core::ffi::c_void, servername: *const u16, namespacename: *const u16, classname: *const u16, requestedclassobject: *mut *mut MI_Class) -> MI_Result>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9044,9 +8831,6 @@ impl Default for MI_DestinationOptions {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_DestinationOptions {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9071,9 +8855,6 @@ impl Default for MI_DestinationOptionsFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_DestinationOptionsFT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9161,9 +8942,6 @@ impl Default for MI_FeatureDecl {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_FeatureDecl {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Filter {
@@ -9175,9 +8953,6 @@ impl Default for MI_Filter {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Filter {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_FilterFT {
@@ -9188,9 +8963,6 @@ impl Default for MI_FilterFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_FilterFT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9204,9 +8976,6 @@ impl Default for MI_HostedProvider {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_HostedProvider {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_HostedProviderFT {
@@ -9217,9 +8986,6 @@ impl Default for MI_HostedProviderFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_HostedProviderFT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MI_INSTANCE: MI_Type = MI_Type(15i32);
 pub const MI_INSTANCEA: MI_Type = MI_Type(31i32);
@@ -9237,9 +9003,6 @@ impl Default for MI_Instance {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Instance {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_InstanceA {
@@ -9250,9 +9013,6 @@ impl Default for MI_InstanceA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_InstanceA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9266,9 +9026,6 @@ impl Default for MI_InstanceAField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_InstanceAField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_InstanceExFT {
@@ -9279,9 +9036,6 @@ impl Default for MI_InstanceExFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_InstanceExFT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9310,9 +9064,6 @@ impl Default for MI_InstanceFT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_InstanceFT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_InstanceField {
@@ -9324,9 +9075,6 @@ impl Default for MI_InstanceField {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_InstanceField {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9344,9 +9092,6 @@ impl Default for MI_Interval {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Interval {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MI_LOCALE_TYPE_CLOSEST_DATA: MI_LocaleType = MI_LocaleType(3i32);
 pub const MI_LOCALE_TYPE_CLOSEST_UI: MI_LocaleType = MI_LocaleType(2i32);
@@ -9387,9 +9132,6 @@ impl Default for MI_MethodDecl {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_MethodDecl {
-    type TypeKind = windows_core::CopyType;
-}
 pub type MI_MethodDecl_Invoke = Option<unsafe extern "system" fn(self_: *const core::ffi::c_void, context: *const MI_Context, namespace: *const u16, classname: *const u16, methodname: *const u16, instancename: *const MI_Instance, parameters: *const MI_Instance)>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9407,9 +9149,6 @@ impl Default for MI_Module {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Module {
-    type TypeKind = windows_core::CopyType;
 }
 pub type MI_Module_Load = Option<unsafe extern "system" fn(self_: *mut *mut MI_Module_Self, context: *const MI_Context)>;
 #[repr(transparent)]
@@ -9447,9 +9186,6 @@ impl Default for MI_ObjectDecl {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ObjectDecl {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Operation {
@@ -9461,9 +9197,6 @@ impl Default for MI_Operation {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Operation {
-    type TypeKind = windows_core::CopyType;
 }
 pub type MI_OperationCallback_Class = Option<unsafe extern "system" fn(operation: *const MI_Operation, callbackcontext: *const core::ffi::c_void, classresult: *const MI_Class, moreresults: u8, resultcode: MI_Result, errorstring: *const u16, errordetails: *const MI_Instance, resultacknowledgement: isize)>;
 pub type MI_OperationCallback_Indication = Option<unsafe extern "system" fn(operation: *const MI_Operation, callbackcontext: *const core::ffi::c_void, instance: *const MI_Instance, bookmark: *const u16, machineid: *const u16, moreresults: u8, resultcode: MI_Result, errorstring: *const u16, errordetails: *const MI_Instance, resultacknowledgement: isize)>;
@@ -9498,9 +9231,6 @@ impl Default for MI_OperationCallbacks {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_OperationCallbacks {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_OperationFT {
@@ -9516,9 +9246,6 @@ impl Default for MI_OperationFT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_OperationFT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_OperationOptions {
@@ -9530,9 +9257,6 @@ impl Default for MI_OperationOptions {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_OperationOptions {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9556,9 +9280,6 @@ impl Default for MI_OperationOptionsFT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_OperationOptionsFT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MI_PROMPTTYPE_CRITICAL: MI_PromptType = MI_PromptType(1i32);
 pub const MI_PROMPTTYPE_NORMAL: MI_PromptType = MI_PromptType(0i32);
 pub const MI_PROVIDER_ARCHITECTURE_32BIT: MI_ProviderArchitecture = MI_ProviderArchitecture(0i32);
@@ -9581,9 +9302,6 @@ impl Default for MI_ParameterDecl {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ParameterDecl {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ParameterSet {
@@ -9595,9 +9313,6 @@ impl Default for MI_ParameterSet {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ParameterSet {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9611,9 +9326,6 @@ impl Default for MI_ParameterSetFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ParameterSetFT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9639,9 +9351,6 @@ impl Default for MI_PropertyDecl {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_PropertyDecl {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_PropertySet {
@@ -9652,9 +9361,6 @@ impl Default for MI_PropertySet {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_PropertySet {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9672,9 +9378,6 @@ impl Default for MI_PropertySetFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_PropertySetFT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9701,9 +9404,6 @@ impl Default for MI_ProviderFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ProviderFT {
-    type TypeKind = windows_core::CopyType;
 }
 pub type MI_ProviderFT_AssociatorInstances = Option<unsafe extern "system" fn(self_: *const core::ffi::c_void, context: *const MI_Context, namespace: *const u16, classname: *const u16, instancename: *const MI_Instance, resultclass: *const u16, role: *const u16, resultrole: *const u16, propertyset: *const MI_PropertySet, keysonly: u8, filter: *const MI_Filter)>;
 pub type MI_ProviderFT_CreateInstance = Option<unsafe extern "system" fn(self_: *const core::ffi::c_void, context: *const MI_Context, namespace: *const u16, classname: *const u16, newinstance: *const MI_Instance)>;
@@ -9732,9 +9432,6 @@ impl Default for MI_Qualifier {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Qualifier {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_QualifierDecl {
@@ -9750,9 +9447,6 @@ impl Default for MI_QualifierDecl {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_QualifierDecl {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_QualifierSet {
@@ -9765,9 +9459,6 @@ impl Default for MI_QualifierSet {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_QualifierSet {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_QualifierSetFT {
@@ -9779,9 +9470,6 @@ impl Default for MI_QualifierSetFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_QualifierSetFT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MI_REAL32: MI_Type = MI_Type(9i32);
 pub const MI_REAL32A: MI_Type = MI_Type(25i32);
@@ -9831,9 +9519,6 @@ impl Default for MI_Real32A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Real32A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Real32AField {
@@ -9845,9 +9530,6 @@ impl Default for MI_Real32AField {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Real32AField {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9861,9 +9543,6 @@ impl Default for MI_Real32Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Real32Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Real64A {
@@ -9874,9 +9553,6 @@ impl Default for MI_Real64A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Real64A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9890,9 +9566,6 @@ impl Default for MI_Real64AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Real64AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Real64Field {
@@ -9905,9 +9578,6 @@ impl Default for MI_Real64Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Real64Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ReferenceA {
@@ -9918,9 +9588,6 @@ impl Default for MI_ReferenceA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ReferenceA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9934,9 +9601,6 @@ impl Default for MI_ReferenceAField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_ReferenceAField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ReferenceField {
@@ -9948,9 +9612,6 @@ impl Default for MI_ReferenceField {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ReferenceField {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9982,9 +9643,6 @@ impl Default for MI_SchemaDecl {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_SchemaDecl {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Serializer {
@@ -9995,9 +9653,6 @@ impl Default for MI_Serializer {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Serializer {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10010,9 +9665,6 @@ impl Default for MI_SerializerFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_SerializerFT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10028,9 +9680,6 @@ impl Default for MI_Server {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Server {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_ServerFT {
@@ -10041,9 +9690,6 @@ impl Default for MI_ServerFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_ServerFT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10057,9 +9703,6 @@ impl Default for MI_Session {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Session {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_SessionCallbacks {
@@ -10071,9 +9714,6 @@ impl Default for MI_SessionCallbacks {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_SessionCallbacks {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10099,9 +9739,6 @@ impl Default for MI_SessionFT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_SessionFT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Sint16A {
@@ -10112,9 +9749,6 @@ impl Default for MI_Sint16A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Sint16A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10128,9 +9762,6 @@ impl Default for MI_Sint16AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Sint16AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Sint16Field {
@@ -10143,9 +9774,6 @@ impl Default for MI_Sint16Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Sint16Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Sint32A {
@@ -10156,9 +9784,6 @@ impl Default for MI_Sint32A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Sint32A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10172,9 +9797,6 @@ impl Default for MI_Sint32AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Sint32AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Sint32Field {
@@ -10187,9 +9809,6 @@ impl Default for MI_Sint32Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Sint32Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Sint64A {
@@ -10200,9 +9819,6 @@ impl Default for MI_Sint64A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Sint64A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10216,9 +9832,6 @@ impl Default for MI_Sint64AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Sint64AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Sint64Field {
@@ -10231,9 +9844,6 @@ impl Default for MI_Sint64Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Sint64Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Sint8A {
@@ -10244,9 +9854,6 @@ impl Default for MI_Sint8A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Sint8A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10260,9 +9867,6 @@ impl Default for MI_Sint8AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Sint8AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Sint8Field {
@@ -10275,9 +9879,6 @@ impl Default for MI_Sint8Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Sint8Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_StringA {
@@ -10288,9 +9889,6 @@ impl Default for MI_StringA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_StringA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10304,9 +9902,6 @@ impl Default for MI_StringAField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_StringAField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_StringField {
@@ -10319,9 +9914,6 @@ impl Default for MI_StringField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_StringField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_SubscriptionDeliveryOptions {
@@ -10333,9 +9925,6 @@ impl Default for MI_SubscriptionDeliveryOptions {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_SubscriptionDeliveryOptions {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10363,9 +9952,6 @@ impl Default for MI_SubscriptionDeliveryOptionsFT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_SubscriptionDeliveryOptionsFT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MI_SubscriptionDeliveryType(pub i32);
@@ -10387,9 +9973,6 @@ impl Default for MI_Timestamp {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Timestamp {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10413,9 +9996,6 @@ impl Default for MI_Uint16A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Uint16A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Uint16AField {
@@ -10427,9 +10007,6 @@ impl Default for MI_Uint16AField {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Uint16AField {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10443,9 +10020,6 @@ impl Default for MI_Uint16Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Uint16Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Uint32A {
@@ -10456,9 +10030,6 @@ impl Default for MI_Uint32A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Uint32A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10472,9 +10043,6 @@ impl Default for MI_Uint32AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Uint32AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Uint32Field {
@@ -10487,9 +10055,6 @@ impl Default for MI_Uint32Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Uint32Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Uint64A {
@@ -10500,9 +10065,6 @@ impl Default for MI_Uint64A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Uint64A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10516,9 +10078,6 @@ impl Default for MI_Uint64AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Uint64AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Uint64Field {
@@ -10531,9 +10090,6 @@ impl Default for MI_Uint64Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Uint64Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Uint8A {
@@ -10544,9 +10100,6 @@ impl Default for MI_Uint8A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_Uint8A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10560,9 +10113,6 @@ impl Default for MI_Uint8AField {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Uint8AField {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_Uint8Field {
@@ -10575,9 +10125,6 @@ impl Default for MI_Uint8Field {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Uint8Field {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MI_UserCredentials {
@@ -10589,9 +10136,6 @@ impl Default for MI_UserCredentials {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_UserCredentials {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union MI_UserCredentials_0 {
@@ -10602,9 +10146,6 @@ impl Default for MI_UserCredentials_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_UserCredentials_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10618,9 +10159,6 @@ impl Default for MI_UsernamePasswordCreds {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_UsernamePasswordCreds {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MI_UtilitiesFT {
@@ -10631,9 +10169,6 @@ impl Default for MI_UtilitiesFT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MI_UtilitiesFT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -10677,9 +10212,6 @@ impl Default for MI_Value {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MI_Value {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MI_WRITEMESSAGE_CHANNEL_DEBUG: u32 = 2u32;
 pub const MI_WRITEMESSAGE_CHANNEL_VERBOSE: u32 = 1u32;
 pub const MI_WRITEMESSAGE_CHANNEL_WARNING: u32 = 0u32;
@@ -10700,9 +10232,6 @@ impl Default for SWbemAnalysisMatrix {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SWbemAnalysisMatrix {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SWbemAnalysisMatrixList {
@@ -10715,9 +10244,6 @@ impl Default for SWbemAnalysisMatrixList {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SWbemAnalysisMatrixList {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -10739,9 +10265,6 @@ impl Default for SWbemAssocQueryInf {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SWbemAssocQueryInf {
-    type TypeKind = windows_core::CloneType;
 }
 pub const SWbemDateTime: windows_core::GUID = windows_core::GUID::from_u128(0x47dfbe54_cf76_11d3_b38f_00105a1f473a);
 pub const SWbemEventSource: windows_core::GUID = windows_core::GUID::from_u128(0x04b83d58_21ae_11d2_8b33_00600806d9b6);
@@ -10777,9 +10300,6 @@ impl Default for SWbemQueryQualifiedName {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SWbemQueryQualifiedName {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SWbemRefreshableItem: windows_core::GUID = windows_core::GUID::from_u128(0x8c6854bc_de4b_11d3_b390_00105a1f473a);
 pub const SWbemRefresher: windows_core::GUID = windows_core::GUID::from_u128(0xd269bf5c_d9c1_11d3_b38f_00105a1f473a);
 #[repr(C)]
@@ -10797,9 +10317,6 @@ impl Default for SWbemRpnConst {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SWbemRpnConst {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10828,9 +10345,6 @@ impl Default for SWbemRpnEncodedQuery {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SWbemRpnEncodedQuery {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct SWbemRpnQueryToken {
@@ -10852,9 +10366,6 @@ impl Default for SWbemRpnQueryToken {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SWbemRpnQueryToken {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SWbemRpnTokenList {
@@ -10866,9 +10377,6 @@ impl Default for SWbemRpnTokenList {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SWbemRpnTokenList {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SWbemSecurity: windows_core::GUID = windows_core::GUID::from_u128(0xb54d66e9_2287_11d2_8b33_00600806d9b6);
 pub const SWbemServices: windows_core::GUID = windows_core::GUID::from_u128(0x04b83d63_21ae_11d2_8b33_00600806d9b6);
@@ -11002,9 +10510,6 @@ impl Default for WBEM_COMPILE_STATUS_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WBEM_COMPILE_STATUS_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
@@ -738,9 +738,6 @@ impl Default for ACCESSTIMEOUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACCESSTIMEOUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ACC_UTILITY_STATE_FLAGS(pub u32);
@@ -1049,9 +1046,6 @@ impl Default for ExtendedProperty {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ExtendedProperty {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FILTERKEYS {
@@ -1066,9 +1060,6 @@ impl Default for FILTERKEYS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILTERKEYS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FillColor_Property_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x6e0ec4d0_e2a8_4a56_9de7_953389933b39);
 #[repr(transparent)]
@@ -1121,9 +1112,6 @@ impl Default for HIGHCONTRASTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HIGHCONTRASTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HIGHCONTRASTW {
@@ -1135,9 +1123,6 @@ impl Default for HIGHCONTRASTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HIGHCONTRASTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -16806,9 +16791,6 @@ impl Default for MOUSEKEYS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MOUSEKEYS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MSAAMENUINFO {
@@ -16820,9 +16802,6 @@ impl Default for MSAAMENUINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSAAMENUINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSAA_MENU_SIG: i32 = -1441927155i32;
 pub const MenuBar_Control_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xcc384250_0e7b_4ae8_95ae_a08f261b52ee);
@@ -17089,9 +17068,6 @@ impl Default for SERIALKEYSA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SERIALKEYSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SERIALKEYSW {
@@ -17107,9 +17083,6 @@ impl Default for SERIALKEYSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SERIALKEYSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17198,9 +17171,6 @@ impl Default for SOUNDSENTRYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOUNDSENTRYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SOUNDSENTRYW {
@@ -17221,9 +17191,6 @@ impl Default for SOUNDSENTRYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SOUNDSENTRYW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17296,9 +17263,6 @@ impl Default for STICKYKEYS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STICKYKEYS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -17528,9 +17492,6 @@ impl Default for TOGGLEKEYS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOGGLEKEYS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TabItem_Control_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x2c6a634f_921b_4e6e_b26e_08fcb0798f4c);
 pub const Tab_Control_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x38cd1f2d_337a_4bd2_a5e3_adb469e30bd3);
@@ -18078,9 +18039,6 @@ impl Default for UIAutomationEventInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UIAutomationEventInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UIAutomationMethodInfo {
@@ -18096,9 +18054,6 @@ impl Default for UIAutomationMethodInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UIAutomationMethodInfo {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UIAutomationParameter {
@@ -18109,9 +18064,6 @@ impl Default for UIAutomationParameter {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UIAutomationParameter {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
@@ -18133,9 +18085,6 @@ impl Default for UIAutomationPatternInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UIAutomationPatternInfo {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UIAutomationPropertyInfo {
@@ -18147,9 +18096,6 @@ impl Default for UIAutomationPropertyInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UIAutomationPropertyInfo {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -18229,9 +18175,6 @@ impl Default for UiaAndOrCondition {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UiaAndOrCondition {
-    type TypeKind = windows_core::CopyType;
-}
 pub const UiaAppendRuntimeId: u32 = 3u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18245,9 +18188,6 @@ impl Default for UiaAsyncContentLoadedEventArgs {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UiaAsyncContentLoadedEventArgs {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18264,9 +18204,6 @@ impl Default for UiaCacheRequest {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UiaCacheRequest {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -18287,10 +18224,6 @@ impl Default for UiaChangeInfo {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for UiaChangeInfo {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18306,10 +18239,6 @@ impl Default for UiaChangesEventArgs {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for UiaChangesEventArgs {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UiaCondition {
@@ -18319,9 +18248,6 @@ impl Default for UiaCondition {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UiaCondition {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18333,9 +18259,6 @@ impl Default for UiaEventArgs {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UiaEventArgs {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_System_Com")]
 pub type UiaEventCallback = Option<unsafe extern "system" fn(pargs: *mut UiaEventArgs, prequesteddata: *mut super::super::System::Com::SAFEARRAY, ptreestructure: windows_core::BSTR)>;
@@ -18352,9 +18275,6 @@ impl Default for UiaFindParams {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UiaFindParams {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UiaNotCondition {
@@ -18366,9 +18286,6 @@ impl Default for UiaNotCondition {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UiaNotCondition {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UiaPoint {
@@ -18379,9 +18296,6 @@ impl Default for UiaPoint {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UiaPoint {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
@@ -18404,10 +18318,6 @@ impl Default for UiaPropertyChangedEventArgs {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for UiaPropertyChangedEventArgs {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
 pub struct UiaPropertyCondition {
@@ -18428,10 +18338,6 @@ impl Default for UiaPropertyCondition {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for UiaPropertyCondition {
-    type TypeKind = windows_core::CloneType;
-}
 #[cfg(feature = "Win32_System_Com")]
 pub type UiaProviderCallback = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, providertype: ProviderType) -> *mut super::super::System::Com::SAFEARRAY>;
 #[repr(C)]
@@ -18446,9 +18352,6 @@ impl Default for UiaRect {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UiaRect {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UiaRootObjectId: i32 = -25i32;
 #[repr(C)]
@@ -18465,9 +18368,6 @@ impl Default for UiaStructureChangedEventArgs {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UiaStructureChangedEventArgs {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Com")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -18483,10 +18383,6 @@ impl Default for UiaTextEditTextChangedEventArgs {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for UiaTextEditTextChangedEventArgs {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UiaWindowClosedEventArgs {
@@ -18499,9 +18395,6 @@ impl Default for UiaWindowClosedEventArgs {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UiaWindowClosedEventArgs {
-    type TypeKind = windows_core::CopyType;
 }
 pub const Value_IsReadOnly_Property_GUID: windows_core::GUID = windows_core::GUID::from_u128(0xeb090f30_e24c_4799_a705_0d247bc037f8);
 pub const Value_Pattern_GUID: windows_core::GUID = windows_core::GUID::from_u128(0x17faad9e_c877_475b_b933_77332779b637);

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
@@ -828,9 +828,6 @@ impl Default for BlackInformation {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BlackInformation {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CATID_WcsPlugin: windows_core::GUID = windows_core::GUID::from_u128(0xa0b402e0_8240_405f_8a16_8a5b4df2f0dd);
 pub const CMM_DESCRIPTION: u32 = 5u32;
 pub const CMM_DLL_VERSION: u32 = 3u32;
@@ -870,9 +867,6 @@ impl Default for CMYKCOLOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMYKCOLOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union COLOR {
@@ -892,9 +886,6 @@ impl Default for COLOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COLOR_0 {
@@ -905,9 +896,6 @@ impl Default for COLOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -942,10 +930,6 @@ impl Default for COLORMATCHSETUPA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for COLORMATCHSETUPA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -975,10 +959,6 @@ impl Default for COLORMATCHSETUPW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for COLORMATCHSETUPW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1051,10 +1031,6 @@ impl Default for EMRCREATECOLORSPACE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for EMRCREATECOLORSPACE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1071,10 +1047,6 @@ impl Default for EMRCREATECOLORSPACEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for EMRCREATECOLORSPACEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENABLE_GAMUT_CHECKING: u32 = 65536u32;
 #[repr(C)]
@@ -1106,9 +1078,6 @@ impl Default for ENUMTYPEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ENUMTYPEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ENUMTYPEW {
@@ -1137,9 +1106,6 @@ impl Default for ENUMTYPEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for ENUMTYPEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENUM_TYPE_VERSION: u32 = 768u32;
 pub const ET_ATTRIBUTES: u32 = 8192u32;
@@ -1177,9 +1143,6 @@ impl Default for GENERIC3CHANNEL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GENERIC3CHANNEL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GRAYCOLOR {
@@ -1189,9 +1152,6 @@ impl Default for GRAYCOLOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GRAYCOLOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1208,9 +1168,6 @@ impl Default for GamutBoundaryDescription {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GamutBoundaryDescription {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GamutShell {
@@ -1226,9 +1183,6 @@ impl Default for GamutShell {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GamutShell {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GamutShellTriangle {
@@ -1238,9 +1192,6 @@ impl Default for GamutShellTriangle {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GamutShellTriangle {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1276,9 +1227,6 @@ impl Default for HiFiCOLOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HiFiCOLOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub type ICMENUMPROCA = Option<unsafe extern "system" fn(param0: windows_core::PCSTR, param1: super::super::Foundation::LPARAM) -> i32>;
 pub type ICMENUMPROCW = Option<unsafe extern "system" fn(param0: windows_core::PCWSTR, param1: super::super::Foundation::LPARAM) -> i32>;
@@ -1530,9 +1478,6 @@ impl Default for JChColorF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for JChColorF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct JabColorF {
@@ -1544,9 +1489,6 @@ impl Default for JabColorF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for JabColorF {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1575,10 +1517,6 @@ impl Default for LOGCOLORSPACEA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for LOGCOLORSPACEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1600,10 +1538,6 @@ impl Default for LOGCOLORSPACEW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for LOGCOLORSPACEW {
-    type TypeKind = windows_core::CopyType;
-}
 pub type LPBMCALLBACKFN = Option<unsafe extern "system" fn(param0: u32, param1: u32, param2: super::super::Foundation::LPARAM) -> super::super::Foundation::BOOL>;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1617,9 +1551,6 @@ impl Default for LabCOLOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LabCOLOR {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MAX_COLOR_CHANNELS: u32 = 8u32;
 pub const MicrosoftHardwareColorV2: WCS_DEVICE_CAPABILITIES_TYPE = WCS_DEVICE_CAPABILITIES_TYPE(2i32);
 #[repr(C)]
@@ -1631,9 +1562,6 @@ impl Default for NAMEDCOLOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NAMEDCOLOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1648,9 +1576,6 @@ impl Default for NAMED_PROFILE_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NAMED_PROFILE_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NORMAL_MODE: u32 = 2u32;
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -1669,9 +1594,6 @@ impl Default for PROFILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROFILE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1701,10 +1623,6 @@ impl Default for PROFILEHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PROFILEHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PROFILE_FILENAME: u32 = 1u32;
 pub const PROFILE_MEMBUFFER: u32 = 2u32;
 pub const PROFILE_READ: u32 = 1u32;
@@ -1727,9 +1645,6 @@ impl Default for PrimaryJabColors {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PrimaryJabColors {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PrimaryXYZColors {
@@ -1747,9 +1662,6 @@ impl Default for PrimaryXYZColors {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PrimaryXYZColors {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RESERVED: u32 = 2147483648u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1762,9 +1674,6 @@ impl Default for RGBCOLOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RGBCOLOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SEQUENTIAL_TRANSFORM: u32 = 2155872256u32;
 pub const USE_RELATIVE_COLORIMETRIC: u32 = 131072u32;
@@ -1788,9 +1697,6 @@ impl Default for WCS_DEVICE_MHC2_CAPABILITIES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WCS_DEVICE_MHC2_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WCS_DEVICE_VCGT_CAPABILITIES {
@@ -1801,9 +1707,6 @@ impl Default for WCS_DEVICE_VCGT_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WCS_DEVICE_VCGT_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WCS_ICCONLY: i32 = 65536i32;
 #[repr(transparent)]
@@ -1823,9 +1726,6 @@ impl Default for XYZCOLOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XYZCOLOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XYZColorF {
@@ -1838,9 +1738,6 @@ impl Default for XYZColorF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XYZColorF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct YxyCOLOR {
@@ -1852,7 +1749,4 @@ impl Default for YxyCOLOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for YxyCOLOR {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
@@ -213,10 +213,6 @@ impl Default for CHOOSECOLORA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for CHOOSECOLORA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -236,10 +232,6 @@ impl Default for CHOOSECOLORA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for CHOOSECOLORA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -261,10 +253,6 @@ impl Default for CHOOSECOLORW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for CHOOSECOLORW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -284,10 +272,6 @@ impl Default for CHOOSECOLORW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for CHOOSECOLORW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -354,11 +338,6 @@ impl Default for CHOOSEFONTA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CHOOSEFONTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -387,11 +366,6 @@ impl Default for CHOOSEFONTA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CHOOSEFONTA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -422,11 +396,6 @@ impl Default for CHOOSEFONTW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CHOOSEFONTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -455,11 +424,6 @@ impl Default for CHOOSEFONTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CHOOSEFONTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -584,10 +548,6 @@ impl Default for DEVNAMES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DEVNAMES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -602,10 +562,6 @@ impl Default for DEVNAMES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DEVNAMES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DLG_COLOR: u32 = 10u32;
 pub const DN_DEFAULTPRN: u32 = 1u32;
@@ -637,10 +593,6 @@ impl Default for FINDREPLACEA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FINDREPLACEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -662,10 +614,6 @@ impl Default for FINDREPLACEA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FINDREPLACEA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -689,10 +637,6 @@ impl Default for FINDREPLACEW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FINDREPLACEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -714,10 +658,6 @@ impl Default for FINDREPLACEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FINDREPLACEW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -929,10 +869,6 @@ impl Default for OFNOTIFYA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OFNOTIFYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -947,10 +883,6 @@ impl Default for OFNOTIFYA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OFNOTIFYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -965,10 +897,6 @@ impl Default for OFNOTIFYEXA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OFNOTIFYEXA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -985,10 +913,6 @@ impl Default for OFNOTIFYEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OFNOTIFYEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -1003,10 +927,6 @@ impl Default for OFNOTIFYEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OFNOTIFYEXW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1023,10 +943,6 @@ impl Default for OFNOTIFYEXW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OFNOTIFYEXW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -1041,10 +957,6 @@ impl Default for OFNOTIFYW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OFNOTIFYW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1058,10 +970,6 @@ impl Default for OFNOTIFYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OFNOTIFYW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OFN_ALLOWMULTISELECT: OPEN_FILENAME_FLAGS = OPEN_FILENAME_FLAGS(512u32);
 pub const OFN_CREATEPROMPT: OPEN_FILENAME_FLAGS = OPEN_FILENAME_FLAGS(8192u32);
@@ -1128,10 +1036,6 @@ impl Default for OPENFILENAMEA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OPENFILENAMEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1166,10 +1070,6 @@ impl Default for OPENFILENAMEA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OPENFILENAMEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -1203,10 +1103,6 @@ impl Default for OPENFILENAMEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OPENFILENAMEW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1242,10 +1138,6 @@ impl Default for OPENFILENAMEW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OPENFILENAMEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -1276,10 +1168,6 @@ impl Default for OPENFILENAME_NT4A {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OPENFILENAME_NT4A {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1312,10 +1200,6 @@ impl Default for OPENFILENAME_NT4A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OPENFILENAME_NT4A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -1347,10 +1231,6 @@ impl Default for OPENFILENAME_NT4W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OPENFILENAME_NT4W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1381,10 +1261,6 @@ impl Default for OPENFILENAME_NT4W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OPENFILENAME_NT4W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1483,10 +1359,6 @@ impl Default for PAGESETUPDLGA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for PAGESETUPDLGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1511,10 +1383,6 @@ impl Default for PAGESETUPDLGA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for PAGESETUPDLGA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -1541,10 +1409,6 @@ impl Default for PAGESETUPDLGW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for PAGESETUPDLGW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1569,10 +1433,6 @@ impl Default for PAGESETUPDLGW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for PAGESETUPDLGW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1686,11 +1546,6 @@ impl Default for PRINTDLGA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTDLGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1723,11 +1578,6 @@ impl Default for PRINTDLGA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTDLGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1760,11 +1610,6 @@ impl Default for PRINTDLGEXA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTDLGEXA {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1800,11 +1645,6 @@ impl Default for PRINTDLGEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTDLGEXA {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1837,11 +1677,6 @@ impl Default for PRINTDLGEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTDLGEXW {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1876,11 +1711,6 @@ impl Default for PRINTDLGEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTDLGEXW {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1950,11 +1780,6 @@ impl Default for PRINTDLGW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTDLGW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1987,11 +1812,6 @@ impl Default for PRINTDLGW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for PRINTDLGW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PRINTER_FONTTYPE: CHOOSEFONT_FONT_TYPE = CHOOSEFONT_FONT_TYPE(16384u16);
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -2006,10 +1826,6 @@ impl Default for PRINTPAGERANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for PRINTPAGERANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -2022,10 +1838,6 @@ impl Default for PRINTPAGERANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for PRINTPAGERANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PSD_DEFAULTMINMARGINS: PAGESETUPDLG_FLAGS = PAGESETUPDLG_FLAGS(0u32);
 pub const PSD_DISABLEMARGINS: PAGESETUPDLG_FLAGS = PAGESETUPDLG_FLAGS(16u32);

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
@@ -22,9 +22,6 @@ impl Default for BIDIOPTIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BIDIOPTIONS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const BOE_CONTEXTALIGNMENT: u32 = 16u32;
 pub const BOE_CONTEXTREADING: u32 = 8u32;
 pub const BOE_FORCERECALC: u32 = 32u32;
@@ -56,10 +53,6 @@ impl Default for CARET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CARET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CARET_ITALIC: CARET_FLAGS = CARET_FLAGS(32i32);
 pub const CARET_NONE: CARET_FLAGS = CARET_FLAGS(0i32);
@@ -222,9 +215,6 @@ impl Default for CHANGENOTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGENOTIFY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CHANGETYPE(pub i32);
@@ -251,10 +241,6 @@ impl Default for CHARFORMAT2A {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CHARFORMAT2A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -267,10 +253,6 @@ impl Default for CHARFORMAT2A_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CHARFORMAT2A_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -295,10 +277,6 @@ impl Default for CHARFORMAT2W {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CHARFORMAT2W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -311,10 +289,6 @@ impl Default for CHARFORMAT2W_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CHARFORMAT2W_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -336,10 +310,6 @@ impl Default for CHARFORMATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CHARFORMATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -360,10 +330,6 @@ impl Default for CHARFORMATW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CHARFORMATW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CHARRANGE {
@@ -374,9 +340,6 @@ impl Default for CHARRANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CHARRANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -390,10 +353,6 @@ impl Default for CLIPBOARDFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for CLIPBOARDFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -407,10 +366,6 @@ impl Default for CLIPBOARDFORMAT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for CLIPBOARDFORMAT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CN_GENERIC: CHANGETYPE = CHANGETYPE(0i32);
 pub const CN_NEWREDO: CHANGETYPE = CHANGETYPE(4i32);
@@ -427,9 +382,6 @@ impl Default for COMPCOLOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COMPCOLOR {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CTFMODEBIAS_CONVERSATION: u32 = 5u32;
 pub const CTFMODEBIAS_DATETIME: u32 = 4u32;
@@ -473,10 +425,6 @@ impl Default for EDITSTREAM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for EDITSTREAM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -490,10 +438,6 @@ impl Default for EDITSTREAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for EDITSTREAM {
-    type TypeKind = windows_core::CopyType;
 }
 pub type EDITSTREAMCALLBACK = Option<unsafe extern "system" fn(dwcookie: usize, pbbuff: *mut u8, cb: i32, pcb: *mut i32) -> u32>;
 pub type EDITWORDBREAKPROCEX = Option<unsafe extern "system" fn(pchtext: windows_core::PCSTR, cchtext: i32, bcharset: u8, action: i32) -> i32>;
@@ -635,10 +579,6 @@ impl Default for ENCORRECTTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ENCORRECTTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -653,10 +593,6 @@ impl Default for ENCORRECTTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ENCORRECTTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -670,10 +606,6 @@ impl Default for ENDCOMPOSITIONNOTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ENDCOMPOSITIONNOTIFY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -686,10 +618,6 @@ impl Default for ENDCOMPOSITIONNOTIFY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ENDCOMPOSITIONNOTIFY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -709,10 +637,6 @@ impl Default for ENDROPFILES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ENDROPFILES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -728,10 +652,6 @@ impl Default for ENDROPFILES {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ENDROPFILES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -747,10 +667,6 @@ impl Default for ENLINK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ENLINK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -768,10 +684,6 @@ impl Default for ENLINK {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ENLINK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -785,10 +697,6 @@ impl Default for ENLOWFIRTF {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ENLOWFIRTF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -801,10 +709,6 @@ impl Default for ENLOWFIRTF {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ENLOWFIRTF {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ENM_CHANGE: u32 = 1u32;
 pub const ENM_CLIPFORMAT: u32 = 128u32;
@@ -846,10 +750,6 @@ impl Default for ENOLEOPFAILED {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ENOLEOPFAILED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -865,10 +765,6 @@ impl Default for ENOLEOPFAILED {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ENOLEOPFAILED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -884,10 +780,6 @@ impl Default for ENPROTECTED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ENPROTECTED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -905,10 +797,6 @@ impl Default for ENPROTECTED {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ENPROTECTED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -923,10 +811,6 @@ impl Default for ENSAVECLIPBOARD {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for ENSAVECLIPBOARD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -940,10 +824,6 @@ impl Default for ENSAVECLIPBOARD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for ENSAVECLIPBOARD {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EN_ALIGNLTR: u32 = 1808u32;
 pub const EN_ALIGNRTL: u32 = 1809u32;
@@ -993,10 +873,6 @@ impl Default for FINDTEXTA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FINDTEXTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -1010,10 +886,6 @@ impl Default for FINDTEXTA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FINDTEXTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1027,10 +899,6 @@ impl Default for FINDTEXTEXA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FINDTEXTEXA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1046,10 +914,6 @@ impl Default for FINDTEXTEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FINDTEXTEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1063,10 +927,6 @@ impl Default for FINDTEXTEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FINDTEXTEXW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1082,10 +942,6 @@ impl Default for FINDTEXTEXW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FINDTEXTEXW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1099,10 +955,6 @@ impl Default for FINDTEXTW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for FINDTEXTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -1115,10 +967,6 @@ impl Default for FINDTEXTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for FINDTEXTW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -1138,11 +986,6 @@ impl Default for FORMATRANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for FORMATRANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -1160,11 +1003,6 @@ impl Default for FORMATRANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for FORMATRANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GCMF_GRIPPER: u32 = 1u32;
 pub const GCMF_MOUSEMENU: u32 = 8192u32;
@@ -1188,10 +1026,6 @@ impl Default for GETCONTEXTMENUEX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for GETCONTEXTMENUEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -1207,10 +1041,6 @@ impl Default for GETCONTEXTMENUEX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for GETCONTEXTMENUEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1226,10 +1056,6 @@ impl Default for GETTEXTEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for GETTEXTEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -1247,10 +1073,6 @@ impl Default for GETTEXTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for GETTEXTEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct GETTEXTEX_FLAGS(pub u32);
@@ -1264,9 +1086,6 @@ impl Default for GETTEXTLENGTHEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GETTEXTLENGTHEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1315,9 +1134,6 @@ impl Default for GROUPTYPINGCHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GROUPTYPINGCHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GTL_CLOSE: GETTEXTLENGTHEX_FLAGS = GETTEXTLENGTHEX_FLAGS(4u32);
 pub const GTL_DEFAULT: GETTEXTLENGTHEX_FLAGS = GETTEXTLENGTHEX_FLAGS(0u32);
 pub const GTL_NUMBYTES: GETTEXTLENGTHEX_FLAGS = GETTEXTLENGTHEX_FLAGS(16u32);
@@ -1343,10 +1159,6 @@ impl Default for HYPHENATEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for HYPHENATEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -1361,10 +1173,6 @@ impl Default for HYPHENATEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for HYPHENATEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HYPHRESULT {
@@ -1376,9 +1184,6 @@ impl Default for HYPHRESULT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HYPHRESULT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ICM_CTF: u32 = 5u32;
 pub const ICM_LEVEL2: u32 = 2u32;
@@ -1397,9 +1202,6 @@ impl Default for IMECOMPTEXT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMECOMPTEXT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9478,10 +9280,6 @@ impl Default for MSGFILTER {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for MSGFILTER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -9496,10 +9294,6 @@ impl Default for MSGFILTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for MSGFILTER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSTRCH: MANCODE = MANCODE(10i32);
 pub const MTAIL: MANCODE = MANCODE(9i32);
@@ -9517,10 +9311,6 @@ impl Default for OBJECTPOSITIONS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OBJECTPOSITIONS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -9534,10 +9324,6 @@ impl Default for OBJECTPOSITIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OBJECTPOSITIONS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9562,9 +9348,6 @@ impl Default for PARAFORMAT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PARAFORMAT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union PARAFORMAT_0 {
@@ -9575,9 +9358,6 @@ impl Default for PARAFORMAT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PARAFORMAT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -9602,9 +9382,6 @@ impl Default for PARAFORMAT2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PARAFORMAT2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9817,10 +9594,6 @@ impl Default for PUNCTUATION {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for PUNCTUATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -9833,10 +9606,6 @@ impl Default for PUNCTUATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for PUNCTUATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
@@ -9858,10 +9627,6 @@ impl Default for REOBJECT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
-impl windows_core::TypeKind for REOBJECT {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9940,11 +9705,6 @@ impl Default for REPASTESPECIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for REPASTESPECIAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Com")]
@@ -9960,11 +9720,6 @@ impl Default for REPASTESPECIAL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for REPASTESPECIAL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9978,10 +9733,6 @@ impl Default for REQRESIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for REQRESIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -9994,10 +9745,6 @@ impl Default for REQRESIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for REQRESIZE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RICHEDIT60_CLASS: windows_core::PCWSTR = windows_core::w!("RICHEDIT60W");
 pub const RICHEDIT_CLASS: windows_core::PCWSTR = windows_core::w!("RichEdit20W");
@@ -10023,11 +9770,6 @@ impl Default for RICHEDIT_IMAGE_PARAMETERS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RICHEDIT_IMAGE_PARAMETERS {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Com")]
@@ -10045,11 +9787,6 @@ impl Default for RICHEDIT_IMAGE_PARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for RICHEDIT_IMAGE_PARAMETERS {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10150,10 +9887,6 @@ impl Default for SELCHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SELCHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -10167,10 +9900,6 @@ impl Default for SELCHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SELCHANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SEL_EMPTY: RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE = RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE(0u16);
 pub const SEL_MULTICHAR: RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE = RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE(4u16);
@@ -10231,9 +9960,6 @@ impl Default for SETTEXTEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SETTEXTEX {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SFF_KEEPDOCINFO: u32 = 4096u32;
 pub const SFF_PERSISTVIEWSCALE: u32 = 8192u32;
 pub const SFF_PLAINRTF: u32 = 16384u32;
@@ -10278,9 +10004,6 @@ impl Default for TABLECELLPARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TABLECELLPARMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TABLEROWPARMS {
@@ -10301,9 +10024,6 @@ impl Default for TABLEROWPARMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TABLEROWPARMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TEXTMODE(pub i32);
@@ -10320,10 +10040,6 @@ impl Default for TEXTRANGEA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for TEXTRANGEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -10336,10 +10052,6 @@ impl Default for TEXTRANGEA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for TEXTRANGEA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(target_arch = "x86")]
@@ -10354,10 +10066,6 @@ impl Default for TEXTRANGEW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for TEXTRANGEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(4))]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy)]
@@ -10370,10 +10078,6 @@ impl Default for TEXTRANGEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for TEXTRANGEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TM_MULTICODEPAGE: TEXTMODE = TEXTMODE(32i32);
 pub const TM_MULTILEVELUNDO: TEXTMODE = TEXTMODE(8i32);

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
@@ -1431,9 +1431,6 @@ impl Default for BP_ANIMATIONPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BP_ANIMATIONPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BP_ANIMATIONSTYLE(pub i32);
@@ -1460,10 +1457,6 @@ impl Default for BP_PAINTPARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for BP_PAINTPARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1545,9 +1538,6 @@ impl Default for BUTTON_IMAGELIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BUTTON_IMAGELIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BUTTON_IMAGELIST_ALIGN(pub u32);
@@ -1568,9 +1558,6 @@ impl Default for BUTTON_SPLITINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BUTTON_SPLITINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1719,10 +1706,6 @@ impl Default for CCINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CCINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1748,10 +1731,6 @@ impl Default for CCINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for CCINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CCM_DPISCALE: u32 = 8204u32;
 pub const CCM_FIRST: u32 = 8192u32;
@@ -1780,9 +1759,6 @@ impl Default for CCSTYLEA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CCSTYLEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CCSTYLEFLAGA {
@@ -1795,9 +1771,6 @@ impl Default for CCSTYLEFLAGA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CCSTYLEFLAGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CCSTYLEFLAGW {
@@ -1809,9 +1782,6 @@ impl Default for CCSTYLEFLAGW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CCSTYLEFLAGW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1826,9 +1796,6 @@ impl Default for CCSTYLEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CCSTYLEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CCS_ADJUSTABLE: i32 = 32i32;
 pub const CCS_BOTTOM: i32 = 3i32;
@@ -1932,9 +1899,6 @@ impl Default for COLORMAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COLORMAP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const COLORMGMTDLGORD: u32 = 1551u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1947,9 +1911,6 @@ impl Default for COLORSCHEME {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COLORSCHEME {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1969,9 +1930,6 @@ impl Default for COMBOBOXEXITEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMBOBOXEXITEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COMBOBOXEXITEMW {
@@ -1990,9 +1948,6 @@ impl Default for COMBOBOXEXITEMW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMBOBOXEXITEMW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct COMBOBOXINFO {
@@ -2008,9 +1963,6 @@ impl Default for COMBOBOXINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COMBOBOXINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2083,9 +2035,6 @@ impl Default for COMPAREITEMSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COMPAREITEMSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2190,9 +2139,6 @@ impl Default for DATETIMEPICKERINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DATETIMEPICKERINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DATETIMEPICK_CLASS: windows_core::PCWSTR = windows_core::w!("SysDateTimePick32");
 pub const DATETIMEPICK_CLASSA: windows_core::PCSTR = windows_core::s!("SysDateTimePick32");
 pub const DATETIMEPICK_CLASSW: windows_core::PCWSTR = windows_core::w!("SysDateTimePick32");
@@ -2240,9 +2186,6 @@ impl Default for DELETEITEMSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DELETEITEMSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2326,9 +2269,6 @@ impl Default for DPASTREAMINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DPASTREAMINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DPAS_INSERTAFTER: u32 = 4u32;
 pub const DPAS_INSERTBEFORE: u32 = 2u32;
 pub const DPAS_SORTED: u32 = 1u32;
@@ -2363,9 +2303,6 @@ impl Default for DRAGLISTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DRAGLISTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DRAGLISTINFO_NOTIFICATION_FLAGS(pub u32);
@@ -2389,10 +2326,6 @@ impl Default for DRAWITEMSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DRAWITEMSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2455,9 +2388,6 @@ impl Default for DTBGOPTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DTBGOPTS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DTBG_CLIPRECT: u32 = 1u32;
 pub const DTBG_COMPUTINGREGION: u32 = 16u32;
@@ -2539,10 +2469,6 @@ impl Default for DTTOPTS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for DTTOPTS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2670,9 +2596,6 @@ impl Default for EDITBALLOONTIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EDITBALLOONTIP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3010,9 +2933,6 @@ impl Default for HDHITTESTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HDHITTESTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HDIS_FOCUSED: HEADER_CONTROL_FORMAT_STATE = HEADER_CONTROL_FORMAT_STATE(1u32);
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -3037,10 +2957,6 @@ impl Default for HDITEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for HDITEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3063,10 +2979,6 @@ impl Default for HDITEMW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for HDITEMW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HDI_BITMAP: HDI_MASK = HDI_MASK(16u32);
 pub const HDI_DI_SETITEM: HDI_MASK = HDI_MASK(64u32);
@@ -3127,10 +3039,6 @@ impl Default for HDLAYOUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for HDLAYOUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HDM_CLEARFILTER: u32 = 4632u32;
 pub const HDM_CREATEDRAGIMAGE: u32 = 4624u32;
@@ -3268,9 +3176,6 @@ impl Default for HD_TEXTFILTERA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HD_TEXTFILTERA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HD_TEXTFILTERW {
@@ -3281,9 +3186,6 @@ impl Default for HD_TEXTFILTERW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HD_TEXTFILTERW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4303,10 +4205,6 @@ impl Default for IMAGEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for IMAGEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct IMAGELAYOUT(pub i32);
@@ -4338,10 +4236,6 @@ impl Default for IMAGELISTDRAWPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for IMAGELISTDRAWPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMAGELISTSTATS {
@@ -4354,9 +4248,6 @@ impl Default for IMAGELISTSTATS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMAGELISTSTATS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4487,9 +4378,6 @@ impl Default for INITCOMMONCONTROLSEX {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INITCOMMONCONTROLSEX {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct INITCOMMONCONTROLSEX_ICC(pub u32);
@@ -4536,9 +4424,6 @@ impl Default for INTLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INVALID_LINK_INDEX: i32 = -1i32;
 pub const IPM_CLEARADDRESS: u32 = 1124u32;
@@ -4604,9 +4489,6 @@ impl Default for LHITTESTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LHITTESTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LIF_ITEMID: LIST_ITEM_FLAGS = LIST_ITEM_FLAGS(4u32);
 pub const LIF_ITEMINDEX: LIST_ITEM_FLAGS = LIST_ITEM_FLAGS(1u32);
@@ -4913,9 +4795,6 @@ impl Default for LITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LITEM {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LM_GETIDEALHEIGHT: u32 = 1793u32;
 pub const LM_GETIDEALSIZE: u32 = 1793u32;
 pub const LM_GETITEM: u32 = 1795u32;
@@ -4972,10 +4851,6 @@ impl Default for LVBKIMAGEA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for LVBKIMAGEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4992,10 +4867,6 @@ impl Default for LVBKIMAGEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for LVBKIMAGEW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LVCB_HOVER: COLLAPSEBUTTONSTATES = COLLAPSEBUTTONSTATES(2i32);
 pub const LVCB_NORMAL: COLLAPSEBUTTONSTATES = COLLAPSEBUTTONSTATES(1i32);
@@ -5050,9 +4921,6 @@ impl Default for LVCOLUMNA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LVCOLUMNA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LVCOLUMNW {
@@ -5072,9 +4940,6 @@ impl Default for LVCOLUMNW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LVCOLUMNW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5168,9 +5033,6 @@ impl Default for LVFINDINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LVFINDINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LVFINDINFOW {
@@ -5184,9 +5046,6 @@ impl Default for LVFINDINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LVFINDINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5244,9 +5103,6 @@ impl Default for LVFOOTERINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LVFOOTERINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LVFOOTERITEM {
@@ -5261,9 +5117,6 @@ impl Default for LVFOOTERITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LVFOOTERITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5364,9 +5217,6 @@ impl Default for LVGROUP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LVGROUP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LVGROUPMETRICS {
@@ -5387,9 +5237,6 @@ impl Default for LVGROUPMETRICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LVGROUPMETRICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5449,9 +5296,6 @@ impl Default for LVHITTESTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LVHITTESTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5529,9 +5373,6 @@ impl Default for LVINSERTGROUPSORTED {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LVINSERTGROUPSORTED {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LVINSERTMARK {
@@ -5544,9 +5385,6 @@ impl Default for LVINSERTMARK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LVINSERTMARK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LVIR_BOUNDS: u32 = 0u32;
 pub const LVIR_ICON: u32 = 1u32;
@@ -5584,9 +5422,6 @@ impl Default for LVITEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LVITEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct LVITEMA_GROUP_ID(pub i32);
@@ -5600,9 +5435,6 @@ impl Default for LVITEMINDEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LVITEMINDEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5627,9 +5459,6 @@ impl Default for LVITEMW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LVITEMW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LVKF_ALT: u32 = 1u32;
 pub const LVKF_CONTROL: u32 = 2u32;
@@ -5874,9 +5703,6 @@ impl Default for LVSETINFOTIP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LVSETINFOTIP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LVSICF_NOINVALIDATEALL: u32 = 1u32;
 pub const LVSICF_NOSCROLL: u32 = 2u32;
 pub const LVSIL_GROUPHEADER: u32 = 3u32;
@@ -5949,9 +5775,6 @@ impl Default for LVTILEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LVTILEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LVTILEVIEWINFO {
@@ -5966,9 +5789,6 @@ impl Default for LVTILEVIEWINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LVTILEVIEWINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6076,9 +5896,6 @@ impl Default for MARGINS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MARGINS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MARKUPTEXTSTATES(pub i32);
@@ -6159,9 +5976,6 @@ impl Default for MCGRIDINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MCGRIDINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MCGRIDINFO_FLAGS(pub u32);
@@ -6217,9 +6031,6 @@ impl Default for MCHITTESTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MCHITTESTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6414,9 +6225,6 @@ impl Default for MEASUREITEMSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEASUREITEMSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MENUBANDPARTS(pub i32);
@@ -6573,9 +6381,6 @@ impl Default for NMBCDROPDOWN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMBCDROPDOWN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMBCHOTITEM {
@@ -6586,9 +6391,6 @@ impl Default for NMBCHOTITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMBCHOTITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6602,9 +6404,6 @@ impl Default for NMCBEDRAGBEGINA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMCBEDRAGBEGINA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMCBEDRAGBEGINW {
@@ -6616,9 +6415,6 @@ impl Default for NMCBEDRAGBEGINW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMCBEDRAGBEGINW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6634,9 +6430,6 @@ impl Default for NMCBEENDEDITA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMCBEENDEDITA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMCBEENDEDITW {
@@ -6651,9 +6444,6 @@ impl Default for NMCBEENDEDITW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMCBEENDEDITW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMCHAR {
@@ -6667,9 +6457,6 @@ impl Default for NMCHAR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMCHAR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMCOMBOBOXEXA {
@@ -6681,9 +6468,6 @@ impl Default for NMCOMBOBOXEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMCOMBOBOXEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMCOMBOBOXEXW {
@@ -6694,9 +6478,6 @@ impl Default for NMCOMBOBOXEXW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMCOMBOBOXEXW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -6715,10 +6496,6 @@ impl Default for NMCUSTOMDRAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NMCUSTOMDRAW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6772,9 +6549,6 @@ impl Default for NMCUSTOMSPLITRECTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMCUSTOMSPLITRECTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6793,10 +6567,6 @@ impl Default for NMCUSTOMTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NMCUSTOMTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMDATETIMECHANGE {
@@ -6808,9 +6578,6 @@ impl Default for NMDATETIMECHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMDATETIMECHANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6829,9 +6596,6 @@ impl Default for NMDATETIMEFORMATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMDATETIMEFORMATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMDATETIMEFORMATQUERYA {
@@ -6844,9 +6608,6 @@ impl Default for NMDATETIMEFORMATQUERYA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMDATETIMEFORMATQUERYA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMDATETIMEFORMATQUERYW {
@@ -6858,9 +6619,6 @@ impl Default for NMDATETIMEFORMATQUERYW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMDATETIMEFORMATQUERYW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6876,9 +6634,6 @@ impl Default for NMDATETIMEFORMATW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMDATETIMEFORMATW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMDATETIMESTRINGA {
@@ -6891,9 +6646,6 @@ impl Default for NMDATETIMESTRINGA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMDATETIMESTRINGA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6908,9 +6660,6 @@ impl Default for NMDATETIMESTRINGW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMDATETIMESTRINGW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMDATETIMEWMKEYDOWNA {
@@ -6923,9 +6672,6 @@ impl Default for NMDATETIMEWMKEYDOWNA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMDATETIMEWMKEYDOWNA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6940,9 +6686,6 @@ impl Default for NMDATETIMEWMKEYDOWNW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMDATETIMEWMKEYDOWNW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMDAYSTATE {
@@ -6955,9 +6698,6 @@ impl Default for NMDAYSTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMDAYSTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6975,9 +6715,6 @@ impl Default for NMHDDISPINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMHDDISPINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMHDDISPINFOW {
@@ -6994,9 +6731,6 @@ impl Default for NMHDDISPINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMHDDISPINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMHDFILTERBTNCLICK {
@@ -7009,9 +6743,6 @@ impl Default for NMHDFILTERBTNCLICK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMHDFILTERBTNCLICK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMHDR {
@@ -7023,9 +6754,6 @@ impl Default for NMHDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMHDR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -7042,10 +6770,6 @@ impl Default for NMHEADERA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NMHEADERA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7061,10 +6785,6 @@ impl Default for NMHEADERW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NMHEADERW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMIPADDRESS {
@@ -7076,9 +6796,6 @@ impl Default for NMIPADDRESS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMIPADDRESS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7098,9 +6815,6 @@ impl Default for NMITEMACTIVATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMITEMACTIVATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMKEY {
@@ -7113,9 +6827,6 @@ impl Default for NMKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMLINK {
@@ -7126,9 +6837,6 @@ impl Default for NMLINK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMLINK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7147,9 +6855,6 @@ impl Default for NMLISTVIEW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMLISTVIEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMLVCACHEHINT {
@@ -7161,9 +6866,6 @@ impl Default for NMLVCACHEHINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMLVCACHEHINT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -7188,10 +6890,6 @@ impl Default for NMLVCUSTOMDRAW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NMLVCUSTOMDRAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NMLVCUSTOMDRAW_ITEM_TYPE(pub u32);
@@ -7206,9 +6904,6 @@ impl Default for NMLVDISPINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMLVDISPINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMLVDISPINFOW {
@@ -7219,9 +6914,6 @@ impl Default for NMLVDISPINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMLVDISPINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7234,9 +6926,6 @@ impl Default for NMLVEMPTYMARKUP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMLVEMPTYMARKUP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7253,9 +6942,6 @@ impl Default for NMLVFINDITEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMLVFINDITEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMLVFINDITEMW {
@@ -7267,9 +6953,6 @@ impl Default for NMLVFINDITEMW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMLVFINDITEMW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7287,9 +6970,6 @@ impl Default for NMLVGETINFOTIPA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMLVGETINFOTIPA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMLVGETINFOTIPW {
@@ -7306,9 +6986,6 @@ impl Default for NMLVGETINFOTIPW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMLVGETINFOTIPW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NMLVGETINFOTIP_FLAGS(pub u32);
@@ -7324,9 +7001,6 @@ impl Default for NMLVKEYDOWN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMLVKEYDOWN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMLVLINK {
@@ -7339,9 +7013,6 @@ impl Default for NMLVLINK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMLVLINK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7357,9 +7028,6 @@ impl Default for NMLVODSTATECHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMLVODSTATECHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMLVSCROLL {
@@ -7371,9 +7039,6 @@ impl Default for NMLVSCROLL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMLVSCROLL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7388,9 +7053,6 @@ impl Default for NMMOUSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMMOUSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7407,9 +7069,6 @@ impl Default for NMOBJECTNOTIFY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMOBJECTNOTIFY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMPGCALCSIZE {
@@ -7422,9 +7081,6 @@ impl Default for NMPGCALCSIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMPGCALCSIZE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7442,9 +7098,6 @@ impl Default for NMPGHOTITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMPGHOTITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NMPGSCROLL {
@@ -7460,9 +7113,6 @@ impl Default for NMPGSCROLL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMPGSCROLL {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7516,9 +7166,6 @@ impl Default for NMRBAUTOSIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMRBAUTOSIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMREBAR {
@@ -7533,9 +7180,6 @@ impl Default for NMREBAR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMREBAR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7553,9 +7197,6 @@ impl Default for NMREBARAUTOBREAK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMREBARAUTOBREAK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMREBARCHEVRON {
@@ -7571,9 +7212,6 @@ impl Default for NMREBARCHEVRON {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMREBARCHEVRON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMREBARCHILDSIZE {
@@ -7588,9 +7226,6 @@ impl Default for NMREBARCHILDSIZE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMREBARCHILDSIZE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMREBARSPLITTER {
@@ -7601,9 +7236,6 @@ impl Default for NMREBARSPLITTER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMREBARSPLITTER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7654,9 +7286,6 @@ impl Default for NMSEARCHWEB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMSEARCHWEB {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMSELCHANGE {
@@ -7668,9 +7297,6 @@ impl Default for NMSELCHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMSELCHANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -7697,10 +7323,6 @@ impl Default for NMTBCUSTOMDRAW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NMTBCUSTOMDRAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTBDISPINFOA {
@@ -7717,9 +7339,6 @@ impl Default for NMTBDISPINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTBDISPINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTBDISPINFOW {
@@ -7735,9 +7354,6 @@ impl Default for NMTBDISPINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMTBDISPINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7789,9 +7405,6 @@ impl Default for NMTBGETINFOTIPA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTBGETINFOTIPA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTBGETINFOTIPW {
@@ -7806,9 +7419,6 @@ impl Default for NMTBGETINFOTIPW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTBGETINFOTIPW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTBHOTITEM {
@@ -7821,9 +7431,6 @@ impl Default for NMTBHOTITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMTBHOTITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7878,9 +7485,6 @@ impl Default for NMTBRESTORE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTBRESTORE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTBSAVE {
@@ -7897,9 +7501,6 @@ impl Default for NMTBSAVE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTBSAVE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NMTCKEYDOWN {
@@ -7911,9 +7512,6 @@ impl Default for NMTCKEYDOWN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMTCKEYDOWN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7930,9 +7528,6 @@ impl Default for NMTOOLBARA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTOOLBARA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTOOLBARW {
@@ -7948,9 +7543,6 @@ impl Default for NMTOOLBARW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTOOLBARW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTOOLTIPSCREATED {
@@ -7961,9 +7553,6 @@ impl Default for NMTOOLTIPSCREATED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMTOOLTIPSCREATED {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7976,9 +7565,6 @@ impl Default for NMTRBTHUMBPOSCHANGING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMTRBTHUMBPOSCHANGING {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7994,9 +7580,6 @@ impl Default for NMTREEVIEWA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTREEVIEWA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTREEVIEWW {
@@ -8011,9 +7594,6 @@ impl Default for NMTREEVIEWW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTREEVIEWW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8026,10 +7606,6 @@ impl Default for NMTTCUSTOMDRAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NMTTCUSTOMDRAW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8046,9 +7622,6 @@ impl Default for NMTTDISPINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTTDISPINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTTDISPINFOW {
@@ -8063,9 +7636,6 @@ impl Default for NMTTDISPINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMTTDISPINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -8085,10 +7655,6 @@ impl Default for NMTVASYNCDRAW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NMTVASYNCDRAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8104,10 +7670,6 @@ impl Default for NMTVCUSTOMDRAW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NMTVCUSTOMDRAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTVDISPINFOA {
@@ -8118,9 +7680,6 @@ impl Default for NMTVDISPINFOA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMTVDISPINFOA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8133,9 +7692,6 @@ impl Default for NMTVDISPINFOEXA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTVDISPINFOEXA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTVDISPINFOEXW {
@@ -8147,9 +7703,6 @@ impl Default for NMTVDISPINFOEXW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTVDISPINFOEXW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTVDISPINFOW {
@@ -8160,9 +7713,6 @@ impl Default for NMTVDISPINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMTVDISPINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8178,9 +7728,6 @@ impl Default for NMTVGETINFOTIPA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTVGETINFOTIPA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMTVGETINFOTIPW {
@@ -8194,9 +7741,6 @@ impl Default for NMTVGETINFOTIPW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMTVGETINFOTIPW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8213,9 +7757,6 @@ impl Default for NMTVITEMCHANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTVITEMCHANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct NMTVKEYDOWN {
@@ -8227,9 +7768,6 @@ impl Default for NMTVKEYDOWN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMTVKEYDOWN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8244,9 +7782,6 @@ impl Default for NMTVSTATEIMAGECHANGING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMTVSTATEIMAGECHANGING {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMUPDOWN {
@@ -8259,9 +7794,6 @@ impl Default for NMUPDOWN {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NMUPDOWN {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct NMVIEWCHANGE {
@@ -8273,9 +7805,6 @@ impl Default for NMVIEWCHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NMVIEWCHANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NM_CHAR: u32 = 4294967278u32;
 pub const NM_CLICK: u32 = 4294967294u32;
@@ -8479,9 +8008,6 @@ impl Default for PBRANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PBRANGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PBST_ERROR: u32 = 2u32;
 pub const PBST_NORMAL: u32 = 1u32;
 pub const PBST_PAUSED: u32 = 3u32;
@@ -8564,9 +8090,6 @@ impl Default for POINTER_DEVICE_CURSOR_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POINTER_DEVICE_CURSOR_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct POINTER_DEVICE_CURSOR_TYPE(pub i32);
@@ -8592,10 +8115,6 @@ impl Default for POINTER_DEVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for POINTER_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct POINTER_DEVICE_PROPERTY {
@@ -8612,9 +8131,6 @@ impl Default for POINTER_DEVICE_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for POINTER_DEVICE_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8643,10 +8159,6 @@ impl Default for POINTER_TYPE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for POINTER_TYPE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -8659,10 +8171,6 @@ impl Default for POINTER_TYPE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for POINTER_TYPE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8735,10 +8243,6 @@ impl Default for PROPSHEETHEADERA_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERA_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -8751,10 +8255,6 @@ impl Default for PROPSHEETHEADERA_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERA_V1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -8769,10 +8269,6 @@ impl Default for PROPSHEETHEADERA_V1_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERA_V1_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -8785,10 +8281,6 @@ impl Default for PROPSHEETHEADERA_V1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERA_V1_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -8814,10 +8306,6 @@ impl Default for PROPSHEETHEADERA_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERA_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -8830,10 +8318,6 @@ impl Default for PROPSHEETHEADERA_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERA_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -8848,10 +8332,6 @@ impl Default for PROPSHEETHEADERA_V2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERA_V2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -8864,10 +8344,6 @@ impl Default for PROPSHEETHEADERA_V2_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERA_V2_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -8882,10 +8358,6 @@ impl Default for PROPSHEETHEADERA_V2_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERA_V2_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -8898,10 +8370,6 @@ impl Default for PROPSHEETHEADERA_V2_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERA_V2_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -8924,10 +8392,6 @@ impl Default for PROPSHEETHEADERW_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERW_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -8940,10 +8404,6 @@ impl Default for PROPSHEETHEADERW_V1_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERW_V1_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -8958,10 +8418,6 @@ impl Default for PROPSHEETHEADERW_V1_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERW_V1_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -8974,10 +8430,6 @@ impl Default for PROPSHEETHEADERW_V1_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERW_V1_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9003,10 +8455,6 @@ impl Default for PROPSHEETHEADERW_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERW_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9019,10 +8467,6 @@ impl Default for PROPSHEETHEADERW_V2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERW_V2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9037,10 +8481,6 @@ impl Default for PROPSHEETHEADERW_V2_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERW_V2_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9053,10 +8493,6 @@ impl Default for PROPSHEETHEADERW_V2_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERW_V2_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9071,10 +8507,6 @@ impl Default for PROPSHEETHEADERW_V2_3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERW_V2_3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9087,10 +8519,6 @@ impl Default for PROPSHEETHEADERW_V2_4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETHEADERW_V2_4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9117,10 +8545,6 @@ impl Default for PROPSHEETPAGEA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9133,10 +8557,6 @@ impl Default for PROPSHEETPAGEA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9151,10 +8571,6 @@ impl Default for PROPSHEETPAGEA_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9167,10 +8583,6 @@ impl Default for PROPSHEETPAGEA_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9193,10 +8605,6 @@ impl Default for PROPSHEETPAGEA_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9210,10 +8618,6 @@ impl Default for PROPSHEETPAGEA_V1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9226,10 +8630,6 @@ impl Default for PROPSHEETPAGEA_V1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_V1_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9254,10 +8654,6 @@ impl Default for PROPSHEETPAGEA_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9271,10 +8667,6 @@ impl Default for PROPSHEETPAGEA_V2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_V2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9287,10 +8679,6 @@ impl Default for PROPSHEETPAGEA_V2_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_V2_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9316,10 +8704,6 @@ impl Default for PROPSHEETPAGEA_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9333,10 +8717,6 @@ impl Default for PROPSHEETPAGEA_V3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_V3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9349,10 +8729,6 @@ impl Default for PROPSHEETPAGEA_V3_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEA_V3_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9379,10 +8755,6 @@ impl Default for PROPSHEETPAGEW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9395,10 +8767,6 @@ impl Default for PROPSHEETPAGEW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9413,10 +8781,6 @@ impl Default for PROPSHEETPAGEW_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9429,10 +8793,6 @@ impl Default for PROPSHEETPAGEW_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9455,10 +8815,6 @@ impl Default for PROPSHEETPAGEW_V1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_V1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9472,10 +8828,6 @@ impl Default for PROPSHEETPAGEW_V1_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_V1_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9488,10 +8840,6 @@ impl Default for PROPSHEETPAGEW_V1_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_V1_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9516,10 +8864,6 @@ impl Default for PROPSHEETPAGEW_V2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_V2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9533,10 +8877,6 @@ impl Default for PROPSHEETPAGEW_V2_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_V2_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9549,10 +8889,6 @@ impl Default for PROPSHEETPAGEW_V2_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_V2_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
@@ -9578,10 +8914,6 @@ impl Default for PROPSHEETPAGEW_V3 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_V3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9595,10 +8927,6 @@ impl Default for PROPSHEETPAGEW_V3_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_V3_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 #[derive(Clone, Copy)]
@@ -9611,10 +8939,6 @@ impl Default for PROPSHEETPAGEW_V3_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for PROPSHEETPAGEW_V3_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROP_LG_CXDLG: u32 = 252u32;
 pub const PROP_LG_CYDLG: u32 = 218u32;
@@ -9643,9 +8967,6 @@ impl Default for PSHNOTIFY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PSHNOTIFY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PSH_AEROWIZARD: u32 = 16384u32;
 pub const PSH_DEFAULT: u32 = 0u32;
@@ -9814,9 +9135,6 @@ impl Default for RBHITTESTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RBHITTESTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RBHT_CAPTION: u32 = 2u32;
 pub const RBHT_CHEVRON: u32 = 8u32;
 pub const RBHT_CLIENT: u32 = 3u32;
@@ -9947,10 +9265,6 @@ impl Default for REBARBANDINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for REBARBANDINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -9984,10 +9298,6 @@ impl Default for REBARBANDINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for REBARBANDINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const REBARCLASSNAME: windows_core::PCWSTR = windows_core::w!("ReBarWindow32");
 pub const REBARCLASSNAMEA: windows_core::PCSTR = windows_core::s!("ReBarWindow32");
 pub const REBARCLASSNAMEW: windows_core::PCWSTR = windows_core::w!("ReBarWindow32");
@@ -10002,9 +9312,6 @@ impl Default for REBARINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REBARINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10398,10 +9705,6 @@ impl Default for TASKDIALOGCONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for TASKDIALOGCONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -10414,10 +9717,6 @@ impl Default for TASKDIALOGCONFIG_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for TASKDIALOGCONFIG_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -10432,10 +9731,6 @@ impl Default for TASKDIALOGCONFIG_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for TASKDIALOGCONFIG_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TASKDIALOGPARTS(pub i32);
@@ -10449,9 +9744,6 @@ impl Default for TASKDIALOG_BUTTON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TASKDIALOG_BUTTON {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10562,9 +9854,6 @@ impl Default for TA_CUBIC_BEZIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TA_CUBIC_BEZIER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TA_PROPERTY(pub i32);
@@ -10614,9 +9903,6 @@ impl Default for TA_TIMINGFUNCTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TA_TIMINGFUNCTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TA_TIMINGFUNCTION_TYPE(pub i32);
@@ -10634,9 +9920,6 @@ impl Default for TA_TRANSFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TA_TRANSFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TA_TRANSFORM_2D {
@@ -10652,9 +9935,6 @@ impl Default for TA_TRANSFORM_2D {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TA_TRANSFORM_2D {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10673,9 +9953,6 @@ impl Default for TA_TRANSFORM_CLIP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TA_TRANSFORM_CLIP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10725,9 +10002,6 @@ impl Default for TA_TRANSFORM_OPACITY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TA_TRANSFORM_OPACITY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TA_TRANSFORM_TYPE(pub i32);
@@ -10741,9 +10015,6 @@ impl Default for TBADDBITMAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TBADDBITMAP {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TBBF_LARGE: u32 = 1u32;
 #[repr(C)]
@@ -10764,10 +10035,6 @@ impl Default for TBBUTTON {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for TBBUTTON {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10785,10 +10052,6 @@ impl Default for TBBUTTON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for TBBUTTON {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -10809,9 +10072,6 @@ impl Default for TBBUTTONINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TBBUTTONINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TBBUTTONINFOW {
@@ -10830,9 +10090,6 @@ impl Default for TBBUTTONINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TBBUTTONINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10906,9 +10163,6 @@ impl Default for TBINSERTMARK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TBINSERTMARK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TBINSERTMARK_FLAGS(pub u32);
@@ -10928,9 +10182,6 @@ impl Default for TBMETRICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TBMETRICS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TBMF_BARPAD: u32 = 2u32;
 pub const TBMF_BUTTONSPACING: u32 = 4u32;
@@ -11030,9 +10281,6 @@ impl Default for TBREPLACEBITMAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TBREPLACEBITMAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11047,10 +10295,6 @@ impl Default for TBSAVEPARAMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for TBSAVEPARAMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_System_Registry")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -11064,10 +10308,6 @@ impl Default for TBSAVEPARAMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for TBSAVEPARAMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TBSTATE_CHECKED: u32 = 1u32;
 pub const TBSTATE_ELLIPSES: u32 = 64u32;
@@ -11250,9 +10490,6 @@ impl Default for TCHITTESTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCHITTESTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TCHITTESTINFO_FLAGS(pub u32);
@@ -11283,9 +10520,6 @@ impl Default for TCITEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCITEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCITEMHEADERA {
@@ -11300,9 +10534,6 @@ impl Default for TCITEMHEADERA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCITEMHEADERA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -11355,9 +10586,6 @@ impl Default for TCITEMHEADERW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TCITEMHEADERW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TCITEMW {
@@ -11373,9 +10601,6 @@ impl Default for TCITEMW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TCITEMW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TCM_ADJUSTRECT: u32 = 4904u32;
 pub const TCM_DELETEALLITEMS: u32 = 4873u32;
@@ -11960,9 +11185,6 @@ impl Default for TOUCH_HIT_TESTING_INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TOUCH_HIT_TESTING_INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TOUCH_HIT_TESTING_PROXIMITY_EVALUATION {
@@ -11973,9 +11195,6 @@ impl Default for TOUCH_HIT_TESTING_PROXIMITY_EVALUATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOUCH_HIT_TESTING_PROXIMITY_EVALUATION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TP_BUTTON: TOOLBARPARTS = TOOLBARPARTS(1i32);
 pub const TP_DROPDOWNBUTTON: TOOLBARPARTS = TOOLBARPARTS(2i32);
@@ -12107,9 +11326,6 @@ impl Default for TTGETTITLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TTGETTITLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TTHITTESTINFOA {
@@ -12122,9 +11338,6 @@ impl Default for TTHITTESTINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TTHITTESTINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TTHITTESTINFOW {
@@ -12136,9 +11349,6 @@ impl Default for TTHITTESTINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TTHITTESTINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TTIBES_DISABLED: TOPTABITEMBOTHEDGESTATES = TOPTABITEMBOTHEDGESTATES(4i32);
 pub const TTIBES_FOCUSED: TOPTABITEMBOTHEDGESTATES = TOPTABITEMBOTHEDGESTATES(5i32);
@@ -12268,9 +11478,6 @@ impl Default for TTTOOLINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TTTOOLINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TTTOOLINFOW {
@@ -12288,9 +11495,6 @@ impl Default for TTTOOLINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TTTOOLINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TTWS_HOT: WRENCHSTATES = WRENCHSTATES(2i32);
 pub const TTWS_NORMAL: WRENCHSTATES = WRENCHSTATES(1i32);
@@ -12346,9 +11550,6 @@ impl Default for TVGETITEMPARTRECTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TVGETITEMPARTRECTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TVGIPR_BUTTON: TVITEMPART = TVITEMPART(1i32);
 pub const TVGN_CARET: u32 = 9u32;
 pub const TVGN_CHILD: u32 = 4u32;
@@ -12373,9 +11574,6 @@ impl Default for TVHITTESTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TVHITTESTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12448,9 +11646,6 @@ impl Default for TVINSERTSTRUCTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TVINSERTSTRUCTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TVINSERTSTRUCTA_0 {
@@ -12461,9 +11656,6 @@ impl Default for TVINSERTSTRUCTA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TVINSERTSTRUCTA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -12477,9 +11669,6 @@ impl Default for TVINSERTSTRUCTW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TVINSERTSTRUCTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TVINSERTSTRUCTW_0 {
@@ -12490,9 +11679,6 @@ impl Default for TVINSERTSTRUCTW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TVINSERTSTRUCTW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TVIS_BOLD: TREE_VIEW_ITEM_STATE_FLAGS = TREE_VIEW_ITEM_STATE_FLAGS(16u32);
 pub const TVIS_CUT: TREE_VIEW_ITEM_STATE_FLAGS = TREE_VIEW_ITEM_STATE_FLAGS(4u32);
@@ -12526,9 +11712,6 @@ impl Default for TVITEMA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TVITEMA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TVITEMEXA {
@@ -12552,9 +11735,6 @@ impl Default for TVITEMEXA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TVITEMEXA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -12580,9 +11760,6 @@ impl Default for TVITEMEXW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TVITEMEXW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TVITEMEXW_CHILDREN(pub i32);
@@ -12607,9 +11784,6 @@ impl Default for TVITEMW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TVITEMW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12783,9 +11957,6 @@ impl Default for TVSORTCB {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TVSORTCB {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TVS_CHECKBOXES: u32 = 256u32;
 pub const TVS_DISABLEDRAGDROP: u32 = 16u32;
 pub const TVS_EDITLABELS: u32 = 8u32;
@@ -12824,9 +11995,6 @@ impl Default for UDACCEL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UDACCEL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UDM_GETACCEL: u32 = 1132u32;
 pub const UDM_GETBASE: u32 = 1134u32;
@@ -12895,9 +12063,6 @@ impl Default for USAGE_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for USAGE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13150,9 +12315,6 @@ impl Default for WTA_OPTIONS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTA_OPTIONS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTNCA_NODRAWCAPTION: u32 = 1u32;
 pub const WTNCA_NODRAWICON: u32 = 2u32;

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
@@ -491,9 +491,6 @@ impl Default for APPLETIDLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APPLETIDLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct APPLYCANDEXPARAM {
@@ -506,9 +503,6 @@ impl Default for APPLYCANDEXPARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APPLYCANDEXPARAM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ATTR_CONVERTED: u32 = 2u32;
 pub const ATTR_FIXEDCONVERTED: u32 = 5u32;
@@ -529,9 +523,6 @@ impl Default for CANDIDATEFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CANDIDATEFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CANDIDATEINFO {
@@ -545,9 +536,6 @@ impl Default for CANDIDATEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CANDIDATEINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -564,9 +552,6 @@ impl Default for CANDIDATELIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CANDIDATELIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CATID_MSIME_IImePadApplet: windows_core::GUID = windows_core::GUID::from_u128(0x7566cad1_4ec9_4478_9fe9_8ed766619edf);
 pub const CATID_MSIME_IImePadApplet1000: windows_core::GUID = windows_core::GUID::from_u128(0xe081e1d6_2389_43cb_b66f_609f823d9f9c);
@@ -599,9 +584,6 @@ impl Default for COMPOSITIONFORM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COMPOSITIONFORM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -636,9 +618,6 @@ impl Default for COMPOSITIONSTRING {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for COMPOSITIONSTRING {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CPS_CANCEL: NOTIFY_IME_INDEX = NOTIFY_IME_INDEX(4u32);
 pub const CPS_COMPLETE: NOTIFY_IME_INDEX = NOTIFY_IME_INDEX(1u32);
@@ -767,9 +746,6 @@ impl Default for GUIDELINE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GUIDELINE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -4402,10 +4378,6 @@ impl Default for IMEAPPLETCFG {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for IMEAPPLETCFG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMEAPPLETUI {
@@ -4425,9 +4397,6 @@ impl Default for IMEAPPLETUI {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEAPPLETUI {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMECHARINFO {
@@ -4438,9 +4407,6 @@ impl Default for IMECHARINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMECHARINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4455,9 +4421,6 @@ impl Default for IMECHARPOSITION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMECHARPOSITION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4474,9 +4437,6 @@ impl Default for IMECOMPOSITIONSTRINGINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMECOMPOSITIONSTRINGINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMEDLG {
@@ -4490,9 +4450,6 @@ impl Default for IMEDLG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEDLG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMEDP {
@@ -4505,9 +4462,6 @@ impl Default for IMEDP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEDP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMEFAREASTINFO {
@@ -4519,9 +4473,6 @@ impl Default for IMEFAREASTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMEFAREASTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMEFAREASTINFO_TYPE_COMMENT: u32 = 2u32;
 pub const IMEFAREASTINFO_TYPE_COSTTIME: u32 = 3u32;
@@ -4546,9 +4497,6 @@ impl Default for IMEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMEITEM {
@@ -4561,9 +4509,6 @@ impl Default for IMEITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMEITEMCANDIDATE {
@@ -4574,9 +4519,6 @@ impl Default for IMEITEMCANDIDATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMEITEMCANDIDATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMEKEYCTRLMASK_ALT: u32 = 1u32;
 pub const IMEKEYCTRLMASK_CTRL: u32 = 2u32;
@@ -4596,9 +4538,6 @@ impl Default for IMEKMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEKMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMEKMSFUNCDESC {
@@ -4612,9 +4551,6 @@ impl Default for IMEKMSFUNCDESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEKMSFUNCDESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMEKMSINIT {
@@ -4625,9 +4561,6 @@ impl Default for IMEKMSINIT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMEKMSINIT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -4640,9 +4573,6 @@ impl Default for IMEKMSINVK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMEKMSINVK {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -4658,9 +4588,6 @@ impl Default for IMEKMSKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEKMSKEY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union IMEKMSKEY_0 {
@@ -4672,9 +4599,6 @@ impl Default for IMEKMSKEY_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEKMSKEY_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union IMEKMSKEY_1 {
@@ -4685,9 +4609,6 @@ impl Default for IMEKMSKEY_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMEKMSKEY_1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -4705,9 +4626,6 @@ impl Default for IMEKMSKMP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEKMSKMP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMEKMSNTFY {
@@ -4719,9 +4637,6 @@ impl Default for IMEKMSNTFY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMEKMSNTFY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMEKMS_2NDLEVEL: u32 = 4u32;
 pub const IMEKMS_CANDIDATE: u32 = 6u32;
@@ -4751,10 +4666,6 @@ impl Default for IMEMENUITEMINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for IMEMENUITEMINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4774,10 +4685,6 @@ impl Default for IMEMENUITEMINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for IMEMENUITEMINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IMEMENUITEM_STRING_SIZE: u32 = 80u32;
 pub const IMEMOUSERET_NOTHANDLED: i32 = -1i32;
@@ -4875,9 +4782,6 @@ impl Default for IMESHF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMESHF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMESTRINGCANDIDATE {
@@ -4888,9 +4792,6 @@ impl Default for IMESTRINGCANDIDATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMESTRINGCANDIDATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4907,9 +4808,6 @@ impl Default for IMESTRINGCANDIDATEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMESTRINGCANDIDATEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct IMESTRINGINFO {
@@ -4920,9 +4818,6 @@ impl Default for IMESTRINGINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMESTRINGINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4945,9 +4840,6 @@ impl Default for IMEWRD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEWRD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union IMEWRD_0 {
@@ -4959,9 +4851,6 @@ impl Default for IMEWRD_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IMEWRD_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct IMEWRD_0_0 {
@@ -4972,9 +4861,6 @@ impl Default for IMEWRD_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for IMEWRD_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IME_CAND_CODE: u32 = 2u32;
 pub const IME_CAND_MEANING: u32 = 3u32;
@@ -5248,10 +5134,6 @@ impl Default for INPUTCONTEXT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for INPUTCONTEXT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy)]
@@ -5264,10 +5146,6 @@ impl Default for INPUTCONTEXT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for INPUTCONTEXT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const IPACFG_CATEGORY: i32 = 262144i32;
 pub const IPACFG_HELP: i32 = 2i32;
@@ -5498,9 +5376,6 @@ impl Default for MORRSLT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MORRSLT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union MORRSLT_0 {
@@ -5511,9 +5386,6 @@ impl Default for MORRSLT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MORRSLT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -5526,9 +5398,6 @@ impl Default for MORRSLT_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MORRSLT_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union MORRSLT_2 {
@@ -5539,9 +5408,6 @@ impl Default for MORRSLT_2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MORRSLT_2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NI_CHANGECANDIDATELIST: NOTIFY_IME_ACTION = NOTIFY_IME_ACTION(19u32);
 pub const NI_CLOSECANDIDATE: NOTIFY_IME_ACTION = NOTIFY_IME_ACTION(17u32);
@@ -5571,9 +5437,6 @@ impl Default for POSTBL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POSTBL {
-    type TypeKind = windows_core::CopyType;
-}
 pub const POS_UNDEFINED: u32 = 0u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5592,9 +5455,6 @@ impl Default for RECONVERTSTRING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RECONVERTSTRING {
-    type TypeKind = windows_core::CopyType;
-}
 pub const RECONVOPT_NONE: u32 = 0u32;
 pub const RECONVOPT_USECANCELNOTIFY: u32 = 1u32;
 #[repr(C)]
@@ -5608,9 +5468,6 @@ impl Default for REGISTERWORDA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for REGISTERWORDA {
-    type TypeKind = windows_core::CopyType;
-}
 pub type REGISTERWORDENUMPROCA = Option<unsafe extern "system" fn(lpszreading: windows_core::PCSTR, param1: u32, lpszstring: windows_core::PCSTR, param3: *mut core::ffi::c_void) -> i32>;
 pub type REGISTERWORDENUMPROCW = Option<unsafe extern "system" fn(lpszreading: windows_core::PCWSTR, param1: u32, lpszstring: windows_core::PCWSTR, param3: *mut core::ffi::c_void) -> i32>;
 #[repr(C)]
@@ -5623,9 +5480,6 @@ impl Default for REGISTERWORDW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for REGISTERWORDW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const RWM_CHGKEYMAP: windows_core::PCWSTR = windows_core::w!("MSIMEChangeKeyMap");
 pub const RWM_DOCUMENTFEED: windows_core::PCWSTR = windows_core::w!("MSIMEDocumentFeed");
@@ -5667,9 +5521,6 @@ impl Default for SOFTKBDDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SOFTKBDDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SOFTKEYBOARD_TYPE_C1: u32 = 2u32;
 pub const SOFTKEYBOARD_TYPE_T1: u32 = 1u32;
 #[repr(C)]
@@ -5683,9 +5534,6 @@ impl Default for STYLEBUFA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STYLEBUFA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct STYLEBUFW {
@@ -5696,9 +5544,6 @@ impl Default for STYLEBUFW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STYLEBUFW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STYLE_DESCRIPTION_SIZE: u32 = 32u32;
 #[repr(C)]
@@ -5713,9 +5558,6 @@ impl Default for TRANSMSG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TRANSMSG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TRANSMSGLIST {
@@ -5726,9 +5568,6 @@ impl Default for TRANSMSGLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRANSMSGLIST {
-    type TypeKind = windows_core::CopyType;
 }
 pub const UI_CAP_2700: u32 = 1u32;
 pub const UI_CAP_ROT90: u32 = 2u32;
@@ -5760,9 +5599,6 @@ impl Default for WDD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WDD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WDD_0 {
@@ -5774,9 +5610,6 @@ impl Default for WDD_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WDD_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub union WDD_1 {
@@ -5787,9 +5620,6 @@ impl Default for WDD_1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WDD_1 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const cbCommentMax: u32 = 256u32;
 pub type fpCreateIFECommonInstanceType = Option<unsafe extern "system" fn(ppvobj: *mut *mut core::ffi::c_void) -> windows_core::HRESULT>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/KeyboardAndMouse/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/KeyboardAndMouse/mod.rs
@@ -300,9 +300,6 @@ impl Default for DEADKEY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEADKEY {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEC_KBD_ANSI_LAYOUT_TYPE: u32 = 1u32;
 pub const DEC_KBD_JIS_LAYOUT_TYPE: u32 = 2u32;
 pub const DIARESIS: u32 = 776u32;
@@ -335,9 +332,6 @@ impl Default for HARDWAREINPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HARDWAREINPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -412,9 +406,6 @@ impl Default for INPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union INPUT_0 {
@@ -426,9 +417,6 @@ impl Default for INPUT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INPUT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const INPUT_HARDWARE: INPUT_TYPE = INPUT_TYPE(2u32);
 pub const INPUT_KEYBOARD: INPUT_TYPE = INPUT_TYPE(1u32);
@@ -457,9 +445,6 @@ impl Default for KBDNLSTABLES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KBDNLSTABLES {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KBDNLS_ALPHANUM: u32 = 5u32;
 pub const KBDNLS_CODEINPUT: u32 = 10u32;
@@ -509,9 +494,6 @@ impl Default for KBDTABLES {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KBDTABLES {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KBDTABLE_DESC {
@@ -524,9 +506,6 @@ impl Default for KBDTABLE_DESC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KBDTABLE_DESC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KBDTABLE_MULTI {
@@ -537,9 +516,6 @@ impl Default for KBDTABLE_MULTI {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KBDTABLE_MULTI {
-    type TypeKind = windows_core::CopyType;
 }
 pub const KBDTABLE_MULTI_MAX: u32 = 8u32;
 pub const KBD_TYPE: u32 = 4u32;
@@ -555,9 +531,6 @@ impl Default for KBD_TYPE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KBD_TYPE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const KBD_VERSION: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -572,9 +545,6 @@ impl Default for KEYBDINPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KEYBDINPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -643,9 +613,6 @@ impl Default for LASTINPUTINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LASTINPUTINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LIGATURE1 {
@@ -657,9 +624,6 @@ impl Default for LIGATURE1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LIGATURE1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -673,9 +637,6 @@ impl Default for LIGATURE2 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LIGATURE2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LIGATURE3 {
@@ -687,9 +648,6 @@ impl Default for LIGATURE3 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LIGATURE3 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -703,9 +661,6 @@ impl Default for LIGATURE4 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LIGATURE4 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LIGATURE5 {
@@ -717,9 +672,6 @@ impl Default for LIGATURE5 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LIGATURE5 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MACRON: u32 = 772u32;
 pub const MAPVK_VK_TO_CHAR: MAP_VIRTUAL_KEY_TYPE = MAP_VIRTUAL_KEY_TYPE(2u32);
@@ -751,9 +703,6 @@ impl Default for MODIFIERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MODIFIERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MOD_ALT: HOT_KEY_MODIFIERS = HOT_KEY_MODIFIERS(1u32);
 pub const MOD_CONTROL: HOT_KEY_MODIFIERS = HOT_KEY_MODIFIERS(2u32);
@@ -789,9 +738,6 @@ impl Default for MOUSEINPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MOUSEINPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MOUSEMOVEPOINT {
@@ -804,9 +750,6 @@ impl Default for MOUSEMOVEPOINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MOUSEMOVEPOINT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -897,9 +840,6 @@ impl Default for TRACKMOUSEEVENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TRACKMOUSEEVENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -1014,9 +954,6 @@ impl Default for VK_F {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VK_F {
-    type TypeKind = windows_core::CopyType;
-}
 pub const VK_F: VIRTUAL_KEY = VIRTUAL_KEY(70u16);
 pub const VK_F1: VIRTUAL_KEY = VIRTUAL_KEY(112u16);
 pub const VK_F10: VIRTUAL_KEY = VIRTUAL_KEY(121u16);
@@ -1053,9 +990,6 @@ impl Default for VK_FPARAM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VK_FPARAM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VK_G: VIRTUAL_KEY = VIRTUAL_KEY(71u16);
 pub const VK_GAMEPAD_A: VIRTUAL_KEY = VIRTUAL_KEY(195u16);
@@ -1217,9 +1151,6 @@ impl Default for VK_TO_BIT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VK_TO_BIT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VK_TO_WCHARS1 {
@@ -1231,9 +1162,6 @@ impl Default for VK_TO_WCHARS1 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VK_TO_WCHARS1 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1247,9 +1175,6 @@ impl Default for VK_TO_WCHARS10 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VK_TO_WCHARS10 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VK_TO_WCHARS2 {
@@ -1261,9 +1186,6 @@ impl Default for VK_TO_WCHARS2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VK_TO_WCHARS2 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1277,9 +1199,6 @@ impl Default for VK_TO_WCHARS3 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VK_TO_WCHARS3 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VK_TO_WCHARS4 {
@@ -1291,9 +1210,6 @@ impl Default for VK_TO_WCHARS4 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VK_TO_WCHARS4 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1307,9 +1223,6 @@ impl Default for VK_TO_WCHARS5 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VK_TO_WCHARS5 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VK_TO_WCHARS6 {
@@ -1321,9 +1234,6 @@ impl Default for VK_TO_WCHARS6 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VK_TO_WCHARS6 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1337,9 +1247,6 @@ impl Default for VK_TO_WCHARS7 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VK_TO_WCHARS7 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VK_TO_WCHARS8 {
@@ -1351,9 +1258,6 @@ impl Default for VK_TO_WCHARS8 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VK_TO_WCHARS8 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1367,9 +1271,6 @@ impl Default for VK_TO_WCHARS9 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VK_TO_WCHARS9 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VK_TO_WCHAR_TABLE {
@@ -1381,9 +1282,6 @@ impl Default for VK_TO_WCHAR_TABLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VK_TO_WCHAR_TABLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VK_U: VIRTUAL_KEY = VIRTUAL_KEY(85u16);
 pub const VK_UP: VIRTUAL_KEY = VIRTUAL_KEY(38u16);
@@ -1401,9 +1299,6 @@ impl Default for VK_VSC {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VK_VSC {
-    type TypeKind = windows_core::CopyType;
 }
 pub const VK_W: VIRTUAL_KEY = VIRTUAL_KEY(87u16);
 pub const VK_X: VIRTUAL_KEY = VIRTUAL_KEY(88u16);
@@ -1424,9 +1319,6 @@ impl Default for VSC_LPWSTR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for VSC_LPWSTR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct VSC_VK {
@@ -1437,9 +1329,6 @@ impl Default for VSC_VK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VSC_VK {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WCH_DEAD: u32 = 61441u32;
 pub const WCH_LGTR: u32 = 61442u32;

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Pointer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Pointer/mod.rs
@@ -174,9 +174,6 @@ impl Default for INPUT_INJECTION_VALUE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INPUT_INJECTION_VALUE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct INPUT_TRANSFORM {
@@ -186,9 +183,6 @@ impl Default for INPUT_TRANSFORM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INPUT_TRANSFORM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -200,9 +194,6 @@ impl Default for INPUT_TRANSFORM_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INPUT_TRANSFORM_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -228,9 +219,6 @@ impl Default for INPUT_TRANSFORM_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INPUT_TRANSFORM_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -328,10 +316,6 @@ impl Default for POINTER_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for POINTER_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -350,10 +334,6 @@ impl Default for POINTER_PEN_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for POINTER_PEN_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -371,10 +351,6 @@ impl Default for POINTER_TOUCH_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for POINTER_TOUCH_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TOUCH_FEEDBACK_DEFAULT: TOUCH_FEEDBACK_MODE = TOUCH_FEEDBACK_MODE(1u32);
 pub const TOUCH_FEEDBACK_INDIRECT: TOUCH_FEEDBACK_MODE = TOUCH_FEEDBACK_MODE(2u32);

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
@@ -60,9 +60,6 @@ impl Default for GESTURECONFIG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GESTURECONFIG {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct GESTURECONFIG_ID(pub u32);
@@ -117,9 +114,6 @@ impl Default for GESTUREINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GESTUREINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GESTURENOTIFYSTRUCT {
@@ -133,9 +127,6 @@ impl Default for GESTURENOTIFYSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GESTURENOTIFYSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GID_BEGIN: GESTURECONFIG_ID = GESTURECONFIG_ID(1u32);
 pub const GID_END: GESTURECONFIG_ID = GESTURECONFIG_ID(2u32);
@@ -1277,9 +1268,6 @@ impl Default for TOUCHINPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOUCHINPUT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TOUCHINPUTMASKF_CONTACTAREA: TOUCHINPUTMASKF_MASK = TOUCHINPUTMASKF_MASK(4u32);
 pub const TOUCHINPUTMASKF_EXTRAINFO: TOUCHINPUTMASKF_MASK = TOUCHINPUTMASKF_MASK(2u32);

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/XboxController/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/XboxController/mod.rs
@@ -99,9 +99,6 @@ impl Default for XINPUT_BATTERY_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XINPUT_BATTERY_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XINPUT_CAPABILITIES {
@@ -115,9 +112,6 @@ impl Default for XINPUT_CAPABILITIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XINPUT_CAPABILITIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -235,9 +229,6 @@ impl Default for XINPUT_GAMEPAD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XINPUT_GAMEPAD {
-    type TypeKind = windows_core::CopyType;
-}
 pub const XINPUT_GAMEPAD_A: XINPUT_GAMEPAD_BUTTON_FLAGS = XINPUT_GAMEPAD_BUTTON_FLAGS(4096u16);
 pub const XINPUT_GAMEPAD_B: XINPUT_GAMEPAD_BUTTON_FLAGS = XINPUT_GAMEPAD_BUTTON_FLAGS(8192u16);
 pub const XINPUT_GAMEPAD_BACK: XINPUT_GAMEPAD_BUTTON_FLAGS = XINPUT_GAMEPAD_BUTTON_FLAGS(32u16);
@@ -305,9 +296,6 @@ impl Default for XINPUT_KEYSTROKE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XINPUT_KEYSTROKE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct XINPUT_KEYSTROKE_FLAGS(pub u16);
@@ -358,9 +346,6 @@ impl Default for XINPUT_STATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for XINPUT_STATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct XINPUT_VIBRATION {
@@ -371,9 +356,6 @@ impl Default for XINPUT_VIBRATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for XINPUT_VIBRATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/mod.rs
@@ -105,9 +105,6 @@ impl Default for INPUT_MESSAGE_SOURCE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INPUT_MESSAGE_SOURCE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MOUSE_ATTRIBUTES_CHANGED: MOUSE_STATE = MOUSE_STATE(4u16);
 pub const MOUSE_MOVE_ABSOLUTE: MOUSE_STATE = MOUSE_STATE(1u16);
 pub const MOUSE_MOVE_NOCOALESCE: MOUSE_STATE = MOUSE_STATE(8u16);
@@ -128,9 +125,6 @@ impl Default for RAWHID {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAWHID {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RAWINPUT {
@@ -141,9 +135,6 @@ impl Default for RAWINPUT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAWINPUT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -156,9 +147,6 @@ impl Default for RAWINPUT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAWINPUT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -173,9 +161,6 @@ impl Default for RAWINPUTDEVICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAWINPUTDEVICE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RAWINPUTDEVICELIST {
@@ -186,9 +171,6 @@ impl Default for RAWINPUTDEVICELIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAWINPUTDEVICELIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -239,9 +221,6 @@ impl Default for RAWINPUTHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAWINPUTHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RAWKEYBOARD {
@@ -256,9 +235,6 @@ impl Default for RAWKEYBOARD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAWKEYBOARD {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -275,9 +251,6 @@ impl Default for RAWMOUSE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAWMOUSE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RAWMOUSE_0 {
@@ -289,9 +262,6 @@ impl Default for RAWMOUSE_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RAWMOUSE_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RAWMOUSE_0_0 {
@@ -302,9 +272,6 @@ impl Default for RAWMOUSE_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RAWMOUSE_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -337,9 +304,6 @@ impl Default for RID_DEVICE_INFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RID_DEVICE_INFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union RID_DEVICE_INFO_0 {
@@ -351,9 +315,6 @@ impl Default for RID_DEVICE_INFO_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RID_DEVICE_INFO_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -368,9 +329,6 @@ impl Default for RID_DEVICE_INFO_HID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RID_DEVICE_INFO_HID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -387,9 +345,6 @@ impl Default for RID_DEVICE_INFO_KEYBOARD {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RID_DEVICE_INFO_KEYBOARD {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RID_DEVICE_INFO_MOUSE {
@@ -402,9 +357,6 @@ impl Default for RID_DEVICE_INFO_MOUSE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RID_DEVICE_INFO_MOUSE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/UI/InteractionContext/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/InteractionContext/mod.rs
@@ -214,9 +214,6 @@ impl Default for CROSS_SLIDE_PARAMETER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CROSS_SLIDE_PARAMETER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CROSS_SLIDE_THRESHOLD(pub i32);
@@ -279,9 +276,6 @@ impl Default for INTERACTION_ARGUMENTS_CROSS_SLIDE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERACTION_ARGUMENTS_CROSS_SLIDE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERACTION_ARGUMENTS_MANIPULATION {
@@ -295,9 +289,6 @@ impl Default for INTERACTION_ARGUMENTS_MANIPULATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERACTION_ARGUMENTS_MANIPULATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct INTERACTION_ARGUMENTS_TAP {
@@ -307,9 +298,6 @@ impl Default for INTERACTION_ARGUMENTS_TAP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for INTERACTION_ARGUMENTS_TAP {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -386,9 +374,6 @@ impl Default for INTERACTION_CONTEXT_CONFIGURATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INTERACTION_CONTEXT_CONFIGURATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -406,10 +391,6 @@ impl Default for INTERACTION_CONTEXT_OUTPUT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for INTERACTION_CONTEXT_OUTPUT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -423,10 +404,6 @@ impl Default for INTERACTION_CONTEXT_OUTPUT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for INTERACTION_CONTEXT_OUTPUT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -447,10 +424,6 @@ impl Default for INTERACTION_CONTEXT_OUTPUT2 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for INTERACTION_CONTEXT_OUTPUT2 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -464,10 +437,6 @@ impl Default for INTERACTION_CONTEXT_OUTPUT2_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for INTERACTION_CONTEXT_OUTPUT2_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 pub type INTERACTION_CONTEXT_OUTPUT_CALLBACK = Option<unsafe extern "system" fn(clientdata: *const core::ffi::c_void, output: *const INTERACTION_CONTEXT_OUTPUT)>;
@@ -561,9 +530,6 @@ impl Default for MANIPULATION_TRANSFORM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MANIPULATION_TRANSFORM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MANIPULATION_VELOCITY {
@@ -576,9 +542,6 @@ impl Default for MANIPULATION_VELOCITY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MANIPULATION_VELOCITY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/UI/Magnification/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Magnification/mod.rs
@@ -111,9 +111,6 @@ impl Default for MAGCOLOREFFECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MAGCOLOREFFECT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MAGIMAGEHEADER {
@@ -129,9 +126,6 @@ impl Default for MAGIMAGEHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MAGIMAGEHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MAGTRANSFORM {
@@ -141,9 +135,6 @@ impl Default for MAGTRANSFORM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MAGTRANSFORM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MS_CLIPAROUNDCURSOR: i32 = 2i32;
 pub const MS_INVERTCOLORS: i32 = 4i32;

--- a/crates/libs/windows/src/Windows/Win32/UI/Notifications/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Notifications/mod.rs
@@ -41,6 +41,3 @@ impl Default for NOTIFICATION_USER_INPUT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NOTIFICATION_USER_INPUT_DATA {
-    type TypeKind = windows_core::CopyType;
-}

--- a/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
@@ -750,9 +750,6 @@ impl Default for UI_EVENTPARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for UI_EVENTPARAMS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union UI_EVENTPARAMS_0 {
@@ -763,9 +760,6 @@ impl Default for UI_EVENTPARAMS_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UI_EVENTPARAMS_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -781,9 +775,6 @@ impl Default for UI_EVENTPARAMS_COMMAND {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for UI_EVENTPARAMS_COMMAND {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/mod.rs
@@ -9,9 +9,6 @@ impl Default for COMDLG_FILTERSPEC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for COMDLG_FILTERSPEC {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DEVICE_SCALE_FACTOR(pub i32);
@@ -147,9 +144,6 @@ impl Default for ITEMIDLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ITEMIDLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PERCEIVED(pub i32);
@@ -227,9 +221,6 @@ impl Default for SHELLDETAILS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHELLDETAILS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct SHITEMID {
@@ -240,9 +231,6 @@ impl Default for SHITEMID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHITEMID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -255,9 +243,6 @@ impl Default for STRRET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STRRET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union STRRET_0 {
@@ -269,9 +254,6 @@ impl Default for STRRET_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STRRET_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STRRET_CSTR: STRRET_TYPE = STRRET_TYPE(2i32);
 pub const STRRET_OFFSET: STRRET_TYPE = STRRET_TYPE(1i32);

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
@@ -3255,9 +3255,6 @@ impl Default for PROPPRG {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROPPRG {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PSC_DIRTY: PSC_STATE = PSC_STATE(2i32);
 pub const PSC_NORMAL: PSC_STATE = PSC_STATE(0i32);
 pub const PSC_NOTINSOURCE: PSC_STATE = PSC_STATE(1i32);

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
@@ -5350,9 +5350,6 @@ impl Default for AASHELLMENUFILENAME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AASHELLMENUFILENAME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AASHELLMENUITEM {
@@ -5366,9 +5363,6 @@ impl Default for AASHELLMENUITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AASHELLMENUITEM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ABE_BOTTOM: u32 = 3u32;
 pub const ABE_LEFT: u32 = 0u32;
@@ -5609,10 +5603,6 @@ impl Default for APPBARDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for APPBARDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5630,10 +5620,6 @@ impl Default for APPBARDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for APPBARDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct APPCATEGORYINFO {
@@ -5646,9 +5632,6 @@ impl Default for APPCATEGORYINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for APPCATEGORYINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct APPCATEGORYINFOLIST {
@@ -5659,9 +5642,6 @@ impl Default for APPCATEGORYINFOLIST {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APPCATEGORYINFOLIST {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5694,9 +5674,6 @@ impl Default for APPINFODATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for APPINFODATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5838,11 +5815,6 @@ impl Default for ASSOCIATIONELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for ASSOCIATIONELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Registry")]
@@ -5858,11 +5830,6 @@ impl Default for ASSOCIATIONELEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for ASSOCIATIONELEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5980,9 +5947,6 @@ impl Default for AUTO_SCROLL_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for AUTO_SCROLL_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const AVMW_320: APPLICATION_VIEW_MIN_WIDTH = APPLICATION_VIEW_MIN_WIDTH(1i32);
 pub const AVMW_500: APPLICATION_VIEW_MIN_WIDTH = APPLICATION_VIEW_MIN_WIDTH(2i32);
 pub const AVMW_DEFAULT: APPLICATION_VIEW_MIN_WIDTH = APPLICATION_VIEW_MIN_WIDTH(0i32);
@@ -6033,10 +5997,6 @@ impl Default for BANDINFOSFB {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl windows_core::TypeKind for BANDINFOSFB {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BANDSITECID(pub i32);
@@ -6052,9 +6012,6 @@ impl Default for BANDSITEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for BANDSITEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct BANNER_NOTIFICATION {
@@ -6066,9 +6023,6 @@ impl Default for BANNER_NOTIFICATION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for BANNER_NOTIFICATION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6111,10 +6065,6 @@ impl Default for BASEBROWSERDATALH {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
-impl windows_core::TypeKind for BASEBROWSERDATALH {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -6151,10 +6101,6 @@ impl Default for BASEBROWSERDATAXP {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
-impl windows_core::TypeKind for BASEBROWSERDATAXP {
-    type TypeKind = windows_core::CloneType;
 }
 pub type BFFCALLBACK = Option<unsafe extern "system" fn(hwnd: super::super::Foundation::HWND, umsg: u32, lparam: super::super::Foundation::LPARAM, lpdata: super::super::Foundation::LPARAM) -> i32>;
 pub const BFFM_ENABLEOK: u32 = 1125u32;
@@ -6260,10 +6206,6 @@ impl Default for BROWSEINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl windows_core::TypeKind for BROWSEINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6282,10 +6224,6 @@ impl Default for BROWSEINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl windows_core::TypeKind for BROWSEINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const BSF_CANMAXIMIZE: u32 = 1024u32;
 pub const BSF_DELEGATEDNAVIGATION: u32 = 65536u32;
@@ -6339,9 +6277,6 @@ impl Default for CABINETSTATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CABINETSTATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CABINETSTATE_VERSION: u32 = 2u32;
 pub const CAMERAROLL_E_NO_DOWNSAMPLING_REQUIRED: windows_core::HRESULT = windows_core::HRESULT(0x80270120_u32 as _);
 #[repr(transparent)]
@@ -6390,9 +6325,6 @@ impl Default for CATEGORY_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CATEGORY_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CATID_BrowsableShellExt: windows_core::GUID = windows_core::GUID::from_u128(0x00021490_0000_0000_c000_000000000046);
 pub const CATID_BrowseInPlace: windows_core::GUID = windows_core::GUID::from_u128(0x00021491_0000_0000_c000_000000000046);
@@ -6566,9 +6498,6 @@ impl Default for CIDA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CIDA {
-    type TypeKind = windows_core::CopyType;
-}
 #[cfg(feature = "Win32_System_Com")]
 windows_core::imp::define_interface!(CIE4ConnectionPoint, CIE4ConnectionPoint_Vtbl, 0);
 #[cfg(feature = "Win32_System_Com")]
@@ -6729,9 +6658,6 @@ impl Default for CMINVOKECOMMANDINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMINVOKECOMMANDINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CMINVOKECOMMANDINFOEX {
@@ -6755,9 +6681,6 @@ impl Default for CMINVOKECOMMANDINFOEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CMINVOKECOMMANDINFOEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -6784,9 +6707,6 @@ impl Default for CMINVOKECOMMANDINFOEX_REMOTE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CMINVOKECOMMANDINFOEX_REMOTE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CM_COLUMNINFO {
@@ -6802,9 +6722,6 @@ impl Default for CM_COLUMNINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CM_COLUMNINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CM_ENUM_ALL: CM_ENUM_FLAGS = CM_ENUM_FLAGS(1i32);
 #[repr(transparent)]
@@ -6970,9 +6887,6 @@ impl Default for CONFIRM_CONFLICT_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CONFIRM_CONFLICT_ITEM {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CONFIRM_CONFLICT_RESULT_INFO {
@@ -6983,9 +6897,6 @@ impl Default for CONFIRM_CONFLICT_RESULT_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CONFIRM_CONFLICT_RESULT_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONFLICT_RESOLUTION_CLSID_KEY: windows_core::PCWSTR = windows_core::w!("ConflictResolutionCLSID");
 pub const COPYENGINE_E_ACCESSDENIED_READONLY: windows_core::HRESULT = windows_core::HRESULT(0x8027003F_u32 as _);
@@ -7130,9 +7041,6 @@ impl Default for CPLINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CPLINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const CPLPAGE_DISPLAY_BACKGROUND: u32 = 1u32;
 pub const CPLPAGE_KEYBOARD_SPEED: u32 = 1u32;
 pub const CPLPAGE_MOUSE_BUTTONS: u32 = 1u32;
@@ -7253,9 +7161,6 @@ impl Default for CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREDENTIAL_PROVIDER_CREDENTIAL_SERIALIZATION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CREDENTIAL_PROVIDER_FIELD_DESCRIPTOR {
@@ -7268,9 +7173,6 @@ impl Default for CREDENTIAL_PROVIDER_FIELD_DESCRIPTOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREDENTIAL_PROVIDER_FIELD_DESCRIPTOR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7311,10 +7213,6 @@ impl Default for CSFV {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
-impl windows_core::TypeKind for CSFV {
-    type TypeKind = windows_core::CloneType;
 }
 pub const CSIDL_ADMINTOOLS: u32 = 48u32;
 pub const CSIDL_ALTSTARTUP: u32 = 29u32;
@@ -7410,9 +7308,6 @@ impl Default for DATABLOCK_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DATABLOCK_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7554,10 +7449,6 @@ impl Default for DEFCONTEXTMENU {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common"))]
-impl windows_core::TypeKind for DEFCONTEXTMENU {
-    type TypeKind = windows_core::CloneType;
-}
 pub const DEFSHAREID_PUBLIC: DEF_SHARE_ID = DEF_SHARE_ID(2i32);
 pub const DEFSHAREID_USERS: DEF_SHARE_ID = DEF_SHARE_ID(1i32);
 #[repr(transparent)]
@@ -7575,9 +7466,6 @@ impl Default for DELEGATEITEMID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DELEGATEITEMID {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7598,9 +7486,6 @@ impl Default for DESKBANDINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DESKBANDINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7696,10 +7581,6 @@ impl Default for DETAILSINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl windows_core::TypeKind for DETAILSINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const DEVICE_IMMERSIVE: DISPLAY_DEVICE_TYPE = DISPLAY_DEVICE_TYPE(1i32);
 pub const DEVICE_PRIMARY: DISPLAY_DEVICE_TYPE = DISPLAY_DEVICE_TYPE(0i32);
 #[cfg(feature = "Win32_System_Com")]
@@ -7786,9 +7667,6 @@ impl Default for DFMICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DFMICS {
-    type TypeKind = windows_core::CloneType;
 }
 pub const DFMR_DEFAULT: DEFAULT_FOLDER_MENU_RESTRICTIONS = DEFAULT_FOLDER_MENU_RESTRICTIONS(0i32);
 pub const DFMR_NO_ASYNC_VERBS: DEFAULT_FOLDER_MENU_RESTRICTIONS = DEFAULT_FOLDER_MENU_RESTRICTIONS(1024i32);
@@ -7895,9 +7773,6 @@ impl Default for DLLVERSIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DLLVERSIONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DLLVERSIONINFO2 {
@@ -7909,9 +7784,6 @@ impl Default for DLLVERSIONINFO2 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DLLVERSIONINFO2 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DLLVER_BUILD_MASK: u64 = 4294901760u64;
 pub const DLLVER_MAJOR_MASK: u64 = 18446462598732840960u64;
@@ -7940,10 +7812,6 @@ impl Default for DRAGINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DRAGINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7960,10 +7828,6 @@ impl Default for DRAGINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DRAGINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[derive(Clone, Copy)]
@@ -7979,10 +7843,6 @@ impl Default for DRAGINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for DRAGINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -8000,10 +7860,6 @@ impl Default for DRAGINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for DRAGINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct DROPDESCRIPTION {
@@ -8015,9 +7871,6 @@ impl Default for DROPDESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DROPDESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -8031,9 +7884,6 @@ impl Default for DROPFILES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DROPFILES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8403,9 +8253,6 @@ impl Default for EXP_DARWIN_LINK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXP_DARWIN_LINK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct EXP_PROPERTYSTORAGE {
@@ -8417,9 +8264,6 @@ impl Default for EXP_PROPERTYSTORAGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXP_PROPERTYSTORAGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EXP_PROPERTYSTORAGE_SIG: u32 = 2684354569u32;
 #[repr(C, packed(1))]
@@ -8434,9 +8278,6 @@ impl Default for EXP_SPECIAL_FOLDER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXP_SPECIAL_FOLDER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EXP_SPECIAL_FOLDER_SIG: u32 = 2684354565u32;
 pub const EXP_SZ_ICON_SIG: u32 = 2684354567u32;
@@ -8453,9 +8294,6 @@ impl Default for EXP_SZ_LINK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for EXP_SZ_LINK {
-    type TypeKind = windows_core::CopyType;
-}
 pub const EXP_SZ_LINK_SIG: u32 = 2684354561u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -8468,9 +8306,6 @@ impl Default for EXTRASEARCH {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EXTRASEARCH {
-    type TypeKind = windows_core::CopyType;
 }
 pub const E_ACTIVATIONDENIED_SHELLERROR: windows_core::HRESULT = windows_core::HRESULT(0x80270131_u32 as _);
 pub const E_ACTIVATIONDENIED_SHELLNOTREADY: windows_core::HRESULT = windows_core::HRESULT(0x80270134_u32 as _);
@@ -8601,9 +8436,6 @@ impl Default for FILEDESCRIPTORA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILEDESCRIPTORA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct FILEDESCRIPTORW {
@@ -8624,9 +8456,6 @@ impl Default for FILEDESCRIPTORW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILEDESCRIPTORW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct FILEGROUPDESCRIPTORA {
@@ -8638,9 +8467,6 @@ impl Default for FILEGROUPDESCRIPTORA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FILEGROUPDESCRIPTORA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct FILEGROUPDESCRIPTORW {
@@ -8651,9 +8477,6 @@ impl Default for FILEGROUPDESCRIPTORW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILEGROUPDESCRIPTORW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8775,9 +8598,6 @@ impl Default for FILE_ATTRIBUTES_ARRAY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FILE_ATTRIBUTES_ARRAY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -9072,9 +8892,6 @@ impl Default for FOLDERSETDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FOLDERSETDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FOLDERSETTINGS {
@@ -9085,9 +8902,6 @@ impl Default for FOLDERSETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FOLDERSETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FOLDERTYPEID_AccountPictures: windows_core::GUID = windows_core::GUID::from_u128(0xdb2a5d8f_06e6_4007_aba6_af877d526ea6);
 pub const FOLDERTYPEID_Communications: windows_core::GUID = windows_core::GUID::from_u128(0x91475fe5_586b_4eba_8d75_d17434b8cdf6);
@@ -10610,9 +10424,6 @@ impl Default for HELPINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HELPINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HELPINFO_MENUITEM: HELP_INFO_TYPE = HELP_INFO_TYPE(2i32);
 pub const HELPINFO_WINDOW: HELP_INFO_TYPE = HELP_INFO_TYPE(1i32);
 #[repr(C)]
@@ -10631,9 +10442,6 @@ impl Default for HELPWININFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HELPWININFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HELPWININFOW {
@@ -10649,9 +10457,6 @@ impl Default for HELPWININFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HELPWININFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10717,9 +10522,6 @@ impl Default for HLBWINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HLBWINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -10805,9 +10607,6 @@ impl Default for HLITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HLITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct HLNF(pub u32);
@@ -10887,9 +10686,6 @@ impl Default for HLTBINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HLTBINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const HLTB_DOCKEDBOTTOM: HLTB_INFO = HLTB_INFO(3i32);
 pub const HLTB_DOCKEDLEFT: HLTB_INFO = HLTB_INFO(0i32);
@@ -42668,9 +42464,6 @@ impl Default for ITEMSPACING {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ITEMSPACING {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ITSAT_DEFAULT_PRIORITY: u32 = 268435456u32;
 pub const ITSAT_MAX_PRIORITY: u32 = 2147483647u32;
 pub const ITSAT_MIN_PRIORITY: u32 = 0u32;
@@ -46672,9 +46465,6 @@ impl Default for KNOWNFOLDER_DEFINITION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for KNOWNFOLDER_DEFINITION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct KNOWN_FOLDER_FLAG(pub i32);
@@ -46944,9 +46734,6 @@ impl Default for MULTIKEYHELPA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MULTIKEYHELPA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MULTIKEYHELPW {
@@ -46958,9 +46745,6 @@ impl Default for MULTIKEYHELPW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MULTIKEYHELPW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MUS_COMPLETE: MERGE_UPDATE_STATUS = MERGE_UPDATE_STATUS(0i32);
 pub const MUS_FAILED: MERGE_UPDATE_STATUS = MERGE_UPDATE_STATUS(2i32);
@@ -47024,10 +46808,6 @@ impl Default for NC_ADDRESS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_NetworkManagement_IpHelper", feature = "Win32_Networking_WinSock"))]
-impl windows_core::TypeKind for NC_ADDRESS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NDO_LANDSCAPE: NATIVE_DISPLAY_ORIENTATION = NATIVE_DISPLAY_ORIENTATION(0i32);
 pub const NDO_PORTRAIT: NATIVE_DISPLAY_ORIENTATION = NATIVE_DISPLAY_ORIENTATION(1i32);
 pub const NETCACHE_E_NEGATIVE_CACHE: windows_core::HRESULT = windows_core::HRESULT(0x80270100_u32 as _);
@@ -47050,10 +46830,6 @@ impl Default for NEWCPLINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for NEWCPLINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 #[derive(Clone, Copy)]
@@ -47072,10 +46848,6 @@ impl Default for NEWCPLINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for NEWCPLINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NIF_GUID: NOTIFY_ICON_DATA_FLAGS = NOTIFY_ICON_DATA_FLAGS(32u32);
 pub const NIF_ICON: NOTIFY_ICON_DATA_FLAGS = NOTIFY_ICON_DATA_FLAGS(2u32);
@@ -47142,11 +46914,6 @@ impl Default for NOTIFYICONDATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for NOTIFYICONDATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -47161,11 +46928,6 @@ impl Default for NOTIFYICONDATAA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for NOTIFYICONDATAA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -47195,11 +46957,6 @@ impl Default for NOTIFYICONDATAA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for NOTIFYICONDATAA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -47215,11 +46972,6 @@ impl Default for NOTIFYICONDATAA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for NOTIFYICONDATAA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -47248,11 +47000,6 @@ impl Default for NOTIFYICONDATAW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for NOTIFYICONDATAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -47267,11 +47014,6 @@ impl Default for NOTIFYICONDATAW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for NOTIFYICONDATAW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -47301,11 +47043,6 @@ impl Default for NOTIFYICONDATAW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for NOTIFYICONDATAW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -47320,11 +47057,6 @@ impl Default for NOTIFYICONDATAW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for NOTIFYICONDATAW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -47340,10 +47072,6 @@ impl Default for NOTIFYICONIDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for NOTIFYICONIDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -47359,10 +47087,6 @@ impl Default for NOTIFYICONIDENTIFIER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for NOTIFYICONIDENTIFIER {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NOTIFYICON_VERSION: u32 = 3u32;
 pub const NOTIFYICON_VERSION_4: u32 = 4u32;
@@ -47491,10 +47215,6 @@ impl Default for NRESARRAY {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_NetworkManagement_WNet")]
-impl windows_core::TypeKind for NRESARRAY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Controls")]
 #[derive(Clone, Debug, PartialEq)]
@@ -47513,10 +47233,6 @@ impl Default for NSTCCUSTOMDRAW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Controls")]
-impl windows_core::TypeKind for NSTCCUSTOMDRAW {
-    type TypeKind = windows_core::CloneType;
 }
 pub const NSTCDHPOS_ONTOP: i32 = -1i32;
 pub const NSTCECT_BUTTON: _NSTCECLICKTYPE = _NSTCECLICKTYPE(3i32);
@@ -47714,10 +47430,6 @@ impl Default for NT_CONSOLE_PROPS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Console")]
-impl windows_core::TypeKind for NT_CONSOLE_PROPS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const NT_CONSOLE_PROPS_SIG: u32 = 2684354562u32;
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -47729,9 +47441,6 @@ impl Default for NT_FE_CONSOLE_PROPS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NT_FE_CONSOLE_PROPS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NT_FE_CONSOLE_PROPS_SIG: u32 = 2684354564u32;
 pub const NUM_POINTS: u32 = 3u32;
@@ -47826,9 +47535,6 @@ impl Default for OPENASINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for OPENASINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const OPENPROPS_INHIBITPIF: u32 = 32768u32;
 pub const OPENPROPS_NONE: u32 = 0u32;
 #[repr(transparent)]
@@ -47883,10 +47589,6 @@ impl Default for OPEN_PRINTER_PROPS_INFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OPEN_PRINTER_PROPS_INFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -47902,10 +47604,6 @@ impl Default for OPEN_PRINTER_PROPS_INFOA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OPEN_PRINTER_PROPS_INFOA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -47923,10 +47621,6 @@ impl Default for OPEN_PRINTER_PROPS_INFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for OPEN_PRINTER_PROPS_INFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -47942,10 +47636,6 @@ impl Default for OPEN_PRINTER_PROPS_INFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for OPEN_PRINTER_PROPS_INFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const OPPROGDLG_ALLOWUNDO: _OPPROGDLGF = _OPPROGDLGF(256i32);
 pub const OPPROGDLG_DEFAULT: _OPPROGDLGF = _OPPROGDLGF(0i32);
@@ -48044,9 +47734,6 @@ impl Default for PARSEDURLA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PARSEDURLA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PARSEDURLW {
@@ -48061,9 +47748,6 @@ impl Default for PARSEDURLW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PARSEDURLW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PATHCCH_ALLOW_LONG_PATHS: PATHCCH_OPTIONS = PATHCCH_OPTIONS(1u32);
 pub const PATHCCH_CANONICALIZE_SLASHES: PATHCCH_OPTIONS = PATHCCH_OPTIONS(64u32);
@@ -48175,10 +47859,6 @@ impl Default for PERSIST_FOLDER_TARGET_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl windows_core::TypeKind for PERSIST_FOLDER_TARGET_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PES_RUNNING: PACKAGE_EXECUTION_STATE = PACKAGE_EXECUTION_STATE(1i32);
 pub const PES_SUSPENDED: PACKAGE_EXECUTION_STATE = PACKAGE_EXECUTION_STATE(3i32);
@@ -48372,10 +48052,6 @@ impl Default for PREVIEWHANDLERFRAMEINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for PREVIEWHANDLERFRAMEINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const PRF_DONTFINDLNK: PRF_FLAGS = PRF_FLAGS(8i32);
 pub const PRF_FIRSTDIRDEF: PRF_FLAGS = PRF_FLAGS(4i32);
 #[repr(transparent)]
@@ -48443,9 +48119,6 @@ impl Default for PROFILEINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PROFILEINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PROFILEINFOW {
@@ -48462,9 +48135,6 @@ impl Default for PROFILEINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROFILEINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const PROGDLG_AUTOTIME: u32 = 2u32;
 pub const PROGDLG_MARQUEEPROGRESS: u32 = 32u32;
@@ -48513,9 +48183,6 @@ impl Default for PUBAPPINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PUBAPPINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PUBAPPINFOFLAGS(pub i32);
@@ -48542,10 +48209,6 @@ impl Default for QCMINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for QCMINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QCMINFO_IDMAP {
@@ -48557,9 +48220,6 @@ impl Default for QCMINFO_IDMAP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for QCMINFO_IDMAP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct QCMINFO_IDMAP_PLACEMENT {
@@ -48570,9 +48230,6 @@ impl Default for QCMINFO_IDMAP_PLACEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QCMINFO_IDMAP_PLACEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const QCMINFO_PLACE_AFTER: u32 = 1u32;
 pub const QCMINFO_PLACE_BEFORE: u32 = 0u32;
@@ -48588,9 +48245,6 @@ impl Default for QITAB {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for QITAB {
-    type TypeKind = windows_core::CopyType;
 }
 pub const QITIPF_DEFAULT: QITIPF_FLAGS = QITIPF_FLAGS(0i32);
 #[repr(transparent)]
@@ -48997,9 +48651,6 @@ impl Default for SFVM_HELPTOPIC_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SFVM_HELPTOPIC_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SFVM_INITMENUPOPUP: SFVM_MESSAGE_ID = SFVM_MESSAGE_ID(7i32);
 pub const SFVM_INVOKECOMMAND: SFVM_MESSAGE_ID = SFVM_MESSAGE_ID(2i32);
 pub const SFVM_MERGEMENU: SFVM_MESSAGE_ID = SFVM_MESSAGE_ID(1i32);
@@ -49019,10 +48670,6 @@ impl Default for SFVM_PROPPAGE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Controls")]
-impl windows_core::TypeKind for SFVM_PROPPAGE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SFVM_QUERYFSNOTIFY: SFVM_MESSAGE_ID = SFVM_MESSAGE_ID(25i32);
 pub const SFVM_REARRANGE: u32 = 1u32;
@@ -49067,10 +48714,6 @@ impl Default for SFV_CREATE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Ole")]
-impl windows_core::TypeKind for SFV_CREATE {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -49083,10 +48726,6 @@ impl Default for SFV_SETITEMPOS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl windows_core::TypeKind for SFV_SETITEMPOS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHACF_AUTOAPPEND_FORCE_OFF: SHELL_AUTOCOMPLETE_FLAGS = SHELL_AUTOCOMPLETE_FLAGS(2147483648u32);
 pub const SHACF_AUTOAPPEND_FORCE_ON: SHELL_AUTOCOMPLETE_FLAGS = SHELL_AUTOCOMPLETE_FLAGS(1073741824u32);
@@ -49114,9 +48753,6 @@ impl Default for SHARDAPPIDINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHARDAPPIDINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 #[derive(Clone, Copy)]
@@ -49130,10 +48766,6 @@ impl Default for SHARDAPPIDINFOIDLIST {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl windows_core::TypeKind for SHARDAPPIDINFOIDLIST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 pub struct SHARDAPPIDINFOLINK {
     pub psl: core::mem::ManuallyDrop<Option<IShellLinkA>>,
@@ -49143,9 +48775,6 @@ impl Default for SHARDAPPIDINFOLINK {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHARDAPPIDINFOLINK {
-    type TypeKind = windows_core::CloneType;
 }
 pub const SHARD_APPIDINFO: SHARD = SHARD(4i32);
 pub const SHARD_APPIDINFOIDLIST: SHARD = SHARD(5i32);
@@ -49336,9 +48965,6 @@ impl Default for SHCOLUMNDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHCOLUMNDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_System_Variant")]
 #[derive(Clone, Copy)]
@@ -49357,10 +48983,6 @@ impl Default for SHCOLUMNINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Variant")]
-impl windows_core::TypeKind for SHCOLUMNINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SHCOLUMNINIT {
@@ -49372,9 +48994,6 @@ impl Default for SHCOLUMNINIT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHCOLUMNINIT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHCONTF_CHECKING_FOR_CHILDREN: _SHCONTF = _SHCONTF(16i32);
 pub const SHCONTF_ENABLE_ASYNC: _SHCONTF = _SHCONTF(32768i32);
@@ -49415,11 +49034,6 @@ impl Default for SHCREATEPROCESSINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(all(feature = "Win32_Security", feature = "Win32_System_Threading"))]
-impl windows_core::TypeKind for SHCREATEPROCESSINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Security", feature = "Win32_System_Threading"))]
@@ -49446,11 +49060,6 @@ impl Default for SHCREATEPROCESSINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(all(feature = "Win32_Security", feature = "Win32_System_Threading"))]
-impl windows_core::TypeKind for SHCREATEPROCESSINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SHC_E_SHELL_COMPONENT_STARTUP_FAILURE: windows_core::HRESULT = windows_core::HRESULT(0x80270234_u32 as _);
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -49465,9 +49074,6 @@ impl Default for SHChangeDWORDAsIDList {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHChangeDWORDAsIDList {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 #[derive(Clone, Copy)]
@@ -49481,10 +49087,6 @@ impl Default for SHChangeNotifyEntry {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl windows_core::TypeKind for SHChangeNotifyEntry {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
 pub struct SHChangeProductKeyAsIDList {
@@ -49496,9 +49098,6 @@ impl Default for SHChangeProductKeyAsIDList {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHChangeProductKeyAsIDList {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -49516,9 +49115,6 @@ impl Default for SHChangeUpdateImageIDList {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SHChangeUpdateImageIDList {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SHDESCRIPTIONID {
@@ -49529,9 +49125,6 @@ impl Default for SHDESCRIPTIONID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHDESCRIPTIONID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHDID_COMPUTER_AUDIO: SHDID_ID = SHDID_ID(19i32);
 pub const SHDID_COMPUTER_CDROM: SHDID_ID = SHDID_ID(10i32);
@@ -49573,10 +49166,6 @@ impl Default for SHDRAGIMAGE {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for SHDRAGIMAGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SHELLBROWSERSHOWCONTROL(pub i32);
@@ -49608,11 +49197,6 @@ impl Default for SHELLEXECUTEINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for SHELLEXECUTEINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Registry")]
@@ -49627,11 +49211,6 @@ impl Default for SHELLEXECUTEINFOA_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for SHELLEXECUTEINFOA_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -49661,11 +49240,6 @@ impl Default for SHELLEXECUTEINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for SHELLEXECUTEINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Registry")]
@@ -49681,11 +49255,6 @@ impl Default for SHELLEXECUTEINFOA_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for SHELLEXECUTEINFOA_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Registry")]
@@ -49714,11 +49283,6 @@ impl Default for SHELLEXECUTEINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for SHELLEXECUTEINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Registry")]
@@ -49733,11 +49297,6 @@ impl Default for SHELLEXECUTEINFOW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for SHELLEXECUTEINFOW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
@@ -49767,11 +49326,6 @@ impl Default for SHELLEXECUTEINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for SHELLEXECUTEINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_System_Registry")]
@@ -49786,11 +49340,6 @@ impl Default for SHELLEXECUTEINFOW_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_System_Registry")]
-impl windows_core::TypeKind for SHELLEXECUTEINFOW_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -49801,9 +49350,6 @@ impl Default for SHELLFLAGSTATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHELLFLAGSTATE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[derive(Clone, Copy)]
@@ -49821,9 +49367,6 @@ impl Default for SHELLSTATEA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHELLSTATEA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHELLSTATEVERSION_IE4: u32 = 9u32;
 pub const SHELLSTATEVERSION_WIN2K: u32 = 10u32;
@@ -49843,9 +49386,6 @@ impl Default for SHELLSTATEW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHELLSTATEW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -49894,9 +49434,6 @@ impl Default for SHELL_ITEM_RESOURCE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHELL_ITEM_RESOURCE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -49961,11 +49498,6 @@ impl Default for SHFILEINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for SHFILEINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -49984,11 +49516,6 @@ impl Default for SHFILEINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for SHFILEINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -50007,11 +49534,6 @@ impl Default for SHFILEINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for SHFILEINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -50029,11 +49551,6 @@ impl Default for SHFILEINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for SHFILEINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -50054,10 +49571,6 @@ impl Default for SHFILEOPSTRUCTA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SHFILEOPSTRUCTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -50076,10 +49589,6 @@ impl Default for SHFILEOPSTRUCTA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SHFILEOPSTRUCTA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -50100,10 +49609,6 @@ impl Default for SHFILEOPSTRUCTW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SHFILEOPSTRUCTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -50122,10 +49627,6 @@ impl Default for SHFILEOPSTRUCTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SHFILEOPSTRUCTW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHFMT_CANCEL: SHFMT_RET = SHFMT_RET(4294967294u32);
 pub const SHFMT_ERROR: SHFMT_RET = SHFMT_RET(4294967295u32);
@@ -50199,9 +49700,6 @@ impl Default for SHFOLDERCUSTOMSETTINGS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHFOLDERCUSTOMSETTINGS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHGDFIL_DESCRIPTIONID: SHGDFIL_FORMAT = SHGDFIL_FORMAT(3i32);
 pub const SHGDFIL_FINDDATA: SHGDFIL_FORMAT = SHGDFIL_FORMAT(1i32);
@@ -50366,10 +49864,6 @@ impl Default for SHNAMEMAPPINGA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SHNAMEMAPPINGA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -50384,10 +49878,6 @@ impl Default for SHNAMEMAPPINGA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SHNAMEMAPPINGA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C, packed(1))]
 #[cfg(target_arch = "x86")]
@@ -50404,10 +49894,6 @@ impl Default for SHNAMEMAPPINGW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SHNAMEMAPPINGW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -50422,10 +49908,6 @@ impl Default for SHNAMEMAPPINGW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SHNAMEMAPPINGW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHOP_FILEPATH: SHOP_TYPE = SHOP_TYPE(2i32);
 pub const SHOP_PRINTERNAME: SHOP_TYPE = SHOP_TYPE(1i32);
@@ -50492,10 +49974,6 @@ impl Default for SHQUERYRBINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-impl windows_core::TypeKind for SHQUERYRBINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -50509,10 +49987,6 @@ impl Default for SHQUERYRBINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-impl windows_core::TypeKind for SHQUERYRBINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHREGDEL_BOTH: SHREGDEL_FLAGS = SHREGDEL_FLAGS(17i32);
 pub const SHREGDEL_DEFAULT: SHREGDEL_FLAGS = SHREGDEL_FLAGS(0i32);
@@ -50553,11 +50027,6 @@ impl Default for SHSTOCKICONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(target_arch = "x86")]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for SHSTOCKICONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -50575,11 +50044,6 @@ impl Default for SHSTOCKICONINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(any(target_arch = "aarch64", target_arch = "arm64ec", target_arch = "x86_64"))]
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for SHSTOCKICONINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -50892,9 +50356,6 @@ impl Default for SLOWAPPINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SLOWAPPINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SLR_ANY_MATCH: SLR_FLAGS = SLR_FLAGS(2i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -50964,10 +50425,6 @@ impl Default for SMCSHCHANGENOTIFYSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl windows_core::TypeKind for SMCSHCHANGENOTIFYSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SMC_AUTOEXPANDCHANGE: u32 = 66u32;
 pub const SMC_CHEVRONEXPAND: u32 = 25u32;
 pub const SMC_CHEVRONGETTIP: u32 = 47u32;
@@ -51017,10 +50474,6 @@ impl Default for SMDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
-impl windows_core::TypeKind for SMDATA {
-    type TypeKind = windows_core::CloneType;
-}
 pub const SMDM_HMENU: u32 = 2u32;
 pub const SMDM_SHELLFOLDER: u32 = 1u32;
 pub const SMDM_TOOLBAR: u32 = 4u32;
@@ -51052,9 +50505,6 @@ impl Default for SMINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SMINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -51091,9 +50541,6 @@ impl Default for SORTCOLUMN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SORTCOLUMN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -51388,10 +50835,6 @@ impl Default for SV2CVW2_PARAMS {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_System_Ole")]
-impl windows_core::TypeKind for SV2CVW2_PARAMS {
-    type TypeKind = windows_core::CloneType;
-}
 pub const SV3CVW3_DEFAULT: _SV3CVW3_FLAGS = _SV3CVW3_FLAGS(0i32);
 pub const SV3CVW3_FORCEFOLDERFLAGS: _SV3CVW3_FLAGS = _SV3CVW3_FLAGS(4i32);
 pub const SV3CVW3_FORCEVIEWMODE: _SV3CVW3_FLAGS = _SV3CVW3_FLAGS(2i32);
@@ -51465,10 +50908,6 @@ impl Default for SYNCMGRHANDLERINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for SYNCMGRHANDLERINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SYNCMGRHANDLER_ALWAYSLISTHANDLER: SYNCMGRHANDLERFLAGS = SYNCMGRHANDLERFLAGS(4i32);
 pub const SYNCMGRHANDLER_HASPROPERTIES: SYNCMGRHANDLERFLAGS = SYNCMGRHANDLERFLAGS(1i32);
 pub const SYNCMGRHANDLER_HIDDEN: SYNCMGRHANDLERFLAGS = SYNCMGRHANDLERFLAGS(8i32);
@@ -51495,10 +50934,6 @@ impl Default for SYNCMGRITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for SYNCMGRITEM {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -51529,9 +50964,6 @@ impl Default for SYNCMGRLOGERRORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYNCMGRLOGERRORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SYNCMGRLOGERROR_ERRORFLAGS: u32 = 1u32;
 pub const SYNCMGRLOGERROR_ERRORID: u32 = 2u32;
 pub const SYNCMGRLOGERROR_ITEMID: u32 = 4u32;
@@ -51556,9 +50988,6 @@ impl Default for SYNCMGRPROGRESSITEM {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SYNCMGRPROGRESSITEM {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SYNCMGRPROGRESSITEM_MAXVALUE: u32 = 8u32;
 pub const SYNCMGRPROGRESSITEM_PROGVALUE: u32 = 4u32;
@@ -51606,10 +51035,6 @@ impl Default for SYNCMGR_CONFLICT_ID_INFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_System_Com")]
-impl windows_core::TypeKind for SYNCMGR_CONFLICT_ID_INFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -51854,9 +51279,6 @@ impl Default for TBINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TBINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TBPFLAG(pub i32);
@@ -51925,10 +51347,6 @@ impl Default for THUMBBUTTON {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_WindowsAndMessaging")]
-impl windows_core::TypeKind for THUMBBUTTON {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -52040,10 +51458,6 @@ impl Default for TOOLBARITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Ole"))]
-impl windows_core::TypeKind for TOOLBARITEM {
-    type TypeKind = windows_core::CloneType;
-}
 pub const TRANSLATEURL_FL_GUESS_PROTOCOL: TRANSLATEURL_IN_FLAGS = TRANSLATEURL_IN_FLAGS(1i32);
 pub const TRANSLATEURL_FL_USE_DEFAULT_PROTOCOL: TRANSLATEURL_IN_FLAGS = TRANSLATEURL_IN_FLAGS(2i32);
 #[repr(transparent)]
@@ -52130,9 +51544,6 @@ impl Default for URLINVOKECOMMANDINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for URLINVOKECOMMANDINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct URLINVOKECOMMANDINFOW {
@@ -52145,9 +51556,6 @@ impl Default for URLINVOKECOMMANDINFOW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for URLINVOKECOMMANDINFOW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -52362,10 +51770,6 @@ impl Default for WINDOWDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell_Common")]
-impl windows_core::TypeKind for WINDOWDATA {
-    type TypeKind = windows_core::CopyType;
-}
 pub const WM_CPL_LAUNCH: u32 = 2024u32;
 pub const WM_CPL_LAUNCHED: u32 = 2025u32;
 pub const WPSTYLE_CENTER: u32 = 0u32;
@@ -52530,9 +51934,6 @@ impl Default for WTS_THUMBNAILID {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WTS_THUMBNAILID {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WTS_WIDETHUMBNAILS: WTS_FLAGS = WTS_FLAGS(16384i32);
 pub const WebBrowser: windows_core::GUID = windows_core::GUID::from_u128(0x8856f961_340a_11d0_a96b_00c04fd705a2);

--- a/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
@@ -191,9 +191,6 @@ impl Default for CHARACTER_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHARACTER_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CONFIDENCE_LEVEL(pub i32);
@@ -770,9 +767,6 @@ impl Default for DYNAMIC_RENDERER_CACHED_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DYNAMIC_RENDERER_CACHED_DATA {
-    type TypeKind = windows_core::CloneType;
-}
 pub const DockedBottom: VisualState = VisualState(3i32);
 pub const DockedTop: VisualState = VisualState(2i32);
 pub const DynamicRenderer: windows_core::GUID = windows_core::GUID::from_u128(0xecd32aea_746f_4dcb_bf68_082757faff18);
@@ -891,9 +885,6 @@ impl Default for FLICK_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLICK_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FLICK_POINT {
@@ -903,9 +894,6 @@ impl Default for FLICK_POINT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for FLICK_POINT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const FLICK_WM_HANDLED_MASK: u32 = 1u32;
 pub const Floating: VisualState = VisualState(1i32);
@@ -949,9 +937,6 @@ impl Default for GESTURE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GESTURE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const GESTURE_DIAGONAL_LEFTDOWN: u32 = 61534u32;
 pub const GESTURE_DIAGONAL_LEFTUP: u32 = 61532u32;
@@ -1544,10 +1529,6 @@ impl Default for IEC_GESTUREINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant", feature = "Win32_UI_Controls"))]
-impl windows_core::TypeKind for IEC_GESTUREINFO {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Controls"))]
 #[derive(Clone, Debug, PartialEq)]
@@ -1560,10 +1541,6 @@ impl Default for IEC_RECOGNITIONRESULTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Controls"))]
-impl windows_core::TypeKind for IEC_RECOGNITIONRESULTINFO {
-    type TypeKind = windows_core::CloneType;
 }
 #[repr(C)]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Controls"))]
@@ -1578,10 +1555,6 @@ impl Default for IEC_STROKEINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Controls"))]
-impl windows_core::TypeKind for IEC_STROKEINFO {
-    type TypeKind = windows_core::CloneType;
 }
 pub const IEC__BASE: u32 = 1536u32;
 pub const IEF_CopyFromOriginal: InkExtractFlags = InkExtractFlags(0i32);
@@ -11377,9 +11350,6 @@ impl Default for INKMETRIC {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for INKMETRIC {
-    type TypeKind = windows_core::CopyType;
-}
 pub const INKRECOGNITIONPROPERTY_BOXNUMBER: windows_core::PCWSTR = windows_core::w!("{2C243E3A-F733-4EB6-B1F8-B5DC5C2C4CDA}");
 pub const INKRECOGNITIONPROPERTY_CONFIDENCELEVEL: windows_core::PCWSTR = windows_core::w!("{7DFE11A7-FB5D-4958-8765-154ADF0D833F}");
 pub const INKRECOGNITIONPROPERTY_HOTPOINT: windows_core::PCWSTR = windows_core::w!("{CA6F40DC-5292-452a-91FB-2181C0BEC0DE}");
@@ -13739,9 +13709,6 @@ impl Default for InkRecoGuide {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for InkRecoGuide {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct InkRecognitionAlternatesSelection(pub i32);
@@ -13805,9 +13772,6 @@ impl Default for LATTICE_METRICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for LATTICE_METRICS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const LEFT_BUTTON: MouseButton = MouseButton(1i32);
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13822,9 +13786,6 @@ impl Default for LINE_SEGMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for LINE_SEGMENT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const LM_ASCENDER: LINE_METRICS = LINE_METRICS(2i32);
 pub const LM_BASELINE: LINE_METRICS = LINE_METRICS(0i32);
@@ -13881,9 +13842,6 @@ impl Default for PACKET_DESCRIPTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for PACKET_DESCRIPTION {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PACKET_PROPERTY {
@@ -13894,9 +13852,6 @@ impl Default for PACKET_PROPERTY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PACKET_PROPERTY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13910,9 +13865,6 @@ impl Default for PROPERTY_METRICS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for PROPERTY_METRICS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -13975,9 +13927,6 @@ impl Default for RECO_ATTRS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RECO_ATTRS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RECO_GUIDE {
@@ -13996,9 +13945,6 @@ impl Default for RECO_GUIDE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RECO_GUIDE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RECO_LATTICE {
@@ -14015,9 +13961,6 @@ impl Default for RECO_LATTICE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RECO_LATTICE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RECO_LATTICE_COLUMN {
@@ -14032,9 +13975,6 @@ impl Default for RECO_LATTICE_COLUMN {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RECO_LATTICE_COLUMN {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14051,9 +13991,6 @@ impl Default for RECO_LATTICE_ELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RECO_LATTICE_ELEMENT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RECO_LATTICE_PROPERTIES {
@@ -14064,9 +14001,6 @@ impl Default for RECO_LATTICE_PROPERTIES {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RECO_LATTICE_PROPERTIES {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -14080,9 +14014,6 @@ impl Default for RECO_LATTICE_PROPERTY {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RECO_LATTICE_PROPERTY {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RECO_RANGE {
@@ -14093,9 +14024,6 @@ impl Default for RECO_RANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for RECO_RANGE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -14180,9 +14108,6 @@ impl Default for STROKE_RANGE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STROKE_RANGE {
-    type TypeKind = windows_core::CopyType;
-}
 pub const STR_GUID_ALTITUDEORIENTATION: windows_core::PCWSTR = windows_core::w!("{82DEC5C7-F6BA-4906-894F-66D68DFC456C}");
 pub const STR_GUID_AZIMUTHORIENTATION: windows_core::PCWSTR = windows_core::w!("{029123B4-8828-410B-B250-A0536595E5DC}");
 pub const STR_GUID_BUTTONPRESSURE: windows_core::PCWSTR = windows_core::w!("{8B7FEFC4-96AA-4BFE-AC26-8A5F0BE07BF5}");
@@ -14219,9 +14144,6 @@ impl Default for SYSTEM_EVENT_DATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SYSTEM_EVENT_DATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ScrollBarsConstants(pub i32);
@@ -14244,9 +14166,6 @@ impl Default for StylusInfo {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for StylusInfo {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
@@ -12725,9 +12725,6 @@ impl Default for TF_DA_COLOR {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TF_DA_COLOR {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TF_DA_COLOR_0 {
@@ -12738,9 +12735,6 @@ impl Default for TF_DA_COLOR_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TF_DA_COLOR_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -12769,9 +12763,6 @@ impl Default for TF_DISPLAYATTRIBUTE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TF_DISPLAYATTRIBUTE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TF_DTLBI_NONE: LANG_BAR_ITEM_ICON_MODE_FLAGS = LANG_BAR_ITEM_ICON_MODE_FLAGS(0u32);
 pub const TF_DTLBI_USEPROFILEICON: LANG_BAR_ITEM_ICON_MODE_FLAGS = LANG_BAR_ITEM_ICON_MODE_FLAGS(1u32);
@@ -12822,9 +12813,6 @@ impl Default for TF_HALTCOND {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TF_HALTCOND {
-    type TypeKind = windows_core::CloneType;
-}
 pub const TF_HF_OBJECT: u32 = 1u32;
 pub const TF_IAS_NOQUERY: INSERT_TEXT_AT_SELECTION_FLAGS = INSERT_TEXT_AT_SELECTION_FLAGS(1u32);
 pub const TF_IAS_NO_DEFAULT_COMPOSITION: INSERT_TEXT_AT_SELECTION_FLAGS = INSERT_TEXT_AT_SELECTION_FLAGS(2147483648u32);
@@ -12849,10 +12837,6 @@ impl Default for TF_INPUTPROCESSORPROFILE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Input_KeyboardAndMouse")]
-impl windows_core::TypeKind for TF_INPUTPROCESSORPROFILE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TF_INVALID_COOKIE: u32 = 4294967295u32;
 pub const TF_INVALID_EDIT_COOKIE: u32 = 0u32;
@@ -12887,9 +12871,6 @@ impl Default for TF_LANGBARITEMINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TF_LANGBARITEMINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TF_LANGUAGEPROFILE {
@@ -12904,9 +12885,6 @@ impl Default for TF_LANGUAGEPROFILE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TF_LANGUAGEPROFILE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct TF_LBBALLOONINFO {
@@ -12917,9 +12895,6 @@ impl Default for TF_LBBALLOONINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TF_LBBALLOONINFO {
-    type TypeKind = windows_core::CloneType;
 }
 pub const TF_LBI_BALLOON: u32 = 16u32;
 pub const TF_LBI_BITMAP: u32 = 8u32;
@@ -12973,9 +12948,6 @@ impl Default for TF_LMLATTELEMENT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TF_LMLATTELEMENT {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub union TF_LMLATTELEMENT_0 {
@@ -12985,9 +12957,6 @@ impl Default for TF_LMLATTELEMENT_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TF_LMLATTELEMENT_0 {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TF_LS_DASH: TF_DA_LINESTYLE = TF_DA_LINESTYLE(3i32);
 pub const TF_LS_DOT: TF_DA_LINESTYLE = TF_DA_LINESTYLE(2i32);
@@ -13021,9 +12990,6 @@ impl Default for TF_PERSISTENT_PROPERTY_HEADER_ACP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TF_PERSISTENT_PROPERTY_HEADER_ACP {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TF_POPF_ALL: u32 = 1u32;
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -13035,9 +13001,6 @@ impl Default for TF_PRESERVEDKEY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TF_PRESERVEDKEY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TF_PROCESS_ATOM: windows_core::PCWSTR = windows_core::w!("_CTF_PROCESS_ATOM_");
 pub const TF_PROFILETYPE_INPUTPROCESSOR: u32 = 1u32;
@@ -13074,10 +13037,6 @@ impl Default for TF_PROPERTYVAL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for TF_PROPERTYVAL {
-    type TypeKind = windows_core::CloneType;
-}
 pub const TF_PROPUI_STATUS_SAVETOFILE: u32 = 1u32;
 pub const TF_RCM_COMLESS: u32 = 1u32;
 pub const TF_RCM_HINT_COLLISION: u32 = 8u32;
@@ -13108,9 +13067,6 @@ impl Default for TF_SELECTION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TF_SELECTION {
-    type TypeKind = windows_core::CloneType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TF_SELECTIONSTYLE {
@@ -13121,9 +13077,6 @@ impl Default for TF_SELECTIONSTYLE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TF_SELECTIONSTYLE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TF_SENTENCEMODE_AUTOMATIC: u32 = 4u32;
 pub const TF_SENTENCEMODE_CONVERSATION: u32 = 16u32;
@@ -13306,10 +13259,6 @@ impl Default for TS_ATTRVAL {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_System_Variant"))]
-impl windows_core::TypeKind for TS_ATTRVAL {
-    type TypeKind = windows_core::CloneType;
-}
 pub const TS_ATTR_FIND_BACKWARDS: u32 = 1u32;
 pub const TS_ATTR_FIND_HIDDEN: u32 = 32u32;
 pub const TS_ATTR_FIND_UPDATESTART: u32 = 4u32;
@@ -13361,9 +13310,6 @@ impl Default for TS_RUNINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TS_RUNINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TS_SD_BACKWARD: TsShiftDir = TsShiftDir(0i32);
 pub const TS_SD_EMBEDDEDHANDWRITINGVIEW_ENABLED: u32 = 128u32;
 pub const TS_SD_EMBEDDEDHANDWRITINGVIEW_VISIBLE: u32 = 256u32;
@@ -13386,9 +13332,6 @@ impl Default for TS_SELECTIONSTYLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TS_SELECTIONSTYLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TS_SELECTION_ACP {
@@ -13401,9 +13344,6 @@ impl Default for TS_SELECTION_ACP {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TS_SELECTION_ACP {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct TS_SELECTION_ANCHOR {
@@ -13415,9 +13355,6 @@ impl Default for TS_SELECTION_ANCHOR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TS_SELECTION_ANCHOR {
-    type TypeKind = windows_core::CloneType;
 }
 pub const TS_SHIFT_COUNT_HIDDEN: u32 = 1u32;
 pub const TS_SHIFT_COUNT_ONLY: u32 = 8u32;
@@ -13441,9 +13378,6 @@ impl Default for TS_STATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TS_STATUS {
-    type TypeKind = windows_core::CopyType;
-}
 pub const TS_STRF_END: u32 = 2u32;
 pub const TS_STRF_MID: u32 = 1u32;
 pub const TS_STRF_START: u32 = 0u32;
@@ -13463,9 +13397,6 @@ impl Default for TS_TEXTCHANGE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TS_TEXTCHANGE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TS_VCOOKIE_NUL: u32 = 4294967295u32;
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -2575,9 +2575,6 @@ impl Default for ACCEL {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ACCEL {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ACCEL_VIRT_FLAGS(pub u8);
@@ -2632,9 +2629,6 @@ impl Default for ALTTABINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ALTTABINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct ANIMATE_WINDOW_FLAGS(pub u32);
@@ -2682,9 +2676,6 @@ impl Default for ANIMATIONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for ANIMATIONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const ARW_BOTTOMLEFT: MINIMIZEDMETRICS_ARRANGE = MINIMIZEDMETRICS_ARRANGE(0i32);
 pub const ARW_BOTTOMRIGHT: MINIMIZEDMETRICS_ARRANGE = MINIMIZEDMETRICS_ARRANGE(1i32);
 pub const ARW_DOWN: i32 = 4i32;
@@ -2709,9 +2700,6 @@ impl Default for AUDIODESCRIPTION {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for AUDIODESCRIPTION {
-    type TypeKind = windows_core::CopyType;
 }
 pub const AW_ACTIVATE: ANIMATE_WINDOW_FLAGS = ANIMATE_WINDOW_FLAGS(131072u32);
 pub const AW_BLEND: ANIMATE_WINDOW_FLAGS = ANIMATE_WINDOW_FLAGS(524288u32);
@@ -2850,9 +2838,6 @@ impl Default for CBTACTIVATESTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CBTACTIVATESTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CBT_CREATEWNDA {
@@ -2864,9 +2849,6 @@ impl Default for CBT_CREATEWNDA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CBT_CREATEWNDA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CBT_CREATEWNDW {
@@ -2877,9 +2859,6 @@ impl Default for CBT_CREATEWNDW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CBT_CREATEWNDW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CB_ADDSTRING: u32 = 323u32;
 pub const CB_DELETESTRING: u32 = 324u32;
@@ -2934,9 +2913,6 @@ impl Default for CHANGEFILTERSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CHANGEFILTERSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CHANGE_WINDOW_MESSAGE_FILTER_FLAGS(pub u32);
@@ -2951,9 +2927,6 @@ impl Default for CLIENTCREATESTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CLIENTCREATESTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CONSOLE_APPLICATION_16BIT: u32 = 0u32;
 pub const CONSOLE_CARET_SELECTION: u32 = 1u32;
@@ -2983,9 +2956,6 @@ impl Default for CREATESTRUCTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CREATESTRUCTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CREATESTRUCTW {
@@ -3006,9 +2976,6 @@ impl Default for CREATESTRUCTW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CREATESTRUCTW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CSOUND_SYSTEM: u32 = 16u32;
 pub const CS_BYTEALIGNCLIENT: WNDCLASS_STYLES = WNDCLASS_STYLES(4096u32);
@@ -3045,9 +3012,6 @@ impl Default for CURSORINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CURSORINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct CURSORINFO_FLAGS(pub u32);
@@ -3066,9 +3030,6 @@ impl Default for CURSORSHAPE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CURSORSHAPE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CURSOR_CREATION_SCALING_DEFAULT: u32 = 2u32;
 pub const CURSOR_CREATION_SCALING_NONE: u32 = 1u32;
@@ -3089,9 +3050,6 @@ impl Default for CWPRETSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for CWPRETSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct CWPSTRUCT {
@@ -3104,9 +3062,6 @@ impl Default for CWPSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for CWPSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const CWP_ALL: CWP_FLAGS = CWP_FLAGS(0u32);
 #[repr(transparent)]
@@ -3205,9 +3160,6 @@ impl Default for DEBUGHOOKINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEBUGHOOKINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_EVENT_BECOMING_READY {
@@ -3219,9 +3171,6 @@ impl Default for DEVICE_EVENT_BECOMING_READY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_EVENT_BECOMING_READY {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3237,9 +3186,6 @@ impl Default for DEVICE_EVENT_EXTERNAL_REQUEST {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEVICE_EVENT_EXTERNAL_REQUEST {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEVICE_EVENT_GENERIC_DATA {
@@ -3249,9 +3195,6 @@ impl Default for DEVICE_EVENT_GENERIC_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_EVENT_GENERIC_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3265,9 +3208,6 @@ impl Default for DEVICE_EVENT_MOUNT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_EVENT_MOUNT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3283,9 +3223,6 @@ impl Default for DEVICE_EVENT_RBC_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEVICE_EVENT_RBC_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DEVICE_NOTIFY_ALL_INTERFACE_CLASSES: REGISTER_NOTIFICATION_FLAGS = REGISTER_NOTIFICATION_FLAGS(4u32);
 pub const DEVICE_NOTIFY_CALLBACK: REGISTER_NOTIFICATION_FLAGS = REGISTER_NOTIFICATION_FLAGS(2u32);
@@ -3305,9 +3242,6 @@ impl Default for DEV_BROADCAST_DEVICEINTERFACE_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEV_BROADCAST_DEVICEINTERFACE_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEV_BROADCAST_DEVICEINTERFACE_W {
@@ -3322,9 +3256,6 @@ impl Default for DEV_BROADCAST_DEVICEINTERFACE_W {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEV_BROADCAST_DEVICEINTERFACE_W {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEV_BROADCAST_DEVNODE {
@@ -3337,9 +3268,6 @@ impl Default for DEV_BROADCAST_DEVNODE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEV_BROADCAST_DEVNODE {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3358,9 +3286,6 @@ impl Default for DEV_BROADCAST_HANDLE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEV_BROADCAST_HANDLE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEV_BROADCAST_HANDLE32 {
@@ -3377,9 +3302,6 @@ impl Default for DEV_BROADCAST_HANDLE32 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEV_BROADCAST_HANDLE32 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3398,9 +3320,6 @@ impl Default for DEV_BROADCAST_HANDLE64 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEV_BROADCAST_HANDLE64 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEV_BROADCAST_HDR {
@@ -3412,9 +3331,6 @@ impl Default for DEV_BROADCAST_HDR {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEV_BROADCAST_HDR {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -3433,9 +3349,6 @@ impl Default for DEV_BROADCAST_NET {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEV_BROADCAST_NET {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEV_BROADCAST_OEM {
@@ -3450,9 +3363,6 @@ impl Default for DEV_BROADCAST_OEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEV_BROADCAST_OEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEV_BROADCAST_PORT_A {
@@ -3466,9 +3376,6 @@ impl Default for DEV_BROADCAST_PORT_A {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEV_BROADCAST_PORT_A {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DEV_BROADCAST_PORT_W {
@@ -3481,9 +3388,6 @@ impl Default for DEV_BROADCAST_PORT_W {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DEV_BROADCAST_PORT_W {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -3499,9 +3403,6 @@ impl Default for DEV_BROADCAST_VOLUME {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DEV_BROADCAST_VOLUME {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct DEV_BROADCAST_VOLUME_FLAGS(pub u16);
@@ -3515,9 +3416,6 @@ impl Default for DISK_HEALTH_NOTIFICATION_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DISK_HEALTH_NOTIFICATION_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DI_COMPAT: DI_FLAGS = DI_FLAGS(4u32);
 pub const DI_DEFAULTSIZE: DI_FLAGS = DI_FLAGS(8u32);
@@ -3588,9 +3486,6 @@ impl Default for DLGITEMTEMPLATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for DLGITEMTEMPLATE {
-    type TypeKind = windows_core::CopyType;
-}
 pub type DLGPROC = Option<unsafe extern "system" fn(param0: super::super::Foundation::HWND, param1: u32, param2: super::super::Foundation::WPARAM, param3: super::super::Foundation::LPARAM) -> isize>;
 #[repr(C, packed(2))]
 #[derive(Clone, Copy)]
@@ -3607,9 +3502,6 @@ impl Default for DLGTEMPLATE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DLGTEMPLATE {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DLGWINDOWEXTRA: u32 = 30u32;
 pub const DM_GETDEFID: u32 = 1024u32;
@@ -3638,9 +3530,6 @@ impl Default for DROPSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for DROPSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 pub const DS_3DLOOK: i32 = 4i32;
 pub const DS_ABSALIGN: i32 = 1i32;
@@ -3716,9 +3605,6 @@ impl Default for EVENTMSG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for EVENTMSG {
-    type TypeKind = windows_core::CopyType;
 }
 pub const EVENT_AIA_END: u32 = 45055u32;
 pub const EVENT_AIA_START: u32 = 40960u32;
@@ -3837,9 +3723,6 @@ impl Default for FLASHWINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for FLASHWINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct FLASHWINFO_FLAGS(pub u32);
@@ -3933,9 +3816,6 @@ impl Default for GETCLIPBMETADATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GETCLIPBMETADATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct GET_ANCESTOR_FLAGS(pub u32);
@@ -4004,9 +3884,6 @@ impl Default for GUID_IO_DISK_CLONE_ARRIVAL_INFORMATION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for GUID_IO_DISK_CLONE_ARRIVAL_INFORMATION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const GUID_IO_DISK_HEALTH_NOTIFICATION: windows_core::GUID = windows_core::GUID::from_u128(0x0f1bd644_3916_49c5_b063_991940118fb2);
 pub const GUID_IO_DISK_LAYOUT_CHANGE: windows_core::GUID = windows_core::GUID::from_u128(0x11dff54c_8469_41f9_b3de_ef836487c54a);
 pub const GUID_IO_DRIVE_REQUIRES_CLEANING: windows_core::GUID = windows_core::GUID::from_u128(0x7207877c_90ed_44e5_a000_81428d4c79bb);
@@ -4051,9 +3928,6 @@ impl Default for GUITHREADINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for GUITHREADINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4160,9 +4034,6 @@ impl Default for HARDWAREHOOKSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for HARDWAREHOOKSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub const HBMMENU_CALLBACK: super::super::Graphics::Gdi::HBITMAP = super::super::Graphics::Gdi::HBITMAP(-1i32 as _);
@@ -4445,10 +4316,6 @@ impl Default for ICONINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICONINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4468,10 +4335,6 @@ impl Default for ICONINFOEXA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICONINFOEXA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -4493,10 +4356,6 @@ impl Default for ICONINFOEXW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICONINFOEXW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4513,10 +4372,6 @@ impl Default for ICONMETRICSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICONMETRICSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -4532,10 +4387,6 @@ impl Default for ICONMETRICSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for ICONMETRICSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const ICON_BIG: u32 = 1u32;
 pub const ICON_SMALL: u32 = 0u32;
@@ -4657,9 +4508,6 @@ impl Default for IndexedResourceQualifier {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IndexedResourceQualifier {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct KBDLLHOOKSTRUCT {
@@ -4673,9 +4521,6 @@ impl Default for KBDLLHOOKSTRUCT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for KBDLLHOOKSTRUCT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -4922,9 +4767,6 @@ impl Default for MDICREATESTRUCTA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MDICREATESTRUCTA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MDICREATESTRUCTW {
@@ -4943,9 +4785,6 @@ impl Default for MDICREATESTRUCTW {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MDICREATESTRUCTW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MDINEXTMENU {
@@ -4957,9 +4796,6 @@ impl Default for MDINEXTMENU {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MDINEXTMENU {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MDIS_ALLCHILDSTYLES: u32 = 1u32;
 pub const MDITILE_HORIZONTAL: TILE_WINDOWS_HOW = TILE_WINDOWS_HOW(1u32);
@@ -4980,9 +4816,6 @@ impl Default for MENUBARINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MENUBARINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MENUEX_TEMPLATE_HEADER {
@@ -4994,9 +4827,6 @@ impl Default for MENUEX_TEMPLATE_HEADER {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MENUEX_TEMPLATE_HEADER {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5012,9 +4842,6 @@ impl Default for MENUEX_TEMPLATE_ITEM {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MENUEX_TEMPLATE_ITEM {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MENUGETOBJECTINFO {
@@ -5028,9 +4855,6 @@ impl Default for MENUGETOBJECTINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MENUGETOBJECTINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5052,10 +4876,6 @@ impl Default for MENUINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for MENUINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5152,10 +4972,6 @@ impl Default for MENUITEMINFOA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for MENUITEMINFOA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5179,10 +4995,6 @@ impl Default for MENUITEMINFOW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for MENUITEMINFOW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MENUITEMTEMPLATE {
@@ -5195,9 +5007,6 @@ impl Default for MENUITEMTEMPLATE {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MENUITEMTEMPLATE {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MENUITEMTEMPLATEHEADER {
@@ -5209,9 +5018,6 @@ impl Default for MENUITEMTEMPLATEHEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MENUITEMTEMPLATEHEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MENUTEMPLATEEX {
@@ -5221,9 +5027,6 @@ impl Default for MENUTEMPLATEEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MENUTEMPLATEEX {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -5236,9 +5039,6 @@ impl Default for MENUTEMPLATEEX_0 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MENUTEMPLATEEX_0 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MENUTEMPLATEEX_0_1 {
@@ -5250,9 +5050,6 @@ impl Default for MENUTEMPLATEEX_0_1 {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MENUTEMPLATEEX_0_1 {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MENUTEMPLATEEX_0_0 {
@@ -5263,9 +5060,6 @@ impl Default for MENUTEMPLATEEX_0_0 {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MENUTEMPLATEEX_0_0 {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5462,9 +5256,6 @@ impl Default for MESSAGE_RESOURCE_BLOCK {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MESSAGE_RESOURCE_BLOCK {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MESSAGE_RESOURCE_DATA {
@@ -5475,9 +5266,6 @@ impl Default for MESSAGE_RESOURCE_DATA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MESSAGE_RESOURCE_DATA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5490,9 +5278,6 @@ impl Default for MESSAGE_RESOURCE_ENTRY {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MESSAGE_RESOURCE_ENTRY {
-    type TypeKind = windows_core::CopyType;
 }
 pub const METRICS_USEDEFAULT: i32 = -1i32;
 pub const MFS_CHECKED: MENU_ITEM_STATE = MENU_ITEM_STATE(8u32);
@@ -5569,9 +5354,6 @@ impl Default for MINIMIZEDMETRICS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MINIMIZEDMETRICS {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct MINIMIZEDMETRICS_ARRANGE(pub i32);
@@ -5589,9 +5371,6 @@ impl Default for MINMAXINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MINMAXINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MIN_LOGICALDPIOVERRIDE: i32 = -2i32;
 pub const MKF_AVAILABLE: u32 = 2u32;
@@ -5638,9 +5417,6 @@ impl Default for MOUSEHOOKSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MOUSEHOOKSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MOUSEHOOKSTRUCTEX {
@@ -5651,9 +5427,6 @@ impl Default for MOUSEHOOKSTRUCTEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MOUSEHOOKSTRUCTEX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MOUSEWHEEL_ROUTING_FOCUS: u32 = 0u32;
 pub const MOUSEWHEEL_ROUTING_HYBRID: u32 = 1u32;
@@ -5672,9 +5445,6 @@ impl Default for MSG {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MSG {
-    type TypeKind = windows_core::CopyType;
 }
 #[cfg(feature = "Win32_UI_Shell")]
 pub type MSGBOXCALLBACK = Option<unsafe extern "system" fn(lphelpinfo: *mut super::Shell::HELPINFO)>;
@@ -5699,10 +5469,6 @@ impl Default for MSGBOXPARAMSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_UI_Shell")]
-impl windows_core::TypeKind for MSGBOXPARAMSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_UI_Shell")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5723,10 +5489,6 @@ impl Default for MSGBOXPARAMSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_UI_Shell")]
-impl windows_core::TypeKind for MSGBOXPARAMSW {
-    type TypeKind = windows_core::CopyType;
 }
 pub const MSGFLTINFO_ALLOWED_HIGHER: MSGFLTINFO_STATUS = MSGFLTINFO_STATUS(3u32);
 pub const MSGFLTINFO_ALREADYALLOWED_FORWND: MSGFLTINFO_STATUS = MSGFLTINFO_STATUS(1u32);
@@ -5797,9 +5559,6 @@ impl Default for MSLLHOOKSTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MSLLHOOKSTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const MWMO_ALERTABLE: MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS = MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS(2u32);
 pub const MWMO_INPUTAVAILABLE: MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS = MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS(4u32);
 pub const MWMO_NONE: MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS = MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS(0u32);
@@ -5844,9 +5603,6 @@ impl Default for MrmResourceIndexerHandle {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MrmResourceIndexerHandle {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MrmResourceIndexerMessage {
@@ -5858,9 +5614,6 @@ impl Default for MrmResourceIndexerMessage {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MrmResourceIndexerMessage {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -5881,9 +5634,6 @@ impl Default for NCCALCSIZE_PARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for NCCALCSIZE_PARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const NFR_ANSI: u32 = 1u32;
 pub const NFR_UNICODE: u32 = 2u32;
@@ -5922,10 +5672,6 @@ impl Default for NONCLIENTMETRICSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NONCLIENTMETRICSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -5952,10 +5698,6 @@ impl Default for NONCLIENTMETRICSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for NONCLIENTMETRICSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6359,9 +6101,6 @@ impl Default for SCROLLBARINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for SCROLLBARINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct SCROLLBAR_COMMAND(pub i32);
@@ -6416,9 +6155,6 @@ impl Default for SCROLLINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SCROLLINFO {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -6596,9 +6332,6 @@ impl Default for SHELLHOOKINFO {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SHELLHOOKINFO {
-    type TypeKind = windows_core::CopyType;
 }
 pub const SHOW_FULLSCREEN: u32 = 3u32;
 pub const SHOW_ICONWINDOW: u32 = 2u32;
@@ -7050,9 +6783,6 @@ impl Default for STYLESTRUCT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for STYLESTRUCT {
-    type TypeKind = windows_core::CopyType;
-}
 pub const SWP_ASYNCWINDOWPOS: SET_WINDOW_POS_FLAGS = SET_WINDOW_POS_FLAGS(16384u32);
 pub const SWP_DEFERERASE: SET_WINDOW_POS_FLAGS = SET_WINDOW_POS_FLAGS(8192u32);
 pub const SWP_DRAWFRAME: SET_WINDOW_POS_FLAGS = SET_WINDOW_POS_FLAGS(32u32);
@@ -7191,9 +6921,6 @@ impl Default for TITLEBARINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for TITLEBARINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TITLEBARINFOEX {
@@ -7206,9 +6933,6 @@ impl Default for TITLEBARINFOEX {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TITLEBARINFOEX {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TKF_AVAILABLE: u32 = 2u32;
 pub const TKF_CONFIRMHOTKEY: u32 = 8u32;
@@ -7231,9 +6955,6 @@ impl Default for TOUCHPREDICTIONPARAMETERS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TOUCHPREDICTIONPARAMETERS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TOUCHPREDICTIONPARAMETERS_DEFAULT_LATENCY: u32 = 8u32;
 pub const TOUCHPREDICTIONPARAMETERS_DEFAULT_RLS_DELTA: f32 = 0.001f32;
@@ -7263,9 +6984,6 @@ impl Default for TPMPARAMS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for TPMPARAMS {
-    type TypeKind = windows_core::CopyType;
 }
 pub const TPM_BOTTOMALIGN: TRACK_POPUP_MENU_FLAGS = TRACK_POPUP_MENU_FLAGS(32u32);
 pub const TPM_CENTERALIGN: TRACK_POPUP_MENU_FLAGS = TRACK_POPUP_MENU_FLAGS(4u32);
@@ -7356,10 +7074,6 @@ impl Default for UPDATELAYEREDWINDOWINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for UPDATELAYEREDWINDOWINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct UPDATE_LAYERED_WINDOW_FLAGS(pub u32);
@@ -7380,9 +7094,6 @@ impl Default for VolLockBroadcast {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for VolLockBroadcast {
-    type TypeKind = windows_core::CopyType;
 }
 pub const WA_ACTIVE: u32 = 1u32;
 pub const WA_CLICKACTIVE: u32 = 2u32;
@@ -7430,9 +7141,6 @@ impl Default for WINDOWINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for WINDOWINFO {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WINDOWPLACEMENT {
@@ -7447,9 +7155,6 @@ impl Default for WINDOWPLACEMENT {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINDOWPLACEMENT {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7502,9 +7207,6 @@ impl Default for WINDOWPOS {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for WINDOWPOS {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -7888,10 +7590,6 @@ impl Default for WNDCLASSA {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for WNDCLASSA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7914,10 +7612,6 @@ impl Default for WNDCLASSEXA {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for WNDCLASSEXA {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
@@ -7942,10 +7636,6 @@ impl Default for WNDCLASSEXW {
         unsafe { core::mem::zeroed() }
     }
 }
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for WNDCLASSEXW {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -7966,10 +7656,6 @@ impl Default for WNDCLASSW {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-#[cfg(feature = "Win32_Graphics_Gdi")]
-impl windows_core::TypeKind for WNDCLASSW {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -8101,9 +7787,6 @@ impl Default for _DEV_BROADCAST_HEADER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for _DEV_BROADCAST_HEADER {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct _DEV_BROADCAST_USERDEFINED {
@@ -8114,9 +7797,6 @@ impl Default for _DEV_BROADCAST_USERDEFINED {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for _DEV_BROADCAST_USERDEFINED {
-    type TypeKind = windows_core::CopyType;
 }
 pub const __WARNING_BANNED_API_USAGE: u32 = 28719u32;
 pub const __WARNING_CYCLOMATIC_COMPLEXITY: u32 = 28734u32;

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
@@ -1486,9 +1486,6 @@ impl Default for MILMatrixF {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MILMatrixF {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MilPoint2D {
@@ -1499,9 +1496,6 @@ impl Default for MilPoint2D {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MilPoint2D {
-    type TypeKind = windows_core::CopyType;
 }
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -1515,7 +1509,4 @@ impl Default for MilRectD {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for MilRectD {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/libs/windows/src/Windows/Win32/Web/InternetExplorer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Web/InternetExplorer/mod.rs
@@ -1320,9 +1320,6 @@ impl Default for IELAUNCHURLINFO {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for IELAUNCHURLINFO {
-    type TypeKind = windows_core::CopyType;
-}
 pub const IEPROCESS_MODULE_NAME: windows_core::PCWSTR = windows_core::w!("IERtUtil.dll");
 pub const IEWebDriverManager: windows_core::GUID = windows_core::GUID::from_u128(0x90314af2_5250_47b3_89d8_6295fc23bc22);
 pub const IE_USE_OE_MAIL_HKEY: i32 = -2147483647i32;
@@ -6304,9 +6301,6 @@ impl Default for NAVIGATEDATA {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for NAVIGATEDATA {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct NAVIGATEFRAME_FLAGS(pub i32);
@@ -6499,9 +6493,6 @@ impl Default for STATURL {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for STATURL {
-    type TypeKind = windows_core::CopyType;
 }
 pub const STATURLFLAG_ISCACHED: u32 = 1u32;
 pub const STATURLFLAG_ISTOPLEVEL: u32 = 2u32;

--- a/crates/tests/bindgen/src/derive_cpp_struct.rs
+++ b/crates/tests/bindgen/src/derive_cpp_struct.rs
@@ -17,9 +17,6 @@ impl Default for POINT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for POINT {
-    type TypeKind = windows_core::CopyType;
-}
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SIZE {
@@ -30,7 +27,4 @@ impl Default for SIZE {
     fn default() -> Self {
         unsafe { core::mem::zeroed() }
     }
-}
-impl windows_core::TypeKind for SIZE {
-    type TypeKind = windows_core::CopyType;
 }

--- a/crates/tests/bindgen/src/fn_return_void_win.rs
+++ b/crates/tests/bindgen/src/fn_return_void_win.rs
@@ -28,6 +28,3 @@ impl Default for MEMORYSTATUS {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for MEMORYSTATUS {
-    type TypeKind = windows_core::CopyType;
-}

--- a/crates/tests/bindgen/src/interface_cpp_return_udt.rs
+++ b/crates/tests/bindgen/src/interface_cpp_return_udt.rs
@@ -17,9 +17,6 @@ impl Default for D2D_SIZE_F {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D2D_SIZE_F {
-    type TypeKind = windows_core::CopyType;
-}
 windows_core::imp::define_interface!(
     ID2D1Bitmap,
     ID2D1Bitmap_Vtbl,

--- a/crates/tests/bindgen/src/multi.rs
+++ b/crates/tests/bindgen/src/multi.rs
@@ -17,7 +17,4 @@ impl Default for HTTP_VERSION {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for HTTP_VERSION {
-    type TypeKind = windows_core::CopyType;
-}
 pub const HTTP_VERSION: windows_core::PCWSTR = windows_core::w!("HTTP/1.0");

--- a/crates/tests/bindgen/src/struct_cpp_win.rs
+++ b/crates/tests/bindgen/src/struct_cpp_win.rs
@@ -19,6 +19,3 @@ impl Default for RECT {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for RECT {
-    type TypeKind = windows_core::CopyType;
-}

--- a/crates/tests/bindgen/src/struct_with_cpp_interface.rs
+++ b/crates/tests/bindgen/src/struct_with_cpp_interface.rs
@@ -16,9 +16,6 @@ impl Default for D3D12_RESOURCE_UAV_BARRIER {
         unsafe { core::mem::zeroed() }
     }
 }
-impl windows_core::TypeKind for D3D12_RESOURCE_UAV_BARRIER {
-    type TypeKind = windows_core::CloneType;
-}
 windows_core::imp::define_interface!(
     ID3D12DeviceChild,
     ID3D12DeviceChild_Vtbl,


### PR DESCRIPTION
With #3359 I mostly went for code gen parity (for validation) but with an eye toward greatly simplifying the resulting code gen once the new generator was available. Here are the first two of those simplifications: 

* Remove the "return void" hint to simplify the various Win32 style method permutations. I'd like to simplify this further but this is a good start. 

* Remove the `TypeKind` implementation on all Win32 structs. It really should only be needed for some WinRT types. I'd like to remove them on Win32 handles as well but that will require a bit more work so I'll handle that separately. 🙂

And this is why:

<img width="336" alt="image" src="https://github.com/user-attachments/assets/2c4364e0-aef5-4842-b086-c964aff89ae4">