### PR TITLE
Use `track_caller` in more places

### DIFF
--- a/crates/libs/bindgen/src/type_map.rs
+++ b/crates/libs/bindgen/src/type_map.rs
@@ -16,6 +16,7 @@ impl TypeMap {
         Self(HashMap::new())
     }
 
+    #[track_caller]
     pub fn filter(reader: &'static Reader, filter: &Filter, references: &References) -> Self {
         let mut dependencies = Self::new();
 

--- a/crates/libs/bindgen/src/types/cpp_interface.rs
+++ b/crates/libs/bindgen/src/types/cpp_interface.rs
@@ -423,6 +423,7 @@ impl CppInterface {
         quote! { #namespace #name }
     }
 
+    #[track_caller]
     pub fn dependencies(&self, dependencies: &mut TypeMap) {
         let base_interfaces = self.base_interfaces();
 

--- a/crates/libs/bindgen/src/types/mod.rs
+++ b/crates/libs/bindgen/src/types/mod.rs
@@ -201,6 +201,7 @@ impl Type {
         }
     }
 
+    #[track_caller]
     pub fn from_ref(code: TypeDefOrRef, enclosing: Option<&CppStruct>, generics: &[Self]) -> Self {
         if let TypeDefOrRef::TypeSpec(def) = code {
             let mut blob = def.blob(0);
@@ -227,6 +228,7 @@ impl Type {
             .unwrap_full_name(code_name.namespace(), code_name.name())
     }
 
+    #[track_caller]
     pub fn from_blob(blob: &mut Blob, enclosing: Option<&CppStruct>, generics: &[Self]) -> Self {
         // Used by WinRT to indicate that a struct input parameter is passed by reference rather than by value on the ABI.
         let is_const = blob.read_modifiers().iter().any(|def| {
@@ -267,6 +269,7 @@ impl Type {
         }
     }
 
+    #[track_caller]
     fn from_blob_impl(blob: &mut Blob, enclosing: Option<&CppStruct>, generics: &[Self]) -> Self {
         let code = blob.read_usize();
 
@@ -600,6 +603,7 @@ impl Type {
         }
     }
 
+    #[track_caller]
     pub fn dependencies(&self, dependencies: &mut TypeMap) {
         let ty = self.decay();
 


### PR DESCRIPTION
Following on from #3383, I noticed a few more instances where `track_caller` can simplify debugging build scripts as I've been helping to update various projects to the latest version of `windows-bindgen`. 