### PR TITLE
Use `Ref` for generic type parameters

### DIFF
--- a/crates/libs/bindgen/src/types/method.rs
+++ b/crates/libs/bindgen/src/types/method.rs
@@ -47,7 +47,7 @@ impl Method {
                     quote! { core::slice::from_raw_parts(core::mem::transmute_copy(&#name), #abi_size_name as usize) }
                 } else if param.0.is_primitive() {
                     quote! { #name }
-                } else if param.0.is_const_ref() || param.0.is_interface() {
+                } else if param.0.is_const_ref() || param.0.is_interface() || matches!(&param.0, Type::Param(_))  {
                     quote! { core::mem::transmute_copy(&#name) }
                 } else {
                     quote! { core::mem::transmute(&#name) }
@@ -155,6 +155,9 @@ impl Method {
                 } else if p.0.is_interface() {
                     let type_name = p.0.write_name(writer);
                     quote! { windows_core::Ref<#type_name> }
+                } else if matches!(&p.0, Type::Param(_)) {
+                    let type_name = p.0.write_name(writer);
+                    quote! { <#type_name as windows_core::Type<#type_name>>::Ref }
                 } else {
                     quote! { &#default_type }
                 }

--- a/crates/libs/core/src/type.rs
+++ b/crates/libs/core/src/type.rs
@@ -17,12 +17,17 @@ pub struct CopyType;
 #[doc(hidden)]
 pub trait Type<T: TypeKind, C = <T as TypeKind>::TypeKind>: TypeKind + Sized + Clone {
     type Abi;
+    type Ref;
     type Default;
 
     fn is_null(abi: &Self::Abi) -> bool;
     unsafe fn assume_init_ref(abi: &Self::Abi) -> &Self;
     unsafe fn from_abi(abi: Self::Abi) -> Result<Self>;
     fn from_default(default: &Self::Default) -> Result<Self>;
+
+    fn deref(param: &Self::Ref) -> &Self::Default {
+        unsafe { core::mem::transmute(param) }
+    }
 }
 
 impl<T> Type<T, InterfaceType> for T
@@ -30,6 +35,7 @@ where
     T: TypeKind<TypeKind = InterfaceType> + Clone,
 {
     type Abi = *mut core::ffi::c_void;
+    type Ref = Ref<T>;
     type Default = Option<Self>;
 
     fn is_null(abi: &Self::Abi) -> bool {
@@ -60,6 +66,7 @@ where
     T: TypeKind<TypeKind = CloneType> + Clone,
 {
     type Abi = core::mem::MaybeUninit<Self>;
+    type Ref = Ref<T>;
     type Default = Self;
 
     fn is_null(_: &Self::Abi) -> bool {
@@ -84,6 +91,7 @@ where
     T: TypeKind<TypeKind = CopyType> + Clone,
 {
     type Abi = Self;
+    type Ref = Self;
     type Default = Self;
 
     fn is_null(_: &Self::Abi) -> bool {

--- a/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
@@ -434,12 +434,12 @@ where
     K: windows_core::RuntimeType + 'static,
     V: windows_core::RuntimeType + 'static,
 {
-    fn Lookup(&self, key: &<K as windows_core::Type<K>>::Default) -> windows_core::Result<V>;
+    fn Lookup(&self, key: <K as windows_core::Type<K>>::Ref) -> windows_core::Result<V>;
     fn Size(&self) -> windows_core::Result<u32>;
-    fn HasKey(&self, key: &<K as windows_core::Type<K>>::Default) -> windows_core::Result<bool>;
+    fn HasKey(&self, key: <K as windows_core::Type<K>>::Ref) -> windows_core::Result<bool>;
     fn GetView(&self) -> windows_core::Result<IMapView<K, V>>;
-    fn Insert(&self, key: &<K as windows_core::Type<K>>::Default, value: &<V as windows_core::Type<V>>::Default) -> windows_core::Result<bool>;
-    fn Remove(&self, key: &<K as windows_core::Type<K>>::Default) -> windows_core::Result<()>;
+    fn Insert(&self, key: <K as windows_core::Type<K>>::Ref, value: <V as windows_core::Type<V>>::Ref) -> windows_core::Result<bool>;
+    fn Remove(&self, key: <K as windows_core::Type<K>>::Ref) -> windows_core::Result<()>;
     fn Clear(&self) -> windows_core::Result<()>;
 }
 impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> IMap_Vtbl<K, V> {
@@ -447,7 +447,7 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
         unsafe extern "system" fn Lookup<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static, Identity: IMap_Impl<K, V>, const OFFSET: isize>(this: *mut core::ffi::c_void, key: windows_core::AbiType<K>, result__: *mut windows_core::AbiType<V>) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                match IMap_Impl::Lookup(this, core::mem::transmute(&key)) {
+                match IMap_Impl::Lookup(this, core::mem::transmute_copy(&key)) {
                     Ok(ok__) => {
                         result__.write(core::mem::transmute_copy(&ok__));
                         core::mem::forget(ok__);
@@ -472,7 +472,7 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
         unsafe extern "system" fn HasKey<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static, Identity: IMap_Impl<K, V>, const OFFSET: isize>(this: *mut core::ffi::c_void, key: windows_core::AbiType<K>, result__: *mut bool) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                match IMap_Impl::HasKey(this, core::mem::transmute(&key)) {
+                match IMap_Impl::HasKey(this, core::mem::transmute_copy(&key)) {
                     Ok(ok__) => {
                         result__.write(core::mem::transmute_copy(&ok__));
                         windows_core::HRESULT(0)
@@ -497,7 +497,7 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
         unsafe extern "system" fn Insert<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static, Identity: IMap_Impl<K, V>, const OFFSET: isize>(this: *mut core::ffi::c_void, key: windows_core::AbiType<K>, value: windows_core::AbiType<V>, result__: *mut bool) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                match IMap_Impl::Insert(this, core::mem::transmute(&key), core::mem::transmute(&value)) {
+                match IMap_Impl::Insert(this, core::mem::transmute_copy(&key), core::mem::transmute_copy(&value)) {
                     Ok(ok__) => {
                         result__.write(core::mem::transmute_copy(&ok__));
                         windows_core::HRESULT(0)
@@ -509,7 +509,7 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
         unsafe extern "system" fn Remove<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static, Identity: IMap_Impl<K, V>, const OFFSET: isize>(this: *mut core::ffi::c_void, key: windows_core::AbiType<K>) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IMap_Impl::Remove(this, core::mem::transmute(&key)).into()
+                IMap_Impl::Remove(this, core::mem::transmute_copy(&key)).into()
             }
         }
         unsafe extern "system" fn Clear<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static, Identity: IMap_Impl<K, V>, const OFFSET: isize>(this: *mut core::ffi::c_void) -> windows_core::HRESULT {
@@ -720,9 +720,9 @@ where
     K: windows_core::RuntimeType + 'static,
     V: windows_core::RuntimeType + 'static,
 {
-    fn Lookup(&self, key: &<K as windows_core::Type<K>>::Default) -> windows_core::Result<V>;
+    fn Lookup(&self, key: <K as windows_core::Type<K>>::Ref) -> windows_core::Result<V>;
     fn Size(&self) -> windows_core::Result<u32>;
-    fn HasKey(&self, key: &<K as windows_core::Type<K>>::Default) -> windows_core::Result<bool>;
+    fn HasKey(&self, key: <K as windows_core::Type<K>>::Ref) -> windows_core::Result<bool>;
     fn Split(&self, first: windows_core::OutRef<'_, IMapView<K, V>>, second: windows_core::OutRef<'_, IMapView<K, V>>) -> windows_core::Result<()>;
 }
 impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> IMapView_Vtbl<K, V> {
@@ -730,7 +730,7 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
         unsafe extern "system" fn Lookup<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static, Identity: IMapView_Impl<K, V>, const OFFSET: isize>(this: *mut core::ffi::c_void, key: windows_core::AbiType<K>, result__: *mut windows_core::AbiType<V>) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                match IMapView_Impl::Lookup(this, core::mem::transmute(&key)) {
+                match IMapView_Impl::Lookup(this, core::mem::transmute_copy(&key)) {
                     Ok(ok__) => {
                         result__.write(core::mem::transmute_copy(&ok__));
                         core::mem::forget(ok__);
@@ -755,7 +755,7 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
         unsafe extern "system" fn HasKey<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static, Identity: IMapView_Impl<K, V>, const OFFSET: isize>(this: *mut core::ffi::c_void, key: windows_core::AbiType<K>, result__: *mut bool) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                match IMapView_Impl::HasKey(this, core::mem::transmute(&key)) {
+                match IMapView_Impl::HasKey(this, core::mem::transmute_copy(&key)) {
                     Ok(ok__) => {
                         result__.write(core::mem::transmute_copy(&ok__));
                         windows_core::HRESULT(0)
@@ -1380,11 +1380,11 @@ where
     fn GetAt(&self, index: u32) -> windows_core::Result<T>;
     fn Size(&self) -> windows_core::Result<u32>;
     fn GetView(&self) -> windows_core::Result<IVectorView<T>>;
-    fn IndexOf(&self, value: &<T as windows_core::Type<T>>::Default, index: &mut u32) -> windows_core::Result<bool>;
-    fn SetAt(&self, index: u32, value: &<T as windows_core::Type<T>>::Default) -> windows_core::Result<()>;
-    fn InsertAt(&self, index: u32, value: &<T as windows_core::Type<T>>::Default) -> windows_core::Result<()>;
+    fn IndexOf(&self, value: <T as windows_core::Type<T>>::Ref, index: &mut u32) -> windows_core::Result<bool>;
+    fn SetAt(&self, index: u32, value: <T as windows_core::Type<T>>::Ref) -> windows_core::Result<()>;
+    fn InsertAt(&self, index: u32, value: <T as windows_core::Type<T>>::Ref) -> windows_core::Result<()>;
     fn RemoveAt(&self, index: u32) -> windows_core::Result<()>;
-    fn Append(&self, value: &<T as windows_core::Type<T>>::Default) -> windows_core::Result<()>;
+    fn Append(&self, value: <T as windows_core::Type<T>>::Ref) -> windows_core::Result<()>;
     fn RemoveAtEnd(&self) -> windows_core::Result<()>;
     fn Clear(&self) -> windows_core::Result<()>;
     fn GetMany(&self, startIndex: u32, items: &mut [<T as windows_core::Type<T>>::Default]) -> windows_core::Result<u32>;
@@ -1433,7 +1433,7 @@ impl<T: windows_core::RuntimeType + 'static> IVector_Vtbl<T> {
         unsafe extern "system" fn IndexOf<T: windows_core::RuntimeType + 'static, Identity: IVector_Impl<T>, const OFFSET: isize>(this: *mut core::ffi::c_void, value: windows_core::AbiType<T>, index: *mut u32, result__: *mut bool) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                match IVector_Impl::IndexOf(this, core::mem::transmute(&value), core::mem::transmute_copy(&index)) {
+                match IVector_Impl::IndexOf(this, core::mem::transmute_copy(&value), core::mem::transmute_copy(&index)) {
                     Ok(ok__) => {
                         result__.write(core::mem::transmute_copy(&ok__));
                         windows_core::HRESULT(0)
@@ -1445,13 +1445,13 @@ impl<T: windows_core::RuntimeType + 'static> IVector_Vtbl<T> {
         unsafe extern "system" fn SetAt<T: windows_core::RuntimeType + 'static, Identity: IVector_Impl<T>, const OFFSET: isize>(this: *mut core::ffi::c_void, index: u32, value: windows_core::AbiType<T>) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IVector_Impl::SetAt(this, index, core::mem::transmute(&value)).into()
+                IVector_Impl::SetAt(this, index, core::mem::transmute_copy(&value)).into()
             }
         }
         unsafe extern "system" fn InsertAt<T: windows_core::RuntimeType + 'static, Identity: IVector_Impl<T>, const OFFSET: isize>(this: *mut core::ffi::c_void, index: u32, value: windows_core::AbiType<T>) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IVector_Impl::InsertAt(this, index, core::mem::transmute(&value)).into()
+                IVector_Impl::InsertAt(this, index, core::mem::transmute_copy(&value)).into()
             }
         }
         unsafe extern "system" fn RemoveAt<T: windows_core::RuntimeType + 'static, Identity: IVector_Impl<T>, const OFFSET: isize>(this: *mut core::ffi::c_void, index: u32) -> windows_core::HRESULT {
@@ -1463,7 +1463,7 @@ impl<T: windows_core::RuntimeType + 'static> IVector_Vtbl<T> {
         unsafe extern "system" fn Append<T: windows_core::RuntimeType + 'static, Identity: IVector_Impl<T>, const OFFSET: isize>(this: *mut core::ffi::c_void, value: windows_core::AbiType<T>) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IVector_Impl::Append(this, core::mem::transmute(&value)).into()
+                IVector_Impl::Append(this, core::mem::transmute_copy(&value)).into()
             }
         }
         unsafe extern "system" fn RemoveAtEnd<T: windows_core::RuntimeType + 'static, Identity: IVector_Impl<T>, const OFFSET: isize>(this: *mut core::ffi::c_void) -> windows_core::HRESULT {
@@ -1687,7 +1687,7 @@ where
 {
     fn GetAt(&self, index: u32) -> windows_core::Result<T>;
     fn Size(&self) -> windows_core::Result<u32>;
-    fn IndexOf(&self, value: &<T as windows_core::Type<T>>::Default, index: &mut u32) -> windows_core::Result<bool>;
+    fn IndexOf(&self, value: <T as windows_core::Type<T>>::Ref, index: &mut u32) -> windows_core::Result<bool>;
     fn GetMany(&self, startIndex: u32, items: &mut [<T as windows_core::Type<T>>::Default]) -> windows_core::Result<u32>;
 }
 impl<T: windows_core::RuntimeType + 'static> IVectorView_Vtbl<T> {
@@ -1720,7 +1720,7 @@ impl<T: windows_core::RuntimeType + 'static> IVectorView_Vtbl<T> {
         unsafe extern "system" fn IndexOf<T: windows_core::RuntimeType + 'static, Identity: IVectorView_Impl<T>, const OFFSET: isize>(this: *mut core::ffi::c_void, value: windows_core::AbiType<T>, index: *mut u32, result__: *mut bool) -> windows_core::HRESULT {
             unsafe {
                 let this: &Identity = &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                match IVectorView_Impl::IndexOf(this, core::mem::transmute(&value), core::mem::transmute_copy(&index)) {
+                match IVectorView_Impl::IndexOf(this, core::mem::transmute_copy(&value), core::mem::transmute_copy(&index)) {
                     Ok(ok__) => {
                         result__.write(core::mem::transmute_copy(&ok__));
                         windows_core::HRESULT(0)

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -87,7 +87,7 @@ impl<TProgress: windows_core::RuntimeType + 'static> windows_core::RuntimeType f
     const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::new().push_slice(b"pinterface({6d844858-0cff-4590-ae89-95a5a5c8b4b8}").push_slice(b";").push_other(TProgress::SIGNATURE).push_slice(b")");
 }
 impl<TProgress: windows_core::RuntimeType + 'static> AsyncActionProgressHandler<TProgress> {
-    pub fn new<F: FnMut(windows_core::Ref<IAsyncActionWithProgress<TProgress>>, &<TProgress as windows_core::Type<TProgress>>::Default) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
+    pub fn new<F: FnMut(windows_core::Ref<IAsyncActionWithProgress<TProgress>>, <TProgress as windows_core::Type<TProgress>>::Ref) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = AsyncActionProgressHandlerBox { vtable: &AsyncActionProgressHandlerBox::<TProgress, F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
         unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
     }
@@ -110,7 +110,7 @@ where
     TProgress: core::marker::PhantomData<TProgress>,
 }
 #[repr(C)]
-struct AsyncActionProgressHandlerBox<TProgress, F: FnMut(windows_core::Ref<IAsyncActionWithProgress<TProgress>>, &<TProgress as windows_core::Type<TProgress>>::Default) -> windows_core::Result<()> + Send + 'static>
+struct AsyncActionProgressHandlerBox<TProgress, F: FnMut(windows_core::Ref<IAsyncActionWithProgress<TProgress>>, <TProgress as windows_core::Type<TProgress>>::Ref) -> windows_core::Result<()> + Send + 'static>
 where
     TProgress: windows_core::RuntimeType + 'static,
 {
@@ -118,7 +118,7 @@ where
     invoke: F,
     count: windows_core::imp::RefCount,
 }
-impl<TProgress: windows_core::RuntimeType + 'static, F: FnMut(windows_core::Ref<IAsyncActionWithProgress<TProgress>>, &<TProgress as windows_core::Type<TProgress>>::Default) -> windows_core::Result<()> + Send + 'static> AsyncActionProgressHandlerBox<TProgress, F> {
+impl<TProgress: windows_core::RuntimeType + 'static, F: FnMut(windows_core::Ref<IAsyncActionWithProgress<TProgress>>, <TProgress as windows_core::Type<TProgress>>::Ref) -> windows_core::Result<()> + Send + 'static> AsyncActionProgressHandlerBox<TProgress, F> {
     const VTABLE: AsyncActionProgressHandler_Vtbl<TProgress> = AsyncActionProgressHandler_Vtbl::<TProgress> {
         base__: windows_core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
@@ -158,7 +158,7 @@ impl<TProgress: windows_core::RuntimeType + 'static, F: FnMut(windows_core::Ref<
     unsafe extern "system" fn Invoke(this: *mut core::ffi::c_void, asyncinfo: *mut core::ffi::c_void, progressinfo: windows_core::AbiType<TProgress>) -> windows_core::HRESULT {
         unsafe {
             let this = &mut *(this as *mut *mut core::ffi::c_void as *mut Self);
-            (this.invoke)(core::mem::transmute_copy(&asyncinfo), core::mem::transmute(&progressinfo)).into()
+            (this.invoke)(core::mem::transmute_copy(&asyncinfo), core::mem::transmute_copy(&progressinfo)).into()
         }
     }
 }
@@ -350,7 +350,7 @@ impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::Runt
     const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::new().push_slice(b"pinterface({55690902-0aab-421a-8778-f8ce5026d758}").push_slice(b";").push_other(TResult::SIGNATURE).push_slice(b";").push_other(TProgress::SIGNATURE).push_slice(b")");
 }
 impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> AsyncOperationProgressHandler<TResult, TProgress> {
-    pub fn new<F: FnMut(windows_core::Ref<IAsyncOperationWithProgress<TResult, TProgress>>, &<TProgress as windows_core::Type<TProgress>>::Default) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
+    pub fn new<F: FnMut(windows_core::Ref<IAsyncOperationWithProgress<TResult, TProgress>>, <TProgress as windows_core::Type<TProgress>>::Ref) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = AsyncOperationProgressHandlerBox { vtable: &AsyncOperationProgressHandlerBox::<TResult, TProgress, F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
         unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
     }
@@ -375,7 +375,7 @@ where
     TProgress: core::marker::PhantomData<TProgress>,
 }
 #[repr(C)]
-struct AsyncOperationProgressHandlerBox<TResult, TProgress, F: FnMut(windows_core::Ref<IAsyncOperationWithProgress<TResult, TProgress>>, &<TProgress as windows_core::Type<TProgress>>::Default) -> windows_core::Result<()> + Send + 'static>
+struct AsyncOperationProgressHandlerBox<TResult, TProgress, F: FnMut(windows_core::Ref<IAsyncOperationWithProgress<TResult, TProgress>>, <TProgress as windows_core::Type<TProgress>>::Ref) -> windows_core::Result<()> + Send + 'static>
 where
     TResult: windows_core::RuntimeType + 'static,
     TProgress: windows_core::RuntimeType + 'static,
@@ -384,7 +384,7 @@ where
     invoke: F,
     count: windows_core::imp::RefCount,
 }
-impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static, F: FnMut(windows_core::Ref<IAsyncOperationWithProgress<TResult, TProgress>>, &<TProgress as windows_core::Type<TProgress>>::Default) -> windows_core::Result<()> + Send + 'static> AsyncOperationProgressHandlerBox<TResult, TProgress, F> {
+impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static, F: FnMut(windows_core::Ref<IAsyncOperationWithProgress<TResult, TProgress>>, <TProgress as windows_core::Type<TProgress>>::Ref) -> windows_core::Result<()> + Send + 'static> AsyncOperationProgressHandlerBox<TResult, TProgress, F> {
     const VTABLE: AsyncOperationProgressHandler_Vtbl<TResult, TProgress> = AsyncOperationProgressHandler_Vtbl::<TResult, TProgress> {
         base__: windows_core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
@@ -425,7 +425,7 @@ impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::Runt
     unsafe extern "system" fn Invoke(this: *mut core::ffi::c_void, asyncinfo: *mut core::ffi::c_void, progressinfo: windows_core::AbiType<TProgress>) -> windows_core::HRESULT {
         unsafe {
             let this = &mut *(this as *mut *mut core::ffi::c_void as *mut Self);
-            (this.invoke)(core::mem::transmute_copy(&asyncinfo), core::mem::transmute(&progressinfo)).into()
+            (this.invoke)(core::mem::transmute_copy(&asyncinfo), core::mem::transmute_copy(&progressinfo)).into()
         }
     }
 }
@@ -665,7 +665,7 @@ impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for Event
     const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::new().push_slice(b"pinterface({9de1c535-6ae1-11e0-84e1-18a905bcc53f}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")");
 }
 impl<T: windows_core::RuntimeType + 'static> EventHandler<T> {
-    pub fn new<F: FnMut(windows_core::Ref<windows_core::IInspectable>, &<T as windows_core::Type<T>>::Default) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
+    pub fn new<F: FnMut(windows_core::Ref<windows_core::IInspectable>, <T as windows_core::Type<T>>::Ref) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = EventHandlerBox { vtable: &EventHandlerBox::<T, F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
         unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
     }
@@ -688,7 +688,7 @@ where
     T: core::marker::PhantomData<T>,
 }
 #[repr(C)]
-struct EventHandlerBox<T, F: FnMut(windows_core::Ref<windows_core::IInspectable>, &<T as windows_core::Type<T>>::Default) -> windows_core::Result<()> + Send + 'static>
+struct EventHandlerBox<T, F: FnMut(windows_core::Ref<windows_core::IInspectable>, <T as windows_core::Type<T>>::Ref) -> windows_core::Result<()> + Send + 'static>
 where
     T: windows_core::RuntimeType + 'static,
 {
@@ -696,7 +696,7 @@ where
     invoke: F,
     count: windows_core::imp::RefCount,
 }
-impl<T: windows_core::RuntimeType + 'static, F: FnMut(windows_core::Ref<windows_core::IInspectable>, &<T as windows_core::Type<T>>::Default) -> windows_core::Result<()> + Send + 'static> EventHandlerBox<T, F> {
+impl<T: windows_core::RuntimeType + 'static, F: FnMut(windows_core::Ref<windows_core::IInspectable>, <T as windows_core::Type<T>>::Ref) -> windows_core::Result<()> + Send + 'static> EventHandlerBox<T, F> {
     const VTABLE: EventHandler_Vtbl<T> = EventHandler_Vtbl::<T> {
         base__: windows_core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
@@ -736,7 +736,7 @@ impl<T: windows_core::RuntimeType + 'static, F: FnMut(windows_core::Ref<windows_
     unsafe extern "system" fn Invoke(this: *mut core::ffi::c_void, sender: *mut core::ffi::c_void, args: windows_core::AbiType<T>) -> windows_core::HRESULT {
         unsafe {
             let this = &mut *(this as *mut *mut core::ffi::c_void as *mut Self);
-            (this.invoke)(core::mem::transmute_copy(&sender), core::mem::transmute(&args)).into()
+            (this.invoke)(core::mem::transmute_copy(&sender), core::mem::transmute_copy(&args)).into()
         }
     }
 }
@@ -3685,7 +3685,7 @@ impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::Runtim
     const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::new().push_slice(b"pinterface({9de1c534-6ae1-11e0-84e1-18a905bcc53f}").push_slice(b";").push_other(TSender::SIGNATURE).push_slice(b";").push_other(TResult::SIGNATURE).push_slice(b")");
 }
 impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::RuntimeType + 'static> TypedEventHandler<TSender, TResult> {
-    pub fn new<F: FnMut(&<TSender as windows_core::Type<TSender>>::Default, &<TResult as windows_core::Type<TResult>>::Default) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
+    pub fn new<F: FnMut(<TSender as windows_core::Type<TSender>>::Ref, <TResult as windows_core::Type<TResult>>::Ref) -> windows_core::Result<()> + Send + 'static>(invoke: F) -> Self {
         let com = TypedEventHandlerBox { vtable: &TypedEventHandlerBox::<TSender, TResult, F>::VTABLE, count: windows_core::imp::RefCount::new(1), invoke };
         unsafe { core::mem::transmute(windows_core::imp::Box::new(com)) }
     }
@@ -3710,7 +3710,7 @@ where
     TResult: core::marker::PhantomData<TResult>,
 }
 #[repr(C)]
-struct TypedEventHandlerBox<TSender, TResult, F: FnMut(&<TSender as windows_core::Type<TSender>>::Default, &<TResult as windows_core::Type<TResult>>::Default) -> windows_core::Result<()> + Send + 'static>
+struct TypedEventHandlerBox<TSender, TResult, F: FnMut(<TSender as windows_core::Type<TSender>>::Ref, <TResult as windows_core::Type<TResult>>::Ref) -> windows_core::Result<()> + Send + 'static>
 where
     TSender: windows_core::RuntimeType + 'static,
     TResult: windows_core::RuntimeType + 'static,
@@ -3719,7 +3719,7 @@ where
     invoke: F,
     count: windows_core::imp::RefCount,
 }
-impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::RuntimeType + 'static, F: FnMut(&<TSender as windows_core::Type<TSender>>::Default, &<TResult as windows_core::Type<TResult>>::Default) -> windows_core::Result<()> + Send + 'static> TypedEventHandlerBox<TSender, TResult, F> {
+impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::RuntimeType + 'static, F: FnMut(<TSender as windows_core::Type<TSender>>::Ref, <TResult as windows_core::Type<TResult>>::Ref) -> windows_core::Result<()> + Send + 'static> TypedEventHandlerBox<TSender, TResult, F> {
     const VTABLE: TypedEventHandler_Vtbl<TSender, TResult> = TypedEventHandler_Vtbl::<TSender, TResult> {
         base__: windows_core::IUnknown_Vtbl { QueryInterface: Self::QueryInterface, AddRef: Self::AddRef, Release: Self::Release },
         Invoke: Self::Invoke,
@@ -3760,7 +3760,7 @@ impl<TSender: windows_core::RuntimeType + 'static, TResult: windows_core::Runtim
     unsafe extern "system" fn Invoke(this: *mut core::ffi::c_void, sender: windows_core::AbiType<TSender>, args: windows_core::AbiType<TResult>) -> windows_core::HRESULT {
         unsafe {
             let this = &mut *(this as *mut *mut core::ffi::c_void as *mut Self);
-            (this.invoke)(core::mem::transmute(&sender), core::mem::transmute(&args)).into()
+            (this.invoke)(core::mem::transmute_copy(&sender), core::mem::transmute_copy(&args)).into()
         }
     }
 }

--- a/crates/libs/windows/src/extensions/Foundation/Collections/MapView.rs
+++ b/crates/libs/windows/src/extensions/Foundation/Collections/MapView.rs
@@ -1,4 +1,4 @@
-use crate::Foundation::Collections::{IIterable, IIterable_Impl, IIterator, IIterator_Impl, IKeyValuePair, IKeyValuePair_Impl, IMapView, IMapView_Impl};
+use crate::Foundation::Collections::*;
 
 #[windows_core::implement(IMapView<K, V>, IIterable<IKeyValuePair<K, V>>)]
 struct StockMapView<K, V>
@@ -32,15 +32,15 @@ where
     K::Default: Clone + Ord,
     V::Default: Clone,
 {
-    fn Lookup(&self, key: &K::Default) -> windows_core::Result<V> {
-        let value = self.map.get(key).ok_or_else(|| windows_core::Error::from(windows_core::imp::E_BOUNDS))?;
+    fn Lookup(&self, key: K::Ref) -> windows_core::Result<V> {
+        let value = self.map.get(K::deref(&key)).ok_or_else(|| windows_core::Error::from(windows_core::imp::E_BOUNDS))?;
         V::from_default(value)
     }
     fn Size(&self) -> windows_core::Result<u32> {
         Ok(self.map.len().try_into()?)
     }
-    fn HasKey(&self, key: &K::Default) -> windows_core::Result<bool> {
-        Ok(self.map.contains_key(key))
+    fn HasKey(&self, key: K::Ref) -> windows_core::Result<bool> {
+        Ok(self.map.contains_key(K::deref(&key)))
     }
     fn Split(&self, first: windows_core::OutRef<'_, IMapView<K, V>>, second: windows_core::OutRef<'_, IMapView<K, V>>) -> windows_core::Result<()> {
         _ = first.write(None);

--- a/crates/libs/windows/src/extensions/Foundation/Collections/VectorView.rs
+++ b/crates/libs/windows/src/extensions/Foundation/Collections/VectorView.rs
@@ -1,4 +1,4 @@
-use crate::Foundation::Collections::{IIterable, IIterable_Impl, IIterator, IIterator_Impl, IVectorView, IVectorView_Impl};
+use crate::Foundation::Collections::*;
 
 #[windows_core::implement(IVectorView<T>, IIterable<T>)]
 struct StockVectorView<T>
@@ -33,8 +33,8 @@ where
     fn Size(&self) -> windows_core::Result<u32> {
         Ok(self.values.len().try_into()?)
     }
-    fn IndexOf(&self, value: &T::Default, result: &mut u32) -> windows_core::Result<bool> {
-        match self.values.iter().position(|element| element == value) {
+    fn IndexOf(&self, value: T::Ref, result: &mut u32) -> windows_core::Result<bool> {
+        match self.values.iter().position(|element| element == T::deref(&value)) {
             Some(index) => {
                 *result = index as u32;
                 Ok(true)

--- a/crates/tests/bindgen/src/class_dep.rs
+++ b/crates/tests/bindgen/src/class_dep.rs
@@ -462,11 +462,7 @@ where
 {
     fn GetAt(&self, index: u32) -> windows_core::Result<T>;
     fn Size(&self) -> windows_core::Result<u32>;
-    fn IndexOf(
-        &self,
-        value: &<T as windows_core::Type<T>>::Default,
-        index: &mut u32,
-    ) -> windows_core::Result<bool>;
+    fn IndexOf(&self, value: windows_core::Ref<T>, index: &mut u32) -> windows_core::Result<bool>;
     fn GetMany(
         &self,
         startIndex: u32,
@@ -532,7 +528,7 @@ impl<T: windows_core::RuntimeType + 'static> IVectorView_Vtbl<T> {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 match IVectorView_Impl::IndexOf(
                     this,
-                    core::mem::transmute(&value),
+                    core::mem::transmute_copy(&value),
                     core::mem::transmute_copy(&index),
                 ) {
                     Ok(ok__) => {

--- a/crates/tests/bindgen/src/class_dep.rs
+++ b/crates/tests/bindgen/src/class_dep.rs
@@ -462,7 +462,11 @@ where
 {
     fn GetAt(&self, index: u32) -> windows_core::Result<T>;
     fn Size(&self) -> windows_core::Result<u32>;
-    fn IndexOf(&self, value: windows_core::Ref<T>, index: &mut u32) -> windows_core::Result<bool>;
+    fn IndexOf(
+        &self,
+        value: <T as windows_core::Type<T>>::Ref,
+        index: &mut u32,
+    ) -> windows_core::Result<bool>;
     fn GetMany(
         &self,
         startIndex: u32,

--- a/crates/tests/bindgen/src/delegate_generic.rs
+++ b/crates/tests/bindgen/src/delegate_generic.rs
@@ -27,7 +27,7 @@ impl<T: windows_core::RuntimeType + 'static> EventHandler<T> {
     pub fn new<
         F: FnMut(
                 windows_core::Ref<windows_core::IInspectable>,
-                windows_core::Ref<T>,
+                <T as windows_core::Type<T>>::Ref,
             ) -> windows_core::Result<()>
             + Send
             + 'static,
@@ -75,7 +75,7 @@ struct EventHandlerBox<
     T,
     F: FnMut(
             windows_core::Ref<windows_core::IInspectable>,
-            windows_core::Ref<T>,
+            <T as windows_core::Type<T>>::Ref,
         ) -> windows_core::Result<()>
         + Send
         + 'static,
@@ -90,7 +90,7 @@ impl<
         T: windows_core::RuntimeType + 'static,
         F: FnMut(
                 windows_core::Ref<windows_core::IInspectable>,
-                windows_core::Ref<T>,
+                <T as windows_core::Type<T>>::Ref,
             ) -> windows_core::Result<()>
             + Send
             + 'static,

--- a/crates/tests/bindgen/src/delegate_generic.rs
+++ b/crates/tests/bindgen/src/delegate_generic.rs
@@ -27,7 +27,7 @@ impl<T: windows_core::RuntimeType + 'static> EventHandler<T> {
     pub fn new<
         F: FnMut(
                 windows_core::Ref<windows_core::IInspectable>,
-                &<T as windows_core::Type<T>>::Default,
+                windows_core::Ref<T>,
             ) -> windows_core::Result<()>
             + Send
             + 'static,
@@ -75,7 +75,7 @@ struct EventHandlerBox<
     T,
     F: FnMut(
             windows_core::Ref<windows_core::IInspectable>,
-            &<T as windows_core::Type<T>>::Default,
+            windows_core::Ref<T>,
         ) -> windows_core::Result<()>
         + Send
         + 'static,
@@ -90,7 +90,7 @@ impl<
         T: windows_core::RuntimeType + 'static,
         F: FnMut(
                 windows_core::Ref<windows_core::IInspectable>,
-                &<T as windows_core::Type<T>>::Default,
+                windows_core::Ref<T>,
             ) -> windows_core::Result<()>
             + Send
             + 'static,
@@ -156,7 +156,7 @@ impl<
             let this = &mut *(this as *mut *mut core::ffi::c_void as *mut Self);
             (this.invoke)(
                 core::mem::transmute_copy(&sender),
-                core::mem::transmute(&args),
+                core::mem::transmute_copy(&args),
             )
             .into()
         }

--- a/crates/tests/bindgen/src/interface_iterable.rs
+++ b/crates/tests/bindgen/src/interface_iterable.rs
@@ -543,23 +543,11 @@ where
 {
     fn GetAt(&self, index: u32) -> windows_core::Result<T>;
     fn Size(&self) -> windows_core::Result<u32>;
-    fn IndexOf(
-        &self,
-        value: &<T as windows_core::Type<T>>::Default,
-        index: &mut u32,
-    ) -> windows_core::Result<bool>;
-    fn SetAt(
-        &self,
-        index: u32,
-        value: &<T as windows_core::Type<T>>::Default,
-    ) -> windows_core::Result<()>;
-    fn InsertAt(
-        &self,
-        index: u32,
-        value: &<T as windows_core::Type<T>>::Default,
-    ) -> windows_core::Result<()>;
+    fn IndexOf(&self, value: windows_core::Ref<T>, index: &mut u32) -> windows_core::Result<bool>;
+    fn SetAt(&self, index: u32, value: windows_core::Ref<T>) -> windows_core::Result<()>;
+    fn InsertAt(&self, index: u32, value: windows_core::Ref<T>) -> windows_core::Result<()>;
     fn RemoveAt(&self, index: u32) -> windows_core::Result<()>;
-    fn Append(&self, value: &<T as windows_core::Type<T>>::Default) -> windows_core::Result<()>;
+    fn Append(&self, value: windows_core::Ref<T>) -> windows_core::Result<()>;
     fn RemoveAtEnd(&self) -> windows_core::Result<()>;
     fn Clear(&self) -> windows_core::Result<()>;
     fn GetMany(
@@ -631,7 +619,7 @@ impl<T: windows_core::RuntimeType + 'static> IVector_Vtbl<T> {
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
                 match IVector_Impl::IndexOf(
                     this,
-                    core::mem::transmute(&value),
+                    core::mem::transmute_copy(&value),
                     core::mem::transmute_copy(&index),
                 ) {
                     Ok(ok__) => {
@@ -654,7 +642,7 @@ impl<T: windows_core::RuntimeType + 'static> IVector_Vtbl<T> {
             unsafe {
                 let this: &Identity =
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IVector_Impl::SetAt(this, index, core::mem::transmute(&value)).into()
+                IVector_Impl::SetAt(this, index, core::mem::transmute_copy(&value)).into()
             }
         }
         unsafe extern "system" fn InsertAt<
@@ -669,7 +657,7 @@ impl<T: windows_core::RuntimeType + 'static> IVector_Vtbl<T> {
             unsafe {
                 let this: &Identity =
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IVector_Impl::InsertAt(this, index, core::mem::transmute(&value)).into()
+                IVector_Impl::InsertAt(this, index, core::mem::transmute_copy(&value)).into()
             }
         }
         unsafe extern "system" fn RemoveAt<
@@ -697,7 +685,7 @@ impl<T: windows_core::RuntimeType + 'static> IVector_Vtbl<T> {
             unsafe {
                 let this: &Identity =
                     &*((this as *const *const ()).offset(OFFSET) as *const Identity);
-                IVector_Impl::Append(this, core::mem::transmute(&value)).into()
+                IVector_Impl::Append(this, core::mem::transmute_copy(&value)).into()
             }
         }
         unsafe extern "system" fn RemoveAtEnd<

--- a/crates/tests/bindgen/src/interface_iterable.rs
+++ b/crates/tests/bindgen/src/interface_iterable.rs
@@ -543,11 +543,23 @@ where
 {
     fn GetAt(&self, index: u32) -> windows_core::Result<T>;
     fn Size(&self) -> windows_core::Result<u32>;
-    fn IndexOf(&self, value: windows_core::Ref<T>, index: &mut u32) -> windows_core::Result<bool>;
-    fn SetAt(&self, index: u32, value: windows_core::Ref<T>) -> windows_core::Result<()>;
-    fn InsertAt(&self, index: u32, value: windows_core::Ref<T>) -> windows_core::Result<()>;
+    fn IndexOf(
+        &self,
+        value: <T as windows_core::Type<T>>::Ref,
+        index: &mut u32,
+    ) -> windows_core::Result<bool>;
+    fn SetAt(
+        &self,
+        index: u32,
+        value: <T as windows_core::Type<T>>::Ref,
+    ) -> windows_core::Result<()>;
+    fn InsertAt(
+        &self,
+        index: u32,
+        value: <T as windows_core::Type<T>>::Ref,
+    ) -> windows_core::Result<()>;
     fn RemoveAt(&self, index: u32) -> windows_core::Result<()>;
-    fn Append(&self, value: windows_core::Ref<T>) -> windows_core::Result<()>;
+    fn Append(&self, value: <T as windows_core::Type<T>>::Ref) -> windows_core::Result<()>;
     fn RemoveAtEnd(&self) -> windows_core::Result<()>;
     fn Clear(&self) -> windows_core::Result<()>;
     fn GetMany(

--- a/crates/tests/misc/implement/tests/generic_default.rs
+++ b/crates/tests/misc/implement/tests/generic_default.rs
@@ -29,8 +29,12 @@ where
         Ok(self.0.len() as u32)
     }
 
-    fn IndexOf(&self, value: &T::Default, result: &mut u32) -> Result<bool> {
-        match self.0.iter().position(|element| element == value) {
+    fn IndexOf(&self, value: T::Ref, result: &mut u32) -> Result<bool> {
+        match self
+            .0
+            .iter()
+            .position(|element| element == T::deref(&value))
+        {
             Some(index) => {
                 *result = index as u32;
                 Ok(true)

--- a/crates/tests/misc/implement/tests/generic_generic.rs
+++ b/crates/tests/misc/implement/tests/generic_generic.rs
@@ -24,7 +24,7 @@ where
         panic!();
     }
 
-    fn IndexOf(&self, _value: &T::Default, _index: &mut u32) -> Result<bool> {
+    fn IndexOf(&self, _value: T::Ref, _index: &mut u32) -> Result<bool> {
         panic!();
     }
 

--- a/crates/tests/misc/implement/tests/generic_primitive.rs
+++ b/crates/tests/misc/implement/tests/generic_primitive.rs
@@ -19,8 +19,8 @@ impl IVectorView_Impl<i32> for Thing_Impl {
         Ok(123)
     }
 
-    fn IndexOf(&self, value: &i32, index: &mut u32) -> Result<bool> {
-        *index = *value as u32;
+    fn IndexOf(&self, value: i32, index: &mut u32) -> Result<bool> {
+        *index = value as u32;
         Ok(true)
     }
 

--- a/crates/tests/misc/implement/tests/generic_stringable.rs
+++ b/crates/tests/misc/implement/tests/generic_stringable.rs
@@ -17,7 +17,7 @@ impl IVectorView_Impl<IStringable> for Thing_Impl {
         panic!();
     }
 
-    fn IndexOf(&self, _value: &Option<IStringable>, _index: &mut u32) -> Result<bool> {
+    fn IndexOf(&self, _value: Ref<IStringable>, _index: &mut u32) -> Result<bool> {
         panic!();
     }
 

--- a/crates/tests/misc/implement/tests/map.rs
+++ b/crates/tests/misc/implement/tests/map.rs
@@ -46,10 +46,10 @@ struct MapView();
 #[allow(non_snake_case)]
 impl IMapView_Impl<i32, f32> for MapView_Impl {
     // TODO: shouldn't require & for primtiive
-    fn HasKey(&self, _key: &i32) -> Result<bool> {
+    fn HasKey(&self, _key: i32) -> Result<bool> {
         Ok(true)
     }
-    fn Lookup(&self, _key: &i32) -> Result<f32> {
+    fn Lookup(&self, _key: i32) -> Result<f32> {
         Ok(0.0)
     }
     fn Split(
@@ -85,16 +85,16 @@ impl IMap_Impl<i32, f32> for Map_Impl {
     fn GetView(&self) -> Result<IMapView<i32, f32>> {
         Ok(MapView().into())
     }
-    fn HasKey(&self, _key: &i32) -> Result<bool> {
+    fn HasKey(&self, _key: i32) -> Result<bool> {
         Ok(true)
     }
-    fn Insert(&self, _key: &i32, _value: &f32) -> Result<bool> {
+    fn Insert(&self, _key: i32, _value: f32) -> Result<bool> {
         Ok(true)
     }
-    fn Lookup(&self, _key: &i32) -> Result<f32> {
+    fn Lookup(&self, _key: i32) -> Result<f32> {
         Ok(0.0)
     }
-    fn Remove(&self, _key: &i32) -> Result<()> {
+    fn Remove(&self, _key: i32) -> Result<()> {
         Ok(())
     }
     fn Size(&self) -> Result<u32> {

--- a/crates/tests/misc/implement/tests/vector.rs
+++ b/crates/tests/misc/implement/tests/vector.rs
@@ -48,9 +48,12 @@ where
         let reader = self.0.read().unwrap();
         Ok(reader.len() as u32)
     }
-    fn IndexOf(&self, value: &T::Default, result: &mut u32) -> Result<bool> {
+    fn IndexOf(&self, value: T::Ref, result: &mut u32) -> Result<bool> {
         let reader = self.0.read().unwrap();
-        match reader.iter().position(|element| element == value) {
+        match reader
+            .iter()
+            .position(|element| element == T::deref(&value))
+        {
             Some(index) => {
                 *result = index as u32;
                 Ok(true)
@@ -77,16 +80,16 @@ where
     fn GetView(&self) -> Result<windows::Foundation::Collections::IVectorView<T>> {
         unsafe { self.cast() }
     }
-    fn IndexOf(&self, value: &T::Default, result: &mut u32) -> Result<bool> {
+    fn IndexOf(&self, value: T::Ref, result: &mut u32) -> Result<bool> {
         self.IndexOf(value, result)
     }
-    fn SetAt(&self, index: u32, value: &T::Default) -> Result<()> {
+    fn SetAt(&self, index: u32, value: T::Ref) -> Result<()> {
         let mut writer = self.0.write().unwrap();
         let item = writer.get_mut(index as usize).ok_or_else(err_bounds)?;
-        *item = value.clone();
+        *item = T::deref(&value).clone();
         Ok(())
     }
-    fn InsertAt(&self, index: u32, value: &T::Default) -> Result<()> {
+    fn InsertAt(&self, index: u32, value: T::Ref) -> Result<()> {
         let mut writer = self.0.write().unwrap();
         let index = index as usize;
         if index > writer.len() {
@@ -94,7 +97,7 @@ where
         } else {
             let len = writer.len();
             writer.try_reserve(len + 1).map_err(|_| err_memory())?;
-            writer.insert(index, value.clone());
+            writer.insert(index, T::deref(&value).clone());
             Ok(())
         }
     }
@@ -108,11 +111,11 @@ where
             Err(err_bounds())
         }
     }
-    fn Append(&self, value: &T::Default) -> Result<()> {
+    fn Append(&self, value: T::Ref) -> Result<()> {
         let mut writer = self.0.write().unwrap();
         let len = writer.len();
         writer.try_reserve(len + 1).map_err(|_| err_memory())?;
-        writer.insert(len, value.clone());
+        writer.insert(len, T::deref(&value).clone());
         Ok(())
     }
     fn RemoveAtEnd(&self) -> Result<()> {
@@ -154,7 +157,7 @@ where
     fn Size(&self) -> Result<u32> {
         self.Size()
     }
-    fn IndexOf(&self, value: &T::Default, result: &mut u32) -> Result<bool> {
+    fn IndexOf(&self, value: T::Ref, result: &mut u32) -> Result<bool> {
         self.IndexOf(value, result)
     }
     fn GetMany(&self, startindex: u32, items: &mut [T::Default]) -> Result<u32> {

--- a/crates/tests/winrt/event_core/tests/tests.rs
+++ b/crates/tests/winrt/event_core/tests/tests.rs
@@ -14,7 +14,7 @@ fn add_remove() -> Result<()> {
 
     // Add event handler.
     event.add(&EventHandler::<i32>::new(move |_, args| {
-        check_sender.store(*args, Ordering::Relaxed);
+        check_sender.store(args, Ordering::Relaxed);
         Ok(())
     }))?;
 
@@ -57,7 +57,7 @@ fn multiple() -> Result<()> {
     assert_eq!(c_check.load(Ordering::Relaxed), 0);
 
     let a_token = event.add(&EventHandler::<i32>::new(move |_, args| {
-        a_check_sender.store(*args, Ordering::Relaxed);
+        a_check_sender.store(args, Ordering::Relaxed);
         Ok(())
     }))?;
 
@@ -70,7 +70,7 @@ fn multiple() -> Result<()> {
     assert_eq!(c_check.load(Ordering::Relaxed), 0);
 
     let b_token = event.add(&EventHandler::<i32>::new(move |_, args| {
-        b_check_sender.store(*args, Ordering::Relaxed);
+        b_check_sender.store(args, Ordering::Relaxed);
         Ok(())
     }))?;
 
@@ -83,7 +83,7 @@ fn multiple() -> Result<()> {
     assert_eq!(c_check.load(Ordering::Relaxed), 0);
 
     let c_token = event.add(&EventHandler::<i32>::new(move |_, args| {
-        c_check_sender.store(*args, Ordering::Relaxed);
+        c_check_sender.store(args, Ordering::Relaxed);
         Ok(())
     }))?;
 

--- a/crates/tests/winrt/events_client/src/lib.rs
+++ b/crates/tests/winrt/events_client/src/lib.rs
@@ -14,9 +14,9 @@ fn test() -> Result<()> {
     assert_eq!(0, class.Signal(1)?);
 
     let token = class.Event(&TypedEventHandler::new(
-        move |sender: &Option<Class>, args: &i32| {
+        move |sender: Ref<Class>, args: i32| {
             assert_eq!(sender.as_ref().unwrap(), class);
-            assert_eq!(*args, 2);
+            assert_eq!(args, 2);
             Ok(())
         },
     ))?;
@@ -27,17 +27,17 @@ fn test() -> Result<()> {
 
     class.Event(&TypedEventHandler::new(
         // TODO: ideally generics also use Ref<T> here
-        move |sender: &Option<Class>, args: &i32| {
+        move |sender: Ref<Class>, args: i32| {
             assert_eq!(sender.as_ref().unwrap(), class);
-            assert_eq!(*args, 4);
+            assert_eq!(args, 4);
             Ok(())
         },
     ))?;
 
     class.Event(&TypedEventHandler::new(
-        move |sender: &Option<Class>, args: &i32| {
+        move |sender: Ref<Class>, args: i32| {
             assert_eq!(sender.as_ref().unwrap(), class);
-            assert_eq!(*args, 4);
+            assert_eq!(args, 4);
             Ok(())
         },
     ))?;
@@ -51,7 +51,7 @@ fn test_static() -> Result<()> {
     assert_eq!(0, Class::StaticSignal(1)?);
 
     let token = Class::StaticEvent(&EventHandler::new(move |_, args| {
-        assert_eq!(*args, 2);
+        assert_eq!(args, 2);
         Ok(())
     }))?;
 
@@ -60,12 +60,12 @@ fn test_static() -> Result<()> {
     assert_eq!(0, Class::StaticSignal(3)?);
 
     Class::StaticEvent(&EventHandler::new(move |_, args| {
-        assert_eq!(*args, 4);
+        assert_eq!(args, 4);
         Ok(())
     }))?;
 
     Class::StaticEvent(&EventHandler::new(move |_, args| {
-        assert_eq!(*args, 4);
+        assert_eq!(args, 4);
         Ok(())
     }))?;
 

--- a/crates/tests/winrt/old/tests/delegates.rs
+++ b/crates/tests/winrt/old/tests/delegates.rs
@@ -47,7 +47,7 @@ fn generic() -> windows::core::Result<()> {
         tx.send(true).unwrap();
 
         // TODO: ideally primitives would be passed by value
-        assert!(*port == 80);
+        assert!(port == 80);
         Ok(())
     });
 


### PR DESCRIPTION
Now that `Ref` no longer requires a lifetime parameter #3433 we can use it in a trait as a type alias and generalize the concept of a reference or input parameter for generic WinRT types. This solves a longstanding problem with generic type parameters where they were generated as references "just in case" since there was no way to know whether it would be specialized with a copyable or non-copyable type. 

So now whether you're implementing specializations of `IVector<T>` or writing a closure for `TypedEventHandler<Sender, Result>`, you can directly use the generic type arguments without having to indirect through a reference. For generic implementations - implementations that have to deal with any kind of `T` - you can use the `Type::deref` helper to convert a `T::Ref` into a `&T::Default` for efficient but generic handling of type parameters. 

This also gets us closer to resolving #3233 and #1339.