### PR TITLE
Fix provenance in direct32 sample

### DIFF
--- a/crates/samples/windows/direct3d12/src/main.rs
+++ b/crates/samples/windows/direct3d12/src/main.rs
@@ -5,8 +5,6 @@ use windows::{
     Win32::UI::WindowsAndMessaging::*,
 };
 
-use std::mem::transmute;
-
 trait DXSample {
     fn new(command_line: &SampleCommandLine) -> Result<Self>
     where
@@ -151,7 +149,7 @@ extern "system" fn wndproc<S: DXSample>(
     match message {
         WM_CREATE => {
             unsafe {
-                let create_struct: &CREATESTRUCTA = transmute(lparam);
+                let create_struct: &CREATESTRUCTA = &*(lparam.0 as *const CREATESTRUCTA);
                 SetWindowLongPtrA(window, GWLP_USERDATA, create_struct.lpCreateParams as _);
             }
             LRESULT::default()


### PR DESCRIPTION
Using transmute creates a pointer without [provenance](https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance). Using an `as` cast instead fixes this.

Fixes: #3406
