### PR TITLE
Simplify internal `windows-bindgen` caching

### DIFF
--- a/crates/libs/bindgen/src/config.rs
+++ b/crates/libs/bindgen/src/config.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+static CONFIG: AtomicPtr<Config> = AtomicPtr::new(std::ptr::null_mut());
+
+pub fn config() -> &'static Config {
+    let ptr = CONFIG.load(Ordering::Relaxed);
+
+    if ptr.is_null() {
+        panic!();
+    } else {
+        unsafe { &*ptr }
+    }
+}
+
+pub struct Config {
+    pub types: TypeMap,
+    pub references: References,
+    pub output: String,
+    pub flat: bool,
+    pub no_allow: bool,
+    pub no_comment: bool,
+    pub no_core: bool,
+    pub no_toml: bool,
+    pub package: bool,
+    pub rustfmt: String,
+    pub sys: bool,
+    pub implement: bool,
+    pub derive: Derive,
+}
+
+impl Config {
+    pub fn init(value: Self) {
+        let config = Box::leak(Box::new(value));
+        CONFIG.store(config, Ordering::Relaxed);
+    }
+}

--- a/crates/libs/bindgen/src/derive.rs
+++ b/crates/libs/bindgen/src/derive.rs
@@ -3,7 +3,7 @@ use super::*;
 pub struct Derive(HashMap<TypeName, Vec<String>>);
 
 impl Derive {
-    pub fn new(reader: &Reader, types: &TypeMap, derive: &[&str]) -> Self {
+    pub fn new(types: &TypeMap, derive: &[&str]) -> Self {
         let mut map = HashMap::new();
 
         for derive in derive {
@@ -11,7 +11,7 @@ impl Derive {
                 panic!("`--derive` must be `<type name>=Comma,Separated,List");
             };
 
-            let tn = get_type_name(reader, name);
+            let tn = get_type_name(name);
 
             if !types.contains_key(&tn) {
                 panic!("type not included: `{name}`");
@@ -33,15 +33,15 @@ impl Derive {
     }
 }
 
-fn get_type_name(reader: &Reader, path: &str) -> TypeName {
+fn get_type_name(path: &str) -> TypeName {
     if let Some((namespace, name)) = path.rsplit_once('.') {
-        if let Some((namespace, types)) = reader.get_key_value(namespace) {
+        if let Some((namespace, types)) = reader().get_key_value(namespace) {
             if let Some((name, _)) = types.get_key_value(name) {
                 return TypeName(namespace, name);
             }
         }
     } else {
-        for (namespace, types) in reader.iter() {
+        for (namespace, types) in reader().iter() {
             if let Some((name, _)) = types.get_key_value(path) {
                 return TypeName(namespace, name);
             }

--- a/crates/libs/bindgen/src/derive_writer.rs
+++ b/crates/libs/bindgen/src/derive_writer.rs
@@ -3,9 +3,9 @@ use super::*;
 pub struct DeriveWriter(BTreeSet<String>);
 
 impl DeriveWriter {
-    pub fn new(writer: &Writer, type_name: TypeName) -> Self {
+    pub fn new(type_name: TypeName) -> Self {
         let mut derive = BTreeSet::new();
-        derive.extend(writer.config.derive.get(type_name));
+        derive.extend(config().derive.get(type_name));
         Self(derive)
     }
 

--- a/crates/libs/bindgen/src/filter.rs
+++ b/crates/libs/bindgen/src/filter.rs
@@ -4,15 +4,15 @@ use super::*;
 pub struct Filter(Vec<(String, bool)>);
 
 impl Filter {
-    pub fn new(reader: &Reader, include: &[&str], exclude: &[&str]) -> Self {
+    pub fn new(include: &[&str], exclude: &[&str]) -> Self {
         let mut rules = vec![];
 
         for filter in include {
-            push_filter(reader, &mut rules, filter, true);
+            push_filter(&mut rules, filter, true);
         }
 
         for filter in exclude {
-            push_filter(reader, &mut rules, filter, false)
+            push_filter(&mut rules, filter, false)
         }
 
         debug_assert!(!rules.is_empty());
@@ -68,7 +68,9 @@ impl Filter {
     }
 }
 
-fn push_filter(reader: &Reader, rules: &mut Vec<(String, bool)>, filter: &str, include: bool) {
+fn push_filter(rules: &mut Vec<(String, bool)>, filter: &str, include: bool) {
+    let reader = reader();
+
     if reader.contains_key(filter) {
         rules.push((filter.to_string(), include));
         return;

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -159,11 +159,11 @@ where
         panic!("at least one `--filter` required");
     }
 
-    let reader = Reader::new(expand_input(&input));
-    let filter = Filter::new(reader, &include, &exclude);
-    let references = References::new(reader, references);
-    let types = TypeMap::filter(reader, &filter, &references);
-    let derive = Derive::new(reader, &types, &derive);
+    Reader::init(expand_input(&input));
+    let filter = Filter::new(&include, &exclude);
+    let references = References::new(references);
+    let types = TypeMap::filter(&filter, &references);
+    let derive = Derive::new(&types, &derive);
 
     let config = Box::leak(Box::new(Config {
         types,

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -6,6 +6,7 @@
     clippy::needless_doctest_main
 )]
 
+mod config;
 mod derive;
 mod derive_writer;
 mod filter;
@@ -24,6 +25,7 @@ mod value;
 mod winmd;
 mod writer;
 
+use config::*;
 use derive::*;
 use derive_writer::*;
 use filter::*;
@@ -46,22 +48,6 @@ use winmd::*;
 use writer::*;
 mod method_names;
 use method_names::*;
-
-struct Config {
-    pub types: TypeMap,
-    pub references: References,
-    pub output: String,
-    pub flat: bool,
-    pub no_allow: bool,
-    pub no_comment: bool,
-    pub no_core: bool,
-    pub no_toml: bool,
-    pub package: bool,
-    pub rustfmt: String,
-    pub sys: bool,
-    pub implement: bool,
-    pub derive: Derive,
-}
 
 /// The Windows code generator.
 #[track_caller]
@@ -165,7 +151,7 @@ where
     let types = TypeMap::filter(&filter, &references);
     let derive = Derive::new(&types, &derive);
 
-    let config = Box::leak(Box::new(Config {
+    Config::init(Config {
         types,
         flat,
         references,
@@ -179,16 +165,11 @@ where
         output,
         sys,
         implement,
-    }));
+    });
 
-    let tree = TypeTree::new(&config.types);
+    let writer = Writer { namespace: "" };
 
-    let writer = Writer {
-        config,
-        namespace: "",
-    };
-
-    writer.write(tree)
+    writer.write(TypeTree::new())
 }
 
 enum ArgKind {

--- a/crates/libs/bindgen/src/references.rs
+++ b/crates/libs/bindgen/src/references.rs
@@ -68,13 +68,13 @@ pub struct Reference {
 pub struct References(Vec<Reference>);
 
 impl References {
-    pub fn new(reader: &'static Reader, stage: Vec<ReferenceStage>) -> Self {
+    pub fn new(stage: Vec<ReferenceStage>) -> Self {
         Self(
             stage
                 .into_iter()
                 .map(|stage| {
-                    let filter = Filter::new(reader, &[&stage.path], &[]);
-                    let types = TypeMap::filter(reader, &filter, &References::default());
+                    let filter = Filter::new(&[&stage.path], &[]);
+                    let types = TypeMap::filter(&filter, &References::default());
 
                     Reference {
                         name: stage.name,

--- a/crates/libs/bindgen/src/tables/attribute.rs
+++ b/crates/libs/bindgen/src/tables/attribute.rs
@@ -29,7 +29,7 @@ impl Attribute {
         let ret_type = sig.read_usize();
         std::debug_assert_eq!(ret_type, 1);
         let mut args = Vec::with_capacity(fixed_arg_count);
-        let reader = self.reader();
+        let reader = reader();
 
         for _ in 0..fixed_arg_count {
             let arg = match Type::from_blob(&mut sig, None, &[]) {

--- a/crates/libs/bindgen/src/tables/method_def.rs
+++ b/crates/libs/bindgen/src/tables/method_def.rs
@@ -36,6 +36,7 @@ impl MethodDef {
         let _param_count = blob.read_usize();
         let mut return_type = Type::from_blob(&mut blob, None, generics);
         let mut return_param = None;
+        let reader = reader();
 
         let mut params = vec![];
 
@@ -61,7 +62,7 @@ impl MethodDef {
                 if !param_is_output {
                     if let Some(attribute) = param.find_attribute("AssociatedEnumAttribute") {
                         if let Some((_, Value::Str(name))) = attribute.args().first() {
-                            let overload = param.reader().unwrap_full_name(namespace, name);
+                            let overload = reader.unwrap_full_name(namespace, name);
 
                             ty = Type::PrimitiveOrEnum(Box::new(ty), Box::new(overload));
                         }

--- a/crates/libs/bindgen/src/tables/type_def.rs
+++ b/crates/libs/bindgen/src/tables/type_def.rs
@@ -81,7 +81,7 @@ impl TypeDef {
         if let Some(attribute) = self.find_attribute("RAIIFreeAttribute") {
             if let Some((_, Value::Str(name))) = attribute.args().first() {
                 if let Some(Type::CppFn(ty)) =
-                    self.reader().with_full_name(self.namespace(), name).next()
+                    reader().with_full_name(self.namespace(), name).next()
                 {
                     return Some(ty);
                 }

--- a/crates/libs/bindgen/src/type_map.rs
+++ b/crates/libs/bindgen/src/type_map.rs
@@ -17,8 +17,9 @@ impl TypeMap {
     }
 
     #[track_caller]
-    pub fn filter(reader: &'static Reader, filter: &Filter, references: &References) -> Self {
+    pub fn filter(filter: &Filter, references: &References) -> Self {
         let mut dependencies = Self::new();
+        let reader = reader();
 
         for namespace in reader.keys() {
             if filter.includes_namespace(namespace) {

--- a/crates/libs/bindgen/src/type_map.rs
+++ b/crates/libs/bindgen/src/type_map.rs
@@ -82,7 +82,7 @@ impl TypeMap {
         )
     }
 
-    pub fn included(&self, config: &Config) -> bool {
+    pub fn included(&self) -> bool {
         self.0.iter().all(|(tn, _)| {
             // An empty namespace covers core types like `HRESULT`. This way we don't exclude methods
             // that depend on core types that aren't explicitly included in the filter.
@@ -90,11 +90,11 @@ impl TypeMap {
                 return true;
             }
 
-            if config.types.contains_key(tn) {
+            if config().types.contains_key(tn) {
                 return true;
             }
 
-            if config.references.contains(*tn).is_some() {
+            if config().references.contains(*tn).is_some() {
                 return true;
             }
 

--- a/crates/libs/bindgen/src/type_tree.rs
+++ b/crates/libs/bindgen/src/type_tree.rs
@@ -9,10 +9,10 @@ pub struct TypeTree {
 }
 
 impl TypeTree {
-    pub fn new(dependencies: &TypeMap) -> Self {
+    pub fn new() -> Self {
         let mut tree = Self::with_namespace("");
 
-        for (tn, types) in dependencies.iter() {
+        for (tn, types) in config().types.iter() {
             let tree = tree.insert_namespace(tn.namespace());
             types.iter().for_each(|ty| {
                 tree.types.insert(ty.clone());

--- a/crates/libs/bindgen/src/types/class.rs
+++ b/crates/libs/bindgen/src/types/class.rs
@@ -17,7 +17,7 @@ impl Class {
         let name = to_ident(type_name.name());
         let mut dependencies = TypeMap::new();
 
-        if writer.config.package {
+        if config().package {
             self.dependencies(&mut dependencies);
         }
 
@@ -38,7 +38,7 @@ impl Class {
             let mut virtual_names = MethodNames::new();
 
             for method in interface
-                .get_methods(writer)
+                .get_methods()
                 .iter()
                 .filter_map(|method| match &method {
                     MethodOrName::Method(method) => Some(method),
@@ -47,7 +47,7 @@ impl Class {
             {
                 let mut difference = TypeMap::new();
 
-                if writer.config.package {
+                if config().package {
                     difference = method.dependencies.difference(&dependencies);
                 }
 

--- a/crates/libs/bindgen/src/types/class.rs
+++ b/crates/libs/bindgen/src/types/class.rs
@@ -253,7 +253,7 @@ impl Class {
     fn bases(&self) -> Vec<Self> {
         let mut bases = Vec::new();
         let mut def = self.def;
-        let reader = def.reader();
+        let reader = reader();
 
         loop {
             let extends = def.extends().unwrap();
@@ -309,6 +309,8 @@ impl Class {
             walk(base.def, &[], true, &mut set);
         }
 
+        let reader = reader();
+
         for attribute in self.def.attributes() {
             let kind = match attribute.name() {
                 "StaticAttribute" | "ActivatableAttribute" => InterfaceKind::Static,
@@ -318,10 +320,8 @@ impl Class {
 
             for (_, arg) in attribute.args() {
                 if let Value::TypeName(tn) = arg {
-                    let Type::Interface(mut interface) = self
-                        .def
-                        .reader()
-                        .unwrap_full_name(tn.namespace(), tn.name())
+                    let Type::Interface(mut interface) =
+                        reader.unwrap_full_name(tn.namespace(), tn.name())
                     else {
                         panic!("type not found: {tn}");
                     };

--- a/crates/libs/bindgen/src/types/cpp_const.rs
+++ b/crates/libs/bindgen/src/types/cpp_const.rs
@@ -38,7 +38,7 @@ impl CppConst {
 
         let mut dependencies = TypeMap::new();
 
-        if writer.config.package {
+        if config().package {
             self.dependencies(&mut dependencies);
         }
 
@@ -52,7 +52,7 @@ impl CppConst {
                     let crate_name = writer.write_core();
                     let value = constant.value().write();
 
-                    // TODO: if writer.config.no_core then write these literals out as byte strings?
+                    // TODO: if config().no_core then write these literals out as byte strings?
                     if is_ansi_encoding(self.field) {
                         quote! {
                             #cfg
@@ -94,7 +94,7 @@ impl CppConst {
                     value = quote! { #value as _ };
                 }
 
-                if writer.config.sys || field_ty == Type::Bool {
+                if config().sys || field_ty == Type::Bool {
                     quote! {
                         #cfg
                         pub const #name: #ty = #value;

--- a/crates/libs/bindgen/src/types/cpp_delegate.rs
+++ b/crates/libs/bindgen/src/types/cpp_delegate.rs
@@ -49,7 +49,7 @@ impl CppDelegate {
 
         let mut dependencies = TypeMap::new();
 
-        if writer.config.package {
+        if config().package {
             self.dependencies(&mut dependencies);
         }
 

--- a/crates/libs/bindgen/src/types/cpp_enum.rs
+++ b/crates/libs/bindgen/src/types/cpp_enum.rs
@@ -30,17 +30,17 @@ impl CppEnum {
         let tn = self.def.type_name();
         let is_scoped = self.def.has_attribute("ScopedEnumAttribute");
 
-        if !is_scoped && writer.config.sys {
+        if !is_scoped && config().sys {
             return writer.write_cpp_handle(self.def);
         }
 
         let name = to_ident(tn.name());
         let underlying_type = self.def.underlying_type().write_name(writer);
 
-        let mut derive = DeriveWriter::new(writer, tn);
+        let mut derive = DeriveWriter::new(tn);
         derive.extend(["Copy", "Clone"]);
 
-        if !writer.config.sys {
+        if !config().sys {
             derive.extend(["Default", "Debug", "PartialEq", "Eq"]);
         }
 
@@ -67,7 +67,7 @@ impl CppEnum {
             quote! {}
         };
 
-        let flags = if writer.config.sys || !self.def.has_attribute("FlagsAttribute") {
+        let flags = if config().sys || !self.def.has_attribute("FlagsAttribute") {
             quote! {}
         } else {
             quote! {

--- a/crates/libs/bindgen/src/types/cpp_enum.rs
+++ b/crates/libs/bindgen/src/types/cpp_enum.rs
@@ -127,8 +127,7 @@ impl CppEnum {
     pub fn dependencies(&self, dependencies: &mut TypeMap) {
         if let Some(attribute) = self.def.find_attribute("AlsoUsableForAttribute") {
             if let Some((_, Value::Str(type_name))) = attribute.args().first() {
-                self.def
-                    .reader()
+                reader()
                     .unwrap_full_name(self.def.namespace(), type_name)
                     .dependencies(dependencies);
             }

--- a/crates/libs/bindgen/src/types/cpp_fn.rs
+++ b/crates/libs/bindgen/src/types/cpp_fn.rs
@@ -62,12 +62,12 @@ impl CppFn {
 
         let return_sig = writer.write_return_sig(self.method, &signature, underlying_types);
 
-        let vararg =
-            if writer.config.sys && signature.call_flags.contains(MethodCallAttributes::VARARG) {
-                quote! { , ... }
-            } else {
-                quote! {}
-            };
+        let vararg = if config().sys && signature.call_flags.contains(MethodCallAttributes::VARARG)
+        {
+            quote! { , ... }
+        } else {
+            quote! {}
+        };
 
         link_fmt(quote! {
             windows_targets::link!(#library #abi #symbol fn #name(#(#params),* #vararg) #return_sig);
@@ -79,14 +79,14 @@ impl CppFn {
         let signature = self.method.signature(self.namespace, &[]);
         let mut dependencies = TypeMap::new();
 
-        if writer.config.package {
+        if config().package {
             self.dependencies(&mut dependencies);
         }
 
         let link = self.write_link(writer, false);
         let cfg = writer.write_cfg(self.method, self.namespace, &dependencies, false);
         let window_long = self.write_window_long();
-        if writer.config.sys {
+        if config().sys {
             return quote! {
                 #cfg
                 #link

--- a/crates/libs/bindgen/src/types/cpp_fn.rs
+++ b/crates/libs/bindgen/src/types/cpp_fn.rs
@@ -278,8 +278,7 @@ impl CppFn {
         };
 
         if let Some(dependency) = dependency {
-            self.method
-                .reader()
+            reader()
                 .unwrap_full_name(self.namespace, dependency)
                 .dependencies(dependencies);
         }

--- a/crates/libs/bindgen/src/types/cpp_interface.rs
+++ b/crates/libs/bindgen/src/types/cpp_interface.rs
@@ -28,14 +28,14 @@ impl CppInterface {
         self.def.type_name()
     }
 
-    pub fn get_methods(&self, writer: &Writer) -> Vec<CppMethodOrName> {
+    pub fn get_methods(&self) -> Vec<CppMethodOrName> {
         let namespace = self.def.namespace();
 
         self.def
             .methods()
             .map(|def| {
                 let method = CppMethod::new(def, namespace);
-                if method.dependencies.included(writer.config) {
+                if method.dependencies.included() {
                     CppMethodOrName::Method(method)
                 } else {
                     CppMethodOrName::Name(method.def.name())
@@ -45,14 +45,14 @@ impl CppInterface {
     }
 
     pub fn write(&self, writer: &Writer) -> TokenStream {
-        let methods = self.get_methods(writer);
+        let methods = self.get_methods();
 
         let base_interfaces = self.base_interfaces();
         let has_unknown_base = matches!(base_interfaces.first(), Some(Type::IUnknown));
 
         let mut dependencies = TypeMap::new();
 
-        if writer.config.package {
+        if config().package {
             self.dependencies(&mut dependencies);
         }
 
@@ -82,7 +82,7 @@ impl CppInterface {
                 CppMethodOrName::Method(method) => {
                     let mut difference = TypeMap::new();
 
-                    if writer.config.package {
+                    if config().package {
                         difference = method.dependencies.difference(&dependencies);
                     }
 
@@ -122,10 +122,10 @@ impl CppInterface {
             }
         };
 
-        if writer.config.sys {
+        if config().sys {
             let mut result = quote! {};
 
-            if !writer.config.package {
+            if !config().package {
                 if has_unknown_base {
                     if let Some(guid) = self.def.guid_attribute() {
                         let name: TokenStream = format!("IID_{}", self.def.name()).into();
@@ -193,7 +193,7 @@ impl CppInterface {
             }) {
                 let mut difference = TypeMap::new();
 
-                if writer.config.package {
+                if config().package {
                     difference = method.dependencies.difference(&dependencies);
                 }
 
@@ -220,19 +220,19 @@ impl CppInterface {
 
             let impl_name: TokenStream = format!("{}_Impl", self.def.name()).into();
 
-            if writer.config.package {
-                fn collect(interface: &CppInterface, dependencies: &mut TypeMap, writer: &Writer) {
-                    for method in interface.get_methods(writer).iter() {
+            if config().package {
+                fn collect(interface: &CppInterface, dependencies: &mut TypeMap) {
+                    for method in interface.get_methods().iter() {
                         if let CppMethodOrName::Method(method) = method {
                             dependencies.combine(&method.dependencies);
                         }
                     }
                 }
 
-                collect(self, &mut dependencies, writer);
+                collect(self, &mut dependencies);
                 base_interfaces.iter().for_each(|interface| {
                     if let Type::CppInterface(ty) = interface {
-                        collect(ty, &mut dependencies, writer);
+                        collect(ty, &mut dependencies);
                     }
                 });
             }
@@ -404,7 +404,7 @@ impl CppInterface {
     }
 
     pub fn write_name(&self, writer: &Writer) -> TokenStream {
-        if writer.config.sys {
+        if config().sys {
             quote! { *mut core::ffi::c_void }
         } else {
             self.type_name().write(writer, &[])

--- a/crates/libs/bindgen/src/types/cpp_struct.rs
+++ b/crates/libs/bindgen/src/types/cpp_struct.rs
@@ -228,8 +228,7 @@ impl CppStruct {
 
         if let Some(attribute) = self.def.find_attribute("AlsoUsableForAttribute") {
             if let Some((_, Value::Str(type_name))) = attribute.args().first() {
-                self.def
-                    .reader()
+                reader()
                     .unwrap_full_name(self.def.namespace(), type_name)
                     .dependencies(dependencies);
             }

--- a/crates/libs/bindgen/src/types/delegate.rs
+++ b/crates/libs/bindgen/src/types/delegate.rs
@@ -25,7 +25,7 @@ impl Delegate {
 
         let mut dependencies = TypeMap::new();
 
-        if writer.config.package {
+        if config().package {
             self.dependencies(&mut dependencies);
         }
 

--- a/crates/libs/bindgen/src/types/enum.rs
+++ b/crates/libs/bindgen/src/types/enum.rs
@@ -18,10 +18,10 @@ impl Enum {
         let name = to_ident(self.def.name());
         let underlying_type = self.def.underlying_type();
 
-        let mut derive = DeriveWriter::new(writer, self.type_name());
+        let mut derive = DeriveWriter::new(self.type_name());
         derive.extend(["Copy", "Clone"]);
 
-        if !writer.config.sys {
+        if !config().sys {
             derive.extend(["Default", "Debug", "PartialEq", "Eq"]);
         }
 
@@ -38,7 +38,7 @@ impl Enum {
                 }
             });
 
-        let flags = if writer.config.sys || underlying_type != Type::U32 {
+        let flags = if config().sys || underlying_type != Type::U32 {
             quote! {}
         } else {
             quote! {
@@ -81,7 +81,7 @@ impl Enum {
 
         let underlying_type = underlying_type.write_name(writer);
 
-        let win_traits = if writer.config.sys {
+        let win_traits = if config().sys {
             quote! {}
         } else {
             let signature = Literal::byte_string(&self.runtime_signature());

--- a/crates/libs/bindgen/src/types/mod.rs
+++ b/crates/libs/bindgen/src/types/mod.rs
@@ -380,7 +380,7 @@ impl Type {
                 quote! { #name BSTR }
             }
             Self::IUnknown => {
-                if writer.config.sys {
+                if config().sys {
                     quote! { *mut core::ffi::c_void }
                 } else {
                     let name = writer.write_core();
@@ -400,7 +400,7 @@ impl Type {
                 quote! { #name HSTRING }
             }
             Self::Object => {
-                if writer.config.sys {
+                if config().sys {
                     quote! { *mut core::ffi::c_void }
                 } else {
                     let name = writer.write_core();
@@ -454,7 +454,7 @@ impl Type {
             Self::ArrayRef(ty) => ty.write_name(writer),
             Self::ConstRef(ty) => ty.write_name(writer),
             Self::PrimitiveOrEnum(primitive, ty) => {
-                if writer.config.sys {
+                if config().sys {
                     primitive.write_name(writer)
                 } else {
                     ty.write_name(writer)
@@ -472,7 +472,7 @@ impl Type {
 
             if matches!(self, Self::Param(_)) {
                 quote! { <#tokens as windows_core::Type<#tokens>>::Default }
-            } else if self.is_interface() && !writer.config.sys {
+            } else if self.is_interface() && !config().sys {
                 quote! { Option<#tokens> }
             } else {
                 tokens
@@ -493,7 +493,7 @@ impl Type {
     }
 
     pub fn write_abi(&self, writer: &Writer) -> TokenStream {
-        if writer.config.sys {
+        if config().sys {
             return self.write_default(writer);
         }
 
@@ -837,8 +837,8 @@ impl Type {
 }
 
 impl Type {
-    fn write_no_deps(&self, writer: &Writer) -> TokenStream {
-        if !writer.config.no_core {
+    fn write_no_deps(&self) -> TokenStream {
+        if !config().no_core {
             return quote! {};
         }
 
@@ -906,7 +906,7 @@ impl Type {
             Self::Class(ty) => ty.write(writer),
             Self::CppInterface(ty) => ty.write(writer),
 
-            _ => self.write_no_deps(writer),
+            _ => self.write_no_deps(),
         }
     }
 

--- a/crates/libs/bindgen/src/types/mod.rs
+++ b/crates/libs/bindgen/src/types/mod.rs
@@ -224,8 +224,7 @@ impl Type {
             }
         }
 
-        code.reader()
-            .unwrap_full_name(code_name.namespace(), code_name.name())
+        reader().unwrap_full_name(code_name.namespace(), code_name.name())
     }
 
     #[track_caller]
@@ -298,9 +297,7 @@ impl Type {
                 let code = blob.decode::<TypeDefOrRef>();
                 let code_name = code.type_name();
 
-                let mut ty = blob
-                    .reader()
-                    .unwrap_full_name(code_name.namespace(), code_name.name());
+                let mut ty = reader().unwrap_full_name(code_name.namespace(), code_name.name());
 
                 let mut item_generics = vec![];
 
@@ -573,17 +570,11 @@ impl Type {
     pub fn split_generic(&self) -> (Type, Vec<Type>) {
         match self {
             Self::Interface(ty) if !ty.generics.is_empty() => {
-                let base = ty
-                    .def
-                    .reader()
-                    .unwrap_full_name(ty.def.namespace(), ty.def.name());
+                let base = reader().unwrap_full_name(ty.def.namespace(), ty.def.name());
                 (base, ty.generics.clone())
             }
             Self::Delegate(ty) if !ty.generics.is_empty() => {
-                let base = ty
-                    .def
-                    .reader()
-                    .unwrap_full_name(ty.def.namespace(), ty.def.name());
+                let base = reader().unwrap_full_name(ty.def.namespace(), ty.def.name());
                 (base, ty.generics.clone())
             }
             _ => (self.clone(), vec![]),
@@ -630,16 +621,8 @@ impl Type {
         }
 
         if let Some(multi) = match &ty {
-            Self::CppStruct(ty) => Some(
-                ty.def
-                    .reader()
-                    .with_full_name(ty.def.namespace(), ty.def.name()),
-            ),
-            Self::CppFn(ty) => Some(
-                ty.method
-                    .reader()
-                    .with_full_name(ty.namespace, ty.method.name()),
-            ),
+            Self::CppStruct(ty) => Some(reader().with_full_name(ty.def.namespace(), ty.def.name())),
+            Self::CppFn(ty) => Some(reader().with_full_name(ty.namespace, ty.method.name())),
             _ => None,
         } {
             multi.for_each(|multi| {

--- a/crates/libs/bindgen/src/types/struct.rs
+++ b/crates/libs/bindgen/src/types/struct.rs
@@ -25,14 +25,14 @@ impl Struct {
 
         let is_copyable = fields.iter().all(|(_, ty)| ty.is_copyable());
 
-        let mut derive = DeriveWriter::new(writer, self.type_name());
+        let mut derive = DeriveWriter::new(self.type_name());
         derive.extend(["Clone"]);
 
         if is_copyable {
             derive.extend(["Copy"]);
         }
 
-        if !writer.config.sys {
+        if !config().sys {
             derive.extend(["Default", "Debug", "PartialEq"]);
         }
 
@@ -42,7 +42,7 @@ impl Struct {
             quote! { pub #name: #ty, }
         });
 
-        let win_traits = if writer.config.sys {
+        let win_traits = if config().sys {
             quote! {}
         } else {
             let type_kind = if is_copyable {

--- a/crates/libs/bindgen/src/winmd/blob.rs
+++ b/crates/libs/bindgen/src/winmd/blob.rs
@@ -18,10 +18,6 @@ impl Blob {
         Self { file, slice }
     }
 
-    pub fn reader(&self) -> &'static Reader {
-        self.file.reader()
-    }
-
     fn peek(&self) -> (usize, usize) {
         if self[0] & 0x80 == 0 {
             (self[0] as usize, 1)

--- a/crates/libs/bindgen/src/winmd/codes.rs
+++ b/crates/libs/bindgen/src/winmd/codes.rs
@@ -83,12 +83,4 @@ impl TypeDefOrRef {
             rest => panic!("{rest:?}"),
         }
     }
-
-    pub fn reader(&self) -> &'static Reader {
-        match self {
-            Self::TypeDef(row) => row.reader(),
-            Self::TypeRef(row) => row.reader(),
-            Self::TypeSpec(row) => row.reader(),
-        }
-    }
 }

--- a/crates/libs/bindgen/src/winmd/file.rs
+++ b/crates/libs/bindgen/src/winmd/file.rs
@@ -1,7 +1,6 @@
 use super::*;
 
 pub struct File {
-    pub(crate) reader: *const Reader,
     bytes: Vec<u8>,
     strings: usize,
     blobs: usize,
@@ -46,7 +45,6 @@ impl File {
     pub fn new(bytes: Vec<u8>) -> Option<Self> {
         let mut result = File {
             bytes,
-            reader: std::ptr::null(),
             strings: 0,
             blobs: 0,
             tables: Default::default(),
@@ -654,11 +652,6 @@ impl File {
 
     pub(crate) fn table<R: AsRow>(&'static self) -> RowIterator<R> {
         RowIterator::new(self, 0..self.tables[R::TABLE].len)
-    }
-
-    pub(crate) fn reader(&self) -> &'static Reader {
-        // Safety: At this point the File is already pointing to a valid Reader.
-        unsafe { &*self.reader }
     }
 }
 

--- a/crates/libs/bindgen/src/winmd/reader.rs
+++ b/crates/libs/bindgen/src/winmd/reader.rs
@@ -28,7 +28,7 @@ impl std::ops::Deref for Reader {
 }
 
 impl Reader {
-    pub fn new(files: Vec<File>) -> &'static Self {
+    pub fn init(files: Vec<File>) {
         let reader = Box::leak(Box::new(Self(HashMap::new())));
 
         for file in files {
@@ -180,7 +180,6 @@ impl Reader {
         }
 
         READER.store(reader, Ordering::Relaxed);
-        reader
     }
 
     #[track_caller]

--- a/crates/libs/bindgen/src/winmd/row.rs
+++ b/crates/libs/bindgen/src/winmd/row.rs
@@ -21,11 +21,6 @@ pub trait AsRow: Copy {
         self.to_row().file
     }
 
-    fn reader(&self) -> &'static Reader {
-        // Safety: At this point the File is already pointing to a valid Reader.
-        unsafe { &*self.file().reader }
-    }
-
     fn index(&self) -> usize {
         self.to_row().index
     }

--- a/crates/libs/bindgen/src/writer/cpp_handle.rs
+++ b/crates/libs/bindgen/src/writer/cpp_handle.rs
@@ -7,7 +7,7 @@ impl Writer {
         let ty = def.underlying_type();
         let ty_name = ty.write_name(self);
 
-        if self.config.sys {
+        if config().sys {
             quote! {
                 pub type #name = #ty_name;
             }

--- a/crates/libs/bindgen/src/writer/cpp_handle.rs
+++ b/crates/libs/bindgen/src/writer/cpp_handle.rs
@@ -111,7 +111,7 @@ impl Writer {
 
             if let Some(attribute) = def.find_attribute("AlsoUsableForAttribute") {
                 if let Some((_, Value::Str(type_name))) = attribute.args().first() {
-                    let ty = def.reader().unwrap_full_name(def.namespace(), type_name);
+                    let ty = reader().unwrap_full_name(def.namespace(), type_name);
 
                     let ty = ty.write_name(self);
 

--- a/crates/libs/bindgen/src/writer/format.rs
+++ b/crates/libs/bindgen/src/writer/format.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 impl Writer {
     pub fn format(&self, tokens: &str) -> String {
-        let preamble = if self.config.no_comment {
+        let preamble = if config().no_comment {
             String::new()
         } else {
             let version = std::env!("CARGO_PKG_VERSION");
@@ -16,7 +16,7 @@ impl Writer {
             )
         };
 
-        let allow = if self.config.no_allow {
+        let allow = if config().no_allow {
             ""
         } else {
             "#![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, dead_code, clippy::all)]\n\n"
@@ -28,9 +28,9 @@ impl Writer {
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::null());
 
-        if !self.config.rustfmt.is_empty() {
+        if !config().rustfmt.is_empty() {
             cmd.arg("--config");
-            cmd.arg(&self.config.rustfmt);
+            cmd.arg(&config().rustfmt);
         }
 
         let Ok(mut child) = cmd.spawn() else {

--- a/crates/libs/bindgen/src/writer/names.rs
+++ b/crates/libs/bindgen/src/writer/names.rs
@@ -2,10 +2,10 @@ use super::*;
 
 impl Writer {
     pub fn write_core(&self) -> TokenStream {
-        if self.config.sys {
-            if self.config.package || !self.config.no_core {
+        if config().sys {
+            if config().package || !config().no_core {
                 quote! { windows_sys::core:: }
-            } else if self.config.flat {
+            } else if config().flat {
                 quote! {}
             } else {
                 let mut tokens = TokenStream::new();
@@ -56,10 +56,10 @@ impl Writer {
         }
 
         if let Some(reference) = {
-            if self.config.types.contains_key(&type_name) {
+            if config().types.contains_key(&type_name) {
                 None
             } else {
-                self.config.references.contains(type_name)
+                config().references.contains(type_name)
             }
         } {
             tokens.push_str(&reference.name);
@@ -82,7 +82,7 @@ impl Writer {
 
             tokens
         } else {
-            if self.config.flat || type_name.namespace() == self.namespace {
+            if config().flat || type_name.namespace() == self.namespace {
                 return tokens;
             }
 


### PR DESCRIPTION
The `windows-bindgen` crate uses an internal static winmd reader but passing it around constantly is rather cumbersome. This simplifies this by using a static `AtomicPtr` that can be retrieved via the `reader` free function. This then helps to simplify some upcoming refactoring and bug fixing. 

I ended up doing the same for `Config` which is similarly passed around and describes what and how to generate bindings from metadata.