### PR TITLE
Update web workflow to use external origin

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -71,6 +71,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://github.com/${{ github.repository }}
 
           $status = git status --porcelain
           if ($status) {


### PR DESCRIPTION
Fixes an issue where the `gh-pages`-specific workflow fails to trigger by updating the web workflow to use an external origin for committing changes to the `gh-pages` branch.