### PR TITLE
Ensure external references to static factories are generated correctly

### DIFF
--- a/crates/libs/bindgen/src/types/class.rs
+++ b/crates/libs/bindgen/src/types/class.rs
@@ -55,7 +55,7 @@ impl Class {
 
                 let method = method.write(
                     writer,
-                    interface.write_name(writer),
+                    Some(interface),
                     interface.kind,
                     &mut method_names,
                     &mut virtual_names,
@@ -88,12 +88,13 @@ impl Class {
                 if interface.def.methods().next().is_none() {
                     None
                 } else {
+                        let method_name = to_ident(interface.def.name());
                         let interface_type = interface.write_name(writer);
                         let cfg = quote! {};
 
                         Some(quote! {
                             #cfg
-                            fn #interface_type<R, F: FnOnce(&#interface_type) -> windows_core::Result<R>>(
+                            fn #method_name<R, F: FnOnce(&#interface_type) -> windows_core::Result<R>>(
                                 callback: F,
                             ) -> windows_core::Result<R> {
                                 static SHARED: windows_core::imp::FactoryCache<#name, #interface_type> =

--- a/crates/libs/bindgen/src/types/delegate.rs
+++ b/crates/libs/bindgen/src/types/delegate.rs
@@ -33,7 +33,7 @@ impl Delegate {
 
         let invoke = method.write(
             writer,
-            self.write_name(writer),
+            None,
             InterfaceKind::Default,
             &mut MethodNames::new(),
             &mut MethodNames::new(),

--- a/crates/libs/bindgen/src/types/interface.rs
+++ b/crates/libs/bindgen/src/types/interface.rs
@@ -240,7 +240,7 @@ impl Interface {
 
                     let method = method.write(
                         writer,
-                        self.write_name(writer),
+                        Some(self),
                         InterfaceKind::Default,
                         method_names,
                         virtual_names,
@@ -275,7 +275,7 @@ impl Interface {
 
                         let method = method.write(
                             writer,
-                            interface.write_name(writer),
+                            Some(interface),
                             interface.kind,
                             method_names,
                             virtual_names,

--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -280,7 +280,7 @@ impl Method {
     pub fn write(
         &self,
         writer: &Writer,
-        interface_name: TokenStream,
+        interface: Option<&Interface>,
         kind: InterfaceKind,
         method_names: &mut MethodNames,
         virtual_names: &mut MethodNames,
@@ -525,6 +525,8 @@ impl Method {
                     quote! { ? }
                 };
 
+                let interface_name = interface.unwrap().write_name(writer);
+
                 quote! {
                     pub fn #name<#(#generics,)*>(&self, #(#params)*) #return_type #where_clause {
                         let this = &windows_core::Interface::cast::<#interface_name>(self)#unwrap;
@@ -535,6 +537,8 @@ impl Method {
                 }
             }
             InterfaceKind::Static | InterfaceKind::Composable => {
+                let interface_name = to_ident(interface.unwrap().def.name());
+
                 quote! {
                     pub fn #name<#(#generics,)*>(#(#params)*) #return_type #where_clause {
                         Self::#interface_name(|this| unsafe { #vcall })

--- a/crates/tests/bindgen/Cargo.toml
+++ b/crates/tests/bindgen/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies.windows]
 workspace = true
 features = [
-    "Foundation",
+    "Foundation_Collections",
     "Win32_Foundation",
     "Win32_Security",
 ]

--- a/crates/tests/bindgen/src/lib.rs
+++ b/crates/tests/bindgen/src/lib.rs
@@ -68,6 +68,7 @@ pub mod reference_async_action_reference_type;
 pub mod reference_async_info_no_status;
 pub mod reference_async_info_status_filter;
 pub mod reference_async_info_status_reference;
+pub mod reference_class_ref_static;
 pub mod reference_dependency_flat;
 pub mod reference_dependency_full;
 pub mod reference_dependency_skip_root;

--- a/crates/tests/bindgen/src/reference_class_ref_static.rs
+++ b/crates/tests/bindgen/src/reference_class_ref_static.rs
@@ -1,0 +1,334 @@
+#![allow(
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    dead_code,
+    clippy::all
+)]
+
+#[repr(transparent)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Uri(windows_core::IUnknown);
+windows_core::imp::interface_hierarchy!(Uri, windows_core::IUnknown, windows_core::IInspectable);
+windows_core::imp::required_hierarchy!(Uri, windows::Foundation::IStringable);
+impl Uri {
+    pub fn ToString(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = &windows_core::Interface::cast::<windows::Foundation::IStringable>(self)?;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).ToString)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn UnescapeComponent(
+        tounescape: &windows_core::HSTRING,
+    ) -> windows_core::Result<windows_core::HSTRING> {
+        Self::IUriEscapeStatics(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).UnescapeComponent)(
+                windows_core::Interface::as_raw(this),
+                core::mem::transmute_copy(tounescape),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        })
+    }
+    pub fn EscapeComponent(
+        toescape: &windows_core::HSTRING,
+    ) -> windows_core::Result<windows_core::HSTRING> {
+        Self::IUriEscapeStatics(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).EscapeComponent)(
+                windows_core::Interface::as_raw(this),
+                core::mem::transmute_copy(toescape),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        })
+    }
+    pub fn AbsoluteUri(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).AbsoluteUri)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn DisplayUri(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).DisplayUri)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn Domain(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Domain)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn Extension(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Extension)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn Fragment(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Fragment)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn Host(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Host)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn Password(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Password)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn Path(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Path)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn Query(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Query)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn QueryParsed(&self) -> windows_core::Result<windows::Foundation::WwwFormUrlDecoder> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).QueryParsed)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+    pub fn RawUri(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).RawUri)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn SchemeName(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).SchemeName)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn UserName(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).UserName)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn Port(&self) -> windows_core::Result<i32> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Port)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+    pub fn Suspicious(&self) -> windows_core::Result<bool> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Suspicious)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+    pub fn Equals<P0>(&self, puri: P0) -> windows_core::Result<bool>
+    where
+        P0: windows_core::Param<Uri>,
+    {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).Equals)(
+                windows_core::Interface::as_raw(this),
+                puri.param().abi(),
+                &mut result__,
+            )
+            .map(|| result__)
+        }
+    }
+    pub fn CombineUri(&self, relativeuri: &windows_core::HSTRING) -> windows_core::Result<Uri> {
+        let this = self;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).CombineUri)(
+                windows_core::Interface::as_raw(this),
+                core::mem::transmute_copy(relativeuri),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        }
+    }
+    pub fn CreateUri(uri: &windows_core::HSTRING) -> windows_core::Result<Uri> {
+        Self::IUriRuntimeClassFactory(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).CreateUri)(
+                windows_core::Interface::as_raw(this),
+                core::mem::transmute_copy(uri),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        })
+    }
+    pub fn CreateWithRelativeUri(
+        baseuri: &windows_core::HSTRING,
+        relativeuri: &windows_core::HSTRING,
+    ) -> windows_core::Result<Uri> {
+        Self::IUriRuntimeClassFactory(|this| unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).CreateWithRelativeUri)(
+                windows_core::Interface::as_raw(this),
+                core::mem::transmute_copy(baseuri),
+                core::mem::transmute_copy(relativeuri),
+                &mut result__,
+            )
+            .and_then(|| windows_core::Type::from_abi(result__))
+        })
+    }
+    pub fn AbsoluteCanonicalUri(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = &windows_core::Interface::cast::<
+            windows::Foundation::IUriRuntimeClassWithAbsoluteCanonicalUri,
+        >(self)?;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).AbsoluteCanonicalUri)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    pub fn DisplayIri(&self) -> windows_core::Result<windows_core::HSTRING> {
+        let this = &windows_core::Interface::cast::<
+            windows::Foundation::IUriRuntimeClassWithAbsoluteCanonicalUri,
+        >(self)?;
+        unsafe {
+            let mut result__ = core::mem::zeroed();
+            (windows_core::Interface::vtable(this).DisplayIri)(
+                windows_core::Interface::as_raw(this),
+                &mut result__,
+            )
+            .map(|| core::mem::transmute(result__))
+        }
+    }
+    fn IUriEscapeStatics<
+        R,
+        F: FnOnce(&windows::Foundation::IUriEscapeStatics) -> windows_core::Result<R>,
+    >(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<
+            Uri,
+            windows::Foundation::IUriEscapeStatics,
+        > = windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+    fn IUriRuntimeClassFactory<
+        R,
+        F: FnOnce(&windows::Foundation::IUriRuntimeClassFactory) -> windows_core::Result<R>,
+    >(
+        callback: F,
+    ) -> windows_core::Result<R> {
+        static SHARED: windows_core::imp::FactoryCache<
+            Uri,
+            windows::Foundation::IUriRuntimeClassFactory,
+        > = windows_core::imp::FactoryCache::new();
+        SHARED.call(callback)
+    }
+}
+impl windows_core::RuntimeType for Uri {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_class::<Self, windows::Foundation::IUriRuntimeClass>();
+}
+unsafe impl windows_core::Interface for Uri {
+    type Vtable = <windows::Foundation::IUriRuntimeClass as windows_core::Interface>::Vtable;
+    const IID: windows_core::GUID =
+        <windows::Foundation::IUriRuntimeClass as windows_core::Interface>::IID;
+}
+impl windows_core::RuntimeName for Uri {
+    const NAME: &'static str = "Windows.Foundation.Uri";
+}
+unsafe impl Send for Uri {}
+unsafe impl Sync for Uri {}

--- a/crates/tools/bindgen/src/main.rs
+++ b/crates/tools/bindgen/src/main.rs
@@ -126,6 +126,7 @@ fn main() {
     test("--out reference_async_action.rs --filter IAsyncAction");
     test("--out reference_async_action_reference_type.rs --filter IAsyncAction --reference windows,skip-root,IAsyncInfo");
     test("--out reference_async_action_reference_namespace.rs --filter IAsyncAction --reference windows,skip-root,Windows");
+    test("--out reference_class_ref_static.rs --filter Windows.Foundation.Uri --reference windows,skip-root,Windows");
 
     // Tests for struct references
     test("--out reference_struct_filter.rs --filter InkTrailPoint");


### PR DESCRIPTION
The cache functions didn't strip out the namespace correctly when the static type comes from a different module to the class. Admittedly a very obscure scenario but I encountered it through stress testing. 

Added a test for this scenario. 