### PR TITLE
Shorten sample crate names

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -41,18 +41,6 @@ jobs:
         run:  cargo clippy -p sample_bits
       - name: Clippy sample_com_uri
         run:  cargo clippy -p sample_com_uri
-      - name: Clippy sample_component_hello_world
-        run:  cargo clippy -p sample_component_hello_world
-      - name: Clippy sample_component_json_validator
-        run:  cargo clippy -p sample_component_json_validator
-      - name: Clippy sample_component_json_validator_client
-        run:  cargo clippy -p sample_component_json_validator_client
-      - name: Clippy sample_component_json_validator_winrt
-        run:  cargo clippy -p sample_component_json_validator_winrt
-      - name: Clippy sample_component_json_validator_winrt_client
-        run:  cargo clippy -p sample_component_json_validator_winrt_client
-      - name: Clippy sample_component_json_validator_winrt_client_cpp
-        run:  cargo clippy -p sample_component_json_validator_winrt_client_cpp
       - name: Clippy sample_consent
         run:  cargo clippy -p sample_consent
       - name: Clippy sample_core_app
@@ -87,6 +75,16 @@ jobs:
         run:  cargo clippy -p sample_enum_windows_sys
       - name: Clippy sample_file_dialogs
         run:  cargo clippy -p sample_file_dialogs
+      - name: Clippy sample_json_validator
+        run:  cargo clippy -p sample_json_validator
+      - name: Clippy sample_json_validator_client
+        run:  cargo clippy -p sample_json_validator_client
+      - name: Clippy sample_json_validator_winrt
+        run:  cargo clippy -p sample_json_validator_winrt
+      - name: Clippy sample_json_validator_winrt_client
+        run:  cargo clippy -p sample_json_validator_winrt_client
+      - name: Clippy sample_json_validator_winrt_client_cpp
+        run:  cargo clippy -p sample_json_validator_winrt_client_cpp
       - name: Clippy sample_kernel_event
         run:  cargo clippy -p sample_kernel_event
       - name: Clippy sample_memory_buffer

--- a/.github/workflows/raw-dylib.yml
+++ b/.github/workflows/raw-dylib.yml
@@ -68,18 +68,6 @@ jobs:
         run:  cargo test -p sample_bits --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_com_uri
         run:  cargo test -p sample_com_uri --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_hello_world
-        run:  cargo test -p sample_component_hello_world --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_json_validator
-        run:  cargo test -p sample_component_json_validator --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_json_validator_client
-        run:  cargo test -p sample_component_json_validator_client --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_json_validator_winrt
-        run:  cargo test -p sample_component_json_validator_winrt --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_json_validator_winrt_client
-        run:  cargo test -p sample_component_json_validator_winrt_client --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_json_validator_winrt_client_cpp
-        run:  cargo test -p sample_component_json_validator_winrt_client_cpp --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_consent
         run:  cargo test -p sample_consent --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_core_app
@@ -114,6 +102,16 @@ jobs:
         run:  cargo test -p sample_enum_windows_sys --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_file_dialogs
         run:  cargo test -p sample_file_dialogs --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test sample_json_validator
+        run:  cargo test -p sample_json_validator --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test sample_json_validator_client
+        run:  cargo test -p sample_json_validator_client --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test sample_json_validator_winrt
+        run:  cargo test -p sample_json_validator_winrt --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test sample_json_validator_winrt_client
+        run:  cargo test -p sample_json_validator_winrt_client --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test sample_json_validator_winrt_client_cpp
+        run:  cargo test -p sample_json_validator_winrt_client_cpp --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_kernel_event
         run:  cargo test -p sample_kernel_event --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_memory_buffer
@@ -160,10 +158,10 @@ jobs:
         run:  cargo test -p test_alternate_success_code --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_arch
         run:  cargo test -p test_arch --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Clean
-        run:  cargo clean
       - name: Test test_arch_feature
         run:  cargo test -p test_arch_feature --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Clean
+        run:  cargo clean
       - name: Test test_array
         run:  cargo test -p test_array --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_async
@@ -262,10 +260,10 @@ jobs:
         run:  cargo test -p test_readme --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_ref_params
         run:  cargo test -p test_ref_params --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Clean
-        run:  cargo clean
       - name: Test test_reference
         run:  cargo test -p test_reference --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Clean
+        run:  cargo clean
       - name: Test test_reference_client
         run:  cargo test -p test_reference_client --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_reference_float
@@ -364,8 +362,6 @@ jobs:
         run:  cargo test -p windows_x86_64_gnu --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test windows_x86_64_gnullvm
         run:  cargo test -p windows_x86_64_gnullvm --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Clean
-        run:  cargo clean
       - name: Test windows_x86_64_msvc
         run:  cargo test -p windows_x86_64_msvc --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Check diff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,18 +65,6 @@ jobs:
         run:  cargo test -p sample_bits --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_com_uri
         run:  cargo test -p sample_com_uri --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_hello_world
-        run:  cargo test -p sample_component_hello_world --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_json_validator
-        run:  cargo test -p sample_component_json_validator --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_json_validator_client
-        run:  cargo test -p sample_component_json_validator_client --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_json_validator_winrt
-        run:  cargo test -p sample_component_json_validator_winrt --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_json_validator_winrt_client
-        run:  cargo test -p sample_component_json_validator_winrt_client --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Test sample_component_json_validator_winrt_client_cpp
-        run:  cargo test -p sample_component_json_validator_winrt_client_cpp --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_consent
         run:  cargo test -p sample_consent --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_core_app
@@ -111,6 +99,16 @@ jobs:
         run:  cargo test -p sample_enum_windows_sys --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_file_dialogs
         run:  cargo test -p sample_file_dialogs --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test sample_json_validator
+        run:  cargo test -p sample_json_validator --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test sample_json_validator_client
+        run:  cargo test -p sample_json_validator_client --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test sample_json_validator_winrt
+        run:  cargo test -p sample_json_validator_winrt --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test sample_json_validator_winrt_client
+        run:  cargo test -p sample_json_validator_winrt_client --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Test sample_json_validator_winrt_client_cpp
+        run:  cargo test -p sample_json_validator_winrt_client_cpp --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_kernel_event
         run:  cargo test -p sample_kernel_event --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test sample_memory_buffer
@@ -157,10 +155,10 @@ jobs:
         run:  cargo test -p test_alternate_success_code --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_arch
         run:  cargo test -p test_arch --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Clean
-        run:  cargo clean
       - name: Test test_arch_feature
         run:  cargo test -p test_arch_feature --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Clean
+        run:  cargo clean
       - name: Test test_array
         run:  cargo test -p test_array --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_async
@@ -259,10 +257,10 @@ jobs:
         run:  cargo test -p test_readme --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_ref_params
         run:  cargo test -p test_ref_params --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Clean
-        run:  cargo clean
       - name: Test test_reference
         run:  cargo test -p test_reference --target ${{ matrix.target }} ${{ matrix.etc }}
+      - name: Clean
+        run:  cargo clean
       - name: Test test_reference_client
         run:  cargo test -p test_reference_client --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test test_reference_float
@@ -361,8 +359,6 @@ jobs:
         run:  cargo test -p windows_x86_64_gnu --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Test windows_x86_64_gnullvm
         run:  cargo test -p windows_x86_64_gnullvm --target ${{ matrix.target }} ${{ matrix.etc }}
-      - name: Clean
-        run:  cargo clean
       - name: Test windows_x86_64_msvc
         run:  cargo test -p windows_x86_64_msvc --target ${{ matrix.target }} ${{ matrix.etc }}
       - name: Check diff

--- a/crates/samples/components/hello_world/Cargo.toml
+++ b/crates/samples/components/hello_world/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "sample_component_hello_world"
-version = "0.0.0"
-edition = "2021"
-publish = false
-
-[lib]
-crate-type = ["cdylib"]

--- a/crates/samples/components/hello_world/readme.md
+++ b/crates/samples/components/hello_world/readme.md
@@ -1,1 +1,0 @@
-Sample for [Creating your first DLL in Rust](https://kennykerr.ca/rust-getting-started/creating-your-first-dll.html) in [Getting Started with Rust](https://kennykerr.ca/rust-getting-started).

--- a/crates/samples/components/hello_world/src/lib.rs
+++ b/crates/samples/components/hello_world/src/lib.rs
@@ -1,4 +1,0 @@
-#[no_mangle]
-extern "system" fn HelloWorld() -> i32 {
-    123
-}

--- a/crates/samples/components/json_validator/Cargo.toml
+++ b/crates/samples/components/json_validator/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sample_component_json_validator"
+name = "sample_json_validator"
 version = "0.0.0"
 edition = "2021"
 publish = false

--- a/crates/samples/components/json_validator_client/Cargo.toml
+++ b/crates/samples/components/json_validator_client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sample_component_json_validator_client"
+name = "sample_json_validator_client"
 version = "0.0.0"
 edition = "2021"
 publish = false
@@ -12,5 +12,5 @@ workspace = true
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[dependencies.sample_component_json_validator]
+[dependencies.sample_json_validator]
 path = "../json_validator"

--- a/crates/samples/components/json_validator_client/src/client.cpp
+++ b/crates/samples/components/json_validator_client/src/client.cpp
@@ -11,7 +11,7 @@ typedef void (__stdcall *CloseJsonValidator)(uintptr_t handle);
 
 extern "C" {
     void __stdcall client() {
-        auto library = LoadLibraryExW(L"sample_component_json_validator.dll", 0, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+        auto library = LoadLibraryExW(L"sample_json_validator.dll", 0, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
         assert(library != 0);
 
         auto create = reinterpret_cast<CreateJsonValidator>(GetProcAddress(library, "CreateJsonValidator"));

--- a/crates/samples/components/json_validator_winrt/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sample_component_json_validator_winrt"
+name = "sample_json_validator_winrt"
 version = "0.0.0"
 edition = "2021"
 publish = false

--- a/crates/samples/components/json_validator_winrt_client/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt_client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sample_component_json_validator_winrt_client"
+name = "sample_json_validator_winrt_client"
 version = "0.0.0"
 edition = "2021"
 publish = false
@@ -18,5 +18,5 @@ workspace = true
 
 # The build needs the output (.dll) of the component. This causes a warning about lack of linkage target.
 # Cargo doesn't understand cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[dependencies.sample_component_json_validator_winrt]
+[dependencies.sample_json_validator_winrt]
 path = "../json_validator_winrt"

--- a/crates/samples/components/json_validator_winrt_client_cpp/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt_client_cpp/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sample_component_json_validator_winrt_client_cpp"
+name = "sample_json_validator_winrt_client_cpp"
 version = "0.0.0"
 edition = "2021"
 publish = false
@@ -15,5 +15,5 @@ workspace = true
 
 # The build needs the output (.dll) of the component. This causes a warning about lack of linkage target.
 # Cargo doesn't understand cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[dependencies.sample_component_json_validator_winrt]
+[dependencies.sample_json_validator_winrt]
 path = "../json_validator_winrt"


### PR DESCRIPTION
This pull request shortens the names of the sample crates to speed up local testing. The longer qualified names didn't serve a compelling purpose. 