### PR TITLE
Streamline error handling in `windows-bindgen`

### DIFF
--- a/crates/libs/bindgen/src/libraries.rs
+++ b/crates/libs/bindgen/src/libraries.rs
@@ -28,7 +28,7 @@ fn combine_libraries(
 
             // Windows libs are always produced with lower case module names.
             let library = ty.method.module_name().to_lowercase();
-            let impl_map = ty.method.impl_map().expect("ImplMap not found");
+            let impl_map = ty.method.impl_map().unwrap();
             let flags = impl_map.flags();
             let name = impl_map.import_name().to_string();
 

--- a/crates/libs/bindgen/src/tables/constant.rs
+++ b/crates/libs/bindgen/src/tables/constant.rs
@@ -8,7 +8,7 @@ impl std::fmt::Debug for Constant {
 
 impl Constant {
     pub fn ty(&self) -> Type {
-        Type::from_element_type(self.usize(0)).unwrap_or_else(|| panic!("`Constant` type invalid"))
+        Type::from_element_type(self.usize(0)).unwrap()
     }
 
     pub fn value(&self) -> Value {

--- a/crates/libs/bindgen/src/tables/method_def.rs
+++ b/crates/libs/bindgen/src/tables/method_def.rs
@@ -61,11 +61,9 @@ impl MethodDef {
                     if !param_is_output {
                         if let Some(attribute) = param.find_attribute("AssociatedEnumAttribute") {
                             if let Some((_, Value::Str(name))) = attribute.args().first() {
-                                if let Some(overload) =
-                                    param.reader().with_full_name(namespace, name).next()
-                                {
-                                    ty = Type::PrimitiveOrEnum(Box::new(ty), Box::new(overload));
-                                }
+                                let overload = param.reader().unwrap_full_name(namespace, name);
+
+                                ty = Type::PrimitiveOrEnum(Box::new(ty), Box::new(overload));
                             }
                         }
                     }

--- a/crates/libs/bindgen/src/tables/type_def.rs
+++ b/crates/libs/bindgen/src/tables/type_def.rs
@@ -57,7 +57,7 @@ impl TypeDef {
     }
 
     pub fn underlying_type(&self) -> Type {
-        let field = self.fields().next().expect("field not found");
+        let field = self.fields().next().unwrap();
         if let Some(constant) = field.constant() {
             constant.ty()
         } else {

--- a/crates/libs/bindgen/src/types/class.rs
+++ b/crates/libs/bindgen/src/types/class.rs
@@ -261,11 +261,9 @@ impl Class {
                 break;
             }
 
-            let Some(Type::Class(base)) = reader
-                .with_full_name(extends.namespace(), extends.name())
-                .next()
+            let Type::Class(base) = reader.unwrap_full_name(extends.namespace(), extends.name())
             else {
-                panic!("Type not found");
+                panic!("type not found: {extends}");
             };
 
             def = base.def;
@@ -319,17 +317,15 @@ impl Class {
 
             for (_, arg) in attribute.args() {
                 if let Value::TypeName(tn) = arg {
-                    let Some(Type::Interface(mut interface)) = self
+                    let Type::Interface(mut interface) = self
                         .def
                         .reader()
-                        .with_full_name(tn.namespace(), tn.name())
-                        .next()
+                        .unwrap_full_name(tn.namespace(), tn.name())
                     else {
-                        panic!("Type not found");
+                        panic!("type not found: {tn}");
                     };
 
                     interface.kind = kind;
-
                     set.push(interface);
                     break;
                 }

--- a/crates/libs/bindgen/src/types/cpp_enum.rs
+++ b/crates/libs/bindgen/src/types/cpp_enum.rs
@@ -127,14 +127,10 @@ impl CppEnum {
     pub fn dependencies(&self, dependencies: &mut TypeMap) {
         if let Some(attribute) = self.def.find_attribute("AlsoUsableForAttribute") {
             if let Some((_, Value::Str(type_name))) = attribute.args().first() {
-                if let Some(ty) = self
-                    .def
+                self.def
                     .reader()
-                    .with_full_name(self.def.namespace(), type_name)
-                    .next()
-                {
-                    ty.dependencies(dependencies);
-                }
+                    .unwrap_full_name(self.def.namespace(), type_name)
+                    .dependencies(dependencies);
             }
         }
     }

--- a/crates/libs/bindgen/src/types/cpp_struct.rs
+++ b/crates/libs/bindgen/src/types/cpp_struct.rs
@@ -228,14 +228,10 @@ impl CppStruct {
 
         if let Some(attribute) = self.def.find_attribute("AlsoUsableForAttribute") {
             if let Some((_, Value::Str(type_name))) = attribute.args().first() {
-                if let Some(ty) = self
-                    .def
+                self.def
                     .reader()
-                    .with_full_name(self.def.namespace(), type_name)
-                    .next()
-                {
-                    ty.dependencies(dependencies);
-                }
+                    .unwrap_full_name(self.def.namespace(), type_name)
+                    .dependencies(dependencies);
             }
         }
     }

--- a/crates/libs/bindgen/src/winmd/blob.rs
+++ b/crates/libs/bindgen/src/winmd/blob.rs
@@ -101,7 +101,7 @@ impl Blob {
         match self.read_u8() {
             0 => false,
             1 => true,
-            _ => panic!("illegal bool value"),
+            _ => panic!(),
         }
     }
 
@@ -175,7 +175,7 @@ impl Blob {
             Type::U32 => Value::U32(self.read_u32()),
             Type::I64 => Value::I64(self.read_i64()),
             Type::U64 => Value::U64(self.read_u64()),
-            _ => panic!("type is not an integer"),
+            _ => panic!(),
         }
     }
 

--- a/crates/libs/bindgen/src/winmd/reader.rs
+++ b/crates/libs/bindgen/src/winmd/reader.rs
@@ -170,6 +170,7 @@ impl Reader {
         reader
     }
 
+    #[track_caller]
     pub fn unwrap_full_name(&self, namespace: &str, name: &str) -> Type {
         if let Some(ty) = self.with_full_name(namespace, name).next() {
             ty

--- a/crates/libs/bindgen/src/writer/cpp_handle.rs
+++ b/crates/libs/bindgen/src/writer/cpp_handle.rs
@@ -111,22 +111,18 @@ impl Writer {
 
             if let Some(attribute) = def.find_attribute("AlsoUsableForAttribute") {
                 if let Some((_, Value::Str(type_name))) = attribute.args().first() {
-                    if let Some(ty) = def
-                        .reader()
-                        .with_full_name(def.namespace(), type_name)
-                        .next()
-                    {
-                        let ty = ty.write_name(self);
+                    let ty = def.reader().unwrap_full_name(def.namespace(), type_name);
 
-                        result.combine(quote! {
-                            impl windows_core::imp::CanInto<#ty> for #name {}
-                            impl From<#name> for #ty {
-                                fn from(value: #name) -> Self {
-                                    Self(value.0)
-                                }
+                    let ty = ty.write_name(self);
+
+                    result.combine(quote! {
+                        impl windows_core::imp::CanInto<#ty> for #name {}
+                        impl From<#name> for #ty {
+                            fn from(value: #name) -> Self {
+                                Self(value.0)
                             }
-                        });
-                    }
+                        }
+                    });
                 }
             }
 

--- a/crates/tools/bindgen/src/main.rs
+++ b/crates/tools/bindgen/src/main.rs
@@ -206,6 +206,6 @@ fn write_lib() {
     cmd.arg("lib.rs");
 
     if !cmd.status().unwrap().success() {
-        panic!("Failed to run rustfmt");
+        panic!("failed to run rustfmt");
     }
 }


### PR DESCRIPTION
Just a little simpler and more consistent. It also helped to identify this bug: https://github.com/microsoft/win32metadata/issues/2041