### PR TITLE
Update GitHub Actions runners

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -30,7 +30,7 @@ jobs:
         # https://github.com/rust-lang/rust/issues/79577
         # https://sourceforge.net/p/mingw-w64/wiki2/Exception%20Handling
         #
-        image: [macos-latest, ubuntu-latest]
+        image: [macos-latest, ubuntu-22.04]
         target: [x86_64-pc-windows-gnu, aarch64-pc-windows-gnullvm, x86_64-pc-windows-gnullvm, i686-pc-windows-gnullvm]
     runs-on: ${{ matrix.image }}
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   windows:
     name: windows
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
 
   windows-sys:
     name: windows-sys
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
         run: cargo doc --no-deps -p windows-sys
 
   other-crates:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   check:
     name: tool_${{ matrix.tool }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         tool: [bindgen, bindings, yml, license, standalone]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/msrv-windows-bindgen.yml
+++ b/.github/workflows/msrv-windows-bindgen.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         rust: [1.74.0, stable, nightly]
         runs-on:
-          - windows-latest
-          - ubuntu-latest
+          - windows-2022
+          - ubuntu-22.04
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout

--- a/.github/workflows/msrv-windows-core.yml
+++ b/.github/workflows/msrv-windows-core.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         rust: [1.74.0, stable, nightly]
         runs-on:
-          - windows-latest
-          - ubuntu-latest
+          - windows-2022
+          - ubuntu-22.04
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout

--- a/.github/workflows/msrv-windows-registry.yml
+++ b/.github/workflows/msrv-windows-registry.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust: [1.74.0, stable, nightly]
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/msrv-windows-result.yml
+++ b/.github/workflows/msrv-windows-result.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         rust: [1.74.0, stable, nightly]
         runs-on:
-          - windows-latest
-          - ubuntu-latest
+          - windows-2022
+          - ubuntu-22.04
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout

--- a/.github/workflows/msrv-windows-strings.yml
+++ b/.github/workflows/msrv-windows-strings.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust: [1.74.0, stable, nightly]
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/msrv-windows-sys.yml
+++ b/.github/workflows/msrv-windows-sys.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         rust: [1.60.0, stable, nightly]
         runs-on:
-          - windows-latest
-          - ubuntu-latest
+          - windows-2022
+          - ubuntu-22.04
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout

--- a/.github/workflows/msrv-windows-version.yml
+++ b/.github/workflows/msrv-windows-version.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust: [1.74.0, stable, nightly]
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/msrv-windows.yml
+++ b/.github/workflows/msrv-windows.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust: [1.74.0, stable, nightly]
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         rust: [stable, nightly]
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/slim_errors.yml
+++ b/.github/workflows/slim_errors.yml
@@ -25,7 +25,7 @@ jobs:
           - target: x86_64-pc-windows-gnu
           - target: i686-pc-windows-gnu
         runs-on:
-          - windows-latest
+          - windows-2022
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   web:
     if: github.repository == 'microsoft/windows-rs'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This just updates the workflows to use the current latest runner images rather than "*-latest" to avoid all the warnings about the upcoming changes to the latest runners. 

https://github.com/actions/runner-images/issues/10636
