### PR TITLE
Use dedicate arch `cfg` writer

### DIFF
--- a/crates/libs/bindgen/src/types/cpp_delegate.rs
+++ b/crates/libs/bindgen/src/types/cpp_delegate.rs
@@ -53,9 +53,11 @@ impl CppDelegate {
             self.dependencies(&mut dependencies);
         }
 
+        let arches = write_arches(self.def);
         let cfg = writer.write_cfg(self.def, type_name.namespace(), &dependencies, false);
 
         quote! {
+            #arches
             #cfg
             pub type #name = Option<unsafe extern "system" fn(#(#params),*) #return_sig>;
         }

--- a/crates/libs/bindgen/src/types/cpp_fn.rs
+++ b/crates/libs/bindgen/src/types/cpp_fn.rs
@@ -84,8 +84,11 @@ impl CppFn {
         }
 
         let link = self.write_link(writer, false);
+        let arches = write_arches(self.method);
         let cfg = writer.write_cfg(self.method, self.namespace, &dependencies, false);
+        let cfg = quote! { #arches #cfg };
         let window_long = self.write_window_long();
+
         if writer.config.sys {
             return quote! {
                 #cfg

--- a/crates/libs/bindgen/src/types/cpp_struct.rs
+++ b/crates/libs/bindgen/src/types/cpp_struct.rs
@@ -63,8 +63,9 @@ impl CppStruct {
             self.dependencies(&mut dependencies);
         }
 
+        let arches = write_arches(self.def);
         let cfg = writer.write_cfg(self.def, self.def.namespace(), &dependencies, false);
-        self.write_with_cfg(writer, &cfg)
+        self.write_with_cfg(writer, &quote! { #arches #cfg })
     }
 
     fn write_with_cfg(&self, writer: &Writer, cfg: &TokenStream) -> TokenStream {

--- a/crates/libs/bindgen/src/writer/mod.rs
+++ b/crates/libs/bindgen/src/writer/mod.rs
@@ -5,6 +5,7 @@ mod names;
 mod value;
 
 use super::*;
+pub use cfg::*;
 use rayon::prelude::*;
 
 #[derive(Clone)]


### PR DESCRIPTION
On the way to fixing #3425, there are a few areas in which `cfg` generation is quite difficult to reason about. I'll be making a few changes here to simplify and make it more targeted so that we can get more accurate `cfg` generation for feature-gating. 