### PR TITLE
`cppwinrt` should consistently panic on failure 

### DIFF
--- a/crates/libs/cppwinrt/readme.md
+++ b/crates/libs/cppwinrt/readme.md
@@ -16,10 +16,7 @@ version = "0.1"
 Use `cppwinrt` function as needed:
 
 ```rust
-match cppwinrt::cppwinrt(["-help"]) {
-    Ok(output) => println!("{output}"),
-    Err(error) => println!("{error}"),
-};
+println!("{}", cppwinrt::cppwinrt(["-help"]));
 ```
 
 Source:

--- a/crates/libs/cppwinrt/src/lib.rs
+++ b/crates/libs/cppwinrt/src/lib.rs
@@ -6,7 +6,7 @@ const VERSION: &str = "2.0.240405.15";
 /// Calls the C++/WinRT compiler with the given arguments.
 ///
 /// Use `cppwinrt["-help"]` for available options.
-pub fn cppwinrt<I, S>(args: I) -> Result<String, String>
+pub fn cppwinrt<I, S>(args: I) -> String
 where
     I: IntoIterator<Item = S>,
     S: AsRef<std::ffi::OsStr>,
@@ -27,9 +27,9 @@ where
     _ = std::fs::remove_file(path);
 
     if output.status.success() {
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        String::from_utf8_lossy(&output.stdout).to_string()
     } else {
-        Err(String::from_utf8_lossy(&output.stderr).to_string())
+        panic!("{}", String::from_utf8_lossy(&output.stderr))
     }
 }
 
@@ -38,11 +38,14 @@ mod tests {
     use crate::*;
 
     #[test]
-    fn test() {
-        let ok = cppwinrt(["-help"]).unwrap();
-        assert!(ok.contains(VERSION), "unexpected version");
+    #[should_panic(expected = "'-invalid' is not supported")]
+    fn invalid_arg() {
+        cppwinrt(["-invalid"]);
+    }
 
-        let err = cppwinrt(["-invalid"]).unwrap_err();
-        assert!(err.contains("'-invalid' is not supported"));
+    #[test]
+    fn unexpected_version() {
+        let ok = cppwinrt(["-help"]);
+        assert!(ok.contains(VERSION), "unexpected version");
     }
 }

--- a/crates/samples/components/json_validator_winrt_client_cpp/build.rs
+++ b/crates/samples/components/json_validator_winrt_client_cpp/build.rs
@@ -14,8 +14,7 @@ fn main() {
         &format!("{}\\System32\\WinMetadata", env!("windir")),
         "-out",
         &include,
-    ])
-    .unwrap();
+    ]);
 
     cc::Build::new()
         .cpp(true)

--- a/crates/tests/winrt/composable_client/build.rs
+++ b/crates/tests/winrt/composable_client/build.rs
@@ -26,8 +26,7 @@ fn main() {
         "../../../libs/bindgen/default",
         "-out",
         &include,
-    ])
-    .unwrap();
+    ]);
 
     cc::Build::new()
         .cpp(true)

--- a/crates/tests/winrt/constructors_client/build.rs
+++ b/crates/tests/winrt/constructors_client/build.rs
@@ -26,8 +26,7 @@ fn main() {
         "../../../libs/bindgen/default",
         "-out",
         &include,
-    ])
-    .unwrap();
+    ]);
 
     cc::Build::new()
         .cpp(true)

--- a/crates/tests/winrt/noexcept/build.rs
+++ b/crates/tests/winrt/noexcept/build.rs
@@ -47,8 +47,7 @@ fn main() {
         &format!("{}\\System32\\WinMetadata", env!("windir")),
         "-out",
         &include,
-    ])
-    .unwrap();
+    ]);
 
     cc::Build::new()
         .cpp(true)

--- a/crates/tests/winrt/ref_params/build.rs
+++ b/crates/tests/winrt/ref_params/build.rs
@@ -47,8 +47,7 @@ fn main() {
         &format!("{}\\System32\\WinMetadata", env!("windir")),
         "-out",
         &include,
-    ])
-    .unwrap();
+    ]);
 
     cc::Build::new()
         .cpp(true)


### PR DESCRIPTION
This brings the `cppwinrt` crate in line with the `windows-bindgen` crate that consistently panics on failure. As a build tool, this is simpler to consume and provides more reliable build failure information. 